### PR TITLE
Feature/#3683 Add symmetric key capability to moto

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6191,7 +6191,7 @@
 - [X] get_key_policy
 - [X] get_key_rotation_status
 - [ ] get_parameters_for_import
-- [ ] get_public_key
+- [X] get_public_key
 - [ ] import_key_material
 - [ ] list_aliases
 - [ ] list_grants
@@ -6204,13 +6204,13 @@
 - [ ] retire_grant
 - [ ] revoke_grant
 - [X] schedule_key_deletion
-- [ ] sign
+- [X] sign
 - [X] tag_resource
 - [X] untag_resource
 - [ ] update_alias
 - [ ] update_custom_key_store
 - [X] update_key_description
-- [ ] verify
+- [X] verify
 </details>
 
 ## lakeformation

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from boto3 import Session
+from cryptography.hazmat.primitives import serialization
 
 from moto.core import ACCOUNT_ID, BaseBackend, CloudFormationModel
 from moto.core.utils import unix_time
@@ -159,6 +160,14 @@ class KmsBackend(BaseBackend):
         if tags is not None and len(tags) > 0:
             self.tag_resource(key.id, tags)
         return key
+
+    def get_public_key(self, key_id):
+        key = self.keys[self.get_key_id(key_id)]
+        public_key = key.key_material.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return key, public_key
 
     def update_key_description(self, key_id, description):
         key = self.keys[self.get_key_id(key_id)]

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -477,9 +477,10 @@ class KmsResponse(BaseResponse):
         signing_algorithm = self.parameters.get("SigningAlgorithm")
 
         self._validate_key_id(key_id)
+        signature = base64.b64decode(signature)
 
         verified = self.kms_backend.verify(
-            message=message,
+            message=message.encode("utf-8"),
             message_type=message_type,
             signature=signature,
             signing_algorithm=signing_algorithm,

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -30,15 +30,21 @@ Ciphertext = namedtuple("Ciphertext", ("key_id", "iv", "ciphertext", "tag"))
 
 signing_algorithms = {
     "RSASSA_PSS_SHA_256": {
-        "padding": padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=256),
+        "padding": padding.PSS(
+            mgf=padding.MGF1(hashes.SHA256()), salt_length=int(256 / 8)
+        ),
         "hash": hashes.SHA256(),
     },
     "RSASSA_PSS_SHA_384": {
-        "padding": padding.PSS(mgf=padding.MGF1(hashes.SHA384()), salt_length=384),
+        "padding": padding.PSS(
+            mgf=padding.MGF1(hashes.SHA384()), salt_length=int(384 / 8)
+        ),
         "hash": hashes.SHA256(),
     },
     "RSASSA_PSS_SHA_512": {
-        "padding": padding.PSS(mgf=padding.MGF1(hashes.SHA512()), salt_length=512),
+        "padding": padding.PSS(
+            mgf=padding.MGF1(hashes.SHA512()), salt_length=int(512 / 8)
+        ),
         "hash": hashes.SHA256(),
     },
     "RSASSA_PKCS1_V1_5_SHA_256": {

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -15,7 +15,6 @@ from .exceptions import (
     NotFoundException,
 )
 
-
 MASTER_KEY_LEN = 32
 KEY_ID_LEN = 36
 IV_LEN = 12
@@ -159,3 +158,34 @@ def decrypt(master_keys, ciphertext_blob, encryption_context):
         raise InvalidCiphertextException()
 
     return plaintext, ciphertext.key_id
+
+
+def sign(master_keys, key_id, message, encryption_context):
+    """Sign a message using master key material.
+
+    NOTE: This is not necessarily what KMS does, but it retains the same properties.
+
+    NOTE: This function is NOT compatible with KMS APIs.
+    :param dict master_keys: Mapping of a KmsBackend's known master keys
+    :param str key_id: Key ID of moto master key
+    :param bytes message: Plaintext message to sign
+    :param dict[str, str] encryption_context: KMS-style encryption context
+    :returns: Moto-structured ciphertext blob encrypted under a moto master key in master_keys
+    :rtype: bytes
+    """
+    return ""
+
+
+def verify(master_keys, message, signature, encryption_context):
+    """Verify a signature using master key material.
+
+    NOTE: This is not necessarily what KMS does, but it retains the same properties.
+
+    NOTE: This function is NOT compatible with KMS APIs.
+    :param dict master_keys: Mapping of a KmsBackend's known master keys
+    :param bytes plaintext: Plaintext data to encrypt
+    :param dict[str, str] encryption_context: KMS-style encryption context
+    :returns: Moto-structured ciphertext blob encrypted under a moto master key in master_keys
+    :rtype: bytes
+    """
+    return True

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -7,6 +7,8 @@ import struct
 import uuid
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, ec, utils
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 
 from .exceptions import (
@@ -26,6 +28,69 @@ CIPHERTEXT_HEADER_FORMAT = ">{key_id_len}s{iv_len}s{tag_len}s".format(
 )
 Ciphertext = namedtuple("Ciphertext", ("key_id", "iv", "ciphertext", "tag"))
 
+signing_algorithms = {
+    "RSASSA_PSS_SHA_256": {
+        "padding": padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=256),
+        "hash": hashes.SHA256(),
+    },
+    "RSASSA_PSS_SHA_384": {
+        "padding": padding.PSS(mgf=padding.MGF1(hashes.SHA384()), salt_length=384),
+        "hash": hashes.SHA256(),
+    },
+    "RSASSA_PSS_SHA_512": {
+        "padding": padding.PSS(mgf=padding.MGF1(hashes.SHA512()), salt_length=512),
+        "hash": hashes.SHA256(),
+    },
+    "RSASSA_PKCS1_V1_5_SHA_256": {
+        "padding": padding.PKCS1v15(),
+        "hash": hashes.SHA256(),
+    },
+    "RSASSA_PKCS1_V1_5_SHA_384": {
+        "padding": padding.PKCS1v15(),
+        "hash": hashes.SHA384(),
+    },
+    "RSASSA_PKCS1_V1_5_SHA_512": {
+        "padding": padding.PKCS1v15(),
+        "hash": hashes.SHA512(),
+    },
+}
+
+encryption_algorithms = {
+    "RSAES_OAEP_SHA_1": {
+        "padding": padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA1()), algorithm=hashes.SHA1(), label=None
+        )
+    },
+    "RSAES_OAEP_SHA_256": {
+        "padding": padding.OAEP(
+            mgf=padding.MGF1(hashes.SHA256()), algorithm=hashes.SHA256(), label=None
+        )
+    },
+}
+
+key_specs = {
+    "SYMMETRIC_DEFAULT": {"generate": lambda: generate_data_key(MASTER_KEY_LEN),},
+    "RSA_2048": {
+        "generate": lambda: rsa.generate_private_key(
+            public_exponent=65537, key_size=2048
+        ),
+    },
+    "RSA_3072": {
+        "generate": lambda: rsa.generate_private_key(
+            public_exponent=65537, key_size=3072
+        ),
+    },
+    "RSA_4096": {
+        "generate": lambda: rsa.generate_private_key(
+            public_exponent=65537, key_size=4096
+        )
+    },
+    "ECC_NIST_P256": {"generate": lambda: ec.generate_private_key(ec.SECP256R1())},
+    "ECC_NIST_P384": {"generate": lambda: ec.generate_private_key(ec.SECP384R1())},
+    "ECC_NIST_P521": {"generate": lambda: ec.generate_private_key(ec.SECP521R1())},
+    "ECC_SECG_P256K1": {"generate": lambda: ec.generate_private_key(ec.SECP256K1())},
+}
+
 
 def generate_key_id():
     return str(uuid.uuid4())
@@ -36,12 +101,13 @@ def generate_data_key(number_of_bytes):
     return os.urandom(number_of_bytes)
 
 
-def generate_master_key():
+def generate_master_key(key_spec):
     """Generate a master key."""
-    return generate_data_key(MASTER_KEY_LEN)
+    print(key_spec)
+    return key_specs[key_spec]["generate"]()
 
 
-def _serialize_ciphertext_blob(ciphertext):
+def serialize_ciphertext_blob(ciphertext):
     """Serialize Ciphertext object into a ciphertext blob.
 
     NOTE: This is just a simple binary format. It is not what KMS actually does.
@@ -55,7 +121,7 @@ def _serialize_ciphertext_blob(ciphertext):
     return header + ciphertext.ciphertext
 
 
-def _deserialize_ciphertext_blob(ciphertext_blob):
+def deserialize_ciphertext_blob(ciphertext_blob):
     """Deserialize ciphertext blob into a Ciphertext object.
 
     NOTE: This is just a simple binary format. It is not what KMS actually does.
@@ -80,7 +146,7 @@ def _serialize_encryption_context(encryption_context):
     return aad.getvalue()
 
 
-def encrypt(master_keys, key_id, plaintext, encryption_context):
+def encrypt(master_keys, key_id, plaintext, encryption_context, encryption_algorithm):
     """Encrypt data using a master key material.
 
     NOTE: This is not necessarily what KMS does, but it retains the same properties.
@@ -90,6 +156,7 @@ def encrypt(master_keys, key_id, plaintext, encryption_context):
     :param str key_id: Key ID of moto master key
     :param bytes plaintext: Plaintext data to encrypt
     :param dict[str, str] encryption_context: KMS-style encryption context
+    :param str encryption_algorithm: Specifies the encryption algorithm that will be used to encrypt the plaintext.
     :returns: Moto-structured ciphertext blob encrypted under a moto master key in master_keys
     :rtype: bytes
     """
@@ -103,22 +170,26 @@ def encrypt(master_keys, key_id, plaintext, encryption_context):
             )
         )
 
-    iv = os.urandom(IV_LEN)
-    aad = _serialize_encryption_context(encryption_context=encryption_context)
+    if encryption_algorithm == "SYMMETRIC_DEFAULT":
+        iv = os.urandom(IV_LEN)
+        aad = _serialize_encryption_context(encryption_context=encryption_context)
 
-    encryptor = Cipher(
-        algorithms.AES(key.key_material), modes.GCM(iv), backend=default_backend()
-    ).encryptor()
-    encryptor.authenticate_additional_data(aad)
-    ciphertext = encryptor.update(plaintext) + encryptor.finalize()
-    return _serialize_ciphertext_blob(
-        ciphertext=Ciphertext(
+        encryptor = Cipher(
+            algorithms.AES(key.key_material), modes.GCM(iv), backend=default_backend()
+        ).encryptor()
+        encryptor.authenticate_additional_data(aad)
+        ciphertext = encryptor.update(plaintext) + encryptor.finalize()
+        return Ciphertext(
             key_id=key_id, iv=iv, ciphertext=ciphertext, tag=encryptor.tag
         )
-    )
+
+    else:
+        return key.key_material.public_key().encrypt(
+            plaintext, encryption_algorithms[encryption_algorithm]["padding"]
+        )
 
 
-def decrypt(master_keys, ciphertext_blob, encryption_context):
+def decrypt(master_keys, ciphertext, encryption_context, encryption_algorithm, key_id):
     """Decrypt a ciphertext blob using a master key material.
 
     NOTE: This is not necessarily what KMS does, but it retains the same properties.
@@ -126,66 +197,91 @@ def decrypt(master_keys, ciphertext_blob, encryption_context):
     NOTE: This function is NOT compatible with KMS APIs.
 
     :param dict master_keys: Mapping of a KmsBackend's known master keys
-    :param bytes ciphertext_blob: moto-structured ciphertext blob encrypted under a moto master key in master_keys
+    :param bytes ciphertext: moto-structured ciphertext blob encrypted under a moto master key in master_keys
     :param dict[str, str] encryption_context: KMS-style encryption context
+    :param str encryption_algorithm: Specifies the encryption algorithm that will be used to decrypt the ciphertext.
+    :param str key_id: Specifies the customer master key (CMK) that AWS KMS uses to decrypt the ciphertext.
     :returns: plaintext bytes and moto key ID
     :rtype: bytes and str
     """
     try:
-        ciphertext = _deserialize_ciphertext_blob(ciphertext_blob=ciphertext_blob)
-    except Exception:
-        raise InvalidCiphertextException()
-
-    aad = _serialize_encryption_context(encryption_context=encryption_context)
-
-    try:
-        key = master_keys[ciphertext.key_id]
+        key = master_keys[key_id]
     except KeyError:
         raise AccessDeniedException(
             "The ciphertext refers to a customer master key that does not exist, "
             "does not exist in this region, or you are not allowed to access."
         )
 
-    try:
-        decryptor = Cipher(
-            algorithms.AES(key.key_material),
-            modes.GCM(ciphertext.iv, ciphertext.tag),
-            backend=default_backend(),
-        ).decryptor()
-        decryptor.authenticate_additional_data(aad)
-        plaintext = decryptor.update(ciphertext.ciphertext) + decryptor.finalize()
-    except Exception:
-        raise InvalidCiphertextException()
+    if encryption_algorithm == "SYMMETRIC_DEFAULT":
+        aad = _serialize_encryption_context(encryption_context=encryption_context)
+        try:
+            decryptor = Cipher(
+                algorithms.AES(key.key_material),
+                modes.GCM(ciphertext.iv, ciphertext.tag),
+                backend=default_backend(),
+            ).decryptor()
+            decryptor.authenticate_additional_data(aad)
+            plaintext = decryptor.update(ciphertext.ciphertext) + decryptor.finalize()
+        except Exception:
+            raise InvalidCiphertextException()
+    else:
+        plaintext = key.key_material.decrypt(
+            ciphertext, encryption_algorithms[encryption_algorithm]["padding"]
+        )
 
-    return plaintext, ciphertext.key_id
+    return plaintext, key_id
 
 
-def sign(master_keys, key_id, message, encryption_context):
+def sign(master_keys, key_id, message, message_type, signing_algorithm):
     """Sign a message using master key material.
-
     NOTE: This is not necessarily what KMS does, but it retains the same properties.
-
     NOTE: This function is NOT compatible with KMS APIs.
     :param dict master_keys: Mapping of a KmsBackend's known master keys
     :param str key_id: Key ID of moto master key
     :param bytes message: Plaintext message to sign
-    :param dict[str, str] encryption_context: KMS-style encryption context
-    :returns: Moto-structured ciphertext blob encrypted under a moto master key in master_keys
+    :param str message_type: Either DIGEST or RAW.
+    :param signing_algorithm: The signing algorithm to use
+    :returns: Moto-structured signature blob
     :rtype: bytes
     """
-    return ""
+    try:
+        key = master_keys[key_id]
+    except KeyError:
+        is_alias = key_id.startswith("alias/") or ":alias/" in key_id
+        raise NotFoundException(
+            "{id_type} {key_id} is not found.".format(
+                id_type="Alias" if is_alias else "keyId", key_id=key_id
+            )
+        )
+    print(len(message))
+    if message_type == "RAW":
+        return key.key_material.sign(
+            message,
+            signing_algorithms[signing_algorithm]["padding"],
+            signing_algorithms[signing_algorithm]["hash"],
+        )
+    else:
+        return key.key_material.sign(
+            message,
+            signing_algorithms[signing_algorithm]["padding"],
+            signing_algorithms[signing_algorithm]["hash"],
+            utils.Prehashed(signing_algorithms[signing_algorithm]["hash"]),
+        )
 
 
-def verify(master_keys, message, signature, encryption_context):
+def verify(master_keys, key_id, message, message_type, signature, signing_algorithm):
     """Verify a signature using master key material.
 
     NOTE: This is not necessarily what KMS does, but it retains the same properties.
 
     NOTE: This function is NOT compatible with KMS APIs.
     :param dict master_keys: Mapping of a KmsBackend's known master keys
-    :param bytes plaintext: Plaintext data to encrypt
-    :param dict[str, str] encryption_context: KMS-style encryption context
-    :returns: Moto-structured ciphertext blob encrypted under a moto master key in master_keys
-    :rtype: bytes
+    :param str key_id: Key ID of moto master key
+    :param bytes message: The message which was signed
+    :param str message_type: Either 'RAW' or 'DIGEST'
+    :param signature: The signature that the `sign` operation generated
+    :param signing_algorithm: The signing algorithm which was used to generate the signature.
+    :returns: True if the signature is valid, False otherwise.
+    :rtype: bool
     """
     return True

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -54,14 +54,14 @@ def test_create_key():
     key["KeyMetadata"]["Origin"].should.equal("AWS_KMS")
     key["KeyMetadata"].should_not.have.key("SigningAlgorithms")
 
-    key = conn.create_key(KeyUsage="ENCRYPT_DECRYPT", CustomerMasterKeySpec="RSA_2048",)
+    key = conn.create_key(KeyUsage="ENCRYPT_DECRYPT", CustomerMasterKeySpec="RSA_2048", )
 
     sorted(key["KeyMetadata"]["EncryptionAlgorithms"]).should.equal(
         ["RSAES_OAEP_SHA_1", "RSAES_OAEP_SHA_256"]
     )
     key["KeyMetadata"].should_not.have.key("SigningAlgorithms")
 
-    key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="RSA_2048",)
+    key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="RSA_2048", )
 
     key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
     sorted(key["KeyMetadata"]["SigningAlgorithms"]).should.equal(
@@ -98,9 +98,27 @@ def test_create_key():
 
 
 @mock_kms
+def test_get_public_key():
+    client = boto3.client("kms", region_name="us-east-1")
+    for customer_master_key_spec in ['RSA_2048', 'RSA_3072', 'RSA_4096']:
+        key_response = client.create_key(Description="get_public_key",
+                                         KeyUsage="ENCRYPT_DECRYPT",
+                                         CustomerMasterKeySpec=customer_master_key_spec
+                                         )
+        key_id = key_response["KeyMetadata"]["KeyId"]
+        public_key_response = client.get_public_key(KeyId=key_id)
+
+        public_key_response['KeyId'].should.equal(key_id)
+        public_key_response['KeyUsage'].should.equal(key_response['KeyUsage'])
+        public_key_response['CustomerMasterKeySpec'].should.equal(customer_master_key_spec)
+        public_key_response['EncryptionAlgorithms'].should.equal(key_response['EncryptionAlgorithms'])
+        public_key_response['SigningAlgorithms'].should.equal(key_response['SigningAlgorithms'])
+
+
+@mock_kms
 def test_describe_key():
     client = boto3.client("kms", region_name="us-east-1")
-    response = client.create_key(Description="my key", KeyUsage="ENCRYPT_DECRYPT",)
+    response = client.create_key(Description="my key", KeyUsage="ENCRYPT_DECRYPT", )
     key_id = response["KeyMetadata"]["KeyId"]
 
     response = client.describe_key(KeyId=key_id)
@@ -396,11 +414,11 @@ def test_list_resource_tags():
 @pytest.mark.parametrize(
     "kwargs,expected_key_length",
     (
-        (dict(KeySpec="AES_256"), 32),
-        (dict(KeySpec="AES_128"), 16),
-        (dict(NumberOfBytes=64), 64),
-        (dict(NumberOfBytes=1), 1),
-        (dict(NumberOfBytes=1024), 1024),
+            (dict(KeySpec="AES_256"), 32),
+            (dict(KeySpec="AES_128"), 16),
+            (dict(NumberOfBytes=64), 64),
+            (dict(NumberOfBytes=1), 1),
+            (dict(NumberOfBytes=1024), 1024),
     ),
 )
 @mock_kms
@@ -578,7 +596,7 @@ def test_generate_random(number_of_bytes):
 
 @pytest.mark.parametrize(
     "number_of_bytes,error_type",
-    [(2048, botocore.exceptions.ClientError), (1025, botocore.exceptions.ClientError),],
+    [(2048, botocore.exceptions.ClientError), (1025, botocore.exceptions.ClientError), ],
 )
 @mock_kms
 def test_generate_random_invalid_number_of_bytes(number_of_bytes, error_type):

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -54,14 +54,14 @@ def test_create_key():
     key["KeyMetadata"]["Origin"].should.equal("AWS_KMS")
     key["KeyMetadata"].should_not.have.key("SigningAlgorithms")
 
-    key = conn.create_key(KeyUsage="ENCRYPT_DECRYPT", CustomerMasterKeySpec="RSA_2048",)
+    key = conn.create_key(KeyUsage="ENCRYPT_DECRYPT", CustomerMasterKeySpec="RSA_2048", )
 
     sorted(key["KeyMetadata"]["EncryptionAlgorithms"]).should.equal(
         ["RSAES_OAEP_SHA_1", "RSAES_OAEP_SHA_256"]
     )
     key["KeyMetadata"].should_not.have.key("SigningAlgorithms")
 
-    key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="RSA_2048",)
+    key = conn.create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="RSA_2048", )
 
     key["KeyMetadata"].should_not.have.key("EncryptionAlgorithms")
     sorted(key["KeyMetadata"]["SigningAlgorithms"]).should.equal(
@@ -100,7 +100,7 @@ def test_create_key():
 @mock_kms
 def test_describe_key():
     client = boto3.client("kms", region_name="us-east-1")
-    response = client.create_key(Description="my key", KeyUsage="ENCRYPT_DECRYPT",)
+    response = client.create_key(Description="my key", KeyUsage="ENCRYPT_DECRYPT", )
     key_id = response["KeyMetadata"]["KeyId"]
 
     response = client.describe_key(KeyId=key_id)
@@ -228,6 +228,36 @@ def test_kms_encrypt(plaintext):
 
     response = client.decrypt(CiphertextBlob=response["CiphertextBlob"])
     response["Plaintext"].should.equal(_get_encoded_value(plaintext))
+
+
+@pytest.mark.parametrize("message", PLAINTEXT_VECTORS)
+@mock_kms
+def test_kms_sign(message):
+    client = boto3.client("kms", region_name="us-east-1")
+    key = client.create_key(Description="key")
+    for signing_algorithm in [
+        "RSASSA_PSS_SHA_256",
+        "RSASSA_PSS_SHA_384",
+        "RSASSA_PSS_SHA_512"
+    ]:
+        response = client.sign(KeyId=key["KeyMetadata"]["KeyId"],
+                               Message=message,
+                               MessageType='RAW',
+                               SigningAlgorithm=signing_algorithm)
+
+        response['KeyId'].should.equal(key["KeyMetadata"]["KeyId"])
+        response['SigningAlgorithm'].should.equal(signing_algorithm)
+
+        verification_response = client.verify(KeyId=key["KeyMetadata"]["KeyId"],
+                                              Message=message,
+                                              MessageType='RAW',
+                                              Signature=response['Signature'],
+                                              SignatureAlgorithm=signing_algorithm
+                                              )
+
+        verification_response['KeyId'].should.equal(key["KeyMetadata"]["KeyId"])
+        verification_response['SignatureValid'].should.be(True)
+        verification_response['SignatureAlgorithm'].should.be(signing_algorithm)
 
 
 @mock_kms
@@ -359,11 +389,11 @@ def test_list_resource_tags():
 @pytest.mark.parametrize(
     "kwargs,expected_key_length",
     (
-        (dict(KeySpec="AES_256"), 32),
-        (dict(KeySpec="AES_128"), 16),
-        (dict(NumberOfBytes=64), 64),
-        (dict(NumberOfBytes=1), 1),
-        (dict(NumberOfBytes=1024), 1024),
+            (dict(KeySpec="AES_256"), 32),
+            (dict(KeySpec="AES_128"), 16),
+            (dict(NumberOfBytes=64), 64),
+            (dict(NumberOfBytes=1), 1),
+            (dict(NumberOfBytes=1024), 1024),
     ),
 )
 @mock_kms
@@ -535,7 +565,7 @@ def test_generate_random(number_of_bytes):
 
 @pytest.mark.parametrize(
     "number_of_bytes,error_type",
-    [(2048, botocore.exceptions.ClientError), (1025, botocore.exceptions.ClientError),],
+    [(2048, botocore.exceptions.ClientError), (1025, botocore.exceptions.ClientError), ],
 )
 @mock_kms
 def test_generate_random_invalid_number_of_bytes(number_of_bytes, error_type):

--- a/tests/test_kms/test_utils.py
+++ b/tests/test_kms/test_utils.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
+from itertools import product
+
 import sure  # noqa
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
 
 from moto.kms.exceptions import (
     AccessDeniedException,
@@ -10,15 +13,19 @@ from moto.kms.exceptions import (
 )
 from moto.kms.models import Key
 from moto.kms.utils import (
-    _deserialize_ciphertext_blob,
-    _serialize_ciphertext_blob,
+    deserialize_ciphertext_blob,
+    serialize_ciphertext_blob,
     _serialize_encryption_context,
     generate_data_key,
     generate_master_key,
     MASTER_KEY_LEN,
     encrypt,
     decrypt,
-    Ciphertext, sign, verify,
+    Ciphertext,
+    sign,
+    verify,
+    key_specs,
+    signing_algorithms,
 )
 
 ENCRYPTION_CONTEXT_VECTORS = [
@@ -67,10 +74,16 @@ def test_generate_data_key():
 
 
 def test_generate_master_key():
-    test = generate_master_key()
+    for key_spec in key_specs:
+        test = generate_master_key(key_spec)
 
-    test.should.be.a(bytes)
-    len(test).should.equal(MASTER_KEY_LEN)
+        if key_spec == "SYMMETRIC_DEFAULT":
+            test.should.be.a(bytes)
+            len(test).should.equal(MASTER_KEY_LEN)
+        elif key_spec[:3] == "RSA":
+            test.should.be.a(rsa.RSAPrivateKey)
+        elif key_spec[:3] == "ECC":
+            test.should.be.a(ec.EllipticCurvePrivateKey)
 
 
 @pytest.mark.parametrize("raw,serialized", ENCRYPTION_CONTEXT_VECTORS)
@@ -81,20 +94,20 @@ def test_serialize_encryption_context(raw, serialized):
 
 @pytest.mark.parametrize("raw,_serialized", CIPHERTEXT_BLOB_VECTORS)
 def test_cycle_ciphertext_blob(raw, _serialized):
-    test_serialized = _serialize_ciphertext_blob(raw)
-    test_deserialized = _deserialize_ciphertext_blob(test_serialized)
+    test_serialized = serialize_ciphertext_blob(raw)
+    test_deserialized = deserialize_ciphertext_blob(test_serialized)
     test_deserialized.should.equal(raw)
 
 
 @pytest.mark.parametrize("raw,serialized", CIPHERTEXT_BLOB_VECTORS)
 def test_serialize_ciphertext_blob(raw, serialized):
-    test = _serialize_ciphertext_blob(raw)
+    test = serialize_ciphertext_blob(raw)
     test.should.equal(serialized)
 
 
 @pytest.mark.parametrize("raw,serialized", CIPHERTEXT_BLOB_VECTORS)
 def test_deserialize_ciphertext_blob(raw, serialized):
-    test = _deserialize_ciphertext_blob(serialized)
+    test = deserialize_ciphertext_blob(serialized)
     test.should.equal(raw)
 
 
@@ -103,21 +116,25 @@ def test_deserialize_ciphertext_blob(raw, serialized):
 )
 def test_encrypt_decrypt_cycle(encryption_context):
     plaintext = b"some secret plaintext"
-    master_key = Key("nop", "nop", "nop", "nop", "nop")
+    master_key = Key("nop", "nop", "RSA_2048", "nop", "nop")
     master_key_map = {master_key.id: master_key}
 
-    ciphertext_blob = encrypt(
+    ciphertext = encrypt(
         master_keys=master_key_map,
         key_id=master_key.id,
         plaintext=plaintext,
         encryption_context=encryption_context,
+        encryption_algorithm="RSAES_OAEP_SHA_256",
+        # TODO: all the other algorithms
     )
-    ciphertext_blob.should_not.equal(plaintext)
+    ciphertext.should_not.equal(plaintext)
 
     decrypted, decrypting_key_id = decrypt(
         master_keys=master_key_map,
-        ciphertext_blob=ciphertext_blob,
+        ciphertext=ciphertext,
         encryption_context=encryption_context,
+        encryption_algorithm="RSAES_OAEP_SHA_256",
+        key_id=master_key.id,
     )
     decrypted.should.equal(plaintext)
     decrypting_key_id.should.equal(master_key.id)
@@ -130,19 +147,26 @@ def test_encrypt_unknown_key_id():
             key_id="anything",
             plaintext=b"secrets",
             encryption_context={},
+            encryption_algorithm="SYMMETRIC_DEFAULT",
         )
 
 
 def test_decrypt_invalid_ciphertext_format():
-    master_key = Key("nop", "nop", "nop", "nop", "nop")
+    master_key = Key("nop", "nop", None, "nop", "nop")
     master_key_map = {master_key.id: master_key}
 
     with pytest.raises(InvalidCiphertextException):
-        decrypt(master_keys=master_key_map, ciphertext_blob=b"", encryption_context={})
+        decrypt(
+            master_keys=master_key_map,
+            ciphertext=b"",
+            encryption_context={},
+            encryption_algorithm="SYMMETRIC_DEFAULT",
+            key_id=master_key.id,
+        )
 
 
 def test_decrypt_unknown_key_id():
-    ciphertext_blob = (
+    ciphertext = (
         b"d25652e4-d2d2-49f7-929a-671ccda580c6"
         b"123456789012"
         b"1234567890123456"
@@ -150,66 +174,81 @@ def test_decrypt_unknown_key_id():
     )
 
     with pytest.raises(AccessDeniedException):
-        decrypt(master_keys={}, ciphertext_blob=ciphertext_blob, encryption_context={})
+        decrypt(
+            master_keys={},
+            ciphertext=ciphertext,
+            encryption_context={},
+            encryption_algorithm="SYMMETRIC_DEFAULT",
+            key_id=None,
+        )
 
 
 def test_decrypt_invalid_ciphertext():
-    master_key = Key("nop", "nop", "nop", "nop", "nop")
+    master_key = Key("nop", "nop", None, "nop", "nop")
     master_key_map = {master_key.id: master_key}
-    ciphertext_blob = (
-            master_key.id.encode("utf-8") + b"123456789012"
-                                            b"1234567890123456"
-                                            b"some ciphertext"
+    ciphertext = (
+        master_key.id.encode("utf-8") + b"123456789012"
+        b"1234567890123456"
+        b"some ciphertext"
     )
 
     with pytest.raises(InvalidCiphertextException):
         decrypt(
             master_keys=master_key_map,
-            ciphertext_blob=ciphertext_blob,
+            ciphertext=ciphertext,
             encryption_context={},
+            encryption_algorithm="SYMMETRIC_DEFAULT",
+            key_id=master_key.id,
         )
 
 
 def test_decrypt_invalid_encryption_context():
     plaintext = b"some secret plaintext"
-    master_key = Key("nop", "nop", "nop", "nop", "nop")
+    master_key = Key("nop", "nop", None, "nop", "nop")
     master_key_map = {master_key.id: master_key}
 
-    ciphertext_blob = encrypt(
+    ciphertext = encrypt(
         master_keys=master_key_map,
         key_id=master_key.id,
         plaintext=plaintext,
         encryption_context={"some": "encryption", "context": "here"},
+        encryption_algorithm="SYMMETRIC_DEFAULT",
     )
 
     with pytest.raises(InvalidCiphertextException):
         decrypt(
             master_keys=master_key_map,
-            ciphertext_blob=ciphertext_blob,
+            ciphertext=ciphertext,
             encryption_context={},
+            encryption_algorithm="SYMMETRIC_DEFAULT",
+            key_id=master_key.id,
         )
 
 
 @pytest.mark.parametrize(
-    "encryption_context", [ec[0] for ec in ENCRYPTION_CONTEXT_VECTORS]
+    "encryption_context,signing_algorithm",
+    product([ec[0] for ec in ENCRYPTION_CONTEXT_VECTORS], signing_algorithms.keys()),
 )
-def test_sign_verify_cycle(encryption_context):
-    message = b"some message"
-    master_key = Key("nop", "nop", "nop", "nop", "nop")
+def test_sign_verify_cycle(encryption_context, signing_algorithm):
+    message = b"this is a message which needs to be signed."
+    master_key = Key("nop", "nop", "RSA_4096", "nop", "nop")
     master_key_map = {master_key.id: master_key}
 
     signature = sign(
         master_keys=master_key_map,
         key_id=master_key.id,
         message=message,
-        encryption_context=encryption_context,
+        message_type="RAW",
+        signing_algorithm=signing_algorithm,
     )
 
     verified = verify(
         master_keys=master_key_map,
+        key_id=master_key.id,
         message=message,
+        message_type="RAW",
         signature=signature,
-        encryption_context=encryption_context
+        signing_algorithm=signing_algorithm,
     )
 
     verified.should.be(True)

--- a/tests/test_kms/test_utils.py
+++ b/tests/test_kms/test_utils.py
@@ -24,7 +24,7 @@ from moto.kms.utils import (
     Ciphertext,
     sign,
     verify,
-    key_specs,
+    KEY_SPECS,
     signing_algorithms,
 )
 
@@ -74,7 +74,7 @@ def test_generate_data_key():
 
 
 def test_generate_master_key():
-    for key_spec in key_specs:
+    for key_spec in KEY_SPECS:
         test = generate_master_key(key_spec)
 
         if key_spec == "SYMMETRIC_DEFAULT":


### PR DESCRIPTION
Early draft PR for review - not ready for merge, but certainly ready for comment. Things still to do:

- [ ] `test_schedule_key_deletion` was broken locally when I pulled. Need to investigate that.
- [ ] Many of the tests, naturally, assume symmetric keys - I need to rename them to make that obvious (i.e. `test_decrypt_unknown_key_id` becomes `test_symmetric_decrypt_unknown_key_id`) and write a matching asymmetric tests (i.e. `test_asymmetric_decrypt_unknown_key_id`)
- [ ] Some of the failure modes don't match AWS, for example, `AccessDeniedError` seems to get thrown when `InvalidKeyUsageException` might be more appropriate.
- [x] There is something up with 512 byte pad and hash lengths - cryptography moans that there is not sufficient key material.
- [ ] Fix the build for Python = =2.7
- [ ] Add some more of the missing asymmetric endpoints namely
    - [x] `get_public_key`
    - [ ] `generate_data_key_pair`
    - [ ] `generate_data_key_pair_without_plaintext`
    - [x] `generate_random`
    - [x] `sign`
    - [x] `verify`