### PR TITLE
Enhancement/docker dev

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -35,6 +35,48 @@ jobs:
         run: |
           pip install -r requirements-dev.txt
 
+  test_docker-dev:
+    name: Test Docker For Development
+    runs-on: ubuntu-latest
+    needs: cache
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Start MotoServer
+      run: |
+        python setup.py sdist
+        make docker-dev
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: pip cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.py') }}
+    - name: Update pip
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install project dependencies
+      run: |
+        pip install -r requirements-dev.txt
+    - name: Test
+      env:
+        TEST_SERVER_MODE: ${{ true }}
+        MOTO_PORT: 5000
+      run: |
+        pytest -sv tests/test_awslambda/test_lambda_invoke.py::test_invoke_lambda_using_environment_port tests/test_cloudformation/test_cloudformation_custom_resources.py
+
   test_custom_port:
     name: Test Custom Port
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ ENV PYTHONUNBUFFERED 1
 
 WORKDIR /moto/
 RUN  pip3 --no-cache-dir install --upgrade pip setuptools && \
-     pip3 --no-cache-dir install ".[server]"
+     pip3 --no-cache-dir install ".[server]" && \
+     python3 setup.py develop && \
+     pip3 --no-cache-dir install -r requirements-dev.txt
 
-ENTRYPOINT ["/usr/local/bin/moto_server", "-H", "0.0.0.0"]
+CMD ["python3", "/moto/moto/server.py", "-H", "0.0.0.0"]
 
 EXPOSE 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /moto/
 RUN  pip3 --no-cache-dir install --upgrade pip setuptools && \
      pip3 --no-cache-dir install ".[server]" && \
      python3 setup.py develop && \
-     pip3 --no-cache-dir install -r requirements-dev.txt
+     pip3 --no-cache-dir install -r requirements-dev.txt && \
+     apt update && apt install make
 
 CMD ["python3", "/moto/moto/server.py", "-H", "0.0.0.0"]
 

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,6 @@ int_test:
 	@./scripts/int_test.sh
 
 docker-dev: 
-	docker build -t moto . && docker run -dit --name moto -v $(shell pwd):/moto/ moto
+	docker build -t moto . 
+	docker run -dit --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v $(shell pwd):/moto/ -v /var/run/docker.sock:/var/run/docker.sock -p 5000:5000 moto
+	

--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,6 @@ scaffold:
 
 int_test:
 	@./scripts/int_test.sh
+
+docker-dev: 
+	docker build -t moto . && docker run -dit --name moto -v $(shell pwd):/moto/ moto

--- a/docs/docs/contributing/installation.rst
+++ b/docs/docs/contributing/installation.rst
@@ -41,4 +41,21 @@ If black fails, you can run the following command to automatically format the of
 
   make format
 
+Alternatively, it is available to set up the development environment by using Docker. To build a docker container and run a development server, run the following command: 
+
+.. code-block:: bash
+
+  make docker-dev
+
+The code is volumized on the container so any change at the host device should persist without rebuilding a container. 
+
+You can run the above test commands for all the tests or a specific service inside the container by using docker exec command, for example:
+
+.. code-block:: bash
+
+  make docker-dev
+
+
 If any of these steps fail, please see our :ref:`contributing faq` or open an issue on Github.
+
+


### PR DESCRIPTION
Currently the development installation guide only explains about setting moto up in a virtual environment, not with Docker. 
There is already a dockerfile but with the current dockerfile, it requires a few more manual steps to complete running moto such as getting into a docker container, installing make, running a make command to install requirements, etc. 
I updated the dockerfile to implement the initial steps as a part of the docker build and created a new make command `make docker-dev` to build, run and volumize a docker container all in one command. 