### PR TITLE
fix(add owner to service): set self.current_account as VPC Service Endpoint Owner

### DIFF
--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -1,7 +1,7 @@
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import add_tag_specification
 from ._base_response import EC2BaseResponse
-
+from moto.core import DEFAULT_ACCOUNT_ID
 
 class VPCs(EC2BaseResponse):
     def _get_doc_date(self):
@@ -651,7 +651,7 @@ DESCRIBE_VPC_ENDPOINT_SERVICES_RESPONSE = """<DescribeVpcEndpointServicesRespons
                     {% endfor %}
                 </baseEndpointDnsNameSet>
                 <managesVpcEndpoints>{{ 'true' if service.ManagesVpcEndpoints else 'false' }}</managesVpcEndpoints>
-                <owner>{{ service.Owner }}</owner>
+                <owner>{{ DEFAULT_ACCOUNT_ID }}</owner>
                 {% if service.PrivateDnsName is defined %}
                     <privateDnsName>{{ service.PrivateDnsName }}</privateDnsName>
                     <privateDnsNameSet>

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -3,6 +3,7 @@ from moto.ec2.utils import add_tag_specification
 from ._base_response import EC2BaseResponse
 from moto.core import DEFAULT_ACCOUNT_ID
 
+
 class VPCs(EC2BaseResponse):
     def _get_doc_date(self):
         return (

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -1,7 +1,6 @@
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import add_tag_specification
 from ._base_response import EC2BaseResponse
-from moto.core import DEFAULT_ACCOUNT_ID
 
 
 class VPCs(EC2BaseResponse):
@@ -243,7 +242,7 @@ class VPCs(EC2BaseResponse):
             region=self.region,
         )
         template = self.response_template(DESCRIBE_VPC_ENDPOINT_SERVICES_RESPONSE)
-        return template.render(vpc_end_points=vpc_end_point_services)
+        return template.render(vpc_end_points=vpc_end_point_services, account_id=self.current_account)
 
     def describe_vpc_endpoints(self):
         vpc_end_points_ids = self._get_multi_param("VpcEndpointId")
@@ -652,7 +651,7 @@ DESCRIBE_VPC_ENDPOINT_SERVICES_RESPONSE = """<DescribeVpcEndpointServicesRespons
                     {% endfor %}
                 </baseEndpointDnsNameSet>
                 <managesVpcEndpoints>{{ 'true' if service.ManagesVpcEndpoints else 'false' }}</managesVpcEndpoints>
-                <owner>{{ DEFAULT_ACCOUNT_ID }}</owner>
+                <owner>{{ account_id }}</owner>
                 {% if service.PrivateDnsName is defined %}
                     <privateDnsName>{{ service.PrivateDnsName }}</privateDnsName>
                     <privateDnsNameSet>

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -242,7 +242,9 @@ class VPCs(EC2BaseResponse):
             region=self.region,
         )
         template = self.response_template(DESCRIBE_VPC_ENDPOINT_SERVICES_RESPONSE)
-        return template.render(vpc_end_points=vpc_end_point_services, account_id=self.current_account)
+        return template.render(
+            vpc_end_points=vpc_end_point_services, account_id=self.current_account
+        )
 
     def describe_vpc_endpoints(self):
         vpc_end_points_ids = self._get_multi_param("VpcEndpointId")

--- a/tests/test_ec2/test_vpc_endpoint_services_integration.py
+++ b/tests/test_ec2/test_vpc_endpoint_services_integration.py
@@ -254,7 +254,7 @@ def test_describe_vpc_default_endpoint_services():
     assert details["AvailabilityZones"] == ["us-west-1a", "us-west-1b"]
     assert details["BaseEndpointDnsNames"] == ["config.us-west-1.vpce.amazonaws.com"]
     assert details["ManagesVpcEndpoints"] is False
-    assert details["Owner"] == "amazon"
+    assert details["Owner"] == ACCOUNT_ID
     assert details["PrivateDnsName"] == "config.us-west-1.amazonaws.com"
     assert details["PrivateDnsNames"] == [
         {"PrivateDnsName": "config.us-west-1.amazonaws.com"}


### PR DESCRIPTION
Regarding https://github.com/spulec/moto/issues/5605 since the owner in VPC Service Endpoints are always empty, set self.current_account as VPC Service Endpoint Owner.