### PR TITLE
Add TargetKeyId to default kms key alias response.

### DIFF
--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -2,11 +2,10 @@ import base64
 import json
 import os
 import re
-import uuid
 import warnings
 
 from moto.core.responses import BaseResponse
-from moto.kms.utils import RESERVED_ALIASES
+from moto.kms.utils import RESERVED_ALIASES, RESERVED_ALIASE_TARGET_KEY_IDS
 from .models import kms_backends, KmsBackend
 from .policy_validator import validate_policy
 from .exceptions import (
@@ -274,7 +273,7 @@ class KmsResponse(BaseResponse):
                         "TargetKeyId": target_key_id,
                     }
                 )
-        for reserved_alias in RESERVED_ALIASES:
+        for reserved_alias, target_key_id in RESERVED_ALIASE_TARGET_KEY_IDS.items():
             exsisting = [
                 a for a in response_aliases if a["AliasName"] == reserved_alias
             ]
@@ -282,7 +281,7 @@ class KmsResponse(BaseResponse):
                 arn = f"arn:aws:kms:{region}:{self.current_account}:{reserved_alias}"
                 response_aliases.append(
                     {
-                        "TargetKeyId": str(uuid.UUID(int=abs(hash(arn)), version=4)),
+                        "TargetKeyId": target_key_id,
                         "AliasArn": arn,
                         "AliasName": reserved_alias,
                     }

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import re
+import uuid
 import warnings
 
 from moto.core.responses import BaseResponse
@@ -278,9 +279,11 @@ class KmsResponse(BaseResponse):
                 a for a in response_aliases if a["AliasName"] == reserved_alias
             ]
             if not exsisting:
+                arn = f"arn:aws:kms:{region}:{self.current_account}:{reserved_alias}"
                 response_aliases.append(
                     {
-                        "AliasArn": f"arn:aws:kms:{region}:{self.current_account}:{reserved_alias}",
+                        "TargetKeyId": str(uuid.UUID(int=abs(hash(arn)), version=4)),
+                        "AliasArn": arn,
                         "AliasName": reserved_alias,
                     }
                 )

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -25,22 +25,26 @@ HEADER_LEN = KEY_ID_LEN + IV_LEN + TAG_LEN
 CIPHERTEXT_HEADER_FORMAT = f">{KEY_ID_LEN}s{IV_LEN}s{TAG_LEN}s"
 Ciphertext = namedtuple("Ciphertext", ("key_id", "iv", "ciphertext", "tag"))
 
-RESERVED_ALIASES = [
-    "alias/aws/acm",
-    "alias/aws/dynamodb",
-    "alias/aws/ebs",
-    "alias/aws/elasticfilesystem",
-    "alias/aws/es",
-    "alias/aws/glue",
-    "alias/aws/kinesisvideo",
-    "alias/aws/lambda",
-    "alias/aws/rds",
-    "alias/aws/redshift",
-    "alias/aws/s3",
-    "alias/aws/secretsmanager",
-    "alias/aws/ssm",
-    "alias/aws/xray",
-]
+RESERVED_ALIASE_TARGET_KEY_IDS = {
+    # NOTE: These would technically differ across account, but in that they are
+    # out of customer control, testing that they are different would be redundant.
+    "alias/aws/acm": "4f58743d-e279-4214-9270-8cc28277958d",
+    "alias/aws/dynamodb": "7e6aa0ea-15a4-4e72-8b32-58e46e776888",
+    "alias/aws/ebs": "7adeb491-68c9-4a5b-86ec-a86ce5364094",
+    "alias/aws/elasticfilesystem": "0ef0f111-cdc8-4dda-b0bc-bf625bd5f154",
+    "alias/aws/es": "3c7c1880-c353-4cea-9866-d8bc12f05573",
+    "alias/aws/glue": "90fd783f-e582-4cc2-a207-672ee67f8d58",
+    "alias/aws/kinesisvideo": "7fd4bff3-6eb7-4283-8f11-a7e0a793a181",
+    "alias/aws/lambda": "ff9c4f27-2f29-4d9b-bf38-02f88b52a70c",
+    "alias/aws/rds": "f5f30938-abed-41a2-a0f6-5482d02a2489",
+    "alias/aws/redshift": "dcdae9aa-593a-4e0b-9153-37325591901f",
+    "alias/aws/s3": "8c3faf07-f43c-4d11-abdb-9183079214c7",
+    "alias/aws/secretsmanager": "fee5173a-3972-428e-ae73-cd4c2a371222",
+    "alias/aws/ssm": "cb3f6250-5078-48c0-a75f-0290bf47694e",
+    "alias/aws/xray": "e9b758eb-6230-4744-93d1-ad3b7d71f2f6",
+}
+
+RESERVED_ALIASES = list(RESERVED_ALIASE_TARGET_KEY_IDS.keys())
 
 
 def generate_key_id(multi_region=False):

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -283,7 +283,9 @@ def test_list_aliases():
         full_name = f"alias/{name}"
         arn = f"arn:aws:kms:{region}:{ACCOUNT_ID}:{full_name}"
         target_key_id = str(uuid.UUID(int=abs(hash(arn)), version=4))
-        aliases.should.contain({"AliasName": full_name, "AliasArn": arn, "TargetKeyId": target_key_id})
+        aliases.should.contain(
+            {"AliasName": full_name, "AliasArn": arn, "TargetKeyId": target_key_id}
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime
-import uuid
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from unittest import mock
@@ -276,13 +275,20 @@ def test_list_aliases():
     client = boto3.client("kms", region_name=region)
     create_simple_key(client)
 
+    default_alias_target_keys = {
+        "aws/ebs": "7adeb491-68c9-4a5b-86ec-a86ce5364094",
+        "aws/s3": "8c3faf07-f43c-4d11-abdb-9183079214c7",
+        "aws/redshift": "dcdae9aa-593a-4e0b-9153-37325591901f",
+        "aws/rds": "f5f30938-abed-41a2-a0f6-5482d02a2489",
+    }
+    default_alias_names = list(default_alias_target_keys.keys())
+
     aliases = client.list_aliases()["Aliases"]
     aliases.should.have.length_of(14)
-    default_alias_names = ["aws/ebs", "aws/s3", "aws/redshift", "aws/rds"]
     for name in default_alias_names:
         full_name = f"alias/{name}"
         arn = f"arn:aws:kms:{region}:{ACCOUNT_ID}:{full_name}"
-        target_key_id = str(uuid.UUID(int=abs(hash(arn)), version=4))
+        target_key_id = default_alias_target_keys[name]
         aliases.should.contain(
             {"AliasName": full_name, "AliasArn": arn, "TargetKeyId": target_key_id}
         )

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+import uuid
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 from unittest import mock
@@ -281,7 +282,8 @@ def test_list_aliases():
     for name in default_alias_names:
         full_name = f"alias/{name}"
         arn = f"arn:aws:kms:{region}:{ACCOUNT_ID}:{full_name}"
-        aliases.should.contain({"AliasName": full_name, "AliasArn": arn})
+        target_key_id = str(uuid.UUID(int=abs(hash(arn)), version=4))
+        aliases.should.contain({"AliasName": full_name, "AliasArn": arn, "TargetKeyId": target_key_id})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Small "fix" to add in TargetKeyIds to canonical aliased kms keys.

These keys are a curiosity to me. I can't seem to find a way to initialize them via boto3 in actual AWS land. If you setup, say, ssm and add a first key to it using the service kms key it auto-generates. \o/.
