### PR TITLE
5740 ssm param type validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ htmlcov/
 .coverage*
 docs/_build
 moto_recording
+.hypothesis

--- a/docs/docs/contributing/architecture.rst
+++ b/docs/docs/contributing/architecture.rst
@@ -31,7 +31,7 @@ For each request we need to know two things:
  #. Which service is this request for?
  #. Which feature is called?
 
-When using one ore more decorators, Moto will load all urls from `{service}/urls.py::url_bases`.
+When using one or more decorators, Moto will load all urls from `{service}/urls.py::url_bases`.
 Incoming requests are matched against those to figure out which service the request has to go to.
 After that, we try to find right feature by looking at:
 

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -850,12 +850,14 @@ def _document_filter_match(account_id, filters, ssm_doc):
 
     return True
 
+
 def _valid_parameter_type(type_):
     """
     Parameter Type field only allows `SecureString`, `StringList` and `String` (not `str`) values
 
     """
     return type_ in ("SecureString", "StringList", "String")
+
 
 def _valid_parameter_data_type(data_type):
     """

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -850,6 +850,12 @@ def _document_filter_match(account_id, filters, ssm_doc):
 
     return True
 
+def _valid_parameter_type(type_):
+    """
+    Parameter Type field only allows `SecureString`, `StringList` and `String` (not `str`) values
+
+    """
+    return type_ in ("SecureString", "StringList", "String")
 
 def _valid_parameter_data_type(data_type):
     """
@@ -1793,6 +1799,11 @@ class SimpleSystemManagerBackend(BaseBackend):
                     "formed as a mix of letters, numbers and the following 3 symbols .-_"
                 )
             raise ValidationException(invalid_prefix_error)
+
+        if not _valid_parameter_type(parameter_type):
+            raise ValidationException(
+                f"1 validation error detected: Value '{parameter_type}' at 'type' failed to satisfy constraint: Member must satisfy enum value set: [SecureString, StringList, String]",
+            )
 
         if not _valid_parameter_data_type(data_type):
             # The check of the existence of an AMI ID in the account for a parameter of DataType `aws:ec2:image`

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -413,10 +413,11 @@ def test_put_parameter_invalid_data_type(bad_data_type):
         " (Data type names are all lowercase.)"
     )
 
+
 @mock_ssm
 def test_put_parameter_invalid_type():
     client = boto3.client("ssm", region_name="us-east-1")
-    bad_type = "str" # correct value is String
+    bad_type = "str"  # correct value is String
     with pytest.raises(ClientError) as e:
         client.put_parameter(
             Name="test_name", Value="some_value", Type=bad_type, DataType="text"

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -413,6 +413,22 @@ def test_put_parameter_invalid_data_type(bad_data_type):
         " (Data type names are all lowercase.)"
     )
 
+@mock_ssm
+def test_put_parameter_invalid_type():
+    client = boto3.client("ssm", region_name="us-east-1")
+    bad_type = "str" # correct value is String
+    with pytest.raises(ClientError) as e:
+        client.put_parameter(
+            Name="test_name", Value="some_value", Type=bad_type, DataType="text"
+        )
+    ex = e.value
+    ex.operation_name.should.equal("PutParameter")
+    ex.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.response["Error"]["Code"].should.contain("ValidationException")
+    ex.response["Error"]["Message"].should.equal(
+        f"1 validation error detected: Value '{bad_type}' at 'type' failed to satisfy constraint: Member must satisfy enum value set: [SecureString, StringList, String]"
+    )
+
 
 @mock_ssm
 def test_get_parameter():


### PR DESCRIPTION
Fixes #5740

Note that the [architecture page](http://docs.getmoto.org/en/latest/docs/contributing/architecture.html#contributing-architecture) and [development tips](http://docs.getmoto.org/en/latest/docs/contributing/development_tips/index.html#contributing-tips) both say to put parameter validation in `responses.py`. But the validation of the `DataType` parameter was already done in `models.py`. So that's where I added this new validation.

I also fixed an unrelated typo in documentation.

And I added `.hypothesis` to the `.gitignore`.