### PR TITLE
Core: Allow same request to be made multiple times

### DIFF
--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -43,18 +43,13 @@ class BotocoreStubber:
 
         response = None
         response_callback = None
-        found_index = None
-        matchers = self.methods.get(request.method)
+        matchers = self.methods.get(request.method, [])
 
         base_url = request.url.split("?", 1)[0]
-        for i, (pattern, callback) in enumerate(matchers):  # type: ignore[arg-type]
+        for pattern, callback in matchers:
             if pattern.match(base_url):
-                if found_index is None:
-                    found_index = i
-                    response_callback = callback
-                else:
-                    matchers.pop(found_index)
-                    break
+                response_callback = callback
+                break
 
         if response_callback is not None:
             for header, value in request.headers.items():

--- a/tests/test_iot/test_iot_policies.py
+++ b/tests/test_iot/test_iot_policies.py
@@ -33,6 +33,10 @@ def test_attach_policy(iot_client, policy):
     res.should.have.key("policies").which.should.have.length_of(1)
     res["policies"][0]["policyName"].should.equal("my-policy")
 
+    res = iot_client.list_attached_policies(target=cert_arn)
+    res.should.have.key("policies").which.should.have.length_of(1)
+    res["policies"][0]["policyName"].should.equal("my-policy")
+
 
 @mock_cognitoidentity
 def test_attach_policy_to_identity(region_name, iot_client, policy):


### PR DESCRIPTION
Fixes #5791 

As far as I know, the existing logic was copied verbatim from the requests-module. But for our use-case, it doesn't make any sense to remove matched URL's - making repeated calls to the same method is not unusual at all.