### PR TITLE
ec2: default values in ec2 fleet

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -528,7 +528,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         return if_none
 
     def _get_multi_param_dict(self, param_prefix: str) -> Dict[str, Any]:
-        return self._get_multi_param_helper(param_prefix)
+        return self._get_multi_param_helper(param_prefix, skip_result_conversion=True)
 
     def _get_multi_param_helper(
         self,

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -557,7 +557,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             )
             if match:
                 prefix = param_prefix + match.group(1)
-                value = self._get_multi_param(prefix, skip_result_conversion=skip_result_conversion)
+                value = self._get_multi_param(
+                    prefix, skip_result_conversion=skip_result_conversion
+                )
                 tracked_prefixes.add(prefix)
                 name = prefix
                 value_dict[name] = value

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -528,7 +528,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         return if_none
 
     def _get_multi_param_dict(self, param_prefix: str) -> Dict[str, Any]:
-        return self._get_multi_param_helper(param_prefix, skip_result_conversion=True)
+        return self._get_multi_param_helper(param_prefix)
 
     def _get_multi_param_helper(
         self,
@@ -557,9 +557,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             )
             if match:
                 prefix = param_prefix + match.group(1)
-                value = self._get_multi_param(
-                    prefix, skip_result_conversion=skip_result_conversion
-                )
+                value = self._get_multi_param(prefix)
                 tracked_prefixes.add(prefix)
                 name = prefix
                 value_dict[name] = value

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -557,7 +557,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             )
             if match:
                 prefix = param_prefix + match.group(1)
-                value = self._get_multi_param(prefix)
+                value = self._get_multi_param(prefix, skip_result_conversion=skip_result_conversion)
                 tracked_prefixes.add(prefix)
                 name = prefix
                 value_dict[name] = value

--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -1,7 +1,7 @@
+import datetime
 from collections import defaultdict
 
 from moto.ec2.models.spot_requests import SpotFleetLaunchSpec
-
 from .core import TaggedEC2Resource
 from ..utils import (
     random_fleet_id,
@@ -39,7 +39,7 @@ class Fleet(TaggedEC2Resource):
         self.replace_unhealthy_instances = replace_unhealthy_instances
         self.terminate_instances_with_expiration = terminate_instances_with_expiration
         self.fleet_type = fleet_type
-        self.valid_from = valid_from
+        self.valid_from = valid_from or datetime.datetime.now(tz=datetime.timezone.utc)
         self.valid_until = valid_until
         tag_map = convert_tag_spec(tag_specifications).get("fleet", {})
         self.add_tags(tag_map)
@@ -102,12 +102,12 @@ class Fleet(TaggedEC2Resource):
             target_capacity_specification.get("TotalTargetCapacity")
         )
         self.spot_target_capacity = int(
-            target_capacity_specification.get("SpotTargetCapacity")
+            target_capacity_specification.get("SpotTargetCapacity", 0)
         )
         if self.spot_target_capacity > 0:
             self.create_spot_requests(self.spot_target_capacity)
         self.on_demand_target_capacity = int(
-            target_capacity_specification.get("OnDemandTargetCapacity")
+            target_capacity_specification.get("OnDemandTargetCapacity", self.target_capacity)
         )
         if self.on_demand_target_capacity > 0:
             self.create_on_demand_requests(self.on_demand_target_capacity)

--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -107,7 +107,9 @@ class Fleet(TaggedEC2Resource):
         if self.spot_target_capacity > 0:
             self.create_spot_requests(self.spot_target_capacity)
         self.on_demand_target_capacity = int(
-            target_capacity_specification.get("OnDemandTargetCapacity", self.target_capacity)
+            target_capacity_specification.get(
+                "OnDemandTargetCapacity", self.target_capacity
+            )
         )
         if self.on_demand_target_capacity > 0:
             self.create_on_demand_requests(self.on_demand_target_capacity)

--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -31,7 +31,8 @@ class Fleets(BaseResponse):
             "TargetCapacitySpecification"
         )
         launch_template_configs = self._get_multi_param(
-            param_prefix="LaunchTemplateConfigs", skip_result_conversion=True,
+            param_prefix="LaunchTemplateConfigs",
+            skip_result_conversion=True,
         )
 
         excess_capacity_termination_policy = self._get_param(
@@ -211,7 +212,7 @@ DESCRIBE_FLEETS_TEMPLATE = """<DescribeFleetsResponse xmlns="http://ec2.amazonaw
                                 {% endif %}
                                 {% if override.InstanceRequirements.MemoryGiBPerVCpu %}
                                 <memoryGiBPerVCpu>
-                                    {% if override.InstanceRequirements.MemoryGiBPerVCpu.Min %} 
+                                    {% if override.InstanceRequirements.MemoryGiBPerVCpu.Min %}
                                     <min>{{ override.InstanceRequirements.MemoryGiBPerVCpu.Min }}</min>
                                     {% endif %}
                                     {% if override.InstanceRequirements.MemoryGiBPerVCpu.Max %}

--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -30,7 +30,9 @@ class Fleets(BaseResponse):
         target_capacity_specification = self._get_multi_param_dict(
             "TargetCapacitySpecification"
         )
-        launch_template_configs = self._get_multi_param("LaunchTemplateConfigs")
+        launch_template_configs = self._get_multi_param(
+            param_prefix="LaunchTemplateConfigs", skip_result_conversion=True,
+        )
 
         excess_capacity_termination_policy = self._get_param(
             "ExcessCapacityTerminationPolicy"
@@ -209,8 +211,12 @@ DESCRIBE_FLEETS_TEMPLATE = """<DescribeFleetsResponse xmlns="http://ec2.amazonaw
                                 {% endif %}
                                 {% if override.InstanceRequirements.MemoryGiBPerVCpu %}
                                 <memoryGiBPerVCpu>
+                                    {% if override.InstanceRequirements.MemoryGiBPerVCpu.Min %} 
                                     <min>{{ override.InstanceRequirements.MemoryGiBPerVCpu.Min }}</min>
+                                    {% endif %}
+                                    {% if override.InstanceRequirements.MemoryGiBPerVCpu.Max %}
                                     <max>{{ override.InstanceRequirements.MemoryGiBPerVCpu.Max }}</max>
+                                    {% endif %}
                                 </memoryGiBPerVCpu>
                                 {% endif %}
                                 {% if override.InstanceRequirements.MemoryMiB %}
@@ -368,8 +374,12 @@ DESCRIBE_FLEETS_TEMPLATE = """<DescribeFleetsResponse xmlns="http://ec2.amazonaw
             {% endif %}
             <terminateInstancesWithExpiration>{{ request.terminate_instances_with_expiration }}</terminateInstancesWithExpiration>
             <type>{{ request.fleet_type }}</type>
+            {% if request.valid_from %}
             <validFrom>{{ request.valid_from }}</validFrom>
+            {% endif %}
+            {% if request.valid_until %}
             <validUntil>{{ request.valid_until }}</validUntil>
+            {% endif %}
             <replaceUnhealthyInstances>{{ request.replace_unhealthy_instances }}</replaceUnhealthyInstances>
             <tagSet>
                 {% for tag in request.tags %}

--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -31,8 +31,7 @@ class Fleets(BaseResponse):
             "TargetCapacitySpecification"
         )
         launch_template_configs = self._get_multi_param(
-            param_prefix="LaunchTemplateConfigs",
-            skip_result_conversion=True,
+            param_prefix="LaunchTemplateConfigs"
         )
 
         excess_capacity_termination_policy = self._get_param(


### PR DESCRIPTION
# Fixes
**moto/ec2/models/fleets.py**
- Exception handling and default value in case of `NoneType` for `spot_target_capacity` and `on_demand_target_capacity`

**moto/ec2/responses/fleets.py**
- Only add parameter in response if exsists