### PR TITLE
Enable Apple M1 support for Docker-builds with latest-tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,8 @@ jobs:
           docker build -t motoserver/moto . --tag moto:latest
       # Required to get the correct Digest
       # See https://github.com/docker/build-push-action/issues/461
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
@@ -220,6 +222,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: motoserver/moto:latest
       - name: Get version number
         run: |


### PR DESCRIPTION
Fixes #5858 

Related to #5553 - this applies the same solution to our `latest`-releases