### PR TITLE
DynamoDB: transact_write_items() errors on empty GSI keys

### DIFF
--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -34,6 +34,7 @@ class SecondaryIndex(BaseModel):
         self.schema = schema
         self.table_key_attrs = table_key_attrs
         self.projection = projection
+        self.schema_key_attrs = [k["AttributeName"] for k in schema]
 
     def project(self, item: Item) -> Item:
         """


### PR DESCRIPTION
Fixes #5830 