### PR TITLE
ECS: Various improvements

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2371,7 +2371,7 @@
 
 ## ecs
 <details>
-<summary>74% implemented</summary>
+<summary>80% implemented</summary>
 
 - [X] create_capacity_provider
 - [X] create_cluster
@@ -2408,7 +2408,7 @@
 - [X] put_account_setting
 - [ ] put_account_setting_default
 - [X] put_attributes
-- [ ] put_cluster_capacity_providers
+- [X] put_cluster_capacity_providers
 - [X] register_container_instance
 - [X] register_task_definition
 - [X] run_task
@@ -2419,8 +2419,8 @@
 - [ ] submit_task_state_change
 - [X] tag_resource
 - [X] untag_resource
-- [ ] update_capacity_provider
-- [ ] update_cluster
+- [X] update_capacity_provider
+- [X] update_cluster
 - [ ] update_cluster_settings
 - [ ] update_container_agent
 - [X] update_container_instances_state

--- a/docs/docs/services/ecs.rst
+++ b/docs/docs/services/ecs.rst
@@ -29,10 +29,6 @@ ecs
 
 - [X] create_capacity_provider
 - [X] create_cluster
-  
-        The following parameters are not yet implemented: configuration, capacityProviders, defaultCapacityProviderStrategy
-        
-
 - [X] create_service
 - [X] create_task_set
 - [X] delete_account_setting
@@ -92,7 +88,7 @@ ecs
 - [X] put_account_setting
 - [ ] put_account_setting_default
 - [X] put_attributes
-- [ ] put_cluster_capacity_providers
+- [X] put_cluster_capacity_providers
 - [X] register_container_instance
 - [X] register_task_definition
 - [X] run_task
@@ -102,13 +98,13 @@ ecs
 - [ ] submit_container_state_change
 - [ ] submit_task_state_change
 - [X] tag_resource
-  Currently implemented only for services
-
 - [X] untag_resource
-  Currently implemented only for services
+- [X] update_capacity_provider
+- [X] update_cluster
+  
+        The serviceConnectDefaults-parameter is not yet implemented
+        
 
-- [ ] update_capacity_provider
-- [ ] update_cluster
 - [ ] update_cluster_settings
 - [ ] update_container_agent
 - [X] update_container_instances_state

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -521,9 +521,13 @@ class FakeAutoScalingGroup(CloudFormationModel):
             if launch_template:
                 launch_template_id = launch_template.get("launch_template_id")
                 launch_template_name = launch_template.get("launch_template_name")
+                # If no version is specified, AWS will use '$Default'
+                # However, AWS will never show the version if it is not specified
+                # (If the user explicitly specifies '$Default', it will be returned)
                 self.launch_template_version = (
                     launch_template.get("version") or "$Default"
                 )
+                self.provided_launch_template_version = launch_template.get("version")
             elif mixed_instance_policy:
                 spec = mixed_instance_policy["LaunchTemplate"][
                     "LaunchTemplateSpecification"

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -778,7 +778,9 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
         {% elif group.launch_template %}
         <LaunchTemplate>
           <LaunchTemplateId>{{ group.launch_template.id }}</LaunchTemplateId>
-          <Version>{{ group.launch_template_version }}</Version>
+          {% if group.provided_launch_template_version %}}
+          <Version>{{ group.provided_launch_template_version }}</Version>
+          {% endif %}
           <LaunchTemplateName>{{ group.launch_template.name }}</LaunchTemplateName>
         </LaunchTemplate>
         {% endif %}

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -171,6 +171,47 @@ ecr:
   - TestAccECRRepository
   - TestAccECRRepositoryDataSource
   - TestAccECRRepositoryPolicy
+ecs:
+ - TestAccECSCapacityProvider_
+ - TestAccECSCluster_
+ - TestAccECSClusterCapacityProviders_basic
+ - TestAccECSClusterCapacityProviders_defaults
+ - TestAccECSClusterCapacityProviders_disappears
+ - TestAccECSClusterCapacityProviders_Update
+ - TestAccECSService_clusterName
+ - TestAccECSService_deploymentCircuitBreaker
+ - TestAccECSService_alb
+ - TestAccECSService_multipleTargetGroups
+ - TestAccECSService_DeploymentValues
+ - TestAccECSService_iamRole
+ - TestAccECSService_ServiceRegistries_container
+ - TestAccECSService_renamedCluster
+ - TestAccECSService_familyAndRevision
+ - TestAccECSService_replicaSchedulingStrategy
+ - TestAccECSService_DaemonSchedulingStrategy
+ - TestAccECSService_PlacementStrategy_missing
+ - TestAccECSService_disappears
+ - TestAccECSTaskSet_
+ - TestAccECSTaskDefinition_Docker
+ - TestAccECSTaskDefinition_EFSVolume
+ - TestAccECSTaskDefinition_Fargate
+ - TestAccECSTaskDefinition_ipcMode
+ - TestAccECSTaskDefinition_constraint
+ - TestAccECSTaskDefinition_tags
+ - TestAccECSTaskDefinition_pidMode
+ - TestAccECSTaskDefinition_executionRole
+ - TestAccECSTaskDefinition_service
+ - TestAccECSTaskDefinition_disappears
+ - TestAccECSTaskDefinition_taskRoleARN
+ - TestAccECSTaskDefinition_inferenceAccelerator
+ - TestAccECSTaskDefinition_proxy
+ - TestAccECSTaskDefinition_changeVolumesForcesNewResource
+ - TestAccECSTaskDefinition_invalidContainerDefinition
+ - TestAccECSTaskDefinition_arrays
+ - TestAccECSTaskDefinition_scratchVolume
+ - TestAccECSTaskDefinition_runtimePlatform
+ - TestAccECSTaskDefinition_basic
+ - TestAccECSTaskDefinition_networkMode
 efs:
   - TestAccEFSAccessPoint_
   - TestAccEFSAccessPointDataSource

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -221,8 +221,8 @@ def test_create_auto_scaling_from_template_version__no_version():
         "AutoScalingGroups"
     ][0]
     response.should.have.key("LaunchTemplate")
-    # We never specified the version - this is what it defaults to
-    response["LaunchTemplate"].should.have.key("Version").equals("$Default")
+    # We never specified the version - and AWS will not return anything if we don't
+    response["LaunchTemplate"].shouldnt.have.key("Version")
 
 
 @mock_autoscaling

--- a/tests/test_batch/test_batch_compute_envs.py
+++ b/tests/test_batch/test_batch_compute_envs.py
@@ -240,8 +240,10 @@ def test_delete_unmanaged_compute_environment():
     all_names = [e["computeEnvironmentName"] for e in all_envs]
     all_names.shouldnt.contain(compute_name)
 
-    all_clusters = ecs_client.list_clusters()["clusterArns"]
-    all_clusters.shouldnt.contain(our_env["ecsClusterArn"])
+    cluster = ecs_client.describe_clusters(clusters=[our_env["ecsClusterArn"]])[
+        "clusters"
+    ][0]
+    cluster.should.have.key("status").equals("INACTIVE")
 
 
 @mock_ec2
@@ -293,8 +295,10 @@ def test_delete_managed_compute_environment():
         for reservation in resp["Reservations"]:
             reservation["Instances"][0]["State"]["Name"].should.equal("terminated")
 
-    all_clusters = ecs_client.list_clusters()["clusterArns"]
-    all_clusters.shouldnt.contain(our_env["ecsClusterArn"])
+    cluster = ecs_client.describe_clusters(clusters=[our_env["ecsClusterArn"]])[
+        "clusters"
+    ][0]
+    cluster.should.have.key("status").equals("INACTIVE")
 
 
 @mock_ec2

--- a/tests/test_ecs/test_ecs_efs.py
+++ b/tests/test_ecs/test_ecs_efs.py
@@ -1,0 +1,43 @@
+import boto3
+from moto import mock_ecs, mock_efs
+
+
+@mock_ecs
+@mock_efs
+def test_register_task_definition__use_efs_root():
+    client = boto3.client("ecs", region_name="us-east-1")
+
+    container_definition = {
+        "name": "hello_world",
+        "image": "docker/hello-world:latest",
+        "cpu": 1024,
+        "memory": 400,
+    }
+    task_definition = client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[container_definition],
+        volumes=[
+            {
+                "name": "vol1",
+                "efsVolumeConfiguration": {
+                    "fileSystemId": "sth",
+                    "transitEncryption": "ENABLED",
+                },
+            }
+        ],
+    )
+    family = task_definition["taskDefinition"]["family"]
+    task = client.describe_task_definition(taskDefinition=family)["taskDefinition"]
+
+    task["volumes"].should.equal(
+        [
+            {
+                "name": "vol1",
+                "efsVolumeConfiguration": {
+                    "fileSystemId": "sth",
+                    "rootDirectory": "/",
+                    "transitEncryption": "ENABLED",
+                },
+            }
+        ]
+    )

--- a/tests/test_ecs/test_ecs_task_def_tags.py
+++ b/tests/test_ecs/test_ecs_task_def_tags.py
@@ -1,0 +1,44 @@
+import boto3
+import sure  # noqa # pylint: disable=unused-import
+
+from moto import mock_ecs
+
+
+@mock_ecs
+def test_describe_task_definition_with_tags():
+    client = boto3.client("ecs", region_name="us-east-1")
+    task_def = client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+                "essential": True,
+            }
+        ],
+        tags=[{"key": "k1", "value": "v1"}],
+    )["taskDefinition"]
+    task_def_arn = task_def["taskDefinitionArn"]
+
+    response = client.describe_task_definition(
+        taskDefinition="test_ecs_task:1", include=["TAGS"]
+    )
+    response["tags"].should.equal([{"key": "k1", "value": "v1"}])
+
+    client.tag_resource(resourceArn=task_def_arn, tags=[{"key": "k2", "value": "v2"}])
+
+    response = client.describe_task_definition(
+        taskDefinition="test_ecs_task:1", include=["TAGS"]
+    )
+    response["tags"].should.have.length_of(2)
+    response["tags"].should.contain({"key": "k1", "value": "v1"})
+    response["tags"].should.contain({"key": "k2", "value": "v2"})
+
+    client.untag_resource(resourceArn=task_def_arn, tagKeys=["k2"])
+
+    resp = client.list_tags_for_resource(resourceArn=task_def_arn)
+    resp.should.have.key("tags")
+    resp["tags"].should.have.length_of(1)
+    resp["tags"].should.contain({"key": "k1", "value": "v1"})

--- a/tests/test_ecs/test_ecs_tasksets.py
+++ b/tests/test_ecs/test_ecs_tasksets.py
@@ -1,0 +1,398 @@
+from botocore.exceptions import ClientError
+import boto3
+import sure  # noqa # pylint: disable=unused-import
+
+from moto import mock_ecs
+import pytest
+
+
+cluster_name = "test_ecs_cluster"
+service_name = "test_ecs_service"
+task_def_name = "test_ecs_task"
+
+
+@mock_ecs
+def test_create_task_set():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=task_def_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+    load_balancers = [
+        {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:01234567890:targetgroup/c26b93c1bc35466ba792d5b08fe6a5bc/ec39113f8831453a",
+            "containerName": "hello_world",
+            "containerPort": 8080,
+        },
+    ]
+
+    task_set = client.create_task_set(
+        cluster=cluster_name,
+        service=service_name,
+        taskDefinition=task_def_name,
+        loadBalancers=load_balancers,
+    )["taskSet"]
+
+    cluster_arn = client.describe_clusters(clusters=[cluster_name])["clusters"][0][
+        "clusterArn"
+    ]
+    service_arn = client.describe_services(
+        cluster=cluster_name, services=[service_name]
+    )["services"][0]["serviceArn"]
+    task_set["clusterArn"].should.equal(cluster_arn)
+    task_set["serviceArn"].should.equal(service_arn)
+    task_set["taskDefinition"].should.match(f"{task_def_name}:1$")
+    task_set["scale"].should.equal({"value": 100.0, "unit": "PERCENT"})
+    task_set["loadBalancers"][0]["targetGroupArn"].should.equal(
+        "arn:aws:elasticloadbalancing:us-east-1:01234567890:targetgroup/"
+        "c26b93c1bc35466ba792d5b08fe6a5bc/ec39113f8831453a"
+    )
+    task_set["loadBalancers"][0]["containerPort"].should.equal(8080)
+    task_set["loadBalancers"][0]["containerName"].should.equal("hello_world")
+    task_set["launchType"].should.equal("EC2")
+    task_set["platformVersion"].should.equal("LATEST")
+
+
+@mock_ecs
+def test_create_task_set_errors():
+    # given
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=task_def_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    # not existing launch type
+    # when
+    with pytest.raises(ClientError) as e:
+        client.create_task_set(
+            cluster=cluster_name,
+            service=service_name,
+            taskDefinition=task_def_name,
+            launchType="SOMETHING",
+        )
+
+    # then
+    ex = e.value
+    ex.operation_name.should.equal("CreateTaskSet")
+    ex.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.response["Error"]["Code"].should.contain("ClientException")
+    ex.response["Error"]["Message"].should.equal(
+        "launch type should be one of [EC2,FARGATE]"
+    )
+
+
+@mock_ecs
+def test_describe_task_sets():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=task_def_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    load_balancers = [
+        {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:01234567890:targetgroup/c26b93c1bc35466ba792d5b08fe6a5bc/ec39113f8831453a",
+            "containerName": "hello_world",
+            "containerPort": 8080,
+        }
+    ]
+
+    _ = client.create_task_set(
+        cluster=cluster_name,
+        service=service_name,
+        taskDefinition=task_def_name,
+        loadBalancers=load_balancers,
+    )
+    task_sets = client.describe_task_sets(cluster=cluster_name, service=service_name)[
+        "taskSets"
+    ]
+    assert "tags" not in task_sets[0]
+
+    task_sets = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, include=["TAGS"]
+    )["taskSets"]
+
+    cluster_arn = client.describe_clusters(clusters=[cluster_name])["clusters"][0][
+        "clusterArn"
+    ]
+
+    service_arn = client.describe_services(
+        cluster=cluster_name, services=[service_name]
+    )["services"][0]["serviceArn"]
+
+    task_sets.should.have.length_of(1)
+    task_sets[0].should.have.key("tags")
+    task_sets[0]["taskDefinition"].should.match(f"{task_def_name}:1$")
+    task_sets[0]["clusterArn"].should.equal(cluster_arn)
+    task_sets[0]["serviceArn"].should.equal(service_arn)
+    task_sets[0]["serviceArn"].should.match(f"{service_name}$")
+    task_sets[0]["scale"].should.equal({"value": 100.0, "unit": "PERCENT"})
+    task_sets[0]["taskSetArn"].should.match(f"{task_sets[0]['id']}$")
+    task_sets[0]["loadBalancers"][0]["targetGroupArn"].should.equal(
+        "arn:aws:elasticloadbalancing:us-east-1:01234567890:targetgroup/"
+        "c26b93c1bc35466ba792d5b08fe6a5bc/ec39113f8831453a"
+    )
+    task_sets[0]["loadBalancers"][0]["containerPort"].should.equal(8080)
+    task_sets[0]["loadBalancers"][0]["containerName"].should.equal("hello_world")
+    task_sets[0]["launchType"].should.equal("EC2")
+
+
+@mock_ecs
+def test_delete_task_set():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=task_def_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    task_set = client.create_task_set(
+        cluster=cluster_name, service=service_name, taskDefinition=task_def_name
+    )["taskSet"]
+
+    task_sets = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, taskSets=[task_set["taskSetArn"]]
+    )["taskSets"]
+
+    assert len(task_sets) == 1
+
+    task_sets = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, taskSets=[task_set["taskSetArn"]]
+    )["taskSets"]
+
+    assert len(task_sets) == 1
+
+    response = client.delete_task_set(
+        cluster=cluster_name, service=service_name, taskSet=task_set["taskSetArn"]
+    )
+    assert response["taskSet"]["taskSetArn"] == task_set["taskSetArn"]
+
+    task_sets = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, taskSets=[task_set["taskSetArn"]]
+    )["taskSets"]
+
+    assert len(task_sets) == 0
+
+    with pytest.raises(ClientError):
+        _ = client.delete_task_set(
+            cluster=cluster_name, service=service_name, taskSet=task_set["taskSetArn"]
+        )
+
+
+@mock_ecs
+def test_delete_task_set__using_partial_arn():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=task_def_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    task_set = client.create_task_set(
+        cluster=cluster_name, service=service_name, taskDefinition=task_def_name
+    )["taskSet"]
+
+    # Partial ARN match
+    # arn:aws:ecs:us-east-1:123456789012:task-set/test_ecs_cluster/test_ecs_service/ecs-svc/386233676373827416
+    # --> ecs-svc/386233676373827416
+    partial_arn = "/".join(task_set["taskSetArn"].split("/")[-2:])
+    task_sets = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, taskSets=[partial_arn]
+    )["taskSets"]
+
+    assert len(task_sets) == 1
+
+    response = client.delete_task_set(
+        cluster=cluster_name, service=service_name, taskSet=partial_arn
+    )
+    assert response["taskSet"]["taskSetArn"] == task_set["taskSetArn"]
+
+
+@mock_ecs
+def test_update_service_primary_task_set():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    task_set = client.create_task_set(
+        cluster=cluster_name, service=service_name, taskDefinition=task_def_name
+    )["taskSet"]
+
+    service = client.describe_services(cluster=cluster_name, services=[service_name],)[
+        "services"
+    ][0]
+
+    _ = client.update_service_primary_task_set(
+        cluster=cluster_name,
+        service=service_name,
+        primaryTaskSet=task_set["taskSetArn"],
+    )
+
+    service = client.describe_services(cluster=cluster_name, services=[service_name],)[
+        "services"
+    ][0]
+    assert service["taskSets"][0]["status"] == "PRIMARY"
+    assert service["taskDefinition"] == service["taskSets"][0]["taskDefinition"]
+
+    another_task_set = client.create_task_set(
+        cluster=cluster_name, service=service_name, taskDefinition=task_def_name
+    )["taskSet"]
+    service = client.describe_services(cluster=cluster_name, services=[service_name],)[
+        "services"
+    ][0]
+    assert service["taskSets"][1]["status"] == "ACTIVE"
+
+    _ = client.update_service_primary_task_set(
+        cluster=cluster_name,
+        service=service_name,
+        primaryTaskSet=another_task_set["taskSetArn"],
+    )
+    service = client.describe_services(cluster=cluster_name, services=[service_name],)[
+        "services"
+    ][0]
+    assert service["taskSets"][0]["status"] == "ACTIVE"
+    assert service["taskSets"][1]["status"] == "PRIMARY"
+    assert service["taskDefinition"] == service["taskSets"][1]["taskDefinition"]
+
+
+@mock_ecs
+def test_update_task_set():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    task_set = client.create_task_set(
+        cluster=cluster_name, service=service_name, taskDefinition=task_def_name
+    )["taskSet"]
+
+    another_task_set = client.create_task_set(
+        cluster=cluster_name, service=service_name, taskDefinition=task_def_name
+    )["taskSet"]
+    assert another_task_set["scale"]["unit"] == "PERCENT"
+    assert another_task_set["scale"]["value"] == 100.0
+
+    client.update_task_set(
+        cluster=cluster_name,
+        service=service_name,
+        taskSet=task_set["taskSetArn"],
+        scale={"value": 25.0, "unit": "PERCENT"},
+    )
+
+    updated_task_set = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, taskSets=[task_set["taskSetArn"]]
+    )["taskSets"][0]
+    assert updated_task_set["scale"]["value"] == 25.0
+    assert updated_task_set["scale"]["unit"] == "PERCENT"
+
+
+@mock_ecs
+def test_create_task_sets_with_tags():
+    client = boto3.client("ecs", region_name="us-east-1")
+    _ = client.create_cluster(clusterName=cluster_name)
+    create_task_def(client)
+    _ = client.create_service(
+        cluster=cluster_name,
+        serviceName=service_name,
+        taskDefinition=task_def_name,
+        desiredCount=2,
+        deploymentController={"type": "EXTERNAL"},
+    )
+
+    load_balancers = [
+        {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:01234567890:targetgroup/c26b93c1bc35466ba792d5b08fe6a5bc/ec39113f8831453a",
+            "containerName": "hello_world",
+            "containerPort": 8080,
+        }
+    ]
+
+    _ = client.create_task_set(
+        cluster=cluster_name,
+        service=service_name,
+        taskDefinition=task_def_name,
+        loadBalancers=load_balancers,
+        tags=[{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}],
+    )
+
+    task_set = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, include=["TAGS"]
+    )["taskSets"][0]
+    task_set.should.have.key("tags").equals(
+        [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]
+    )
+
+    client.tag_resource(
+        resourceArn=task_set["taskSetArn"], tags=[{"key": "k3", "value": "v3"}]
+    )
+
+    task_set = client.describe_task_sets(
+        cluster=cluster_name, service=service_name, include=["TAGS"]
+    )["taskSets"][0]
+    task_set.should.have.key("tags")
+    task_set["tags"].should.have.length_of(3)
+    task_set["tags"].should.contain({"key": "k1", "value": "v1"})
+    task_set["tags"].should.contain({"key": "k2", "value": "v2"})
+    task_set["tags"].should.contain({"key": "k3", "value": "v3"})
+
+    client.untag_resource(resourceArn=task_set["taskSetArn"], tagKeys=["k2"])
+
+    resp = client.list_tags_for_resource(resourceArn=task_set["taskSetArn"])
+    resp.should.have.key("tags")
+    resp["tags"].should.have.length_of(2)
+    resp["tags"].should.contain({"key": "k1", "value": "v1"})
+    resp["tags"].should.contain({"key": "k3", "value": "v3"})
+
+
+def create_task_def(client):
+    client.register_task_definition(
+        family=task_def_name,
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+                "essential": True,
+                "environment": [
+                    {"name": "AWS_ACCESS_KEY_ID", "value": "SOME_ACCESS_KEY"}
+                ],
+                "logConfiguration": {"logDriver": "json-file"},
+            }
+        ],
+    )


### PR DESCRIPTION
Support for:
ECS: put_cluster_capacity_providers()
ECS: update_capacity_provider()
ECS: update_cluster()

* ECS: create_cluster() now supports the parameters configuration, capacityProviders, defaultCapacityProviderStrategy
* ECS: delete_cluster() now marks the cluster as INACTIVE, rather than removing it outright, inline with how AWS behaves
* ECS: register_task_definition() now supports the parameters proxyConfiguration, inferenceAccelerators, runtimePlatform, ipcMode, pidMode, ephemeralStorage
* ECS now has improved tagging-support
* ECS: run_task() no longer crashes when providing launchType=FARGATE

Closes #2101 