### PR TITLE
EKS: NodeGroups: Verify LaunchTemplateID when providing name, and vice versa

### DIFF
--- a/moto/eks/models.py
+++ b/moto/eks/models.py
@@ -284,6 +284,25 @@ class ManagedNodegroup:
         self.tags = tags
         self.taints = taints
 
+        # Determine LaunchTemplateId from Name (and vice versa)
+        try:
+            from moto.ec2.models import ec2_backends
+
+            ec2 = ec2_backends[account_id][region_name]
+
+            template = None
+            if "name" in self.launch_template:
+                name = self.launch_template["name"]
+                template = ec2.describe_launch_templates(template_names=[name])[0]
+            elif "id" in self.launch_template:
+                _id = self.launch_template["id"]
+                template = ec2.describe_launch_templates(template_ids=[_id])[0]
+
+            self.launch_template["id"] = template.id
+            self.launch_template["name"] = template.name
+        except:  # noqa: E722 Do not use bare except
+            pass
+
     def __iter__(self):
         yield "nodegroupName", self.nodegroup_name
         yield "nodegroupArn", self.arn

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,7 +126,7 @@ ec2instanceconnect =
 ecr =
 ecs =
 efs = sshpubkeys>=3.1.0
-eks =
+eks = sshpubkeys>=3.1.0
 elasticache =
 elasticbeanstalk =
 elastictranscoder =

--- a/tests/test_eks/test_eks_ec2.py
+++ b/tests/test_eks/test_eks_ec2.py
@@ -1,0 +1,73 @@
+import boto3
+
+from moto import mock_ec2, mock_eks
+from .test_eks_constants import NODEROLE_ARN_VALUE, SUBNET_IDS
+
+
+@mock_eks
+def test_passing_an_unknown_launchtemplate_is_supported():
+    eks = boto3.client("eks", "us-east-2")
+    eks.create_cluster(name="a", roleArn=NODEROLE_ARN_VALUE, resourcesVpcConfig={})
+    group = eks.create_nodegroup(
+        clusterName="a",
+        nodegroupName="b",
+        launchTemplate={"name": "random"},
+        nodeRole=NODEROLE_ARN_VALUE,
+        subnets=SUBNET_IDS,
+    )["nodegroup"]
+
+    group["launchTemplate"].should.equal({"name": "random"})
+
+
+@mock_ec2
+@mock_eks
+def test_passing_a_known_launchtemplate_by_name():
+    ec2 = boto3.client("ec2", region_name="us-east-2")
+    eks = boto3.client("eks", "us-east-2")
+
+    lt_id = ec2.create_launch_template(
+        LaunchTemplateName="ltn",
+        LaunchTemplateData={
+            "TagSpecifications": [
+                {"ResourceType": "instance", "Tags": [{"Key": "t", "Value": "v"}]}
+            ]
+        },
+    )["LaunchTemplate"]["LaunchTemplateId"]
+
+    eks.create_cluster(name="a", roleArn=NODEROLE_ARN_VALUE, resourcesVpcConfig={})
+    group = eks.create_nodegroup(
+        clusterName="a",
+        nodegroupName="b",
+        launchTemplate={"name": "ltn"},
+        nodeRole=NODEROLE_ARN_VALUE,
+        subnets=SUBNET_IDS,
+    )["nodegroup"]
+
+    group["launchTemplate"].should.equal({"name": "ltn", "id": lt_id})
+
+
+@mock_ec2
+@mock_eks
+def test_passing_a_known_launchtemplate_by_id():
+    ec2 = boto3.client("ec2", region_name="us-east-2")
+    eks = boto3.client("eks", "us-east-2")
+
+    lt_id = ec2.create_launch_template(
+        LaunchTemplateName="ltn",
+        LaunchTemplateData={
+            "TagSpecifications": [
+                {"ResourceType": "instance", "Tags": [{"Key": "t", "Value": "v"}]}
+            ]
+        },
+    )["LaunchTemplate"]["LaunchTemplateId"]
+
+    eks.create_cluster(name="a", roleArn=NODEROLE_ARN_VALUE, resourcesVpcConfig={})
+    group = eks.create_nodegroup(
+        clusterName="a",
+        nodegroupName="b",
+        launchTemplate={"id": lt_id},
+        nodeRole=NODEROLE_ARN_VALUE,
+        subnets=SUBNET_IDS,
+    )["nodegroup"]
+
+    group["launchTemplate"].should.equal({"name": "ltn", "id": lt_id})


### PR DESCRIPTION
Fixes #5879 