### PR TITLE
EC2: Allow providing NIC template when creating several instances

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -74,7 +74,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self.owner_id = ec2_backend.account_id
         self.lifecycle = kwargs.get("lifecycle")
 
-        nics = kwargs.get("nics", {})
+        nics = copy.deepcopy(kwargs.get("nics", []))
 
         launch_template_arg = kwargs.get("launch_template", {})
         if launch_template_arg and not image_id:


### PR DESCRIPTION
AWS ec2 API allows providing a NIC "template" when creating instances, which does not contain any IP. ec2 assign an IP address automatically for each instance.

With moto, almost everything was made to reproduce the same behaviour, except that the dict containing the params was directly updated with the assigned IP address, and was producing an error the second time when checking if the IP was available, because it was checking it against the previously assigned IP.

The solution is very simple: duplicating the parameter to avoid updating the original entry.
