### PR TITLE
MotoServer - deprecate server-argument

### DIFF
--- a/moto/server.py
+++ b/moto/server.py
@@ -2,6 +2,8 @@ import argparse
 import os
 import signal
 import sys
+import warnings
+
 from werkzeug.serving import run_simple
 
 from moto.moto_server.werkzeug_app import (
@@ -69,6 +71,11 @@ def main(argv=None):
         signal.signal(signal.SIGTERM, signal_handler)
     except Exception:
         pass  # ignore "ValueError: signal only works in main thread"
+
+    if args.service:
+        warnings.warn(
+            f"The service-argument ({args.service}) is considered deprecated, and will be deprecated in a future release. Please let us know if you have any questions: https://github.com/getmoto/moto/issues"
+        )
 
     # Wrap the main application
     main_app = DomainDispatcherApplication(create_backend_app, service=args.service)


### PR DESCRIPTION
Part of a cleanup to simplify the server-logic. The command `moto_server ec2` can be used if you only want to serve EC2 requests on this MotoServer, but I'm not aware of any benefits of this. Running just `moto_server` does the same thing.

This feature was removed from the documentation in https://github.com/getmoto/moto/pull/3728

If someone is using this construct, and is able to show a use-case that I'm not seeing, we can always undo this.
