### PR TITLE
AWSLambda: Try to pull images from multiple repositories

### DIFF
--- a/moto/settings.py
+++ b/moto/settings.py
@@ -89,7 +89,7 @@ def moto_server_host() -> str:
 
 
 def moto_lambda_image() -> str:
-    return os.environ.get("MOTO_DOCKER_LAMBDA_IMAGE", "lambci/lambda")
+    return os.environ.get("MOTO_DOCKER_LAMBDA_IMAGE", "mlupin/docker-lambda")
 
 
 def moto_network_name() -> str:

--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -123,7 +123,7 @@ def test_invoke_event_function():
     function_name = str(uuid4())[0:6]
     conn.create_function(
         FunctionName=function_name,
-        Runtime="python2.7",
+        Runtime="python3.9",
         Role=get_role_name(),
         Handler="lambda_function.lambda_handler",
         Code={"ZipFile": get_test_zip_file1()},


### PR DESCRIPTION
Closes #5886 

When invoking an AWSLambda function, the requested image can be found in one of these repos:
 - `mlupin/docker-lambda` (the repo with up-to-date AWSLambda images
 - `lambci/lambda` (the repo with older/outdated AWSLambda images
 
This PR ensures that we cycle through all of them - when we find the repo that contains our image, we use that one.

For most users, this means the `MOTO_DOCKER_LAMBDA_IMAGE`-variable is no longer required. But we'll keep the functionality in case people want to configure a different repository instead.