### PR TITLE
IAM: Fix resource list matching

### DIFF
--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -378,7 +378,7 @@ class IAMPolicyStatement(object):
         if is_action_concerned:
             if self.is_unknown_principal(self._statement.get("Principal")):
                 return PermissionResult.NEUTRAL
-            same_resource = self._match(self._statement["Resource"], resource)
+            same_resource = self._check_element_matches("Resource", resource)
             if self._statement["Effect"] == "Allow" and same_resource:
                 return PermissionResult.PERMITTED
             else:  # Deny

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -37,6 +37,20 @@ class TestBucketPolicy:
             ({"resource": "arn:aws:s3:::mybucket/test_txt"}, 200),
             ({"resource": "arn:aws:s3:::notmybucket/*"}, 403),
             ({"resource": "arn:aws:s3:::mybucket/other*"}, 403),
+            ({"resource": ["arn:aws:s3:::mybucket", "arn:aws:s3:::mybucket/*"]}, 200),
+            (
+                {
+                    "resource": [
+                        "arn:aws:s3:::notmybucket",
+                        "arn:aws:s3:::notmybucket/*",
+                    ]
+                },
+                403,
+            ),
+            (
+                {"resource": ["arn:aws:s3:::mybucket", "arn:aws:s3:::notmybucket/*"]},
+                403,
+            ),
             ({"effect": "Deny"}, 403),
         ],
     )


### PR DESCRIPTION
This PR fixes `AttributeError` when using policies that have a list of resources:

<https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html>

```js
{
    'Action': 's3:*',
    'Effect': 'Deny',
    'Resource': [
        'arn:aws:s3:::sls-test-local-serverlessdeploymentbuck-3f0d17f0/*',
        'arn:aws:s3:::sls-test-local-serverlessdeploymentbuck-3f0d17f0'
    ]
}
```

```
  ...
  File "/home/viren/repo/moto-ext/moto/core/utils.py", line 106, in __call__
    result = self.callback(request, request.url, dict(request.headers))
  File "/home/viren/repo/moto-ext/moto/utilities/aws_headers.py", line 64, in _wrapper
    response = f(*args, **kwargs)
  File "/home/viren/repo/moto-ext/moto/s3/responses.py", line 1122, in key_response
    response = self._key_response(request, full_url, self.headers)
  File "/home/viren/repo/moto-ext/moto/s3/responses.py", line 1176, in _key_response
    bucket_permissions = bucket.get_permission(action, resource)
  File "/home/viren/repo/moto-ext/moto/s3/models.py", line 952, in get_permission
    return iam_policy.is_action_permitted(action, resource)
  File "/home/viren/repo/moto-ext/moto/iam/access_control.py", line 347, in is_action_permitted
    permission_result = iam_policy_statement.is_action_permitted(
  File "/home/viren/repo/moto-ext/moto/iam/access_control.py", line 381, in is_action_permitted
    same_resource = self._match(self._statement["Resource"], resource)
  File "/home/viren/repo/moto-ext/moto/iam/access_control.py", line 415, in _match
    pattern = pattern.replace("*", ".*")
AttributeError: 'list' object has no attribute 'replace'
```

### Related

https://github.com/getmoto/moto/pull/5883