### PR TITLE
ECS: Fixes to DescribeTaskDefinition and StopTask

### DIFF
--- a/moto/ecs/exceptions.py
+++ b/moto/ecs/exceptions.py
@@ -16,7 +16,7 @@ class TaskDefinitionNotFoundException(JsonRESTError):
     def __init__(self):
         super().__init__(
             error_type="ClientException",
-            message="The specified task definition does not exist.",
+            message="Unable to describe task definition.",
         )
 
 

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1413,7 +1413,8 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception(f"Cluster {cluster.name} has no registered tasks")
         for task in tasks.keys():
             if task.endswith(task_id):
-                if container_instance_arn := tasks[task].container_instance_arn:
+                container_instance_arn = tasks[task].container_instance_arn
+                if container_instance_arn:
                     container_instance = self.container_instances[cluster.name][
                         container_instance_arn.split("/")[-1]
                     ]

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1413,13 +1413,15 @@ class EC2ContainerServiceBackend(BaseBackend):
             raise Exception(f"Cluster {cluster.name} has no registered tasks")
         for task in tasks.keys():
             if task.endswith(task_id):
-                container_instance_arn = tasks[task].container_instance_arn
-                container_instance = self.container_instances[cluster.name][
-                    container_instance_arn.split("/")[-1]
-                ]
-                self.update_container_instance_resources(
-                    container_instance, tasks[task].resource_requirements, removing=True
-                )
+                if container_instance_arn := tasks[task].container_instance_arn:
+                    container_instance = self.container_instances[cluster.name][
+                        container_instance_arn.split("/")[-1]
+                    ]
+                    self.update_container_instance_resources(
+                        container_instance,
+                        tasks[task].resource_requirements,
+                        removing=True,
+                    )
                 tasks[task].last_status = "STOPPED"
                 tasks[task].desired_status = "STOPPED"
                 tasks[task].stopped_reason = reason


### PR DESCRIPTION
This PR has two small fixes:

1. Report the same error message as AWS for `DescribeTaskDefinition`
  
```
$ aws ecs describe-task-definition --task-definition foobar

An error occurred (ClientException) when calling the DescribeTaskDefinition operation: Unable to describe task definition.
```

2. Fix `AttributeError` when stopping Fargate tasks

```
  ...
  File "/home/viren/repo/moto-ext/moto/ecs/responses.py", line 254, in stop_task
    task = self.ecs_backend.stop_task(cluster_str, task, reason)
  File "/home/viren/repo/moto-ext/moto/ecs/models.py", line 1418, in stop_task
    container_instance_arn.split("/")[-1]
AttributeError: 'NoneType' object has no attribute 'split'

```