### PR TITLE
Transcribe: add IdentifyMultipleLanguages and return LanguageCodes

### DIFF
--- a/moto/transcribe/responses.py
+++ b/moto/transcribe/responses.py
@@ -37,6 +37,7 @@ class TranscribeResponse(BaseResponse):
             job_execution_settings=self._get_param("JobExecutionSettings"),
             content_redaction=self._get_param("ContentRedaction"),
             identify_language=self._get_param("IdentifyLanguage"),
+            identify_multiple_languages=self._get_param("IdentifyMultipleLanguages"),
             language_options=self._get_param("LanguageOptions"),
         )
         return json.dumps(response)


### PR DESCRIPTION
The [start_transcription_job method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/transcribe.html#TranscribeService.Client.start_transcription_job) has an IdentifyMultipleLanguages attribute, and returns LanguageCodes if more than one language is found in the recording. 