### PR TITLE
DynamoDB: Support declaration of non-key attributes

### DIFF
--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -251,7 +251,7 @@ class Table(CloudFormationModel):
             if elem["KeyType"] == "HASH":
                 self.hash_key_attr = elem["AttributeName"]
                 self.hash_key_type = attr_type
-            else:
+            elif elem["KeyType"] == "RANGE":
                 self.range_key_attr = elem["AttributeName"]
                 self.range_key_type = attr_type
         self.table_key_attrs = [
@@ -465,7 +465,7 @@ class Table(CloudFormationModel):
 
     @property
     def range_key_names(self) -> List[str]:
-        keys = [self.range_key_attr]
+        keys = [self.range_key_attr] if self.has_range_key else []
         for index in self.global_indexes:
             for key in index.schema:
                 if key["KeyType"] == "RANGE":

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -707,7 +707,7 @@ def test_batch_put_item_with_empty_value():
         TableName="test-table",
         KeySchema=[
             {"AttributeName": "pk", "KeyType": "HASH"},
-            {"AttributeName": "sk", "KeyType": "SORT"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
         ],
         ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
     )


### PR DESCRIPTION
Fixes #5916 

We assumed that when creating a Table, the user would only ever send two attributes: Hash and Range. 
But it is possible to specify a non-key attribute, so we should be very explicit in determining whether something is a Hash-key, Range-key, or something else all-together.