### PR TITLE
S3: Close more filehandles

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1827,8 +1827,6 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         if bucket.is_versioned:
             keys = existing_keys + [new_key]
         else:
-            for key in existing_keys:
-                key.dispose()
             keys = [new_key]
         bucket.keys.setlist(key_name, keys)
 

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -148,6 +148,12 @@ class _VersionedKeyStore(dict):
         elif not isinstance(list_, list):
             list_ = [list_]
 
+        for existing_version in self.getlist(key, []):
+            # Dispose of any FakeKeys that we will not keep
+            # We should only have FakeKeys here - but we're checking hasattr to be sure
+            if existing_version not in list_ and hasattr(existing_version, "dispose"):
+                existing_version.dispose()
+
         super().__setitem__(key, list_)
 
     def _iteritems(self):

--- a/tests/test_s3/test_s3_file_handles.py
+++ b/tests/test_s3/test_s3_file_handles.py
@@ -251,6 +251,17 @@ class TestS3FileHandleClosuresUsingMocks(TestCase):
         with mock_s3():
             pass
 
+    @verify_zero_warnings
+    def test_delete_object_with_version(self):
+        with mock_s3():
+            self.s3.create_bucket(Bucket="foo")
+            self.s3.put_bucket_versioning(
+                Bucket="foo",
+                VersioningConfiguration={"Status": "Enabled", "MFADelete": "Disabled"},
+            )
+            version = self.s3.put_object(Bucket="foo", Key="b", Body="s")["VersionId"]
+            self.s3.delete_object(Bucket="foo", Key="b", VersionId=version)
+
 
 def test_verify_key_can_be_copied_after_disposing():
     # https://github.com/getmoto/moto/issues/5588


### PR DESCRIPTION
Fixes #5937 

Filehandles weren't closed when deleting versioned FakeKeys. 
Moving the dispose-logic to the `_VersionedKeyStore` ensures that we only have to invoke this logic in one place, regardless of whether we're creating, deleting, dealing with a versioned/non-versioned bucket, etc.