### PR TITLE
S3: Fix Signature calculation for requests that contain a querystring

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -130,10 +130,14 @@ class ActionAuthenticatorMixin(object):
             ActionAuthenticatorMixin.request_count
             >= settings.INITIAL_NO_AUTH_ACTION_COUNT
         ):
+            parsed_url = urlparse(self.uri)  # type: ignore[attr-defined]
+            path = parsed_url.path
+            if parsed_url.query:
+                path += "?" + parsed_url.query
             iam_request = iam_request_cls(
                 account_id=self.current_account,  # type: ignore[attr-defined]
                 method=self.method,  # type: ignore[attr-defined]
-                path=self.path,  # type: ignore[attr-defined]
+                path=path,
                 data=self.data,  # type: ignore[attr-defined]
                 headers=self.headers,  # type: ignore[attr-defined]
             )

--- a/tests/test_s3/test_s3_auth.py
+++ b/tests/test_s3/test_s3_auth.py
@@ -52,6 +52,11 @@ def test_head_bucket_with_correct_credentials():
         aws_secret_access_key=iam_keys["SecretAccessKey"],
     )
 
+    # Verify we can make calls that contain a querystring
+    # Specifically, verify that we are able to build/match the AWS signature for a URL with a querystring
+    s3.get_bucket_location(Bucket="mock_bucket")
+    s3.list_objects_v2(Bucket="mock_bucket")
+
 
 @set_initial_no_auth_action_count(4)
 @mock_s3


### PR DESCRIPTION
Fixes #5948 