### PR TITLE
Fix "local variable 'containers' referenced before assignment".

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -606,7 +606,12 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         """
         try:
             import docker
+        except ImportError as err:
+            logger.error(f"Failed to run AWS Batch container {self.name}. Error {err}")
+            self._mark_stopped(success=False)
+            return
 
+        try:
             containers: List[docker.models.containers.Container] = []
 
             self.advance()


### PR DESCRIPTION
If "import docker" fails https://github.com/getmoto/moto/blob/aa332c4d/moto/batch/models.py#L610 `Job.run`  fails with an obscure error `UnboundLocalError` error as:

```
.../_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread MOTO-BATCH-e3d4d43a-b68e-4f64-b2e8-7c396c0f3ad2

  Traceback (most recent call last):
    File ".../lib/python3.9/threading.py", line 973, in _bootstrap_inner
      self.run()
    File ".../moto/batch/models.py", line 854, in run
      for container in containers:
  UnboundLocalError: local variable 'containers' referenced before assignment

    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```

The PR changes the scope of 'containers' variable to prevent the issue.


