### PR TITLE
add arn for rds OptionGroup

### DIFF
--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1228,6 +1228,9 @@ def test_create_option_group():
         "test option group"
     )
     option_group["OptionGroup"]["MajorEngineVersion"].should.equal("5.6")
+    option_group["OptionGroup"]["OptionGroupArn"].should.equal(
+        f"arn:aws:rds:us-west-2:{ACCOUNT_ID}:og:test"
+    )
 
 
 @mock_rds


### PR DESCRIPTION
Creating or describing a RDS `OptionGroup` is missing the parameter `OptionGroupArn`, as [examples described in the docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-option-group.html#examples):

> 
```
{
    "OptionGroup": {
        "OptionGroupName": "myoptiongroup",
        "OptionGroupDescription": "Oracle Database Manager Database Control",
        "EngineName": "oracle-ee",
        "MajorEngineVersion": "11.2",
        "Options": [],
        "AllowsVpcAndNonVpcInstanceMemberships": true,
        "OptionGroupArn": "arn:aws:rds:us-west-2:123456789012:og:myoptiongroup"
    }
}
```
The arn is required e.g. for specific terraform deployments, and was [reported as an issue in LocalStack](https://github.com/localstack/localstack/issues/7721).