### PR TITLE
fix(acm): Include more info to the list_certificates

### DIFF
--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -3,7 +3,7 @@ import base64
 
 from moto.core.responses import BaseResponse
 from typing import Dict, List, Tuple, Union
-from .models import acm_backends, AWSCertificateManagerBackend, datetime_to_epoch
+from .models import acm_backends, AWSCertificateManagerBackend
 from .exceptions import AWSValidationException
 
 
@@ -130,26 +130,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         certs = []
         statuses = self._get_param("CertificateStatuses")
         for cert_bundle in self.acm_backend.get_certificates_list(statuses):
-            cert = {
-                "CertificateArn": cert_bundle.arn,
-                "DomainName": cert_bundle.common_name,
-                "Status": cert_bundle.status,
-                "Type": cert_bundle.type,
-                "NotBefore": datetime_to_epoch(cert_bundle._cert.not_valid_before),
-                "NotAfter": datetime_to_epoch(cert_bundle._cert.not_valid_after),
-                "CreatedAt": datetime_to_epoch(cert_bundle.created_at),
-                "KeyAlgorithm": cert_bundle.describe()["Certificate"]["KeyAlgorithm"],
-                "RenewalEligibility": cert_bundle.describe()["Certificate"][
-                    "RenewalEligibility"
-                ],
-            }
-
-            if cert_bundle.type == "IMPORTED":
-                cert["ImportedAt"] = datetime_to_epoch(cert_bundle.created_at)
-            elif cert_bundle.type == "AMAZON_ISSUED":
-                cert["IssuedAt"] = datetime_to_epoch(cert_bundle.created_at)
-
-            certs.append(cert)
+            certs.append(cert_bundle.describe()["Certificate"])
 
         result = {"CertificateSummaryList": certs}
         return json.dumps(result)

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -144,10 +144,10 @@ class AWSCertificateManagerResponse(BaseResponse):
                 ],
             }
 
-            if self.type == "IMPORTED":
-                cert["ImportedAt"] = datetime_to_epoch(cert_bundle._cert.created_at)
-            elif self.type == "AMAZON_ISSUED":
-                cert["IssuedAt"] = datetime_to_epoch(cert_bundle._cert.created_at)
+            if cert_bundle.type == "IMPORTED":
+                cert["ImportedAt"] = datetime_to_epoch(cert_bundle.created_at)
+            elif cert_bundle.type == "AMAZON_ISSUED":
+                cert["IssuedAt"] = datetime_to_epoch(cert_bundle.created_at)
 
             certs.append(cert)
 

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -3,7 +3,7 @@ import base64
 
 from moto.core.responses import BaseResponse
 from typing import Dict, List, Tuple, Union
-from .models import acm_backends, AWSCertificateManagerBackend
+from .models import acm_backends, AWSCertificateManagerBackend, datetime_to_epoch
 from .exceptions import AWSValidationException
 
 
@@ -130,12 +130,26 @@ class AWSCertificateManagerResponse(BaseResponse):
         certs = []
         statuses = self._get_param("CertificateStatuses")
         for cert_bundle in self.acm_backend.get_certificates_list(statuses):
-            certs.append(
-                {
-                    "CertificateArn": cert_bundle.arn,
-                    "DomainName": cert_bundle.common_name,
-                }
-            )
+            cert = {
+                "CertificateArn": cert_bundle.arn,
+                "DomainName": cert_bundle.common_name,
+                "Status": cert_bundle.status,
+                "Type": cert_bundle.type,
+                "NotBefore": datetime_to_epoch(cert_bundle._cert.not_valid_before),
+                "NotAfter": datetime_to_epoch(cert_bundle._cert.not_valid_after),
+                "CreatedAt": datetime_to_epoch(cert_bundle.created_at),
+                "KeyAlgorithm": cert_bundle.describe()["Certificate"]["KeyAlgorithm"],
+                "RenewalEligibility": cert_bundle.describe()["Certificate"][
+                    "RenewalEligibility"
+                ],
+            }
+
+            if self.type == "IMPORTED":
+                cert["ImportedAt"] = datetime_to_epoch(cert_bundle._cert.created_at)
+            elif self.type == "AMAZON_ISSUED":
+                cert["IssuedAt"] = datetime_to_epoch(cert_bundle._cert.created_at)
+
+            certs.append(cert)
 
         result = {"CertificateSummaryList": certs}
         return json.dumps(result)

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -13,7 +13,7 @@ from freezegun import freeze_time
 from moto import mock_acm, mock_elb, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from unittest import SkipTest, mock
-
+from datetime import datetime, timedelta
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")
 
@@ -89,13 +89,37 @@ def test_import_bad_certificate():
 
 
 @mock_acm
+@freeze_time(datetime.utcnow())
 def test_list_certificates():
     client = boto3.client("acm", region_name="eu-central-1")
     issued_arn = _import_cert(client)
     pending_arn = client.request_certificate(DomainName="google.com")["CertificateArn"]
 
-    moto_arn = {"CertificateArn": issued_arn, "DomainName": SERVER_COMMON_NAME}
-    google_arn = {"CertificateArn": pending_arn, "DomainName": "google.com"}
+    moto_arn = {
+        "CertificateArn": issued_arn,
+        "DomainName": SERVER_COMMON_NAME,
+        "Status": "ISSUED",
+        "Type": "IMPORTED",
+        "NotBefore": datetime(2019, 10, 21, 13, 27, 31),
+        "NotAfter": datetime(2049, 12, 31, 13, 27, 34),
+        "CreatedAt": datetime.utcnow(),
+        "KeyAlgorithm": "RSA_2048",
+        "RenewalEligibility": "INELIGIBLE",
+        "ImportedAt": datetime.utcnow(),
+    }
+
+    google_arn = {
+        "CertificateArn": pending_arn,
+        "DomainName": "google.com",
+        "Status": "ISSUED",
+        "Type": "IMPORTED",
+        "NotBefore": datetime.utcnow(),
+        "NotAfter": datetime.utcnow() + timedelta(days=365),
+        "CreatedAt": datetime.utcnow(),
+        "KeyAlgorithm": "RSA_2048",
+        "RenewalEligibility": "INELIGIBLE",
+        "ImportedAt": datetime.utcnow(),
+    }
 
     certs = client.list_certificates()["CertificateSummaryList"]
     certs.should.contain(moto_arn)


### PR DESCRIPTION
### Context

The purpose of this PR is to approach the behaviour of the ACM `list_certificates` API call including new fields. I don't know if this is a new feature of the ACM API but it would be helpful. 

Also, there are more fields present in the `list_certificates` call that are not covered by moto.

Rationale: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/acm.html#ACM.Client.list_certificates

### Changes

Include the following fields in the `list_certificates` call:
- Status
- Type
- NotBefore
- NotAfter
- CreatedAt
- KeyAlgorithm
- RenewalEligibility
- ImportedAt
- IssuedAt

I don't know if in this case this is the best approach. I didn't make test for that reason, if so I'll do it.
