### PR TITLE
Support CloudFormation and ECS ResourceTypeFilters in ResourceGroupsTaggingAPI get_resources()

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -186,8 +186,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     if not tag_filter(tags):
                         continue
                     yield {"ResourceARN": f"{stack.stack_id}", "Tags": tags}
+
             except Exception:
-                yield {}
+                pass
 
         # ECS
         if not resource_type_filters or "ecs:service" in resource_type_filters:


### PR DESCRIPTION
Add support for cloudformation:stack, ecs:service, ecs:cluster, and ecs:task ResourceTypeFilters for ResourceGroupsTaggingAPI get_resources. 