### PR TITLE
Admin: Use different GH action to create PRs

### DIFF
--- a/.github/workflows/data-update_ec2-instance-offerings.yml
+++ b/.github/workflows/data-update_ec2-instance-offerings.yml
@@ -38,13 +38,12 @@ jobs:
         role-to-assume: arn:aws:iam::486285699788:role/GithubActionsRole
 
     - name: Pull EC2 instance types from AWS
-      uses: technote-space/create-pr-action@v2
+      run: |
+        pip install boto3
+        scripts/ec2_get_instance_type_offerings.py
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v4
       with:
-        EXECUTE_COMMANDS: |
-          pip install boto3
-          scripts/ec2_get_instance_type_offerings.py
-        COMMIT_MESSAGE: 'chore: update EC2 Instance Offerings'
-        COMMIT_NAME: 'Moto Admin'
-        COMMIT_EMAIL: 'admin@getmoto.org'
-        PR_BRANCH_NAME: 'chore-update-ec2-offerings-${{ github.run_number }}'
-        PR_TITLE: 'chore: update EC2 Instance Offerings'
+        branch: 'chore-update-ec2-offerings-${{ github.run_number }}'
+        title: 'chore: update EC2 Instance Offerings'
+        commit-message: 'chore: update EC2 Instance Offerings'

--- a/.github/workflows/data-update_ec2-instance-types.yml
+++ b/.github/workflows/data-update_ec2-instance-types.yml
@@ -37,13 +37,12 @@ jobs:
         role-to-assume: arn:aws:iam::486285699788:role/GithubActionsRole
 
     - name: Pull EC2 instance types from AWS
-      uses: technote-space/create-pr-action@v2
+      run: |
+        pip install boto3
+        scripts/get_instance_info.py
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v4
       with:
-        EXECUTE_COMMANDS: |
-          pip install boto3
-          scripts/get_instance_info.py
-        COMMIT_MESSAGE: 'chore: update EC2 Instance Types'
-        COMMIT_NAME: 'Moto Admin'
-        COMMIT_EMAIL: 'admin@getmoto.org'
-        PR_BRANCH_NAME: 'chore-update-ec2-types-${{ github.run_number }}'
-        PR_TITLE: 'chore: update EC2 Instance Types'
+        branch: 'chore-update-ec2-types-${{ github.run_number }}'
+        title: 'chore: update EC2 Instance Types'
+        commit-message: 'chore: update EC2 Instance Types'

--- a/.github/workflows/data-update_ssm-default-amis.yml
+++ b/.github/workflows/data-update_ssm-default-amis.yml
@@ -37,14 +37,13 @@ jobs:
         role-to-assume: arn:aws:iam::486285699788:role/GithubActionsRole
 
     - name: Pull SSM default AMIs from AWS
-      uses: technote-space/create-pr-action@v2
+      run: |
+        pip install boto3
+        pip install moto[all]
+        python scripts/ssm_get_default_amis.py
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v4
       with:
-        EXECUTE_COMMANDS: |
-          pip install boto3
-          pip install moto[all]
-          python scripts/ssm_get_default_amis.py
-        COMMIT_MESSAGE: "chore: update SSM default AMI's"
-        COMMIT_NAME: 'Moto Admin'
-        COMMIT_EMAIL: 'admin@getmoto.org'
-        PR_BRANCH_NAME: 'chore-update-ssm-amis-${{ github.run_number }}'
-        PR_TITLE: "chore: update SSM Instance AMI's"
+        branch: 'chore-update-ssm-amis-${{ github.run_number }}'
+        title: "chore: update SSM Instance AMI's"
+        commit-message: "chore: update SSM default AMI's"

--- a/.github/workflows/data-update_ssm-default-parameters.yml
+++ b/.github/workflows/data-update_ssm-default-parameters.yml
@@ -38,14 +38,13 @@ jobs:
         role-to-assume: arn:aws:iam::486285699788:role/GithubActionsRole
 
     - name: Pull SSM default Parameters from AWS
-      uses: technote-space/create-pr-action@v2
+      run: |
+        pip install boto3
+        pip install moto[all]
+        python scripts/ssm_get_default_params.py
+    - name: Create PR
+      uses: peter-evans/create-pull-request@v4
       with:
-        EXECUTE_COMMANDS: |
-          pip install boto3
-          pip install moto[all]
-          python scripts/ssm_get_default_params.py
-        COMMIT_MESSAGE: "chore: update SSM default parameters"
-        COMMIT_NAME: 'Moto Admin'
-        COMMIT_EMAIL: 'admin@getmoto.org'
-        PR_BRANCH_NAME: 'chore-update-ssm-params-${{ github.run_number }}'
-        PR_TITLE: "chore: update SSM Instance parameters"
+        branch: 'chore-update-ssm-params-${{ github.run_number }}'
+        title: "chore: update SSM Instance parameters"
+        commit-message: "chore: update SSM default parameters"


### PR DESCRIPTION
Closes #6014 
Closes #6015 
Closes #6016 

The old GH action would, somehow, push commits to it's own branch, but also onto other branches created 2 hours earlier.  (Best shown in #6014, where every GH execution pushed a commit to)