### PR TITLE
Events: Separate Rules by EventBus they're assigned to

### DIFF
--- a/moto/events/notifications.py
+++ b/moto/events/notifications.py
@@ -43,13 +43,14 @@ def _send_safe_notification(
     for account_id, account in events_backends.items():
         for backend in account.values():
             applicable_targets = []
-            for rule in backend.rules.values():
-                if rule.state != "ENABLED":
-                    continue
-                pattern = rule.event_pattern.get_pattern()
-                if source in pattern.get("source", []):
-                    if event_name in pattern.get("detail", {}).get("eventName", []):
-                        applicable_targets.extend(rule.targets)
+            for event_bus in backend.event_buses.values():
+                for rule in event_bus.rules.values():
+                    if rule.state != "ENABLED":
+                        continue
+                    pattern = rule.event_pattern.get_pattern()
+                    if source in pattern.get("source", []):
+                        if event_name in pattern.get("detail", {}).get("eventName", []):
+                            applicable_targets.extend(rule.targets)
 
             for target in applicable_targets:
                 if target.get("Arn", "").startswith("arn:aws:lambda"):

--- a/tests/terraformtests/terraform-tests.success.txt
+++ b/tests/terraformtests/terraform-tests.success.txt
@@ -265,6 +265,18 @@ events:
   - TestAccEventsConnection
   - TestAccEventsConnectionDataSource
   - TestAccEventsPermission
+  - TestAccEventsRule
+  - TestAccEventsTarget_basic
+  - TestAccEventsTarget_batch
+  - TestAccEventsTarget_disappears
+  - TestAccEventsTarget_eventBusName
+  - TestAccEventsTarget_ecs
+  - TestAccEventsTarget_eventBusARN
+  - TestAccEventsTarget_full
+  - TestAccEventsTarget_generatedTargetID
+  - TestAccEventsTarget_inputTransformer
+  - TestAccEventsTarget_kinesis
+  - TestAccEventsTarget_ssmDocument
 firehose:
   - TestAccFirehoseDeliveryStreamDataSource_basic
   - TestAccFirehoseDeliveryStream_basic


### PR DESCRIPTION
Rules used to be stored in one huge bucket at top-level, but it makes more sense to keep them at the event-bus level

Fixes #6027 

The following Events-methods now support the EventBusName-parameter:
delete_rule(), describe_rule(), disable_rule(), enable_rule(), list_rule_names_by_target(), list_rules(), list_targets_by_rule()