### PR TITLE
EC2: create_route() should allow overlapping CIDR's

### DIFF
--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -514,7 +514,7 @@ class RouteBackend:
         for route in route_table.routes.values():
             if not route.destination_cidr_block:
                 continue
-            if not route.local and ip_v4_network.overlaps(
-                ipaddress.IPv4Network(str(route.destination_cidr_block))
+            if not route.local and ip_v4_network == ipaddress.IPv4Network(
+                str(route.destination_cidr_block)
             ):
                 raise RouteAlreadyExistsError(destination_cidr_block)

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -664,16 +664,18 @@ def test_routes_already_exist():
     ex.value.response["ResponseMetadata"].should.have.key("RequestId")
     ex.value.response["Error"]["Code"].should.equal("RouteAlreadyExists")
 
-    with pytest.raises(ClientError) as ex:
-        client.create_route(
-            RouteTableId=main_route_table.id,
-            DestinationCidrBlock=ROUTE_SUB_CIDR,
-            GatewayId=igw.id,
-        )
-
-    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
-    ex.value.response["ResponseMetadata"].should.have.key("RequestId")
-    ex.value.response["Error"]["Code"].should.equal("RouteAlreadyExists")
+    # We can create a sub cidr
+    client.create_route(
+        RouteTableId=main_route_table.id,
+        DestinationCidrBlock=ROUTE_SUB_CIDR,
+        GatewayId=igw.id,
+    )
+    # Or even a catch-all
+    client.create_route(
+        RouteTableId=main_route_table.id,
+        DestinationCidrBlock="0.0.0.0/0",
+        GatewayId=igw.id,
+    )
 
 
 @mock_ec2


### PR DESCRIPTION
Fixes #6096 

Partially reverts #5233 

@mmerrill3 Do you remember the details about the linked PR that you raised? From my testing, overlapping CIDR's are allowed - as long as it's not a direct match.
The docs even mention this scenario, and explain what happens when overlapping routes exist: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/create_route.html

Just wanted to know whether there was a specific reason that you added this check, maybe I missed some important details in my testing.