### PR TITLE
S3: head_bucket() now returns the region-header

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1615,7 +1615,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         except KeyError:
             raise MissingBucket(bucket=bucket_name)
 
-    def head_bucket(self, bucket_name):
+    def head_bucket(self, bucket_name: str) -> FakeBucket:
         return self.get_bucket(bucket_name)
 
     def delete_bucket(self, bucket_name):

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -338,14 +338,14 @@ class S3Response(BaseResponse):
         self._authenticate_and_authorize_s3_action()
 
         try:
-            self.backend.head_bucket(bucket_name)
+            bucket = self.backend.head_bucket(bucket_name)
         except MissingBucket:
             # Unless we do this, boto3 does not raise ClientError on
             # HEAD (which the real API responds with), and instead
             # raises NoSuchBucket, leading to inconsistency in
             # error response between real and mocked responses.
             return 404, {}, ""
-        return 200, {}, ""
+        return 200, {"x-amz-bucket-region": bucket.region_name}, ""
 
     def _set_cors_headers(self, headers, bucket):
         """

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -66,6 +66,10 @@ def test_s3_server_bucket_create(key_name):
     content.should.be.a(dict)
     content["Key"].should.equal(key_name)
 
+    res = test_client.head("http://foobaz.localhost:5000")
+    assert res.status_code == 200
+    assert res.headers.get("x-amz-bucket-region") == "us-east-1"
+
     res = test_client.get(f"/{key_name}", "http://foobaz.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(b"test value")


### PR DESCRIPTION
Fixes #6042 