### PR TITLE
Techdebt: Fix Docker SHA on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Push to DockerHub and GHCR
+      id: build_and_push
       uses: docker/build-push-action@v4
       with:
         platforms: linux/amd64,linux/arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Moto Changelog
 
 4.1.5
 -----
-Docker Digest for 4.1.5: __
+Docker Digest for 4.1.5: _sha256:0e43c36e1b1390106ec43b2e383486c45fef27646838acaa8073cbd2b4a97a31_
 
     General: 
         * Our Docker-images are now also hosted in GHCR:

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -52,7 +52,7 @@ from moto.s3.exceptions import (
 )
 from .cloud_formation import cfn_to_api_encryption, is_replacement_update
 from . import notifications
-from .select_object_content import parse_query, csv_to_json
+from .select_object_content import parse_query
 from .utils import clean_key_name, _VersionedKeyStore, undo_clean_key_name
 from .utils import ARCHIVE_STORAGE_CLASSES, STORAGE_CLASS
 from ..events.notifications import send_notification as events_send_notification
@@ -2331,6 +2331,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         query_input = key.value.decode("utf-8")
         if "CSV" in input_details:
             # input is in CSV - we need to convert it to JSON before parsing
+            from py_partiql_parser._internal.csv_converter import (  # noqa # pylint: disable=unused-import
+                csv_to_json,
+            )
+
             use_headers = input_details["CSV"].get("FileHeaderInfo", "") == "USE"
             query_input = csv_to_json(query_input, use_headers)
         return [

--- a/moto/s3/select_object_content.py
+++ b/moto/s3/select_object_content.py
@@ -1,13 +1,11 @@
 import binascii
 import struct
 from typing import List
-from py_partiql_parser import Parser
-from py_partiql_parser._internal.csv_converter import (  # noqa # pylint: disable=unused-import
-    csv_to_json,
-)
 
 
 def parse_query(text_input, query):
+    from py_partiql_parser import Parser
+
     return Parser(source_data={"s3object": text_input}).parse(query)
 
 


### PR DESCRIPTION
Also moves the S3 Select imports down, to ensure we only need the `py_partiql_parser`-dependency when the user actually makes a request to `select_object_content`