### PR TITLE
EC2: Fix DescribeInstances error due to a deleted subnet

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -1,3 +1,4 @@
+import contextlib
 import copy
 import warnings
 from collections import OrderedDict
@@ -28,6 +29,7 @@ from ..exceptions import (
     InvalidParameterValueErrorUnknownAttribute,
     InvalidSecurityGroupNotFoundError,
     OperationNotPermitted4,
+    InvalidSubnetIdError,
 )
 from ..utils import (
     convert_tag_spec,
@@ -185,8 +187,9 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     @property
     def vpc_id(self) -> Optional[str]:
         if self.subnet_id:
-            subnet: Subnet = self.ec2_backend.get_subnet(self.subnet_id)
-            return subnet.vpc_id
+            with contextlib.suppress(InvalidSubnetIdError):
+                subnet: Subnet = self.ec2_backend.get_subnet(self.subnet_id)
+                return subnet.vpc_id
         if self.nics and 0 in self.nics:
             return self.nics[0].subnet.vpc_id
         return None


### PR DESCRIPTION
Fixes an edge case with `EC2:DescribeInstances` where a deleted subnet associated with a terminated instance caused it to fail.

This was happening because the property `vpc_id` for the `Instance` object is lazily retrieved from its associated subnet. If the subnet has been deleted, the VPC retrieval would fail.

```
awslocal ec2 create-vpc --cidr-block 10.1.0.0/16 --query Vpc.VpcId

awslocal ec2 create-subnet --cidr-block 10.1.1.0/27 --query Subnet.SubnetId --vpc-id vpc-8a985464

awslocal ec2 run-instances --image-id ami-0f09ed56128e994fe --instance-type t2.micro \
  --query Instances[0].InstanceId --subnet-id subnet-fab93c8a 

awslocal ec2 terminate-instances --instance-ids i-ea14e3bd17bd0b6dd

awslocal ec2 delete-subnet --subnet-id subnet-fab93c8a

awslocal ec2 describe-instances  ### error InvalidSubnetID.NotFound
```

Closes https://github.com/localstack/localstack/issues/6076