### PR TITLE
Support Retain DeletionPolicy in stacks

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -834,7 +834,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
             raise last_exception
 
     def delete(self) -> None:
-        # Only try to delete resources with a Retain DeletionPolicy
+        # Only try to delete resources without a Retain DeletionPolicy
         remaining_resources = set(key for key, value in self._resource_json_map.items() if not value.get("DeletionPolicy") == "Retain")
         tries = 1
         while remaining_resources and tries < 5:

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -835,7 +835,11 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
 
     def delete(self) -> None:
         # Only try to delete resources without a Retain DeletionPolicy
-        remaining_resources = set(key for key, value in self._resource_json_map.items() if not value.get("DeletionPolicy") == "Retain")
+        remaining_resources = set(
+            key
+            for key, value in self._resource_json_map.items()
+            if not value.get("DeletionPolicy") == "Retain"
+        )
         tries = 1
         while remaining_resources and tries < 5:
             for resource in remaining_resources.copy():

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -834,7 +834,8 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
             raise last_exception
 
     def delete(self) -> None:
-        remaining_resources = set(self.resources)
+        # Only try to delete resources with a Retain DeletionPolicy
+        remaining_resources = set(key for key, value in self._resource_json_map.items() if not value.get("DeletionPolicy") == "Retain")
         tries = 1
         while remaining_resources and tries < 5:
             for resource in remaining_resources.copy():


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html

I've written this to narrowly support the use case I need: retaining resources when deleting a CloudFormation Stack.

I haven't done anything to implement other DeletionPolicies (Snapshot). Nor have I done anything to change how this interacts with all the various CloudFormation abstractions (StackSets, StackInstances, ChangeSets, etc.)