### PR TITLE
S3: get_object() now returns the AcceptRanges header

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1364,6 +1364,7 @@ class S3Response(BaseResponse):
 
         response_headers.update(key.metadata)
         response_headers.update(key.response_dict)
+        response_headers.update({"AcceptRanges": "bytes"})
         return 200, response_headers, key.value
 
     def _key_response_put(self, request, body, bucket_name, query, key_name):

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -73,6 +73,7 @@ def test_s3_server_bucket_create(key_name):
     res = test_client.get(f"/{key_name}", "http://foobaz.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(b"test value")
+    assert res.headers.get("AcceptRanges") == "bytes"
 
 
 def test_s3_server_ignore_subdomain_for_bucketnames():


### PR DESCRIPTION
Fixes #6116 