### PR TITLE
CloudFormation, Logs: Resolve LogGroup physical id and attributes

### DIFF
--- a/CLOUDFORMATION_COVERAGE.md
+++ b/CLOUDFORMATION_COVERAGE.md
@@ -272,8 +272,7 @@
    - [x] create implemented
    - [ ] update implemented
    - [ ] delete implemented
-   - [ ] Fn::GetAtt implemented
-      - [ ] Arn
+   - [x] Fn::GetAtt implemented
 - AWS::RDS::DBParameterGroup:
    - [x] create implemented
    - [ ] update implemented

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -306,6 +306,10 @@ class LogGroup(CloudFormationModel):
             resource_name, tags, **properties
         )
 
+    @property
+    def physical_resource_id(self) -> str:
+        return self.name
+
     def create_log_stream(self, log_stream_name: str) -> None:
         if log_stream_name in self.streams:
             raise ResourceAlreadyExistsException()

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -307,12 +307,12 @@ class LogGroup(CloudFormationModel):
         )
 
     @classmethod
-    def has_cfn_attr(cls, attr):
+    def has_cfn_attr(cls, attr: str) -> bool:
         return attr in [
             "Arn",
         ]
 
-    def get_cfn_attribute(self, attribute_name):
+    def get_cfn_attribute(self, attribute_name: str):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 
         if attribute_name == "Arn":

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -306,6 +306,19 @@ class LogGroup(CloudFormationModel):
             resource_name, tags, **properties
         )
 
+    @classmethod
+    def has_cfn_attr(cls, attr):
+        return attr in [
+            "Arn",
+        ]
+
+    def get_cfn_attribute(self, attribute_name):
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+
+        if attribute_name == "Arn":
+            return self.arn
+        raise UnformattedGetAttTemplateException()
+
     @property
     def physical_resource_id(self) -> str:
         return self.name

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -312,7 +312,7 @@ class LogGroup(CloudFormationModel):
             "Arn",
         ]
 
-    def get_cfn_attribute(self, attribute_name: str):
+    def get_cfn_attribute(self, attribute_name: str) -> str:
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 
         if attribute_name == "Arn":


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html#aws-resource-logs-loggroup-return-values

This brings CloudFormation's Ref behavior more in line with actual AWS behavior. Previously, it returned an instance of a LogGroup model.

I didn't add a test case for this but I'm happy to do so if requested.