### PR TITLE
feat: dynamodb AttributeUpdate ADD/PUT/DELETE for NS

### DIFF
--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -341,6 +341,8 @@ class Item(BaseModel):
                 # TODO deal with other types
                 if set(update_action["Value"].keys()) == set(["SS"]):
                     self.attrs[attribute_name] = DynamoType({"SS": new_value})
+                elif set(update_action["Value"].keys()) == set(["NS"]):
+                    self.attrs[attribute_name] = DynamoType({"NS": new_value})
                 elif isinstance(new_value, list):
                     self.attrs[attribute_name] = DynamoType({"L": new_value})
                 elif isinstance(new_value, dict):
@@ -367,6 +369,10 @@ class Item(BaseModel):
                     existing = self.attrs.get(attribute_name, DynamoType({"SS": {}}))
                     new_set = set(existing.value).union(set(new_value))
                     self.attrs[attribute_name] = DynamoType({"SS": list(new_set)})
+                elif set(update_action["Value"].keys()) == set(["NS"]):
+                    existing = self.attrs.get(attribute_name, DynamoType({"NS": {}}))
+                    new_set = set(existing.value).union(set(new_value))
+                    self.attrs[attribute_name] = DynamoType({"NS": list(new_set)})
                 elif set(update_action["Value"].keys()) == {"L"}:
                     existing = self.attrs.get(attribute_name, DynamoType({"L": []}))
                     new_list = existing.value + new_value

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -388,6 +388,10 @@ class Item(BaseModel):
                     existing = self.attrs.get(attribute_name, DynamoType({"SS": {}}))
                     new_set = set(existing.value).difference(set(new_value))
                     self.attrs[attribute_name] = DynamoType({"SS": list(new_set)})
+                elif set(update_action["Value"].keys()) == set(["NS"]):
+                    existing = self.attrs.get(attribute_name, DynamoType({"NS": {}}))
+                    new_set = set(existing.value).difference(set(new_value))
+                    self.attrs[attribute_name] = DynamoType({"NS": list(new_set)})
                 else:
                     raise NotImplementedError(
                         "ADD not supported for %s"

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -4915,6 +4915,15 @@ def test_update_item_add_to_num_set_using_legacy_attribute_updates():
     resp = table.get_item(Key={"id": "set_add"})
     resp["Item"]["attr"].should.equal({1, 2, 3, 4, 5})
 
+    table.update_item(
+        TableName="TestTable",
+        Key={"id": "set_add"},
+        AttributeUpdates={"attr": {"Action": "DELETE", "Value": {2, 3}}},
+    )
+
+    resp = table.get_item(Key={"id": "set_add"})
+    resp["Item"]["attr"].should.equal({1, 4, 5})
+
 
 @mock_dynamodb
 def test_get_item_for_non_existent_table_raises_error():


### PR DESCRIPTION
This should handle `ADD`, `PUT` and `DELETE` to set for number sets (NS) in dynamodb `update_item`
- Added test coverage
- tested with AWS backend  
