### PR TITLE
EC2: Support assigning specified private IP addrs

### DIFF
--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -382,16 +382,16 @@ class NetworkInterfaceBackend:
         secondary_ips_count: Optional[int] = None,
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
+        eni_assigned_ips = [
+            item.get("PrivateIpAddress") for item in eni.private_ip_addresses
+        ]
         if private_ip_addresses:
             eni.private_ip_addresses.extend(
                 {"Primary": False, "PrivateIpAddress": ip}
                 for ip in private_ip_addresses
+                if ip not in eni_assigned_ips
             )
             return eni
-
-        eni_assigned_ips = [
-            item.get("PrivateIpAddress") for item in eni.private_ip_addresses
-        ]
         while secondary_ips_count:
             ip = random_private_ip(eni.subnet.cidr_block)
             if ip not in eni_assigned_ips:
@@ -409,7 +409,9 @@ class NetworkInterfaceBackend:
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
         if ipv6_addresses:
-            eni.ipv6_addresses.extend(ipv6_addresses)
+            eni.ipv6_addresses.extend(
+                (ip for ip in ipv6_addresses if ip not in eni.ipv6_addresses)
+            )
 
         while ipv6_count:
             association = list(eni.subnet.ipv6_cidr_block_associations.values())[0]

--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -376,9 +376,19 @@ class NetworkInterfaceBackend:
         return eni
 
     def assign_private_ip_addresses(
-        self, eni_id: str, secondary_ips_count: Optional[int] = None
+        self,
+        eni_id: str,
+        private_ip_addresses: Optional[List[str]] = None,
+        secondary_ips_count: Optional[int] = None,
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
+        if private_ip_addresses:
+            eni.private_ip_addresses.extend(
+                {"Primary": False, "PrivateIpAddress": ip}
+                for ip in private_ip_addresses
+            )
+            return eni
+
         eni_assigned_ips = [
             item.get("PrivateIpAddress") for item in eni.private_ip_addresses
         ]

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -125,7 +125,9 @@ class ElasticNetworkInterfaces(EC2BaseResponse):
         eni_id = self._get_param("NetworkInterfaceId")
         secondary_ips_count = self._get_int_param("SecondaryPrivateIpAddressCount", 0)
         private_ip_addresses = self._get_multi_param("PrivateIpAddress")
-        eni = self.ec2_backend.assign_private_ip_addresses(eni_id, private_ip_addresses, secondary_ips_count)
+        eni = self.ec2_backend.assign_private_ip_addresses(
+            eni_id, private_ip_addresses, secondary_ips_count
+        )
         template = self.response_template(ASSIGN_PRIVATE_IP_ADDRESSES)
         return template.render(eni=eni)
 

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -124,7 +124,8 @@ class ElasticNetworkInterfaces(EC2BaseResponse):
     def assign_private_ip_addresses(self) -> str:
         eni_id = self._get_param("NetworkInterfaceId")
         secondary_ips_count = self._get_int_param("SecondaryPrivateIpAddressCount", 0)
-        eni = self.ec2_backend.assign_private_ip_addresses(eni_id, secondary_ips_count)
+        private_ip_addresses = self._get_multi_param("PrivateIpAddress")
+        eni = self.ec2_backend.assign_private_ip_addresses(eni_id, private_ip_addresses, secondary_ips_count)
         template = self.response_template(ASSIGN_PRIVATE_IP_ADDRESSES)
         return template.render(eni=eni)
 


### PR DESCRIPTION
Currently the `EC2.NetworkInterface.assign_private_ip_addresses()` API only supports the use of `SecondaryPrivateIpAddressCount`, ignoring the `PrivateIpAddresses` parameter. This PR adds very basic support for specifying the IP addrs, based on the implementation of `assign_ipv6_addresses()`.

Note limitations:
- Ignores `AllowReassignment` parameter
- Ignores the fact that specifying `PrivateIpAddresses` together with `SecondaryPrivateIpAddressCount` or similar parameters should be an error.

Tested manually in a docker container, connecting over the default docker bridge:
```
appuser@fd068e185858:~$ export AWS_ACCESS_KEY_ID=key
appuser@fd068e185858:~$ export AWS_SECRET_ACCESS_KEY=key
appuser@fd068e185858:~$ python
Python 3.11.2 (main, Mar 17 2023, 02:28:16) [GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
>>> endpoint_url = "http://172.17.0.7"
>>> client = boto3.client("ec2", endpoint_url=endpoint_url, region_name="us-east-1")
>>> resource = boto3.resource("ec2", endpoint_url=endpoint_url, region_name="us-east-1")
>>> ami = client.describe_images(Owners=["amazon"], Filters=[{"Name": "Architecture", "Values": ["x86_64"]}])["Images"][0]
>>> client.run_instances(ImageId=ami["ImageId"], MinCount=1, MaxCount=1)
{'Groups': [{'GroupName': 'default', 'GroupId': 'sg-245f6a01'}], 'Instances': [{'AmiLaunchIndex': 0, 'ImageId': 'ami-03cf127a', 'InstanceId': 'i-90107662bb5f1ec58', 'InstanceType': 'm1.small', 'KernelId': 'None', 'LaunchTime': datetime.datetime(2023, 3, 28, 11, 13, 4, tzinfo=tzlocal()), 'Monitoring': {'State': 'enabled'}, 'Placement': {'AvailabilityZone': 'us-east-1a', 'GroupName': '', 'Tenancy': 'default'}, 'Platform': 'windows', 'PrivateDnsName': 'ip-10-77-251-164.ec2.internal', 'PrivateIpAddress': '10.77.251.164', 'PublicDnsName': 'ec2-54-214-161-87.compute-1.amazonaws.com', 'PublicIpAddress': '54.214.161.87', 'State': {'Code': 0, 'Name': 'pending'}, 'StateTransitionReason': '', 'SubnetId': 'subnet-715af641', 'VpcId': 'vpc-b319f3bc', 'Architecture': 'x86_64', 'ClientToken': '', 'EbsOptimized': False, 'Hypervisor': 'xen', 'NetworkInterfaces': [{'Association': {'IpOwnerId': '123456789012', 'PublicIp': '54.214.161.87'}, 'Attachment': {'AttachTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=tzlocal()), 'AttachmentId': 'eni-attach-aa933841', 'DeleteOnTermination': True, 'DeviceIndex': 0, 'Status': 'attached'}, 'Description': 'Primary network interface', 'Groups': [{'GroupName': 'default', 'GroupId': 'sg-765f48866be99e4ed'}], 'MacAddress': '1b:2b:3c:4d:5e:6f', 'NetworkInterfaceId': 'eni-1b7b0675', 'OwnerId': '123456789012', 'PrivateIpAddress': '10.77.251.164', 'PrivateIpAddresses': [{'Association': {'IpOwnerId': '123456789012', 'PublicIp': '54.214.161.87'}, 'Primary': True, 'PrivateIpAddress': '10.77.251.164'}], 'SourceDestCheck': True, 'Status': 'in-use', 'SubnetId': 'subnet-715af641', 'VpcId': 'vpc-b319f3bc'}], 'SecurityGroups': [], 'SourceDestCheck': True, 'Tags': [], 'VirtualizationType': 'hvm'}], 'OwnerId': '123456789012', 'ReservationId': 'r-5879a094', 'ResponseMetadata': {'RequestId': '59dbff89-35bd-4eac-99ed-be587EXAMPLE', 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'Werkzeug/2.2.3 Python/3.11.2, amazon.com', 'date': 'Tue, 28 Mar 2023 11:13:04 GMT', 'content-type': 'text/html; charset=utf-8', 'content-length': '2502', 'access-control-allow-origin': '*', 'connection': 'close'}, 'RetryAttempts': 0}}
>>> instance_id = client.describe_instances()["Reservations"][0]["Instances"][0]["InstanceId"]
>>> instance = resource.Instance(instance_id)
>>> eni = instance.network_interfaces[0]
>>> eni.assign_private_ip_addresses(PrivateIpAddresses=["172.31.0.1"], AllowReassignment=True)
{'NetworkInterfaceId': 'eni-00cfaf0d', 'AssignedPrivateIpAddresses': [{'PrivateIpAddress': '10.209.243.56'}, {'PrivateIpAddress': '172.31.0.1'}], 'ResponseMetadata': {'RequestId': '3fb591ba-558c-48f8-ae6b-c2f9d6d06425', 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'Werkzeug/2.2.3 Python/3.11.2, amazon.com', 'date': 'Tue, 28 Mar 2023 11:13:47 GMT', 'content-type': 'text/html; charset=utf-8', 'content-length': '437', 'access-control-allow-origin': '*', 'connection': 'close'}, 'RetryAttempts': 0}}
>>> eni.private_ip_addresses
[{'Primary': True, 'PrivateIpAddress': '10.209.243.56'}, {'Primary': False, 'PrivateIpAddress': '172.31.0.1'}]
```