### PR TITLE
S3: head_object() now returns the AcceptRanges header

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1636,6 +1636,7 @@ class S3Response(BaseResponse):
         if key:
             response_headers.update(key.metadata)
             response_headers.update(key.response_dict)
+            response_headers.update({"AcceptRanges": "bytes"})
 
             if if_unmodified_since:
                 if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -56,6 +56,7 @@ def test_s3_server_bucket_create(key_name):
     res.status_code.should.equal(200)
     assert "ETag" in dict(res.headers)
 
+    # ListBuckets
     res = test_client.get(
         "/", "http://foobaz.localhost:5000/", query_string={"prefix": key_name}
     )
@@ -66,10 +67,17 @@ def test_s3_server_bucket_create(key_name):
     content.should.be.a(dict)
     content["Key"].should.equal(key_name)
 
+    # GetBucket
     res = test_client.head("http://foobaz.localhost:5000")
     assert res.status_code == 200
     assert res.headers.get("x-amz-bucket-region") == "us-east-1"
 
+    # HeadObject
+    res = test_client.head(f"/{key_name}", "http://foobaz.localhost:5000/")
+    res.status_code.should.equal(200)
+    assert res.headers.get("AcceptRanges") == "bytes"
+
+    # GetObject
     res = test_client.get(f"/{key_name}", "http://foobaz.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(b"test value")


### PR DESCRIPTION
Fixes #6116 

Follow-up to #6121 