### PR TITLE
Techdebt: TF tests: Use builtin cache-mechanism from GA

### DIFF
--- a/.github/workflows/test_terraform.yml
+++ b/.github/workflows/test_terraform.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 name: TestTerraform
 jobs:
   prepare_list:
@@ -20,12 +20,13 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: ${{ matrix.go-version }}
     - uses: actions/checkout@v3
       with:
         submodules: 'true'
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache-dependency-path: tests/terraformtests/terraform-provider-aws/go.sum
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -36,15 +37,6 @@ jobs:
         python -m build
         docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e MOTO_PORT=4566 -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 4566:4566 -v /var/run/docker.sock:/var/run/docker.sock python:3.7-buster /moto/scripts/ci_moto_server.sh &
         MOTO_PORT=4566 python scripts/ci_wait_for_server.py
-    - name: Download Cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/tests/terraformtests/terraform-provider-aws/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ matrix.go-version }}-
     - name: Get list of tests for  this service
       id: get-list
       run: echo "testlist=$(python tests/terraformtests/get_tf_tests.py '${{ matrix.service }}')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
`actions/setup-go@v4` has a builtin caching mechanism, so we no longer need to explicitly use `actions/cache@v3`.

With this PR we also stop running the tests when pushing to master. These tests are now only executed for pull requests. Every change that comes in goes through a PR anyway, so there's no point in running these tests twice.