### PR TITLE
Update JS dependencies in MotoServer dashboard

### DIFF
--- a/moto/moto_server/templates/dashboard.html
+++ b/moto/moto_server/templates/dashboard.html
@@ -59,9 +59,9 @@
     </div>
 
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.6/handlebars.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.7/handlebars.js"></script>
 
 
     {% raw %}


### PR DESCRIPTION
Fixes #6162 

The `bootstrap`-dependencies could also be upgraded to 5.x, but that breaks all our CSS, so let's stick with the current version for now until it breaks