### PR TITLE
Add missing double quota to Cognito special characters.

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1999,7 +1999,7 @@ class CognitoIdpBackend(BaseBackend):
         # If we require symbols, we assume False - and check a symbol is present
         # If we don't require symbols, we assume True - and we could technically skip the for-loop
         flag_sc = not require_symbols
-        sc = "^ $ * . [ ] { } ( ) ? ! @ # % & / \\ , > < ' : ; | _ ~ ` = + -"
+        sc = "^ $ * . [ ] { } ( ) ? \" ! @ # % & / \\ , > < ' : ; | _ ~ ` = + -"
         for i in password:
             if i in sc:
                 flag_sc = True


### PR DESCRIPTION
Cognito special characters include a double quota mark (`"`), which is missing in the current version: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html