### PR TITLE
Validate password in NEW_PASSWORD_REQUIRED

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1474,6 +1474,9 @@ class CognitoIdpBackend(BaseBackend):
         if challenge_name == "NEW_PASSWORD_REQUIRED":
             username: str = challenge_responses.get("USERNAME")  # type: ignore[assignment]
             new_password = challenge_responses.get("NEW_PASSWORD")
+            if not new_password:
+                raise InvalidPasswordException()
+            self._validate_password(user_pool.id, new_password)
             user = self.admin_get_user(user_pool.id, username)
 
             user.password = new_password

--- a/tests/test_cognitoidp/test_server.py
+++ b/tests/test_cognitoidp/test_server.py
@@ -132,7 +132,7 @@ def test_admin_create_user_without_authentication():
     data = {
         "UserPoolId": user_pool_id,
         "Username": "test@gmail.com",
-        "TemporaryPassword": "A!12345678",
+        "TemporaryPassword": "A!112345678",
     }
     res = test_client.post(
         "/",
@@ -148,7 +148,7 @@ def test_admin_create_user_without_authentication():
     data = {
         "ClientId": client_id,
         "AuthFlow": "USER_PASSWORD_AUTH",
-        "AuthParameters": {"USERNAME": "test@gmail.com", "PASSWORD": "A!12345678"},
+        "AuthParameters": {"USERNAME": "test@gmail.com", "PASSWORD": "A!112345678"},
     }
     res = test_client.post(
         "/",
@@ -163,7 +163,7 @@ def test_admin_create_user_without_authentication():
         "ChallengeName": "NEW_PASSWORD_REQUIRED",
         "ChallengeResponses": {
             "USERNAME": "test@gmail.com",
-            "NEW_PASSWORD": "A!abcdefgh",
+            "NEW_PASSWORD": "A!1abcdefgh",
         },
         "Session": session,
     }

--- a/tests/test_cognitoidp/test_server.py
+++ b/tests/test_cognitoidp/test_server.py
@@ -132,7 +132,7 @@ def test_admin_create_user_without_authentication():
     data = {
         "UserPoolId": user_pool_id,
         "Username": "test@gmail.com",
-        "TemporaryPassword": "12345678",
+        "TemporaryPassword": "A!12345678",
     }
     res = test_client.post(
         "/",
@@ -148,7 +148,7 @@ def test_admin_create_user_without_authentication():
     data = {
         "ClientId": client_id,
         "AuthFlow": "USER_PASSWORD_AUTH",
-        "AuthParameters": {"USERNAME": "test@gmail.com", "PASSWORD": "12345678"},
+        "AuthParameters": {"USERNAME": "test@gmail.com", "PASSWORD": "A!12345678"},
     }
     res = test_client.post(
         "/",
@@ -163,7 +163,7 @@ def test_admin_create_user_without_authentication():
         "ChallengeName": "NEW_PASSWORD_REQUIRED",
         "ChallengeResponses": {
             "USERNAME": "test@gmail.com",
-            "NEW_PASSWORD": "abcdefgh",
+            "NEW_PASSWORD": "A!abcdefgh",
         },
         "Session": session,
     }

--- a/tests/test_cognitoidp/test_server.py
+++ b/tests/test_cognitoidp/test_server.py
@@ -132,7 +132,7 @@ def test_admin_create_user_without_authentication():
     data = {
         "UserPoolId": user_pool_id,
         "Username": "test@gmail.com",
-        "TemporaryPassword": "A!112345678",
+        "TemporaryPassword": "A!1a12345678",
     }
     res = test_client.post(
         "/",
@@ -148,7 +148,7 @@ def test_admin_create_user_without_authentication():
     data = {
         "ClientId": client_id,
         "AuthFlow": "USER_PASSWORD_AUTH",
-        "AuthParameters": {"USERNAME": "test@gmail.com", "PASSWORD": "A!112345678"},
+        "AuthParameters": {"USERNAME": "test@gmail.com", "PASSWORD": "A!1a12345678"},
     }
     res = test_client.post(
         "/",
@@ -163,7 +163,7 @@ def test_admin_create_user_without_authentication():
         "ChallengeName": "NEW_PASSWORD_REQUIRED",
         "ChallengeResponses": {
             "USERNAME": "test@gmail.com",
-            "NEW_PASSWORD": "A!1abcdefgh",
+            "NEW_PASSWORD": "A!1aabcdefgh",
         },
         "Session": session,
     }


### PR DESCRIPTION
Hi, thanks for creating this useful library. Following on from https://github.com/getmoto/moto/issues/5259 I think that AWS Cognito validates the `new_password` in the `NEW_PASSWORD_REQUIRED` challenge. Therefore it might be nice to validate in `CognitoIdpBackend.respond_to_auth_challenge` in moto also. That is provided in this PR.