### PR TITLE
fix: DynamoDB:query() KeyConditionExpression now allows enclosing the sort key condition in brackets

### DIFF
--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -160,8 +160,10 @@ def parse_expression(
         if crnt_char == "(":
             # hashkey = :id and begins_with(      sortkey,     :sk)
             #                              ^ --> ^
+            # (hash_key = :id) and (sortkey = :sk)
+            #                     ^
             if current_stage in [EXPRESSION_STAGES.INITIAL_STAGE]:
-                if current_phrase != "begins_with":
+                if current_phrase not in ["begins_with", ""]:
                     raise MockValidationException(
                         f"Invalid KeyConditionExpression: Invalid function name; function: {current_phrase}"
                     )

--- a/tests/test_dynamodb/models/test_key_condition_expression_parser.py
+++ b/tests/test_dynamodb/models/test_key_condition_expression_parser.py
@@ -179,6 +179,24 @@ class TestHashAndRangeKey:
         )
         desired_hash_key.should.equal("pk")
 
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "(job_id = :id) and start_date = :sk",
+            "job_id = :id and (start_date = :sk)",
+            "(job_id = :id) and (start_date = :sk)",
+        ],
+    )
+    def test_brackets(self, expr):
+        eav = {":id": "pk", ":sk1": "19", ":sk2": "21"}
+        desired_hash_key, comparison, range_values = parse_expression(
+            expression_attribute_values=eav,
+            key_condition_expression=expr,
+            schema=self.schema,
+            expression_attribute_names=dict(),
+        )
+        desired_hash_key.should.equal("pk")
+
 
 class TestNamesAndValues:
     schema = [{"AttributeName": "job_id", "KeyType": "HASH"}]


### PR DESCRIPTION
Fixes #6150 