### PR TITLE
EC2: Fix egress rules used in ingress revoke method

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -733,7 +733,7 @@ class SecurityGroupBackend:
 
         if security_rule_ids:
             group.ingress_rules = [
-                rule for rule in group.egress_rules if rule.id not in security_rule_ids
+                rule for rule in group.ingress_rules if rule.id not in security_rule_ids
             ]
             return
 


### PR DESCRIPTION
This fixes the `revoke_security_group_ingress` effectively removing all ingress rules when attempting to remove one rule while leaving the rest of the rules in the group.