### PR TITLE
S3: Allow Bucket Creation without specifying Content-Length header

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -740,7 +740,7 @@ class S3Response(BaseResponse):
         return parsed_xml
 
     def _bucket_response_put(self, request, region_name, bucket_name, querystring):
-        if not request.headers.get("Content-Length"):
+        if querystring and not request.headers.get("Content-Length"):
             return 411, {}, "Content-Length required"
 
         self._set_action("BUCKET", "PUT", querystring)


### PR DESCRIPTION
A Bucket Creation does not require a Content-Length header.
All other PUT-requests do.

Because all other PUT-requests use the query-string to indicate the action (`?policy` to set a policy, `?tagging` to add tags to a bucket, etc) it should be safe to assume that a BucketCreation-request never includes a query-string.

Fixes #6179 