### PR TITLE
elbv2-FakeLoadBalancer: export attr load_balancing.cross_zone.enabled

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -596,6 +596,7 @@ class FakeLoadBalancer(CloudFormationModel):
             "access_logs.s3.prefix": None,
             "deletion_protection.enabled": "false",
             # "idle_timeout.timeout_seconds": "60",  # commented out for TF compatibility
+            "load_balancing.cross_zone.enabled": "false",
         }
 
     @property


### PR DESCRIPTION
Export `FakeLoadBalancer` attribute `"load_balancing.cross_zone.enabled"` with default value to `false`.

The field is expected by Ansible Module [`elb_network_lb_module`](https://docs.ansible.com/ansible/latest/collections/community/aws/elb_network_lb_module.html) and is crashing when running it when the attr `cross_zone_load_balancing` is set:

```
KeyError: 'load_balancing_cross_zone_enabled'
fatal: [localhost]: FAILED! => {
    "attempts": 3,
    "changed": false,
    "module_stderr": Traceback (most recent call last):
  File "/.ansible/tmp/ansible-tmp-1681102653.2061028-974426-83965977195528/AnsiballZ_elb_network_lb.py", line 107, in <module>
    _ansiballz_main()
  File "/.ansible/tmp/ansible-tmp-1681102653.2061028-974426-83965977195528/AnsiballZ_elb_network_lb.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/.ansible/tmp/ansible-tmp-1681102653.2061028-974426-83965977195528/AnsiballZ_elb_network_lb.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.elb_network_lb', init_globals=dict(_module_fqn='ansible_collections.community.aws.plugins.modules.elb_network_lb', _modlib_path=modlib_path),
  File "/usr/lib64/python3.8/runpy.py", line 207, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.8/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib64/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_community.aws.elb_network_lb_payload_zuyv2j4f/ansible_community.aws.elb_network_lb_payload.zip/ansible_collections/community/aws/plugins/modules/elb_network_lb.py", line 501, in <module>
  File "/tmp/ansible_community.aws.elb_network_lb_payload_zuyv2j4f/ansible_community.aws.elb_network_lb_payload.zip/ansible_collections/community/aws/plugins/modules/elb_network_lb.py", line 495, in main
  File "/tmp/ansible_community.aws.elb_network_lb_payload_zuyv2j4f/ansible_community.aws.elb_network_lb_payload.zip/ansible_collections/community/aws/plugins/modules/elb_network_lb.py", line 369, in create_or_update_elb
  File "/tmp/ansible_community.aws.elb_network_lb_payload_zuyv2j4f/ansible_community.aws.elb_network_lb_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/elbv2.py", line 528, in modify_elb_attributes
KeyError: 'load_balancing_cross_zone_enabled'
,
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1

```