### PR TITLE
Fix autoscaling policy ARN

### DIFF
--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -180,6 +180,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
         if policy_key in self.policies:
             old_policy = self.policies[policy_key]
             policy = FakeApplicationAutoscalingPolicy(
+                account_id=self.account_id,
                 region_name=self.region_name,
                 policy_name=policy_name,
                 service_namespace=service_namespace,
@@ -190,6 +191,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
             )
         else:
             policy = FakeApplicationAutoscalingPolicy(
+                account_id=self.account_id,
                 region_name=self.region_name,
                 policy_name=policy_name,
                 service_namespace=service_namespace,
@@ -435,6 +437,7 @@ class FakeScalableTarget(BaseModel):
 class FakeApplicationAutoscalingPolicy(BaseModel):
     def __init__(
         self,
+        account_id: str,
         region_name: str,
         policy_name: str,
         service_namespace: str,
@@ -464,7 +467,7 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
         self.policy_name = policy_name
         self.policy_type = policy_type
         self._guid = mock_random.uuid4()
-        self.policy_arn = f"arn:aws:autoscaling:{region_name}:scalingPolicy:{self._guid}:resource/{self.service_namespace}/{self.resource_id}:policyName/{self.policy_name}"
+        self.policy_arn = f"arn:aws:autoscaling:{region_name}:{account_id}:scalingPolicy:{self._guid}:resource/{self.service_namespace}/{self.resource_id}:policyName/{self.policy_name}"
         self.creation_time = time.time()
 
     @staticmethod

--- a/tests/test_applicationautoscaling/test_applicationautoscaling.py
+++ b/tests/test_applicationautoscaling/test_applicationautoscaling.py
@@ -379,7 +379,7 @@ def test_put_scaling_policy(policy_type, policy_body_kwargs):
     )
     response["ResponseMetadata"]["HTTPStatusCode"].should.equal(200)
     response["PolicyARN"].should.match(
-        rf"arn:aws:autoscaling:.*1:scalingPolicy:.*:resource/{namespace}/{resource_id}:policyName/{policy_name}"
+        rf"arn:aws:autoscaling:.*1:{ACCOUNT_ID}:scalingPolicy:.*:resource/{namespace}/{resource_id}:policyName/{policy_name}"
     )
 
 
@@ -432,7 +432,7 @@ def test_describe_scaling_policies():
     policy["PolicyType"].should.equal(policy_type)
     policy["TargetTrackingScalingPolicyConfiguration"].should.equal(policy_body)
     policy["PolicyARN"].should.match(
-        rf"arn:aws:autoscaling:.*1:scalingPolicy:.*:resource/{namespace}/{resource_id}:policyName/{policy_name}"
+        rf"arn:aws:autoscaling:.*1:{ACCOUNT_ID}:scalingPolicy:.*:resource/{namespace}/{resource_id}:policyName/{policy_name}"
     )
     policy.should.have.key("CreationTime").which.should.be.a("datetime.datetime")
 


### PR DESCRIPTION
This PR fixes policy ARNs missing account IDs.

Closes https://github.com/localstack/localstack/issues/8132