### PR TITLE
Store temporary access key in the correct account backend

### DIFF
--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -99,7 +99,8 @@ class STSBackend(BaseBackend):
             duration,
             external_id,
         )
-        self.assumed_roles.append(role)
+        account_backend = sts_backends[account_id]["global"]
+        account_backend.assumed_roles.append(role)
         return role
 
     def get_assumed_role_from_access_key(self, access_key_id):

--- a/tests/test_sts/test_sts_integration.py
+++ b/tests/test_sts/test_sts_integration.py
@@ -24,6 +24,17 @@ class TestStsAssumeRole(unittest.TestCase):
         )
 
         # Assume the new role
+        sts_account_b = boto3.client(
+            "sts",
+            aws_access_key_id=response["Credentials"]["AccessKeyId"],
+            aws_secret_access_key=response["Credentials"]["SecretAccessKey"],
+            aws_session_token=response["Credentials"]["SessionToken"],
+            region_name="us-east-1",
+        )
+        assumed_arn = sts_account_b.get_caller_identity()["Arn"]
+        assumed_arn.should.equal(
+            f"arn:aws:sts::{self.account_b}:assumed-role/my-role/test-session-name"
+        )
         iam_account_b = boto3.client(
             "iam",
             aws_access_key_id=response["Credentials"]["AccessKeyId"],


### PR DESCRIPTION
## Motivation

Currently, when performing sts.AssumeRole, we are storing the AccessKey in the account backend of the requesting account.
This, however, leads to the key not being found e.g. for sts.GetCallerIdentity, and also leads to wrong behavior in this method: https://github.com/getmoto/moto/blob/90d67db6eae20ccde57356b694e013fd5864d14a/moto/iam/models.py#L72 which is necessary for account detection.

## Changes
* Store the access key in the store of the account the role belongs to instead of the one assuming the role. There are points to be made for both, depending on who you think the access key belongs to, but otherwise we would need to adapt the surrounding logic, so I just went forward and assumed the access key always belongs to the account of the role.
* Test the behavior by asserting on the output of sts.GetCallerIdentity