### PR TITLE
fix: adjust last modified response dict for s3

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -230,7 +230,7 @@ class FakeKey(BaseModel, ManagedState):
     def response_dict(self):
         res = {
             "ETag": self.etag,
-            "last-modified": self.last_modified_RFC1123,
+            "last-modified": self.last_modified_ISO8601,
             "content-length": str(self.size),
         }
         if self.encryption is not None:

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -226,7 +226,7 @@ def test_last_modified():
     as_header = resp["ResponseMetadata"]["HTTPHeaders"]["last-modified"]
     as_header.should.be.a(str)
     if not settings.TEST_SERVER_MODE:
-        as_header.should.equal("Sun, 01 Jan 2012 12:00:00 GMT")
+        as_header.should.equal("2012-01-01T12:00:00.000Z")
 
 
 @mock_s3


### PR DESCRIPTION
The AWS `parse_timestamp` only accept these formats:
- iso8601
- rfc822
- epuch (value is an integer)

The format that was returned is `rfc1123` that causes the following error:
```
ValueError: Invalid timestamp "Mon, 05 Apr 2023 14:30:00 EDT": Unknown string format: Mon, 05 Apr 2023 14:30:00 EDT
```

For example, when we have try to `head_object` from s3.


The [`parse_timestamp` botocore implementation](https://github.com/boto/botocore/blob/892c5bc73606ec02a6eff2522da1decff88d1c48/botocore/utils.py#L927).