### PR TITLE
fix: Corrects ECRClient.batch_get_image tag handling

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -624,7 +624,7 @@ class ECRBackend(BaseBackend):
                     "imageDigest" in image_id
                     and image.get_image_digest() == image_id["imageDigest"]
                 ) or (
-                    "imageTag" in image_id and image.image_tag == image_id["imageTag"]
+                    "imageTag" in image_id and image_id["imageTag"] in image.image_tags
                 ):
                     found = True
                     response["images"].append(image.response_batch_get_image)


### PR DESCRIPTION
Currently, `ECRClient.batch_get_image` fails to return an image by any tag other than the one most recently PUT. This appears to be contrary to the functionality of `batch_get_image` against the AWS ECR API.

Code change to correct this issue very small but the PR does include a test case.