### PR TITLE
fix: calculating size of record using decoded data and partition key

### DIFF
--- a/tests/test_kinesis/test_kinesis_stream_limits.py
+++ b/tests/test_kinesis/test_kinesis_stream_limits.py
@@ -89,9 +89,23 @@ def test_total_record_data_exceeds_5mb():
 
 
 @mock_kinesis
+def test_total_record_data_exact_5mb():
+    client = boto3.client("kinesis", region_name="us-east-1")
+    client.create_stream(StreamName="my_stream", ShardCount=1)
+    key = "key"
+    key_size = len(key)
+    data_size = ONE_MB - key_size
+    client.put_records(
+        Records=[{"Data": b"a" * (data_size), "PartitionKey": key}] * 5,
+        StreamName="my_stream",
+    )
+
+
+@mock_kinesis
 def test_too_many_records():
     client = boto3.client("kinesis", region_name="us-east-1")
     client.create_stream(StreamName="my_stream", ShardCount=1)
+    
     with pytest.raises(ClientError) as exc:
         client.put_records(
             Records=[{"Data": b"a", "PartitionKey": "key"}] * 501,

--- a/tests/test_kinesis/test_kinesis_stream_limits.py
+++ b/tests/test_kinesis/test_kinesis_stream_limits.py
@@ -105,7 +105,7 @@ def test_total_record_data_exact_5mb():
 def test_too_many_records():
     client = boto3.client("kinesis", region_name="us-east-1")
     client.create_stream(StreamName="my_stream", ShardCount=1)
-    
+
     with pytest.raises(ClientError) as exc:
         client.put_records(
             Records=[{"Data": b"a", "PartitionKey": "key"}] * 501,

--- a/tests/test_kinesis/test_kinesis_stream_limits.py
+++ b/tests/test_kinesis/test_kinesis_stream_limits.py
@@ -6,19 +6,71 @@ from botocore.exceptions import ClientError
 from moto import mock_kinesis
 
 
+ONE_MB = 2**20
+
+
 @mock_kinesis
 def test_record_data_exceeds_1mb():
     client = boto3.client("kinesis", region_name="us-east-1")
     client.create_stream(StreamName="my_stream", ShardCount=1)
     with pytest.raises(ClientError) as exc:
         client.put_records(
-            Records=[{"Data": b"a" * (2**20 + 1), "PartitionKey": "key"}],
+            Records=[{"Data": b"a" * (ONE_MB + 1), "PartitionKey": "key"}],
             StreamName="my_stream",
         )
     err = exc.value.response["Error"]
     err["Code"].should.equal("ValidationException")
     err["Message"].should.equal(
         "1 validation error detected: Value at 'records.1.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576"
+    )
+
+
+@mock_kinesis
+def test_record_data_and_partition_key_exceeds_1mb():
+    client = boto3.client("kinesis", region_name="us-east-1")
+    client.create_stream(StreamName="my_stream", ShardCount=1)
+
+    key = "key"
+    key_size = len(key)
+    data_size = ONE_MB - key_size + 1
+    with pytest.raises(ClientError) as exc:
+        client.put_records(
+            Records=[{"Data": b"a" * data_size, "PartitionKey": key}],
+            StreamName="my_stream",
+        )
+    err = exc.value.response["Error"]
+    err["Code"].should.equal("ValidationException")
+    err["Message"].should.equal(
+        "1 validation error detected: Value at 'records.1.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576"
+    )
+
+
+@mock_kinesis
+def test_record_data_and_partition_key_exactly_1mb():
+    client = boto3.client("kinesis", region_name="us-east-1")
+    client.create_stream(StreamName="my_stream", ShardCount=1)
+
+    key = "key"
+    key_size = len(key)
+    data_size = ONE_MB - key_size
+
+    client.put_records(
+        Records=[{"Data": b"a" * data_size, "PartitionKey": key}],
+        StreamName="my_stream",
+    )
+
+
+@mock_kinesis
+def test_record_data_and_partition_key_smaller_than_1mb():
+    client = boto3.client("kinesis", region_name="us-east-1")
+    client.create_stream(StreamName="my_stream", ShardCount=1)
+
+    key = "key"
+    key_size = len(key)
+    data_size = ONE_MB - key_size - 1
+    client.put_records(
+        Records=[{"Data": b"a" * data_size, "PartitionKey": key}],
+        StreamName="my_stream",
     )
 
 


### PR DESCRIPTION
Currently, the `put_records` limit validations have the following errors:

- The size of the partition key is not included in the calculation
- The data length is calculated using the base64 encoded data, which is approximately 34% larger
- The total records validation is checking for 5000000 bytes instead of 5*(2**20) bytes
- It is not possible to send a record with exactly 1 MiB
- It is not possible to send 5 MiB worth of records.


ref:
https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
 