### PR TITLE
Implement ReplaceRoute to NetworkInterfaceId

### DIFF
--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -441,9 +441,6 @@ class RouteBackend:
         )
         route = route_table.routes[route_id]
 
-        if interface_id:
-            self.raise_not_implemented_error("ReplaceRoute to NetworkInterfaceId")  # type: ignore[attr-defined]
-
         route.gateway = None
         route.nat_gateway = None
         route.egress_only_igw = None
@@ -466,7 +463,7 @@ class RouteBackend:
             )
 
         route.instance = self.get_instance(instance_id) if instance_id else None  # type: ignore[attr-defined]
-        route.interface = None
+        route.interface = self.get_network_interface(interface_id) if interface_id else None  # type: ignore[attr-defined]
         route.vpc_pcx = (
             self.get_vpc_peering_connection(vpc_peering_connection_id)  # type: ignore[attr-defined]
             if vpc_peering_connection_id

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -560,6 +560,7 @@ def test_routes_replace():
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    subnet = ec2.create_subnet(VpcId=vpc.id, CidrBlock="10.0.0.0/24")
 
     main_route_table_id = client.describe_route_tables(
         Filters=[
@@ -574,6 +575,8 @@ def test_routes_replace():
     igw = ec2.create_internet_gateway()
 
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
+
+    eni = ec2.create_network_interface(SubnetId=subnet.id)
 
     # Create initial route
     main_route_table.create_route(DestinationCidrBlock=ROUTE_CIDR, GatewayId=igw.id)
@@ -600,6 +603,7 @@ def test_routes_replace():
     target_route = get_target_route()
     target_route.shouldnt.have.key("GatewayId")
     target_route["InstanceId"].should.equal(instance.id)
+    target_route.shouldnt.have.key("NetworkInterfaceId")
     target_route["State"].should.equal("active")
     target_route["DestinationCidrBlock"].should.equal(ROUTE_CIDR)
 
@@ -612,6 +616,20 @@ def test_routes_replace():
     target_route = get_target_route()
     target_route["GatewayId"].should.equal(igw.id)
     target_route.shouldnt.have.key("InstanceId")
+    target_route.shouldnt.have.key("NetworkInterfaceId")
+    target_route["State"].should.equal("active")
+    target_route["DestinationCidrBlock"].should.equal(ROUTE_CIDR)
+
+    client.replace_route(
+        RouteTableId=main_route_table.id,
+        DestinationCidrBlock=ROUTE_CIDR,
+        NetworkInterfaceId=eni.id,
+    )
+
+    target_route = get_target_route()
+    target_route.shouldnt.have.key("GatewayId")
+    target_route.shouldnt.have.key("InstanceId")
+    target_route["NetworkInterfaceId"].should.equal(eni.id)
     target_route["State"].should.equal("active")
     target_route["DestinationCidrBlock"].should.equal(ROUTE_CIDR)
 

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -720,22 +720,6 @@ def test_routes_not_supported():
         "InvalidNetworkInterfaceID.NotFound"
     )
 
-    igw = ec2.create_internet_gateway()
-    client.create_route(
-        RouteTableId=main_route_table_id,
-        DestinationCidrBlock=ROUTE_CIDR,
-        GatewayId=igw.id,
-    )
-
-    # Replace
-    if not settings.TEST_SERVER_MODE:
-        args = {
-            "RouteTableId": main_route_table.id,
-            "DestinationCidrBlock": ROUTE_CIDR,
-            "NetworkInterfaceId": "eni-1234abcd",
-        }
-        client.replace_route.when.called_with(**args).should.throw(NotImplementedError)
-
 
 @mock_ec2
 def test_routes_vpc_peering_connection():

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -699,11 +699,9 @@ def test_routes_already_exist():
 @mock_ec2
 def test_routes_not_supported():
     client = boto3.client("ec2", region_name="us-east-1")
-    ec2 = boto3.resource("ec2", region_name="us-east-1")
     main_route_table_id = client.describe_route_tables()["RouteTables"][0][
         "RouteTableId"
     ]
-    main_route_table = ec2.RouteTable(main_route_table_id)
 
     ROUTE_CIDR = "10.0.0.4/24"
 


### PR DESCRIPTION
This PR adds support for using a NetworkInterfaceId as the target in ReplaceRoute.

Also updated test case `test_route_tables.py::test_routes_replace`.