### PR TITLE
S3: get_object() should not return VersionId for non-versioned buckets

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -95,7 +95,7 @@ class FakeKey(BaseModel, ManagedState):
         storage: Optional[str] = "STANDARD",
         etag: Optional[str] = None,
         is_versioned: bool = False,
-        version_id: int = 0,
+        version_id: str = "null",
         max_buffer_size: Optional[int] = None,
         multipart: Optional["FakeMultipart"] = None,
         bucket_name: Optional[str] = None,
@@ -156,7 +156,7 @@ class FakeKey(BaseModel, ManagedState):
         return self.name
 
     @property
-    def version_id(self) -> int:
+    def version_id(self) -> str:
         return self._version_id
 
     @property
@@ -1856,6 +1856,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             storage=storage,
             etag=etag,
             is_versioned=bucket.is_versioned,
+            # AWS uses VersionId=null in both requests and responses
             version_id=str(random.uuid4()) if bucket.is_versioned else "null",  # type: ignore
             multipart=multipart,
             encryption=encryption,

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1348,7 +1348,7 @@ class S3Response(BaseResponse):
         elif key is None:
             raise MissingVersion()
 
-        if key.version_id:
+        if key.version_id != "null":
             response_headers["x-amz-version-id"] = key.version_id
 
         if key.storage_class in ARCHIVE_STORAGE_CLASSES:
@@ -1386,8 +1386,6 @@ class S3Response(BaseResponse):
             attributes_to_get = headers.get("x-amz-object-attributes", "").split(",")
             response_keys = self.backend.get_object_attributes(key, attributes_to_get)
 
-            if key.version_id == "null":  # type: ignore
-                response_headers.pop("x-amz-version-id")
             response_headers["Last-Modified"] = key.last_modified_ISO8601
 
             template = self.response_template(S3_OBJECT_ATTRIBUTES_RESPONSE)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -2476,6 +2476,7 @@ def test_list_object_versions_with_versioning_disabled():
 
     # Test latest object version is returned
     response = s3.get_object(Bucket=bucket_name, Key=key)
+    assert "VersionId" not in response["ResponseMetadata"]["HTTPHeaders"]
     response["Body"].read().should.equal(items[-1])
 
 


### PR DESCRIPTION
Fixes #6232 