### PR TITLE
sns: numeric filtering fixups + parameter validation

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -2,7 +2,6 @@ from werkzeug.exceptions import HTTPException
 from jinja2 import DictLoader, Environment
 from typing import Any, List, Tuple, Optional
 import json
-from xml.sax.saxutils import escape as xml_escape
 
 # TODO: add "<Type>Sender</Type>" to error responses below?
 
@@ -10,7 +9,7 @@ from xml.sax.saxutils import escape as xml_escape
 SINGLE_ERROR_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 <Error>
     <Code>{{error_type}}</Code>
-    <Message>{{message}}</Message>
+    <Message><![CDATA[{{message}}]]></Message>
     {% block extra %}{% endblock %}
     <{{request_id_tag}}>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</{{request_id_tag}}>
 </Error>
@@ -20,7 +19,7 @@ WRAPPED_SINGLE_ERROR_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 <ErrorResponse{% if xmlns is defined %} xmlns="{{xmlns}}"{% endif %}>
     <Error>
         <Code>{{error_type}}</Code>
-        <Message>{{message}}</Message>
+        <Message><![CDATA[{{message}}]]></Message>
         {% block extra %}{% endblock %}
         <{{request_id_tag}}>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</{{request_id_tag}}>
     </Error>
@@ -62,7 +61,7 @@ class RESTError(HTTPException):
             env = Environment(loader=DictLoader(self.templates))
             self.description: str = env.get_template(template).render(  # type: ignore
                 error_type=error_type,
-                message=xml_escape(message),
+                message=message,
                 request_id_tag=self.request_id_tag_name,
                 **kwargs,
             )

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -2,6 +2,7 @@ from werkzeug.exceptions import HTTPException
 from jinja2 import DictLoader, Environment
 from typing import Any, List, Tuple, Optional
 import json
+from xml.sax.saxutils import escape as xml_escape
 
 # TODO: add "<Type>Sender</Type>" to error responses below?
 
@@ -55,6 +56,8 @@ class RESTError(HTTPException):
     ):
         super().__init__()
         self.error_type = error_type
+
+        message = xml_escape(message)
         self.message = message
 
         if template in self.templates.keys():

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -56,15 +56,13 @@ class RESTError(HTTPException):
     ):
         super().__init__()
         self.error_type = error_type
-
-        message = xml_escape(message)
         self.message = message
 
         if template in self.templates.keys():
             env = Environment(loader=DictLoader(self.templates))
             self.description: str = env.get_template(template).render(  # type: ignore
                 error_type=error_type,
-                message=message,
+                message=xml_escape(message),
                 request_id_tag=self.request_id_tag_name,
                 **kwargs,
             )

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -836,7 +836,6 @@ class SNSBackend(BaseBackend):
                         # Example: 'Value of < must be numeric\n at [Source: (String)"{"price":[{"numeric":["<","100"]}]}"; line: 1, column: 28]'
                         # While it probably can be implemented, it doesn't feel as important as the general parameter checking
 
-
                         attributes_copy = attributes[:]
                         if not attributes_copy:
                             raise SNSInvalidParameter(

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -302,6 +302,7 @@ class Subscription(BaseModel):
                         return False
 
                     for attribute_values in attribute_values:
+                        attribute_values = float(attribute_values)
                         # Even the official documentation states a 5 digits of accuracy after the decimal point for numerics, in reality it is 6
                         # https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html#subscription-filter-policy-constraints
                         if int(attribute_values * 1000000) == int(rule * 1000000):
@@ -347,7 +348,7 @@ class Subscription(BaseModel):
                                 [value] if isinstance(value, str) else value
                             )
                             if attr["Type"] == "Number":
-                                actual_values = [str(attr["Value"])]
+                                actual_values = [float(attr["Value"])]
                             elif attr["Type"] == "String":
                                 actual_values = [attr["Value"]]
                             else:
@@ -361,7 +362,7 @@ class Subscription(BaseModel):
                             message_attributes.get(field, {}).get("Type", "")
                             == "Number"
                         ):
-                            msg_value = message_attributes[field]["Value"]
+                            msg_value = float(message_attributes[field]["Value"])
                             matches = []
                             for operator, test_value in numeric_ranges:
                                 test_value = int(test_value)

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -836,7 +836,6 @@ class SNSBackend(BaseBackend):
                         # Example: 'Value of < must be numeric\n at [Source: (String)"{"price":[{"numeric":["<","100"]}]}"; line: 1, column: 28]'
                         # While it probably can be implemented, it doesn't feel as important as the general parameter checking
 
-                        from xml.sax.saxutils import escape
 
                         attributes_copy = attributes[:]
                         if not attributes_copy:
@@ -848,12 +847,12 @@ class SNSBackend(BaseBackend):
 
                         if not isinstance(operator, str):
                             raise SNSInvalidParameter(
-                                f"Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: {escape(str(operator))}\n at ..."
+                                f"Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: {(str(operator))}\n at ..."
                             )
 
                         if operator not in ("<", "<=", "=", ">", ">="):
                             raise SNSInvalidParameter(
-                                f"Invalid parameter: Attributes Reason: FilterPolicy: Unrecognized numeric range operator: {escape(str(operator))}\n at ..."
+                                f"Invalid parameter: Attributes Reason: FilterPolicy: Unrecognized numeric range operator: {(str(operator))}\n at ..."
                             )
 
                         try:
@@ -863,7 +862,7 @@ class SNSBackend(BaseBackend):
 
                         if value is None or not isinstance(value, (int, float)):
                             raise SNSInvalidParameter(
-                                f"Invalid parameter: Attributes Reason: FilterPolicy: Value of {escape(str(operator))} must be numeric\n at ..."
+                                f"Invalid parameter: Attributes Reason: FilterPolicy: Value of {(str(operator))} must be numeric\n at ..."
                             )
 
                         if not attributes_copy:
@@ -878,7 +877,7 @@ class SNSBackend(BaseBackend):
 
                         if second_operator not in ("<", "<="):
                             raise SNSInvalidParameter(
-                                f"Invalid parameter: Attributes Reason: FilterPolicy: Bad numeric range operator: {escape(str(second_operator))}\n at ..."
+                                f"Invalid parameter: Attributes Reason: FilterPolicy: Bad numeric range operator: {(str(second_operator))}\n at ..."
                             )
 
                         try:
@@ -890,7 +889,7 @@ class SNSBackend(BaseBackend):
                             second_value, (int, float)
                         ):
                             raise SNSInvalidParameter(
-                                f"Invalid parameter: Attributes Reason: FilterPolicy: Value of {escape(str(second_operator))} must be numeric\n at ..."
+                                f"Invalid parameter: Attributes Reason: FilterPolicy: Value of {(str(second_operator))} must be numeric\n at ..."
                             )
 
                         if second_value <= value:

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -301,11 +301,11 @@ class Subscription(BaseModel):
                     else:
                         return False
 
-                    for attribute_values in attribute_values:
-                        attribute_values = float(attribute_values)
+                    for attribute_value in attribute_values:
+                        attribute_value = float(attribute_value)
                         # Even the official documentation states a 5 digits of accuracy after the decimal point for numerics, in reality it is 6
                         # https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html#subscription-filter-policy-constraints
-                        if int(attribute_values * 1000000) == int(rule * 1000000):
+                        if int(attribute_value * 1000000) == int(rule * 1000000):
                             return True
                 if isinstance(rule, dict):
                     keyword = list(rule.keys())[0]

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -78,6 +78,7 @@ class SNSResponse(BaseResponse):
                                 "when calling the Publish operation: "
                                 f"Could not cast message attribute '{name}' value to number."
                             )
+                    transform_value = str(transform_value)
                 else:
                     transform_value = value["StringValue"]
             elif "BinaryValue" in value:

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -66,21 +66,19 @@ class SNSResponse(BaseResponse):
 
             transform_value = None
             if "StringValue" in value:
+                transform_value = value["StringValue"]
                 if data_type == "Number":
                     try:
-                        transform_value = int(value["StringValue"])
+                        int(transform_value)
                     except ValueError:
                         try:
-                            transform_value = float(value["StringValue"])
+                            float(transform_value)
                         except ValueError:
                             raise InvalidParameterValue(
                                 "An error occurred (ParameterValueInvalid) "
                                 "when calling the Publish operation: "
                                 f"Could not cast message attribute '{name}' value to number."
                             )
-                    transform_value = str(transform_value)
-                else:
-                    transform_value = value["StringValue"]
             elif "BinaryValue" in value:
                 transform_value = value["BinaryValue"]
             if transform_value == "":

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -230,7 +230,7 @@ def test_publish_to_sqs_msg_attr_number_type():
     message = json.loads(queue.receive_messages()[0].body)
     message["Message"].should.equal("test message")
     message["MessageAttributes"].should.equal(
-        {"retries": {"Type": "Number", "Value": 0}}
+        {"retries": {"Type": "Number", "Value": "0"}}
     )
 
     message = queue_raw.receive_messages()[0]
@@ -731,7 +731,7 @@ def test_filtering_exact_number_int():
     message_bodies = [json.loads(m.body)["Message"] for m in messages]
     message_bodies.should.equal(["match"])
     message_attributes = [json.loads(m.body)["MessageAttributes"] for m in messages]
-    message_attributes.should.equal([{"price": {"Type": "Number", "Value": 100}}])
+    message_attributes.should.equal([{"price": {"Type": "Number", "Value": "100"}}])
 
 
 @mock_sqs
@@ -748,7 +748,7 @@ def test_filtering_exact_number_float():
     message_bodies = [json.loads(m.body)["Message"] for m in messages]
     message_bodies.should.equal(["match"])
     message_attributes = [json.loads(m.body)["MessageAttributes"] for m in messages]
-    message_attributes.should.equal([{"price": {"Type": "Number", "Value": 100.1}}])
+    message_attributes.should.equal([{"price": {"Type": "Number", "Value": "100.1"}}])
 
 
 @mock_sqs
@@ -759,7 +759,7 @@ def test_filtering_exact_number_float_accuracy():
     topic.publish(
         Message="match",
         MessageAttributes={
-            "price": {"DataType": "Number", "StringValue": "100.1234561"}
+            "price": {"DataType": "Number", "StringValue": "100.1234567"}
         },
     )
 
@@ -768,7 +768,7 @@ def test_filtering_exact_number_float_accuracy():
     message_bodies.should.equal(["match"])
     message_attributes = [json.loads(m.body)["MessageAttributes"] for m in messages]
     message_attributes.should.equal(
-        [{"price": {"Type": "Number", "Value": 100.1234561}}]
+        [{"price": {"Type": "Number", "Value": "100.1234567"}}]
     )
 
 
@@ -892,7 +892,7 @@ def test_filtering_string_array_with_number_float_accuracy_match():
         MessageAttributes={
             "price": {
                 "DataType": "String.Array",
-                "StringValue": json.dumps([100.1234561, 50]),
+                "StringValue": json.dumps([100.1234567, 50]),
             }
         },
     )
@@ -902,7 +902,7 @@ def test_filtering_string_array_with_number_float_accuracy_match():
     message_bodies.should.equal(["match"])
     message_attributes = [json.loads(m.body)["MessageAttributes"] for m in messages]
     message_attributes.should.equal(
-        [{"price": {"Type": "String.Array", "Value": json.dumps([100.1234561, 50])}}]
+        [{"price": {"Type": "String.Array", "Value": json.dumps([100.1234567, 50])}}]
     )
 
 
@@ -1083,7 +1083,7 @@ def test_filtering_all_AND_matching_match():
                     "Type": "String.Array",
                     "Value": json.dumps(["basketball", "rugby"]),
                 },
-                "price": {"Type": "Number", "Value": 100},
+                "price": {"Type": "Number", "Value": "100"},
             }
         ]
     )
@@ -1228,7 +1228,7 @@ def test_filtering_anything_but_unknown():
 @mock_sns
 def test_filtering_anything_but_numeric():
     topic, queue = _setup_filter_policy_test(
-        {"customer_interests": [{"anything-but": ["100"]}]}
+        {"customer_interests": [{"anything-but": [100]}]}
     )
 
     for nr, idx in [("50", "1"), ("100", "2"), ("150", "3")]:
@@ -1248,7 +1248,7 @@ def test_filtering_anything_but_numeric():
 @mock_sns
 def test_filtering_numeric_match():
     topic, queue = _setup_filter_policy_test(
-        {"customer_interests": [{"numeric": ["=", "100"]}]}
+        {"customer_interests": [{"numeric": ["=", 100]}]}
     )
 
     for nr, idx in [("50", "1"), ("100", "2"), ("150", "3")]:
@@ -1268,7 +1268,7 @@ def test_filtering_numeric_match():
 @mock_sns
 def test_filtering_numeric_range():
     topic, queue = _setup_filter_policy_test(
-        {"customer_interests": [{"numeric": [">", "49", "<=", "100"]}]}
+        {"customer_interests": [{"numeric": [">", 49, "<=", 100]}]}
     )
 
     for nr, idx in [("50", "1"), ("100", "2"), ("150", "3")]:

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -416,7 +416,7 @@ def test_subscribe_invalid_filter_policy():
     response = conn.list_topics()
     topic_arn = response["Topics"][0]["TopicArn"]
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -425,67 +425,62 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"store": [str(i) for i in range(151)]})
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: FilterPolicy: Filter policy is too complex"
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [["example_corp"]]})},
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: FilterPolicy: Match value must be String, number, true, false, or null"
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [{"exists": None}]})},
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: FilterPolicy: exists match pattern must be either true or false."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [{"error": True}]})},
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: FilterPolicy: Unrecognized match type error"
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [1000000001]})},
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InternalFailure")
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -494,14 +489,13 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"price": [{"numeric": ["<", "100"]}]})
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -512,14 +506,13 @@ def test_subscribe_invalid_filter_policy():
                 )
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Value of <= must be numeric\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -528,42 +521,39 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"price": [{"numeric": [50, "<=", "100"]}]})
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: 50\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": ["<"]}]})},
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": ["0"]}]})},
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Unrecognized numeric range operator: 0\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -572,14 +562,13 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"price": [{"numeric": ["<", 20, ">", 1]}]})
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Too many elements in numeric expression\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -588,14 +577,13 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"price": [{"numeric": [">", 20, ">", 1]}]})
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Bad numeric range operator: >\n at ..."
         )
 
-    try:
+    with pytest.raises(ClientError) as err:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -604,8 +592,7 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"price": [{"numeric": [">", 20, "<", 1]}]})
             },
         )
-        assert False
-    except ClientError as err:
+
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
             "Invalid parameter: Attributes Reason: FilterPolicy: Bottom must be less than top\n at ..."

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -425,6 +425,7 @@ def test_subscribe_invalid_filter_policy():
                 "FilterPolicy": json.dumps({"store": [str(i) for i in range(151)]})
             },
         )
+        assert False
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
@@ -438,6 +439,7 @@ def test_subscribe_invalid_filter_policy():
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [["example_corp"]]})},
         )
+        assert False
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
@@ -451,6 +453,7 @@ def test_subscribe_invalid_filter_policy():
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [{"exists": None}]})},
         )
+        assert False
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
@@ -464,6 +467,7 @@ def test_subscribe_invalid_filter_policy():
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [{"error": True}]})},
         )
+        assert False
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InvalidParameter")
         err.response["Error"]["Message"].should.equal(
@@ -477,8 +481,135 @@ def test_subscribe_invalid_filter_policy():
             Endpoint="http://example.com/",
             Attributes={"FilterPolicy": json.dumps({"store": [1000000001]})},
         )
+        assert False
     except ClientError as err:
         err.response["Error"]["Code"].should.equal("InternalFailure")
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps({"price": [{"numeric": ["<", "100"]}]})
+            },
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps(
+                    {"price": [{"numeric": [">", 50, "<=", "100"]}]}
+                )
+            },
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Value of <= must be numeric\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps({"price": [{"numeric": [50, "<=", "100"]}]})
+            },
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: 50\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": ["<"]}]})},
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": ["0"]}]})},
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Unrecognized numeric range operator: 0\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps({"price": [{"numeric": ["<", 20, ">", 1]}]})
+            },
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Too many elements in numeric expression\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps({"price": [{"numeric": [">", 20, ">", 1]}]})
+            },
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Bad numeric range operator: >\n at ..."
+        )
+
+    try:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps({"price": [{"numeric": [">", 20, "<", 1]}]})
+            },
+        )
+        assert False
+    except ClientError as err:
+        err.response["Error"]["Code"].should.equal("InvalidParameter")
+        err.response["Error"]["Message"].should.equal(
+            "Invalid parameter: Attributes Reason: FilterPolicy: Bottom must be less than top\n at ..."
+        )
 
 
 @mock_sns

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -416,7 +416,7 @@ def test_subscribe_invalid_filter_policy():
     response = conn.list_topics()
     topic_arn = response["Topics"][0]["TopicArn"]
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -426,12 +426,13 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: FilterPolicy: Filter policy is too complex"
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: FilterPolicy: Filter policy is too complex"
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -439,12 +440,13 @@ def test_subscribe_invalid_filter_policy():
             Attributes={"FilterPolicy": json.dumps({"store": [["example_corp"]]})},
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: FilterPolicy: Match value must be String, number, true, false, or null"
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: FilterPolicy: Match value must be String, number, true, false, or null"
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -452,12 +454,13 @@ def test_subscribe_invalid_filter_policy():
             Attributes={"FilterPolicy": json.dumps({"store": [{"exists": None}]})},
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: FilterPolicy: exists match pattern must be either true or false."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: FilterPolicy: exists match pattern must be either true or false."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -465,12 +468,13 @@ def test_subscribe_invalid_filter_policy():
             Attributes={"FilterPolicy": json.dumps({"store": [{"error": True}]})},
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: FilterPolicy: Unrecognized match type error"
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: FilterPolicy: Unrecognized match type error"
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -478,9 +482,10 @@ def test_subscribe_invalid_filter_policy():
             Attributes={"FilterPolicy": json.dumps({"store": [1000000001]})},
         )
 
-        err.response["Error"]["Code"].should.equal("InternalFailure")
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InternalFailure")
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -490,12 +495,13 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -507,12 +513,13 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Value of <= must be numeric\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Value of <= must be numeric\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -522,12 +529,13 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: 50\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: 50\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -535,12 +543,13 @@ def test_subscribe_invalid_filter_policy():
             Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": ["<"]}]})},
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -548,12 +557,13 @@ def test_subscribe_invalid_filter_policy():
             Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": ["0"]}]})},
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Unrecognized numeric range operator: 0\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Unrecognized numeric range operator: 0\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -563,12 +573,13 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Too many elements in numeric expression\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Too many elements in numeric expression\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -578,12 +589,13 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Bad numeric range operator: >\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Bad numeric range operator: >\n at ..."
+    )
 
-    with pytest.raises(ClientError) as err:
+    with pytest.raises(ClientError) as err_info:
         conn.subscribe(
             TopicArn=topic_arn,
             Protocol="http",
@@ -593,10 +605,11 @@ def test_subscribe_invalid_filter_policy():
             },
         )
 
-        err.response["Error"]["Code"].should.equal("InvalidParameter")
-        err.response["Error"]["Message"].should.equal(
-            "Invalid parameter: Attributes Reason: FilterPolicy: Bottom must be less than top\n at ..."
-        )
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Bottom must be less than top\n at ..."
+    )
 
 
 @mock_sns

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -524,6 +524,20 @@ def test_subscribe_invalid_filter_policy():
             TopicArn=topic_arn,
             Protocol="http",
             Endpoint="http://example.com/",
+            Attributes={"FilterPolicy": json.dumps({"price": [{"numeric": []}]})},
+        )
+
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Invalid member in numeric match: ]\n at ..."
+    )
+
+    with pytest.raises(ClientError) as err_info:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
             Attributes={
                 "FilterPolicy": json.dumps({"price": [{"numeric": [50, "<=", "100"]}]})
             },
@@ -609,6 +623,22 @@ def test_subscribe_invalid_filter_policy():
     err.response["Error"]["Code"].should.equal("InvalidParameter")
     err.response["Error"]["Message"].should.equal(
         "Invalid parameter: Attributes Reason: FilterPolicy: Bottom must be less than top\n at ..."
+    )
+
+    with pytest.raises(ClientError) as err_info:
+        conn.subscribe(
+            TopicArn=topic_arn,
+            Protocol="http",
+            Endpoint="http://example.com/",
+            Attributes={
+                "FilterPolicy": json.dumps({"price": [{"numeric": [">", 20, "<"]}]})
+            },
+        )
+
+    err = err_info.value
+    err.response["Error"]["Code"].should.equal("InvalidParameter")
+    err.response["Error"]["Message"].should.equal(
+        "Invalid parameter: Attributes Reason: FilterPolicy: Value of < must be numeric\n at ..."
     )
 
 


### PR DESCRIPTION
During work on https://github.com/getmoto/moto/issues/6087 I've run the `tests/test_sns/test_publishing_boto3.py` tests against the "real" AWS (after some modifications) and I've found out that there are issues with numeric filtering.
It's mostly about the types used.

Changes implemented:
1. [SNS filter policy using "numeric" matching](https://docs.aws.amazon.com/sns/latest/dg/numeric-value-matching.html) checks requires numbers (as in int/float) to be provided in the check, not strings
2. Message attributes of type "Number" should be provided (and returned in responses) as strings. They've been ints/floats till now
3. General parameter validation for numeric matching, although limited. The errors from AWS contain the exact location where the parsing error occurs and doingit the same way here, while doable, is too much effort IMHO. If someone wants to improve on this feel free to do so
4. rounding tests rewritten from using `100.1234561` to `100.1234567`. The latter works as expected with AWS.

Both 1 and 2 are "backwards incompatible", but this shouldn't really matter, as that's how it works in the AWS anyway.