### PR TITLE
sns: support FilterPolicyScope attribute, including filtering

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -4,7 +4,7 @@ import requests
 import re
 
 from collections import OrderedDict
-from typing import Any, Dict, List, Iterable, Optional, Tuple, Union, Callable
+from typing import Any, Dict, List, Iterable, Optional, Tuple
 
 from moto.core import BaseBackend, BackendDict, BaseModel, CloudFormationModel
 from moto.core.utils import (
@@ -28,7 +28,12 @@ from .exceptions import (
     TooManyEntriesInBatchRequest,
     BatchEntryIdsNotDistinct,
 )
-from .utils import make_arn_for_topic, make_arn_for_subscription, is_e164
+from .utils import (
+    make_arn_for_topic,
+    make_arn_for_subscription,
+    is_e164,
+    FilterPolicyMatcher,
+)
 
 
 DEFAULT_PAGE_SIZE = 100
@@ -192,6 +197,7 @@ class Subscription(BaseModel):
         self.arn = make_arn_for_subscription(self.topic.arn)
         self.attributes: Dict[str, Any] = {}
         self._filter_policy = None  # filter policy as a dict, not json.
+        self._filter_policy_matcher = None
         self.confirmed = False
 
     def publish(
@@ -203,8 +209,9 @@ class Subscription(BaseModel):
         group_id: Optional[str] = None,
         deduplication_id: Optional[str] = None,
     ) -> None:
-        if not self._matches_filter_policy(message_attributes, message):
-            return
+        if self._filter_policy_matcher is not None:
+            if not self._filter_policy_matcher.matches(message_attributes, message):
+                return
 
         if self.protocol == "sqs":
             queue_name = self.endpoint.split(":")[-1]
@@ -276,363 +283,6 @@ class Subscription(BaseModel):
             lambda_backends[self.account_id][region].send_sns_message(
                 function_name, message, subject=subject, qualifier=qualifier
             )
-
-    def _matches_filter_policy(
-        self, message_attributes: Optional[Dict[str, Any]], message: str
-    ) -> bool:
-        if not self._filter_policy:
-            return True
-
-        if message_attributes is None:
-            message_attributes = {}
-
-        filter_policy_scope = self.attributes.get(
-            "FilterPolicyScope", "MessageAttributes"
-        )
-
-        def _field_match(
-            field: str,
-            rules: List[Any],
-            dict_body: Dict[str, Any],
-            attributes_based_check: bool = True,
-        ) -> bool:
-            # dict_body = MessageAttributes if attributes_based_check is True
-            # otherwise it's the cut-out part of the MessageBody (so only single-level nesting must be supported)
-
-            def _str_exact_match(value: str, rule: Union[str, List[str]]) -> bool:
-                if value == rule:
-                    return True
-
-                if isinstance(value, list):
-                    if rule in value:
-                        return True
-
-                try:
-                    json_data = json.loads(value)
-                    if rule in json_data:
-                        return True
-                except (ValueError, TypeError):
-                    pass
-
-                return False
-
-            def _number_match(values: List[float], rule: float) -> bool:
-                for value in values:
-                    # Even the official documentation states a 5 digits of accuracy after the decimal point for numerics, in reality it is 6
-                    # https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html#subscription-filter-policy-constraints
-                    if int(value * 1000000) == int(rule * 1000000):
-                        return True
-
-                return False
-
-            def _exists_match(
-                should_exist: bool, field: str, dict_body: Dict[str, Any]
-            ) -> bool:
-                if should_exist and field in dict_body:
-                    return True
-                elif not should_exist and field not in dict_body:
-                    return True
-
-                return False
-
-            def _prefix_match(prefix: str, value: str) -> bool:
-                return value.startswith(prefix)
-
-            def _anything_but_match(
-                filter_value: Union[Dict[str, Any], List[str], str],
-                actual_values: List[str],
-            ) -> bool:
-                if isinstance(filter_value, dict):
-                    # We can combine anything-but with the prefix-filter
-                    anything_but_key = list(filter_value.keys())[0]
-                    anything_but_val = list(filter_value.values())[0]
-                    if anything_but_key != "prefix":
-                        return False
-                    if all([not v.startswith(anything_but_val) for v in actual_values]):
-                        return True
-                else:
-                    undesired_values = (
-                        [filter_value]
-                        if isinstance(filter_value, str)
-                        else filter_value
-                    )
-                    if all([v not in undesired_values for v in actual_values]):
-                        return True
-
-                return False
-
-            def _numeric_match(
-                numeric_ranges: Iterable[Tuple[str, float]], numeric_value: float
-            ) -> bool:
-                # numeric_ranges' format:
-                # [(< x), (=, y), (>=, z)]
-                msg_value = numeric_value
-                matches = []
-                for operator, test_value in numeric_ranges:
-                    if operator == ">":
-                        matches.append((msg_value > test_value))
-                    if operator == ">=":
-                        matches.append((msg_value >= test_value))
-                    if operator == "=":
-                        matches.append((msg_value == test_value))
-                    if operator == "<":
-                        matches.append((msg_value < test_value))
-                    if operator == "<=":
-                        matches.append((msg_value <= test_value))
-                return all(matches)
-
-            for rule in rules:
-                #  TODO: boolean value matching is not supported, SNS behavior unknown
-                if isinstance(rule, str):
-                    if attributes_based_check:
-                        if field not in dict_body:
-                            return False
-                        if _str_exact_match(dict_body[field]["Value"], rule):
-                            return True
-                    else:
-                        if field not in dict_body:
-                            return False
-                        if _str_exact_match(dict_body[field], rule):
-                            return True
-
-                if isinstance(rule, (int, float)):
-                    if attributes_based_check:
-                        if field not in dict_body:
-                            return False
-                        if dict_body[field]["Type"] == "Number":
-                            attribute_values = [dict_body[field]["Value"]]
-                        elif dict_body[field]["Type"] == "String.Array":
-                            try:
-                                attribute_values = json.loads(dict_body[field]["Value"])
-                                if not isinstance(attribute_values, list):
-                                    attribute_values = [attribute_values]
-                            except (ValueError, TypeError):
-                                return False
-                        else:
-                            return False
-
-                        values = [float(value) for value in attribute_values]
-                        if _number_match(values, rule):
-                            return True
-                    else:
-                        if field not in dict_body:
-                            return False
-
-                        if isinstance(dict_body[field], (int, float)):
-                            values = [dict_body[field]]
-                        elif isinstance(dict_body[field], list):
-                            values = [float(value) for value in dict_body[field]]
-                        else:
-                            return False
-
-                        if _number_match(values, rule):
-                            return True
-
-                if isinstance(rule, dict):
-                    keyword = list(rule.keys())[0]
-                    value = list(rule.values())[0]
-                    if keyword == "exists":
-                        if attributes_based_check:
-                            if _exists_match(value, field, dict_body):
-                                return True
-                        else:
-                            if _exists_match(value, field, dict_body):
-                                return True
-                    elif keyword == "prefix" and isinstance(value, str):
-                        if attributes_based_check:
-                            if field in dict_body:
-                                attr = dict_body[field]
-                                if attr["Type"] == "String":
-                                    if _prefix_match(value, attr["Value"]):
-                                        return True
-                        else:
-                            if field in dict_body:
-                                if _prefix_match(value, dict_body[field]):
-                                    return True
-
-                    elif keyword == "anything-but":
-                        if attributes_based_check:
-                            if field not in dict_body:
-                                return False
-                            attr = dict_body[field]
-                            if isinstance(value, dict):
-                                # We can combine anything-but with the prefix-filter
-                                if attr["Type"] == "String":
-                                    actual_values = [attr["Value"]]
-                                else:
-                                    actual_values = [v for v in attr["Value"]]
-                            else:
-                                if attr["Type"] == "Number":
-                                    actual_values = [float(attr["Value"])]
-                                elif attr["Type"] == "String":
-                                    actual_values = [attr["Value"]]
-                                else:
-                                    actual_values = [v for v in attr["Value"]]
-
-                            if _anything_but_match(value, actual_values):
-                                return True
-                        else:
-                            if field not in dict_body:
-                                return False
-                            attr = dict_body[field]
-                            if isinstance(value, dict):
-                                if isinstance(attr, str):
-                                    actual_values = [attr]
-                                elif isinstance(attr, list):
-                                    actual_values = attr
-                                else:
-                                    return False
-                            else:
-                                if isinstance(attr, (int, float, str)):
-                                    actual_values = [attr]
-                                elif isinstance(attr, list):
-                                    actual_values = attr
-                                else:
-                                    return False
-
-                            if _anything_but_match(value, actual_values):
-                                return True
-
-                    elif keyword == "numeric" and isinstance(value, list):
-                        if attributes_based_check:
-                            if dict_body.get(field, {}).get("Type", "") == "Number":
-
-                                checks = value
-                                numeric_ranges = zip(checks[0::2], checks[1::2])
-                                if _numeric_match(
-                                    numeric_ranges, float(dict_body[field]["Value"])
-                                ):
-                                    return True
-                        else:
-                            if field not in dict_body:
-                                return False
-
-                            checks = value
-                            numeric_ranges = zip(checks[0::2], checks[1::2])
-                            if _numeric_match(numeric_ranges, dict_body[field]):
-                                return True
-
-            return False
-
-        if filter_policy_scope == "MessageAttributes":
-            return all(
-                _field_match(field, rules, message_attributes)
-                for field, rules in self._filter_policy.items()
-            )
-        else:
-
-            class CheckException(Exception):
-                pass
-
-            def compute_checks(
-                filter_policy: Dict[str, Union[Dict[str, Any], List[Any]]],
-                message_body: Union[Dict[str, Any], List[Any]],
-            ) -> Tuple[Callable[[Iterable[Any]], bool], Any]:
-                """
-                Generate (possibly nested) list of checks to be performed based on the filter policy
-                Returned list is of format (any|all, checks), where first elem defines what aggregation should be used in checking
-                and the second argument is a list containing sublists of the same format or concrete checks (field, rule, body): Tuple[str, List[Any], Dict[str, Any]]
-
-                All the checks returned by this function will only require one-level-deep entry into dict in _field_match function
-                This is done this way to simplify the actual check logic and keep it as close as possible between MessageAttributes and MessageBody
-
-                Given message_body:
-                {"Records": [
-                   {
-                       "eventName": "ObjectCreated:Put",
-                   },
-                   {
-                       "eventName": "ObjectCreated:Delete",
-                   },
-                ]}
-
-                and filter policy:
-                {"Records": {
-                   "eventName": [{"prefix": "ObjectCreated:"}],
-                }}
-
-                the following check list would be computed:
-                (<built-in function all>, (
-                   (<built-in function all>, (
-                       (<built-in function any>, (
-                           ('eventName', [{'prefix': 'ObjectCreated:'}], {'eventName': 'ObjectCreated:Put'}),
-                           ('eventName', [{'prefix': 'ObjectCreated:'}], {'eventName': 'ObjectCreated:Delete'}))
-                       ),
-                   )
-                ),))
-                """
-                rules = []
-                for filter_key, filter_value in filter_policy.items():
-                    if isinstance(filter_value, dict):
-                        if isinstance(message_body, dict):
-                            message_value = message_body.get(filter_key)
-                            if message_value is not None:
-                                rules.append(
-                                    compute_checks(filter_value, message_value)
-                                )
-                            else:
-                                raise CheckException
-                        elif isinstance(message_body, list):
-                            subchecks = []
-                            for entry in message_body:
-                                subchecks.append(compute_checks(filter_policy, entry))
-                            rules.append((any, tuple(subchecks)))
-                        else:
-                            raise CheckException
-
-                    elif isinstance(filter_value, list):
-                        # These are the real rules, same as in MessageAttributes case
-
-                        concrete_checks = []
-                        if isinstance(message_body, dict):
-                            if message_body is not None:
-                                concrete_checks.append(
-                                    (filter_key, filter_value, message_body)
-                                )
-                            else:
-                                raise CheckException
-                        elif isinstance(message_body, list):
-                            # Apply policy to each element of the list, pass if at list one element matches
-                            for list_elem in message_body:
-                                concrete_checks.append(
-                                    (filter_key, filter_value, list_elem)
-                                )
-                        else:
-                            raise CheckException
-                        rules.append((any, tuple(concrete_checks)))
-                    else:
-                        raise CheckException
-
-                return (all, tuple(rules))
-
-            try:
-                message_dict = json.loads(message)
-            except ValueError:
-                return False
-
-            try:
-                checks = compute_checks(self._filter_policy, message_dict)
-            except CheckException:
-                return False
-
-            def perform_checks(check: Any) -> bool:
-                # If the checks are a list, only a single elem has to pass
-                # otherwise all the entries have to pass
-
-                if isinstance(check, tuple):
-                    if len(check) == 2:
-                        # (any|all, checks)
-                        aggregate_func, checks = check
-                        return aggregate_func(
-                            perform_checks(single_check) for single_check in checks
-                        )
-                    elif len(check) == 3:
-                        field, rules, dict_body = check
-                        return _field_match(field, rules, dict_body, False)
-
-                raise CheckException(f"Check is not a tuple: {str(check)}")
-
-            return perform_checks(checks)
 
     def get_post_data(
         self,
@@ -1099,6 +749,9 @@ class SNSBackend(BaseBackend):
             filter_policy_scope = subscription.attributes.get("FilterPolicyScope")
             self._validate_filter_policy(filter_policy, scope=filter_policy_scope)
             subscription._filter_policy = filter_policy
+            subscription._filter_policy_matcher = FilterPolicyMatcher(
+                filter_policy, filter_policy_scope
+            )
 
         subscription.attributes[name] = value
 

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -226,6 +226,13 @@ class SNSResponse(BaseResponse):
         subscription = self.backend.subscribe(topic_arn, endpoint, protocol)
 
         if attributes is not None:
+            # We need to set the FilterPolicyScope first, as the validation of the FilterPolicy will depend on it
+            if "FilterPolicyScope" in attributes:
+                filter_policy_scope = attributes.pop("FilterPolicyScope")
+                self.backend.set_subscription_attributes(
+                    subscription.arn, "FilterPolicyScope", filter_policy_scope
+                )
+
             for attr_name, attr_value in attributes.items():
                 self.backend.set_subscription_attributes(
                     subscription.arn, attr_name, attr_value

--- a/moto/sns/utils.py
+++ b/moto/sns/utils.py
@@ -1,5 +1,7 @@
 import re
 from moto.moto_api._internal import mock_random
+from typing import Any, Dict, List, Iterable, Optional, Tuple, Union, Callable
+import json
 
 E164_REGEX = re.compile(r"^\+?[1-9]\d{1,14}$")
 
@@ -15,3 +17,376 @@ def make_arn_for_subscription(topic_arn: str) -> str:
 
 def is_e164(number: str) -> bool:
     return E164_REGEX.match(number) is not None
+
+
+class FilterPolicyMatcher:
+    class CheckException(Exception):
+        pass
+
+    def __init__(self, filter_policy: Dict[str, Any], filter_policy_scope: str):
+        self.filter_policy = filter_policy
+        self.filter_policy_scope = (
+            filter_policy_scope
+            if filter_policy_scope is not None
+            else "MessageAttributes"
+        )
+
+        if self.filter_policy_scope not in ("MessageAttributes", "MessageBody"):
+            raise FilterPolicyMatcher.CheckException(
+                f"Unsupported filter_policy_scope: {filter_policy_scope}"
+            )
+
+    def matches(
+        self, message_attributes: Optional[Dict[str, Any]], message: str
+    ) -> bool:
+        if not self.filter_policy:
+            return True
+
+        if self.filter_policy_scope == "MessageAttributes":
+            if message_attributes is None:
+                message_attributes = {}
+
+            return self._attributes_based_match(message_attributes)
+        else:
+            try:
+                message_dict = json.loads(message)
+            except ValueError:
+                return False
+            return self._body_based_match(message_dict)
+
+    def _attributes_based_match(self, message_attributes: Dict[str, Any]) -> bool:
+        return all(
+            FilterPolicyMatcher._field_match(field, rules, message_attributes)
+            for field, rules in self.filter_policy.items()
+        )
+
+    def _body_based_match(self, message_dict: Dict[str, Any]) -> bool:
+        try:
+            checks = self._compute_body_checks(self.filter_policy, message_dict)
+        except FilterPolicyMatcher.CheckException:
+            return False
+
+        return self._perform_body_checks(checks)
+
+    def _perform_body_checks(self, check: Any) -> bool:
+        # If the checks are a list, only a single elem has to pass
+        # otherwise all the entries have to pass
+
+        if isinstance(check, tuple):
+            if len(check) == 2:
+                # (any|all, checks)
+                aggregate_func, checks = check
+                return aggregate_func(
+                    self._perform_body_checks(single_check) for single_check in checks
+                )
+            elif len(check) == 3:
+                field, rules, dict_body = check
+                return FilterPolicyMatcher._field_match(field, rules, dict_body, False)
+
+        raise FilterPolicyMatcher.CheckException(f"Check is not a tuple: {str(check)}")
+
+    def _compute_body_checks(
+        self,
+        filter_policy: Dict[str, Union[Dict[str, Any], List[Any]]],
+        message_body: Union[Dict[str, Any], List[Any]],
+    ) -> Tuple[Callable[[Iterable[Any]], bool], Any]:
+        """
+        Generate (possibly nested) list of checks to be performed based on the filter policy
+        Returned list is of format (any|all, checks), where first elem defines what aggregation should be used in checking
+        and the second argument is a list containing sublists of the same format or concrete checks (field, rule, body): Tuple[str, List[Any], Dict[str, Any]]
+
+        All the checks returned by this function will only require one-level-deep entry into dict in _field_match function
+        This is done this way to simplify the actual check logic and keep it as close as possible between MessageAttributes and MessageBody
+
+        Given message_body:
+        {"Records": [
+            {
+                "eventName": "ObjectCreated:Put",
+            },
+            {
+                "eventName": "ObjectCreated:Delete",
+            },
+        ]}
+
+        and filter policy:
+        {"Records": {
+            "eventName": [{"prefix": "ObjectCreated:"}],
+        }}
+
+        the following check list would be computed:
+        (<built-in function all>, (
+            (<built-in function all>, (
+                (<built-in function any>, (
+                    ('eventName', [{'prefix': 'ObjectCreated:'}], {'eventName': 'ObjectCreated:Put'}),
+                    ('eventName', [{'prefix': 'ObjectCreated:'}], {'eventName': 'ObjectCreated:Delete'}))
+                ),
+            )
+        ),))
+        """
+        rules = []
+        for filter_key, filter_value in filter_policy.items():
+            if isinstance(filter_value, dict):
+                if isinstance(message_body, dict):
+                    message_value = message_body.get(filter_key)
+                    if message_value is not None:
+                        rules.append(
+                            self._compute_body_checks(filter_value, message_value)
+                        )
+                    else:
+                        raise FilterPolicyMatcher.CheckException
+                elif isinstance(message_body, list):
+                    subchecks = []
+                    for entry in message_body:
+                        subchecks.append(
+                            self._compute_body_checks(filter_policy, entry)
+                        )
+                    rules.append((any, tuple(subchecks)))
+                else:
+                    raise FilterPolicyMatcher.CheckException
+
+            elif isinstance(filter_value, list):
+                # These are the real rules, same as in MessageAttributes case
+
+                concrete_checks = []
+                if isinstance(message_body, dict):
+                    if message_body is not None:
+                        concrete_checks.append((filter_key, filter_value, message_body))
+                    else:
+                        raise FilterPolicyMatcher.CheckException
+                elif isinstance(message_body, list):
+                    # Apply policy to each element of the list, pass if at list one element matches
+                    for list_elem in message_body:
+                        concrete_checks.append((filter_key, filter_value, list_elem))
+                else:
+                    raise FilterPolicyMatcher.CheckException
+                rules.append((any, tuple(concrete_checks)))
+            else:
+                raise FilterPolicyMatcher.CheckException
+
+        return (all, tuple(rules))
+
+    @staticmethod
+    def _field_match(  # type: ignore # decorated function contains type Any
+        field: str,
+        rules: List[Any],
+        dict_body: Dict[str, Any],
+        attributes_based_check: bool = True,
+    ) -> bool:
+        # dict_body = MessageAttributes if attributes_based_check is True
+        # otherwise it's the cut-out part of the MessageBody (so only single-level nesting must be supported)
+
+        # Iterate over every rule from the list of rules
+        # At least one rule has to match the field for the function to return a match
+
+        def _str_exact_match(value: str, rule: Union[str, List[str]]) -> bool:
+            if value == rule:
+                return True
+
+            if isinstance(value, list):
+                if rule in value:
+                    return True
+
+            try:
+                json_data = json.loads(value)
+                if rule in json_data:
+                    return True
+            except (ValueError, TypeError):
+                pass
+
+            return False
+
+        def _number_match(values: List[float], rule: float) -> bool:
+            for value in values:
+                # Even the official documentation states a 5 digits of accuracy after the decimal point for numerics, in reality it is 6
+                # https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html#subscription-filter-policy-constraints
+                if int(value * 1000000) == int(rule * 1000000):
+                    return True
+
+            return False
+
+        def _exists_match(
+            should_exist: bool, field: str, dict_body: Dict[str, Any]
+        ) -> bool:
+            if should_exist and field in dict_body:
+                return True
+            elif not should_exist and field not in dict_body:
+                return True
+
+            return False
+
+        def _prefix_match(prefix: str, value: str) -> bool:
+            return value.startswith(prefix)
+
+        def _anything_but_match(
+            filter_value: Union[Dict[str, Any], List[str], str],
+            actual_values: List[str],
+        ) -> bool:
+            if isinstance(filter_value, dict):
+                # We can combine anything-but with the prefix-filter
+                anything_but_key = list(filter_value.keys())[0]
+                anything_but_val = list(filter_value.values())[0]
+                if anything_but_key != "prefix":
+                    return False
+                if all([not v.startswith(anything_but_val) for v in actual_values]):
+                    return True
+            else:
+                undesired_values = (
+                    [filter_value] if isinstance(filter_value, str) else filter_value
+                )
+                if all([v not in undesired_values for v in actual_values]):
+                    return True
+
+            return False
+
+        def _numeric_match(
+            numeric_ranges: Iterable[Tuple[str, float]], numeric_value: float
+        ) -> bool:
+            # numeric_ranges' format:
+            # [(< x), (=, y), (>=, z)]
+            msg_value = numeric_value
+            matches = []
+            for operator, test_value in numeric_ranges:
+                if operator == ">":
+                    matches.append((msg_value > test_value))
+                if operator == ">=":
+                    matches.append((msg_value >= test_value))
+                if operator == "=":
+                    matches.append((msg_value == test_value))
+                if operator == "<":
+                    matches.append((msg_value < test_value))
+                if operator == "<=":
+                    matches.append((msg_value <= test_value))
+            return all(matches)
+
+        for rule in rules:
+            #  TODO: boolean value matching is not supported, SNS behavior unknown
+            if isinstance(rule, str):
+                if attributes_based_check:
+                    if field not in dict_body:
+                        return False
+                    if _str_exact_match(dict_body[field]["Value"], rule):
+                        return True
+                else:
+                    if field not in dict_body:
+                        return False
+                    if _str_exact_match(dict_body[field], rule):
+                        return True
+
+            if isinstance(rule, (int, float)):
+                if attributes_based_check:
+                    if field not in dict_body:
+                        return False
+                    if dict_body[field]["Type"] == "Number":
+                        attribute_values = [dict_body[field]["Value"]]
+                    elif dict_body[field]["Type"] == "String.Array":
+                        try:
+                            attribute_values = json.loads(dict_body[field]["Value"])
+                            if not isinstance(attribute_values, list):
+                                attribute_values = [attribute_values]
+                        except (ValueError, TypeError):
+                            return False
+                    else:
+                        return False
+
+                    values = [float(value) for value in attribute_values]
+                    if _number_match(values, rule):
+                        return True
+                else:
+                    if field not in dict_body:
+                        return False
+
+                    if isinstance(dict_body[field], (int, float)):
+                        values = [dict_body[field]]
+                    elif isinstance(dict_body[field], list):
+                        values = [float(value) for value in dict_body[field]]
+                    else:
+                        return False
+
+                    if _number_match(values, rule):
+                        return True
+
+            if isinstance(rule, dict):
+                keyword = list(rule.keys())[0]
+                value = list(rule.values())[0]
+                if keyword == "exists":
+                    if attributes_based_check:
+                        if _exists_match(value, field, dict_body):
+                            return True
+                    else:
+                        if _exists_match(value, field, dict_body):
+                            return True
+                elif keyword == "prefix" and isinstance(value, str):
+                    if attributes_based_check:
+                        if field in dict_body:
+                            attr = dict_body[field]
+                            if attr["Type"] == "String":
+                                if _prefix_match(value, attr["Value"]):
+                                    return True
+                    else:
+                        if field in dict_body:
+                            if _prefix_match(value, dict_body[field]):
+                                return True
+
+                elif keyword == "anything-but":
+                    if attributes_based_check:
+                        if field not in dict_body:
+                            return False
+                        attr = dict_body[field]
+                        if isinstance(value, dict):
+                            # We can combine anything-but with the prefix-filter
+                            if attr["Type"] == "String":
+                                actual_values = [attr["Value"]]
+                            else:
+                                actual_values = [v for v in attr["Value"]]
+                        else:
+                            if attr["Type"] == "Number":
+                                actual_values = [float(attr["Value"])]
+                            elif attr["Type"] == "String":
+                                actual_values = [attr["Value"]]
+                            else:
+                                actual_values = [v for v in attr["Value"]]
+
+                        if _anything_but_match(value, actual_values):
+                            return True
+                    else:
+                        if field not in dict_body:
+                            return False
+                        attr = dict_body[field]
+                        if isinstance(value, dict):
+                            if isinstance(attr, str):
+                                actual_values = [attr]
+                            elif isinstance(attr, list):
+                                actual_values = attr
+                            else:
+                                return False
+                        else:
+                            if isinstance(attr, (int, float, str)):
+                                actual_values = [attr]
+                            elif isinstance(attr, list):
+                                actual_values = attr
+                            else:
+                                return False
+
+                        if _anything_but_match(value, actual_values):
+                            return True
+
+                elif keyword == "numeric" and isinstance(value, list):
+                    if attributes_based_check:
+                        if dict_body.get(field, {}).get("Type", "") == "Number":
+
+                            checks = value
+                            numeric_ranges = zip(checks[0::2], checks[1::2])
+                            if _numeric_match(
+                                numeric_ranges, float(dict_body[field]["Value"])
+                            ):
+                                return True
+                    else:
+                        if field not in dict_body:
+                            return False
+
+                        checks = value
+                        numeric_ranges = zip(checks[0::2], checks[1::2])
+                        if _numeric_match(numeric_ranges, dict_body[field]):
+                            return True
+
+        return False

--- a/tests/test_sns/test_utils.py
+++ b/tests/test_sns/test_utils.py
@@ -1,0 +1,17 @@
+from moto.sns.utils import FilterPolicyMatcher
+import pytest
+
+
+def test_filter_policy_matcher_scope_sanity_check():
+    with pytest.raises(FilterPolicyMatcher.CheckException):
+        FilterPolicyMatcher({}, "IncorrectFilterPolicyScope")
+
+
+def test_filter_policy_matcher_empty_message_attributes():
+    matcher = FilterPolicyMatcher({}, None)
+    assert matcher.matches(None, "")
+
+
+def test_filter_policy_matcher_empty_message_attributes_filtering_fail():
+    matcher = FilterPolicyMatcher({"store": ["test"]}, None)
+    assert not matcher.matches(None, "")


### PR DESCRIPTION
This resolves: https://github.com/getmoto/moto/issues/6087
[AWS blog article about the feature](https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/)

## What's added?
1. Recognition of the [`FilterPolicyScope` attribute](https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html#sns-message-filtering-scope) for an SNS subscription
2. Validation of the [filter policy's complexity](https://docs.aws.amazon.com/sns/latest/dg/subscription-filter-policy-constraints.html)
3. Actual logic for filtering the messages based on `FilterPolicyScope` that's set

Both 1 and 2 were pretty much taken as-is from https://github.com/localstack/moto/pull/62.

## General idea
The biggest change is in the `_matches_filter_policy` function, I've created subfunctions for checking the actual conditions (to be shared between both `FilterPolicyScope` variants). For attributes based filtering everything stayed roughly the same, for payload based filtering:
1. A nested list of simplified checks is generated, so nested traversing is not required in the "actual checker" function
2. The checks are run separately, results are concatenated so either one of the checks in a list has to pass or all of them

## Testing
Most of the tests for `MessageBody` variant were copy-pasted from the `MessageAttributes` variant (the ones that were already implemented) and modified accordingly. This is done as a sanity check for the filtering.

AWS docs don't provide many examples that utilize the most interesting part of `MessageBody` filtering, that is nesting.
Few tests were adapted from [AWS blog article](https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/) and some were crafted during the development to clarify some doubts.

All of the tests have been run (with minor modifications required) against AWS and were confirmed valid this way.

## Concerns
1. I wanted to keep the "layout" of everything mostly the same, e.g. all the logic is contained within the original `matches_filter_policy` function. It looks crammed now, do you think separating it to its own class/file would be OK?
2. I feel like general cleanup for this is needed, but I don't really have an idea how to simplify it without overengineering. Any comments would be appreciated