### PR TITLE
Scheduler: Fix update_schedule raising ResourceNotFound errors when using schedule groups

### DIFF
--- a/moto/scheduler/responses.py
+++ b/moto/scheduler/responses.py
@@ -60,7 +60,7 @@ class EventBridgeSchedulerResponse(BaseResponse):
         return "{}"
 
     def update_schedule(self) -> str:
-        group_name = self._get_param("groupName")
+        group_name = self._get_param("GroupName")
         name = self.uri.split("?")[0].split("/")[-1]
         description = self._get_param("Description")
         end_date = self._get_param("EndDate")

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -81,11 +81,22 @@ def test_create_get_delete__in_different_group():
     assert err["Code"] == "ResourceNotFoundException"
 
 
+@pytest.mark.parametrize(
+    "extra_kwargs",
+    [
+        ({}),
+        ({"GroupName": "some-group"}),
+    ],
+    ids=["without_group", "with_group"],
+)
 @mock_scheduler
-def test_update_schedule():
+def test_update_schedule(extra_kwargs):
     client = boto3.client("scheduler", region_name="eu-west-1")
 
+    client.create_schedule_group(Name="some-group")
+
     client.create_schedule(
+        **extra_kwargs,
         Name="my-schedule",
         ScheduleExpression="some cron",
         FlexibleTimeWindow={
@@ -99,6 +110,7 @@ def test_update_schedule():
     )
 
     client.update_schedule(
+        **extra_kwargs,
         Name="my-schedule",
         Description="new desc",
         ScheduleExpression="new cron",
@@ -113,7 +125,7 @@ def test_update_schedule():
         },
     )
 
-    schedule = client.get_schedule(Name="my-schedule")
+    schedule = client.get_schedule(**extra_kwargs, Name="my-schedule")
     assert schedule["Description"] == "new desc"
     assert schedule["ScheduleExpression"] == "new cron"
     assert schedule["State"] == "DISABLED"


### PR DESCRIPTION
The `scheduler:UpdateSchedule` method is broken when using schedule groups since it cannot find the targeted schedule:

```
botocore.errorfactory.ResourceNotFoundException: An error occurred (ResourceNotFoundException) when calling the UpdateSchedule operation: Schedule not found
```

The issue is that the retrieved parameter is `groupName` whereas the right parameter for the UpdateSchedule seems to be `GroupName`.

Also, added a new test for this use case.