### PR TITLE
Do not unquote the key two times on multipart upload complete

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1888,9 +1888,13 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         return new_key
 
     def put_object_acl(
-        self, bucket_name: str, key_name: str, acl: Optional[FakeAcl]
+        self,
+        bucket_name: str,
+        key_name: str,
+        acl: Optional[FakeAcl],
+        key_is_clean: bool = False,
     ) -> None:
-        key = self.get_object(bucket_name, key_name)
+        key = self.get_object(bucket_name, key_name, key_is_clean=key_is_clean)
         # TODO: Support the XML-based ACL format
         if key is not None:
             key.set_acl(acl)

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2173,7 +2173,12 @@ class S3Response(BaseResponse):
             )
             key.set_metadata(multipart.metadata)
             self.backend.set_key_tags(key, multipart.tags)
-            self.backend.put_object_acl(bucket_name, key.name, multipart.acl)
+            self.backend.put_object_acl(
+                bucket_name=bucket_name,
+                key_name=key.name,
+                acl=multipart.acl,
+                key_is_clean=True,
+            )
 
             template = self.response_template(S3_MULTIPART_COMPLETE_RESPONSE)
             headers: Dict[str, Any] = {}


### PR DESCRIPTION
Current implementation unquotes key two times, firstly in `self.backend.put_object` and then in `self.backend.put_object_acl` -> `self.get_object`. To fix this issue I have exposed `key_is_clean` in `put_object_acl` and set it to `True`.