### PR TITLE
fix copy in place for S3 bucket with encryption

### DIFF
--- a/tests/test_s3/test_s3_encryption.py
+++ b/tests/test_s3/test_s3_encryption.py
@@ -127,3 +127,24 @@ def test_encryption_status_on_copied_objects():
     # verify encryption status on object2 does have encryption
     res = s3.get_object(Bucket=bucket_name, Key="file2.txt")
     res.should.have.key("ServerSideEncryption").equals("AES256")
+
+
+@mock_s3
+def test_encryption_bucket_key_for_aes_not_returned():
+    bucket_name = str(uuid4())
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket=bucket_name)
+    # enable encryption
+    sse_config = {
+        "Rules": [
+            {
+                "ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"},
+                "BucketKeyEnabled": False,
+            }
+        ]
+    }
+    s3.put_bucket_encryption(
+        Bucket=bucket_name, ServerSideEncryptionConfiguration=sse_config
+    )
+    res = s3.put_object(Bucket=bucket_name, Body=b"test", Key="file.txt")
+    res.shouldnt.have.key("BucketKeyEnabled")


### PR DESCRIPTION
This PR would fix #6300

With S3 new default encryption for bucket, I've overlooked one case where the bucket would have a manually set encryption configuration. In that case, S3 will allow copying in place. For now, it is rather simple to fix, we just need to check if the bucket has encryption, but this will become a bit more complicated when we implement the default encryption with our bucket has well. 

I've also sneaked a little fix regarding `BucketKeyEnabled` header, as it should not be returned when the encryption is not `aws:kms` (verified with AWS as well).