### PR TITLE
S3: fix copy in place when requesting checksum

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1627,7 +1627,7 @@ class S3Response(BaseResponse):
             checksum_algorithm = request.headers.get("x-amz-checksum-algorithm")
             if checksum_algorithm:
                 checksum_value = compute_checksum(
-                    key_to_copy.value, algorithm=checksum_algorithm
+                    new_key.value, algorithm=checksum_algorithm
                 ).decode("utf-8")
                 response_headers.update(
                     {"Checksum": {f"Checksum{checksum_algorithm}": checksum_value}}

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -68,6 +68,18 @@ def test_copy_key_boto3_with_sha256_checksum():
     assert "ChecksumSHA256" in resp["Checksum"]
     assert resp["Checksum"]["ChecksumSHA256"] == expected_hash
 
+    # Verify in place
+    copy_in_place = client.copy_object(
+        Bucket=bucket,
+        CopySource=f"{bucket}/{new_key}",
+        Key=new_key,
+        ChecksumAlgorithm="SHA256",
+        MetadataDirective="REPLACE",
+    )
+
+    assert "ChecksumSHA256" in copy_in_place["CopyObjectResult"]
+    assert copy_in_place["CopyObjectResult"]["ChecksumSHA256"] == expected_hash
+
 
 @mock_s3
 def test_copy_key_with_version_boto3():


### PR DESCRIPTION
This PR would fix #6307. 

When copying in place, we would try to access the already overwritten key and it would raise an exception.
This makes use of the new key to calculate the checksum. 