### PR TITLE
S3: fix checksum calculation

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2418,6 +2418,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             # Object copied from Glacier object should not have expiry
             new_key.set_expiry(None)
 
+        if src_key.checksum_value:
+            new_key.checksum_value = src_key.checksum_value
+            new_key.checksum_algorithm = src_key.checksum_algorithm
+
         # Send notifications that an object was copied
         notifications.send_event(
             self.account_id, notifications.S3_OBJECT_CREATE_COPY, bucket, new_key

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -200,7 +200,7 @@ def compute_checksum(body: bytes, algorithm: str) -> bytes:
     if algorithm == "SHA1":
         hashed_body = _hash(hashlib.sha1, (body,))
     elif algorithm == "CRC32" or algorithm == "CRC32C":
-        hashed_body = f"{binascii.crc32(body)}".encode("utf-8")
+        hashed_body = binascii.crc32(body).to_bytes(4, "big")
     else:
         hashed_body = _hash(hashlib.sha256, (body,))
     return base64.b64encode(hashed_body)
@@ -208,10 +208,10 @@ def compute_checksum(body: bytes, algorithm: str) -> bytes:
 
 def _hash(fn: Any, args: Any) -> bytes:
     try:
-        return fn(*args, usedforsecurity=False).hexdigest().encode("utf-8")
+        return fn(*args, usedforsecurity=False).digest()
     except TypeError:
         # The usedforsecurity-parameter is only available as of Python 3.9
-        return fn(*args).hexdigest().encode("utf-8")
+        return fn(*args).digest()
 
 
 def cors_matches_origin(origin_header: str, allowed_origins: List[str]) -> bool:

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -734,7 +734,8 @@ def test_copy_object_in_place_with_bucket_encryption():
 
 @mock_s3
 @pytest.mark.parametrize(
-    "algorithm", ["CRC32", "SHA1", "SHA256"],
+    "algorithm",
+    ["CRC32", "SHA1", "SHA256"],
 )
 def test_copy_key_boto3_with_both_sha256_checksum(algorithm):
     # This test will validate that moto S3 checksum calculations are correct

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -46,7 +46,7 @@ def test_copy_key_boto3_with_sha256_checksum():
     key_name = "key"
     new_key = "new_key"
     bucket = "foobar"
-    expected_hash = "YWIzZDA3ZjMxNjljY2JkMGVkNmM0YjQ1ZGUyMTUxOWY5ZjkzOGM3MmQyNDEyNDk5OGFhYjk0OWNlODNiYjUxYg=="
+    expected_hash = "qz0H8xacy9DtbEtF3iFRn5+TjHLSQSSZiquUnOg7tRs="
 
     s3.create_bucket(Bucket=bucket)
     key = s3.Object("foobar", key_name)

--- a/tests/test_s3/test_s3_utils.py
+++ b/tests/test_s3/test_s3_utils.py
@@ -124,24 +124,22 @@ def test_undo_clean_key_name(key, expected):
 
 
 def test_checksum_sha256():
-    checksum = b"ODdkMTQ5Y2I0MjRjMDM4NzY1NmYyMTFkMjU4OWZiNWIxZTE2MjI5OTIxMzA5ZTk4NTg4NDE5Y2NjYThhNzM2Mg=="
+    checksum = b"h9FJy0JMA4dlbyEdJYn7Wx4WIpkhMJ6YWIQZzMqKc2I="
     compute_checksum(b"somedata", "SHA256").should.equal(checksum)
     # Unknown algorithms fallback to SHA256 for now
     compute_checksum(b"somedata", algorithm="unknown").should.equal(checksum)
 
 
 def test_checksum_sha1():
-    compute_checksum(b"somedata", "SHA1").should.equal(
-        b"ZWZhYTMxMWFlNDQ4YTczNzRjMTIyMDYxYmZlZDk1MmQ5NDBlOWUzNw=="
-    )
+    compute_checksum(b"somedata", "SHA1").should.equal(b"76oxGuRIpzdMEiBhv+2VLZQOnjc=")
 
 
 def test_checksum_crc32():
-    compute_checksum(b"somedata", "CRC32").should.equal(b"MTM5MzM0Mzk1Mg==")
+    compute_checksum(b"somedata", "CRC32").should.equal(b"Uwy90A==")
 
 
 def test_checksum_crc32c():
-    compute_checksum(b"somedata", "CRC32C").should.equal(b"MTM5MzM0Mzk1Mg==")
+    compute_checksum(b"somedata", "CRC32C").should.equal(b"Uwy90A==")
 
 
 def test_cors_utils():


### PR DESCRIPTION
While working against AWS, I realised moto was returning different checksum after copying an object and recalculating its checksum. It seems the calculation was bit wrong, as it was using `hexdigest` instead of the binary `digest` when passing the hash to the base64 encoding.
I've tried to add a test to cover all checksum calculation by using a checksum recalculation property of `CopyObject`.

Also fixed CopyObject behaviour, when copying a key that has a Checksum, if not asked to be recalculated, it will also copy it to the destination key. This has been verified with AWS (same with the values, so we can check that the recalculation works properly, even when not provided by boto in the first request like in `test_copy_key_boto3_with_both_sha256_checksum`). 