### PR TITLE
Autoscaling: Add metrics for E2 target tracking scaling

### DIFF
--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -1027,7 +1027,10 @@ DESCRIBE_SCALING_POLICIES_TEMPLATE = """<DescribePoliciesResponse xmlns="http://
                 {% for metric in policy.target_tracking_config["CustomizedMetricSpecification"].get("Metrics", []) %}
                 <member>
                   <Id>{{ metric.get("Id") }}</Id>
+                  {% if metric.get("MetricStat") is none %}
                   <Expression>{{ metric.get("Expression") }}</Expression>
+                  {% endif %}
+                  {% if metric.get("Expression") is none %}
                   <MetricStat>
                     <Metric>
                       <Namespace>{{ metric.get("MetricStat", {}).get("Metric", {}).get("Namespace") }}</Namespace>
@@ -1044,8 +1047,9 @@ DESCRIBE_SCALING_POLICIES_TEMPLATE = """<DescribePoliciesResponse xmlns="http://
                     <Stat>{{ metric.get("MetricStat", {}).get("Stat") }}</Stat>
                     <Unit>{{ metric.get("MetricStat", {}).get("Unit") }}</Unit>
                   </MetricStat>
+                  {% endif %}
                   <Label>{{ metric.get("Label") }}</Label>
-                  <ReturnData>{{ 'true' if metric.get("ReturnData") else 'false' }}</ReturnData>
+                  <ReturnData>{{ 'true' if metric.get("ReturnData") is none else metric.get("ReturnData") }}</ReturnData>
                 </member>
                 {% endfor %}
               </Metrics>

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -1022,6 +1022,34 @@ DESCRIBE_SCALING_POLICIES_TEMPLATE = """<DescribePoliciesResponse xmlns="http://
               {% if policy.target_tracking_config["CustomizedMetricSpecification"].get("Unit") %}
               <Unit>{{ policy.target_tracking_config["CustomizedMetricSpecification"].get("Unit") }}</Unit>
               {% endif %}
+              {% if policy.target_tracking_config["CustomizedMetricSpecification"].get("Metrics") %}
+              <Metrics>
+                {% for metric in policy.target_tracking_config["CustomizedMetricSpecification"].get("Metrics", []) %}
+                <member>
+                  <Id>{{ metric.get("Id") }}</Id>
+                  <Expression>{{ metric.get("Expression") }}</Expression>
+                  <MetricStat>
+                    <Metric>
+                      <Namespace>{{ metric.get("MetricStat", {}).get("Metric", {}).get("Namespace") }}</Namespace>
+                      <MetricName>{{ metric.get("MetricStat", {}).get("Metric", {}).get("MetricName") }}</MetricName>
+                      <Dimensions>
+                      {% for dim in metric.get("MetricStat", {}).get("Metric", {}).get("Dimensions", []) %}
+                        <member>
+                          <Name>{{ dim.get("Name") }}</Name>
+                          <Value>{{ dim.get("Value") }}</Value>
+                        </member>
+                      {% endfor %}
+                      </Dimensions>
+                    </Metric>
+                    <Stat>{{ metric.get("MetricStat", {}).get("Stat") }}</Stat>
+                    <Unit>{{ metric.get("MetricStat", {}).get("Unit") }}</Unit>
+                  </MetricStat>
+                  <Label>{{ metric.get("Label") }}</Label>
+                  <ReturnData>{{ 'true' if metric.get("ReturnData") else 'false' }}</ReturnData>
+                </member>
+                {% endfor %}
+              </Metrics>
+              {% endif %}
             </CustomizedMetricSpecification>
             {% endif %}
             <TargetValue>{{ policy.target_tracking_config.get("TargetValue") }}</TargetValue>

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -781,21 +781,18 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
                                 "MetricName": "CPUUtilization",
                                 "Namespace": "AWS/EC2",
                                 "Dimensions": [
-                                    {
-                                        "Name": "AutoScalingGroupName",
-                                        "Value": asg_name
-                                    }
-                                ]
+                                    {"Name": "AutoScalingGroupName", "Value": asg_name}
+                                ],
                             },
-                            "Stat": "Average"
+                            "Stat": "Average",
                         },
-                        "ReturnData": False
+                        "ReturnData": False,
                     },
                     {
                         "Label": "Calculate square cpu",
                         "Id": "load",
-                        "Expression": "cpu^2"
-                    }
+                        "Expression": "cpu^2",
+                    },
                 ],
             },
         },
@@ -827,23 +824,20 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
                                 "MetricName": "CPUUtilization",
                                 "Namespace": "AWS/EC2",
                                 "Dimensions": [
-                                    {
-                                        "Name": "AutoScalingGroupName",
-                                        "Value": asg_name
-                                    }
-                                ]
+                                    {"Name": "AutoScalingGroupName", "Value": asg_name}
+                                ],
                             },
                             "Stat": "Average",
-                            "Unit": "None"
+                            "Unit": "None",
                         },
-                        "ReturnData": False
+                        "ReturnData": False,
                     },
                     {
                         "Label": "Calculate square cpu",
                         "Id": "load",
                         "Expression": "cpu^2",
-                        "ReturnData": True
-                    }
+                        "ReturnData": True,
+                    },
                 ],
             },
             "TargetValue": 1000000.0,

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -774,28 +774,27 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
             "CustomizedMetricSpecification": {
                 "Metrics": [
                     {
-                    "Label": "Get ASGAverageCPUUtilization",
-                    "Id": "cpu",
-                    "MetricStat": {
-                        "Metric": {
-                        "MetricName": "CPUUtilization",
-                        "Namespace": "AWS/EC2",
-                        "Dimensions": [
-                            {
-                            "Name": "AutoScalingGroupName",
-                            "Value": asg_name
-                            }
-                        ]
+                        "Label": "Get ASGAverageCPUUtilization",
+                        "Id": "cpu",
+                        "MetricStat": {
+                            "Metric": {
+                                "MetricName": "CPUUtilization",
+                                "Namespace": "AWS/EC2",
+                                "Dimensions": [
+                                    {
+                                        "Name": "AutoScalingGroupName",
+                                        "Value": asg_name
+                                    }
+                                ]
+                            },
+                            "Stat": "Average"
                         },
-                        "Stat": "Average"
-                    },
-                    "ReturnData": False
+                        "ReturnData": False
                     },
                     {
-                    "Label": "Calculate square cpu",
-                    "Id": "load",
-                    "Expression": "cpu^2",
-                    "ReturnData": True
+                        "Label": "Calculate square cpu",
+                        "Id": "load",
+                        "Expression": "cpu^2"
                     }
                 ],
             },
@@ -821,29 +820,29 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
                 "Statistic": "None",
                 "Metrics": [
                     {
-                    "Label": "Get ASGAverageCPUUtilization",
-                    "Id": "cpu",
-                    "MetricStat": {
-                        "Metric": {
-                        "MetricName": "CPUUtilization",
-                        "Namespace": "AWS/EC2",
-                        "Dimensions": [
-                            {
-                            "Name": "AutoScalingGroupName",
-                            "Value": asg_name
-                            }
-                        ]
+                        "Label": "Get ASGAverageCPUUtilization",
+                        "Id": "cpu",
+                        "MetricStat": {
+                            "Metric": {
+                                "MetricName": "CPUUtilization",
+                                "Namespace": "AWS/EC2",
+                                "Dimensions": [
+                                    {
+                                        "Name": "AutoScalingGroupName",
+                                        "Value": asg_name
+                                    }
+                                ]
+                            },
+                            "Stat": "Average",
+                            "Unit": "None"
                         },
-                        "Stat": "Average",
-                        "Unit": "None"
-                    },
-                    "ReturnData": False
+                        "ReturnData": False
                     },
                     {
-                    "Label": "Calculate square cpu",
-                    "Id": "load",
-                    "Expression": "cpu^2",
-                    "ReturnData": True
+                        "Label": "Calculate square cpu",
+                        "Id": "load",
+                        "Expression": "cpu^2",
+                        "ReturnData": True
                     }
                 ],
             },

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -771,6 +771,34 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
                 "PredefinedMetricType": "ASGAverageNetworkIn",
             },
             "TargetValue": 1000000.0,
+            "CustomizedMetricSpecification": {
+                "Metrics": [
+                    {
+                    "Label": "Get ASGAverageCPUUtilization",
+                    "Id": "cpu",
+                    "MetricStat": {
+                        "Metric": {
+                        "MetricName": "CPUUtilization",
+                        "Namespace": "AWS/EC2",
+                        "Dimensions": [
+                            {
+                            "Name": "AutoScalingGroupName",
+                            "Value": asg_name
+                            }
+                        ]
+                        },
+                        "Stat": "Average"
+                    },
+                    "ReturnData": False
+                    },
+                    {
+                    "Label": "Calculate square cpu",
+                    "Id": "load",
+                    "Expression": "cpu^2",
+                    "ReturnData": True
+                    }
+                ],
+            },
         },
     )
 
@@ -785,6 +813,39 @@ def test_create_autoscaling_policy_with_policytype__targettrackingscaling():
         {
             "PredefinedMetricSpecification": {
                 "PredefinedMetricType": "ASGAverageNetworkIn",
+            },
+            "CustomizedMetricSpecification": {
+                "MetricName": "None",
+                "Namespace": "None",
+                "Dimensions": [],
+                "Statistic": "None",
+                "Metrics": [
+                    {
+                    "Label": "Get ASGAverageCPUUtilization",
+                    "Id": "cpu",
+                    "MetricStat": {
+                        "Metric": {
+                        "MetricName": "CPUUtilization",
+                        "Namespace": "AWS/EC2",
+                        "Dimensions": [
+                            {
+                            "Name": "AutoScalingGroupName",
+                            "Value": asg_name
+                            }
+                        ]
+                        },
+                        "Stat": "Average",
+                        "Unit": "None"
+                    },
+                    "ReturnData": False
+                    },
+                    {
+                    "Label": "Calculate square cpu",
+                    "Id": "load",
+                    "Expression": "cpu^2",
+                    "ReturnData": True
+                    }
+                ],
             },
             "TargetValue": 1000000.0,
         }


### PR DESCRIPTION
## Purpose

AWS recently added support of metric math for target tracking scaling and changed scheme by adding new field `Metrics` to `CustomizedMetricSpecification`.

AWS blog announcement - https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-ec2-auto-scaling-supports-metric-math-target-tracking-policies/

This PR adds `Metrics` to moto responses for ec2 target tracking scaling.