### PR TITLE
S3: Accept-Ranges headers should have dash

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1393,7 +1393,7 @@ class S3Response(BaseResponse):
 
         response_headers.update(key.metadata)
         response_headers.update(key.response_dict)
-        response_headers.update({"AcceptRanges": "bytes"})
+        response_headers.update({"Accept-Ranges": "bytes"})
         return 200, response_headers, key.value
 
     def _key_response_put(
@@ -1698,7 +1698,7 @@ class S3Response(BaseResponse):
         if key:
             response_headers.update(key.metadata)
             response_headers.update(key.response_dict)
-            response_headers.update({"AcceptRanges": "bytes"})
+            response_headers.update({"Accept-Ranges": "bytes"})
 
             if if_unmodified_since:
                 if_unmodified_since = str_to_rfc_1123_datetime(if_unmodified_since)

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -75,13 +75,13 @@ def test_s3_server_bucket_create(key_name):
     # HeadObject
     res = test_client.head(f"/{key_name}", "http://foobaz.localhost:5000/")
     res.status_code.should.equal(200)
-    assert res.headers.get("AcceptRanges") == "bytes"
+    assert res.headers.get("Accept-Ranges") == "bytes"
 
     # GetObject
     res = test_client.get(f"/{key_name}", "http://foobaz.localhost:5000/")
     res.status_code.should.equal(200)
     res.data.should.equal(b"test value")
-    assert res.headers.get("AcceptRanges") == "bytes"
+    assert res.headers.get("Accept-Ranges") == "bytes"
 
 
 def test_s3_server_ignore_subdomain_for_bucketnames():


### PR DESCRIPTION
Followup to #6121 and #6157 

Typo: We should return `Accept-Ranges`, not `AcceptRanges`