### PR TITLE
SNS: Cross-account access for topics

### DIFF
--- a/moto/utilities/arns.py
+++ b/moto/utilities/arns.py
@@ -1,0 +1,33 @@
+from collections import namedtuple
+
+Arn = namedtuple(
+    "Arn", ["account", "region", "service", "resource_type", "resource_id"]
+)
+
+
+def parse_arn(arn: str) -> Arn:
+    # http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+    # this method needs probably some more fine tuning,
+    # when also other targets are supported
+    _, _, service, region, account, resource = arn.split(":", 5)
+
+    if ":" in resource and "/" in resource:
+        if resource.index(":") < resource.index("/"):
+            resource_type, resource_id = resource.split(":", 1)
+        else:
+            resource_type, resource_id = resource.split("/", 1)
+    elif ":" in resource:
+        resource_type, resource_id = resource.split(":", 1)
+    elif "/" in resource:
+        resource_type, resource_id = resource.split("/", 1)
+    else:
+        resource_type = None
+        resource_id = resource
+
+    return Arn(
+        account=account,
+        region=region,
+        service=service,
+        resource_type=resource_type,
+        resource_id=resource_id,
+    )

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -96,9 +96,9 @@ def test_create_topic_should_be_indempodent():
 @mock_sns
 def test_get_missing_topic():
     conn = boto3.client("sns", region_name="us-east-1")
-    conn.get_topic_attributes.when.called_with(TopicArn="arn:aws:sns:us-east-1:424242424242:a-fake-arn").should.throw(
-        ClientError
-    )
+    conn.get_topic_attributes.when.called_with(
+        TopicArn="arn:aws:sns:us-east-1:424242424242:a-fake-arn"
+    ).should.throw(ClientError)
 
 
 @mock_sns
@@ -360,7 +360,10 @@ def test_add_permission_errors():
         Label="test-2",
         AWSAccountId=["999999999999"],
         ActionName=["AddPermission"],
-    ).should.throw(ClientError, f"An error occurred (NotFound) when calling the AddPermission operation: Topic with arn {topic_arn + '-not-existing'} not found")
+    ).should.throw(
+        ClientError,
+        f"An error occurred (NotFound) when calling the AddPermission operation: Topic with arn {topic_arn + '-not-existing'} not found",
+    )
 
     client.add_permission.when.called_with(
         TopicArn=topic_arn,
@@ -383,7 +386,10 @@ def test_remove_permission_errors():
 
     client.remove_permission.when.called_with(
         TopicArn=topic_arn + "-not-existing", Label="test"
-    ).should.throw(ClientError, f"An error occurred (NotFound) when calling the RemovePermission operation: Topic with arn {topic_arn + '-not-existing'} not found")
+    ).should.throw(
+        ClientError,
+        f"An error occurred (NotFound) when calling the RemovePermission operation: Topic with arn {topic_arn + '-not-existing'} not found",
+    )
 
 
 @mock_sns

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -96,7 +96,7 @@ def test_create_topic_should_be_indempodent():
 @mock_sns
 def test_get_missing_topic():
     conn = boto3.client("sns", region_name="us-east-1")
-    conn.get_topic_attributes.when.called_with(TopicArn="a-fake-arn").should.throw(
+    conn.get_topic_attributes.when.called_with(TopicArn="arn:aws:sns:us-east-1:424242424242:a-fake-arn").should.throw(
         ClientError
     )
 
@@ -360,7 +360,7 @@ def test_add_permission_errors():
         Label="test-2",
         AWSAccountId=["999999999999"],
         ActionName=["AddPermission"],
-    ).should.throw(ClientError, "Topic does not exist")
+    ).should.throw(ClientError, f"An error occurred (NotFound) when calling the AddPermission operation: Topic with arn {topic_arn + '-not-existing'} not found")
 
     client.add_permission.when.called_with(
         TopicArn=topic_arn,
@@ -383,7 +383,7 @@ def test_remove_permission_errors():
 
     client.remove_permission.when.called_with(
         TopicArn=topic_arn + "-not-existing", Label="test"
-    ).should.throw(ClientError, "Topic does not exist")
+    ).should.throw(ClientError, f"An error occurred (NotFound) when calling the RemovePermission operation: Topic with arn {topic_arn + '-not-existing'} not found")
 
 
 @mock_sns


### PR DESCRIPTION
This PR introduces cross-account support for SNS topics.

This basically means that topics will now be retrieved from the appropriate backend based on the value of account ID and region in the ARN. Any account can now retrieve an SNS topic with its ARN.

Cross-account access now works for `GetTopicAttributes`, `SetTopicAttributes`, `AddPermission`, `RemovePermission`, `DeleteTopic`, `Subscribe`, `ListSubscriptionsByTopic`, `Publish`, similar to AWS. 

IAM enforcement is left out of scope.