### PR TITLE
add tags to service-control-policies (organizations client)

### DIFF
--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -200,6 +200,7 @@ class FakePolicy(BaseModel):
         self.organization_id = organization.id
         self.master_account_id = organization.master_account_id
         self.attachments: List[Any] = []
+        self.tags = {tag["Key"]: tag["Value"] for tag in kwargs.get("Tags", [])}
 
         if not FakePolicy.supported_policy_type(self.type):
             raise InvalidInputException("You specified an invalid value.")


### PR DESCRIPTION
add tags to FakePolicy under organizations client. 

Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/organizations/client/tag_resource.html#tag-resource 