### PR TITLE
add CreateTime property to EC2 key pairs

### DIFF
--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -15,6 +15,7 @@ from ..utils import (
     generic_filter,
     random_key_pair_id,
 )
+from moto.core.utils import iso_8601_datetime_with_milliseconds
 
 
 class KeyPair(BaseModel):
@@ -24,6 +25,10 @@ class KeyPair(BaseModel):
         self.fingerprint = fingerprint
         self.material = material
         self.create_time = datetime.utcnow()
+
+    @property
+    def created_iso_8601(self) -> str:
+        return iso_8601_datetime_with_milliseconds(self.create_time)
 
     def get_filter_value(self, filter_name: str) -> str:
         if filter_name == "key-name":

--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List
+from datetime import datetime
 
 from moto.core import BaseModel
 from ..exceptions import (
@@ -22,6 +23,7 @@ class KeyPair(BaseModel):
         self.name = name
         self.fingerprint = fingerprint
         self.material = material
+        self.create_time = datetime.utcnow()
 
     def get_filter_value(self, filter_name: str) -> str:
         if filter_name == "key-name":

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -37,7 +37,7 @@ DESCRIBE_KEY_PAIRS_RESPONSE = """<DescribeKeyPairsResponse xmlns="http://ec2.ama
     <keySet>
     {% for keypair in keypairs %}
       <item>
-           <createTime>{{ keypair.create_time }}</createTime>
+           <createTime>{{ keypair.created_iso_8601 }}</createTime>
            <keyPairId>{{ keypair.id }}</keyPairId>
            <keyName>{{ keypair.name }}</keyName>
            <keyFingerprint>{{ keypair.fingerprint }}</keyFingerprint>

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -37,6 +37,7 @@ DESCRIBE_KEY_PAIRS_RESPONSE = """<DescribeKeyPairsResponse xmlns="http://ec2.ama
     <keySet>
     {% for keypair in keypairs %}
       <item>
+           <createTime>{{ keypair.create_time }}</createTime>
            <keyPairId>{{ keypair.id }}</keyPairId>
            <keyName>{{ keypair.name }}</keyName>
            <keyFingerprint>{{ keypair.fingerprint }}</keyFingerprint>

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 
 import sure  # noqa # pylint: disable=unused-import
 import boto3
@@ -7,6 +8,7 @@ from botocore.exceptions import ClientError
 from moto import mock_ec2, settings
 from uuid import uuid4
 from unittest import SkipTest
+from freezegun import freeze_time
 
 from .helpers import rsa_check_private_key
 
@@ -77,6 +79,7 @@ def test_key_pairs_create_dryrun_boto3():
 
 
 @mock_ec2
+@freeze_time("2014-01-01 05:00:00")
 def test_key_pairs_create_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
@@ -101,6 +104,7 @@ def test_key_pairs_create_boto3():
     kps[0].should.have.key("KeyPairId")
     kps[0].should.have.key("KeyName").equal(key_name)
     kps[0].should.have.key("KeyFingerprint")
+    kps[0].should.have.key("CreateTime").equal(datetime(2014, 1, 1, 5, 0, 0))
 
 
 @mock_ec2

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -104,7 +104,9 @@ def test_key_pairs_create_boto3():
     kps[0].should.have.key("KeyPairId")
     kps[0].should.have.key("KeyName").equal(key_name)
     kps[0].should.have.key("KeyFingerprint")
-    kps[0].should.have.key("CreateTime").equal(datetime(2014, 1, 1, 5, 0, 0))
+    kps[0]["CreateTime"].replace(tzinfo=None).should.equal(
+        datetime(2014, 1, 1, 5, 0, 0)
+    )
 
 
 @mock_ec2

--- a/tests/test_ec2/test_key_pairs.py
+++ b/tests/test_ec2/test_key_pairs.py
@@ -8,7 +8,6 @@ from botocore.exceptions import ClientError
 from moto import mock_ec2, settings
 from uuid import uuid4
 from unittest import SkipTest
-from freezegun import freeze_time
 
 from .helpers import rsa_check_private_key
 
@@ -79,7 +78,6 @@ def test_key_pairs_create_dryrun_boto3():
 
 
 @mock_ec2
-@freeze_time("2014-01-01 05:00:00")
 def test_key_pairs_create_boto3():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")
@@ -104,9 +102,7 @@ def test_key_pairs_create_boto3():
     kps[0].should.have.key("KeyPairId")
     kps[0].should.have.key("KeyName").equal(key_name)
     kps[0].should.have.key("KeyFingerprint")
-    kps[0]["CreateTime"].replace(tzinfo=None).should.equal(
-        datetime(2014, 1, 1, 5, 0, 0)
-    )
+    kps[0].should.have.key("CreateTime").should.be.a(datetime)
 
 
 @mock_ec2


### PR DESCRIPTION
currently the EC2 Key Pair model doesn't expose the `CreateTime` property (this property [is returned](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_key_pairs.html) by `boto3`, however)

I've implemented this by following the same pattern established with the `CreateDate` property on an IAM User in `moto`