### PR TITLE
SNS: Disable cross-region access

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -493,7 +493,7 @@ class SNSBackend(BaseBackend):
     def get_topic(self, arn: str) -> Topic:
         parsed_arn = parse_arn(arn)
         try:
-            return sns_backends[parsed_arn.account][parsed_arn.region].topics[arn]
+            return sns_backends[parsed_arn.account][self.region_name].topics[arn]
         except KeyError:
             raise TopicNotFound
 


### PR DESCRIPTION
Fixes #6354 

Looks like this snuck in with #6330. Cross-account access for topic is good, but we should not allow access across regions.

@viren-nadkarni Do you see any problems with this change?