### PR TITLE
SSM: Implement physical_resource_id property

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -349,6 +349,10 @@ class Parameter(CloudFormationModel):
 
         ssm_backend.delete_parameter(properties.get("Name"))
 
+    @property
+    def physical_resource_id(self):
+        return self.name
+
 
 MAX_TIMEOUT_SECONDS = 3600
 

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -350,7 +350,7 @@ class Parameter(CloudFormationModel):
         ssm_backend.delete_parameter(properties.get("Name"))
 
     @property
-    def physical_resource_id(self):
+    def physical_resource_id(self) -> str:
         return self.name
 
 

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1730,6 +1730,10 @@ def test_ssm_parameter():
     waiter = cfn.get_waiter("stack_create_complete")
     waiter.wait(StackName=stack_name)
 
+    stack_resources = cfn.list_stack_resources(StackName=stack_name)
+    ssm_resource = stack_resources.get("StackResourceSummaries")[0]
+    ssm_resource.get("PhysicalResourceId").should.equal("test_ssm")
+
     ssm_client = boto3.client("ssm", region_name="us-west-2")
     parameters = ssm_client.get_parameters(Names=["test_ssm"], WithDecryption=False)[
         "Parameters"


### PR DESCRIPTION
The current SSM model does not provide the PhysicalResourceId, resulting in an empty string value when calling the `list_stack_resources` from a CloudFormation client.