### PR TITLE
DynamoDB: Support projection expressions in lists

### DIFF
--- a/moto/dynamodb/models/utilities.py
+++ b/moto/dynamodb/models/utilities.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any
+import re
+from typing import Any, Dict, List, Optional
 
 
 class DynamoJsonEncoder(json.JSONEncoder):
@@ -14,3 +15,110 @@ def dynamo_json_dump(dynamo_object: Any) -> str:
 
 def bytesize(val: str) -> int:
     return len(val.encode("utf-8"))
+
+
+def find_nested_key(
+    keys: List[str],
+    dct: Dict[str, Any],
+    processed_keys: Optional[List[str]] = None,
+    result: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    keys   : A list of keys that may be present in the provided dictionary
+             ["level1", "level2"]
+    dct    : A dictionary that we want to inspect
+             {"level1": {"level2": "val", "irrelevant": ..}
+
+    processed_keys:
+        Should not be set by the caller, only by recursive invocations.
+        Example value: ["level1"]
+    result:
+        Should not be set by the caller, only by recursive invocations
+        Example value: {"level1": {}}
+
+    returns: {"level1": {"level2": "val"}}
+    """
+    if result is None:
+        result = {}
+    if processed_keys is None:
+        processed_keys = []
+
+    # A key can refer to a list-item: 'level1[1].level2'
+    is_list_expression = re.match(pattern=r"(.+)\[(\d+)\]$", string=keys[0])
+
+    if len(keys) == 1:
+        # Set 'current_key' and 'value'
+        #   or return an empty dictionary if the key does not exist in our dictionary
+        if is_list_expression:
+            current_key = is_list_expression.group(1)
+            idx = int(is_list_expression.group(2))
+            if (
+                current_key in dct
+                and isinstance(dct[current_key], list)
+                and len(dct[current_key]) >= idx
+            ):
+                value = [dct[current_key][idx]]
+            else:
+                return {}
+        elif keys[0] in dct:
+            current_key = keys[0]
+            value = dct[current_key]
+        else:
+            return {}
+
+        # We may have already processed some keys
+        # Dig into the result to find the appropriate key to append the value to
+        #
+        # result: {'level1': {'level2': {}}}
+        # processed_keys: ['level1', 'level2']
+        #     -->
+        # result: {'level1': {'level2': value}}
+        temp_result = result
+        for key in processed_keys:
+            if isinstance(temp_result, list):
+                temp_result = temp_result[0][key]
+            else:
+                temp_result = temp_result[key]
+        if isinstance(temp_result, list):
+            temp_result.append({current_key: value})
+        else:
+            temp_result[current_key] = value
+        return result
+    else:
+        # Set 'current_key'
+        #   or return an empty dictionary if the key does not exist in our dictionary
+        if is_list_expression:
+            current_key = is_list_expression.group(1)
+            idx = int(is_list_expression.group(2))
+            if (
+                current_key in dct
+                and isinstance(dct[current_key], list)
+                and len(dct[current_key]) >= idx
+            ):
+                pass
+            else:
+                return {}
+        elif keys[0] in dct:
+            current_key = keys[0]
+        else:
+            return {}
+
+        # Append the 'current_key' to the dictionary that is our result (so far)
+        # {'level1': {}} --> {'level1': {current_key: {}}
+        temp_result = result
+        for key in processed_keys:
+            temp_result = temp_result[key]
+        if isinstance(temp_result, list):
+            temp_result.append({current_key: [] if is_list_expression else {}})
+        else:
+            temp_result[current_key] = [] if is_list_expression else {}
+        remaining_dct = (
+            dct[current_key][idx] if is_list_expression else dct[current_key]
+        )
+
+        return find_nested_key(
+            keys[1:],
+            remaining_dct,
+            processed_keys=processed_keys + [current_key],
+            result=result,
+        )

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -199,7 +199,6 @@ def test_update_item_range_key_set():
 
 @mock_dynamodb
 def test_batch_get_item_non_existing_table():
-
     client = boto3.client("dynamodb", region_name="us-west-2")
 
     with pytest.raises(client.exceptions.ResourceNotFoundException) as exc:
@@ -768,7 +767,6 @@ def test_query_begins_with_without_brackets():
 
 @mock_dynamodb
 def test_transact_write_items_multiple_operations_fail():
-
     # Setup
     schema = {
         "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],

--- a/tests/test_dynamodb/models/test_item.py
+++ b/tests/test_dynamodb/models/test_item.py
@@ -1,0 +1,110 @@
+from moto.dynamodb.models.dynamo_type import DynamoType, Item
+from moto.dynamodb.models.dynamo_type import serializer
+
+
+class TestFindNestedKeys:
+    def setup(self):
+        self.dct = {
+            "simplestring": "val",
+            "nesteddict": {
+                "level21": {"ll31": "val", "ll32": "val"},
+                "level22": {"ll31": "val", "ll32": "val"},
+                "nestedlist": [
+                    {"ll21": {"ll31": "val", "ll32": "val"}},
+                    {"ll22": {"ll31": "val", "ll32": "val"}},
+                ],
+            },
+            "rootlist": [
+                {"ll21": {"ll31": "val", "ll32": "val"}},
+                {"ll22": {"ll31": "val", "ll32": "val"}},
+            ],
+        }
+        x = serializer.serialize(self.dct)["M"]
+        self.item = Item(
+            hash_key=DynamoType({"pk": {"S": "v"}}), range_key=None, attrs=x
+        )
+
+    def _project(self, expression, result):
+        x = self.item.project(expression)
+        y = Item(
+            hash_key=DynamoType({"pk": {"S": "v"}}),
+            range_key=None,
+            attrs=serializer.serialize(result)["M"],
+        )
+        assert x == y
+
+    def test_find_nothing(self):
+        self._project("", result={})
+
+    def test_find_unknown_key(self):
+        self._project("unknown", result={})
+
+    def test_project_single_key_string(self):
+        self._project("simplestring", result={"simplestring": "val"})
+
+    def test_project_single_key_dict(self):
+        self._project(
+            "nesteddict",
+            result={
+                "nesteddict": {
+                    "level21": {"ll31": "val", "ll32": "val"},
+                    "level22": {"ll31": "val", "ll32": "val"},
+                    "nestedlist": [
+                        {"ll21": {"ll31": "val", "ll32": "val"}},
+                        {"ll22": {"ll31": "val", "ll32": "val"}},
+                    ],
+                }
+            },
+        )
+
+    def test_project_nested_key(self):
+        self._project(
+            "nesteddict.level21",
+            result={"nesteddict": {"level21": {"ll31": "val", "ll32": "val"}}},
+        )
+
+    def test_project_multi_level_nested_key(self):
+        self._project(
+            "nesteddict.level21.ll32",
+            result={"nesteddict": {"level21": {"ll32": "val"}}},
+        )
+
+    def test_project_nested_key__partial_fix(self):
+        self._project("nesteddict.levelunknown", result={})
+
+    def test_project_nested_key__partial_fix2(self):
+        self._project("nesteddict.unknown.unknown2", result={})
+
+    def test_list_index(self):
+        self._project(
+            "rootlist[0]",
+            result={"rootlist": [{"ll21": {"ll31": "val", "ll32": "val"}}]},
+        )
+
+    def test_nested_list_index(self):
+        self._project(
+            "nesteddict.nestedlist[1]",
+            result={
+                "nesteddict": {"nestedlist": [{"ll22": {"ll31": "val", "ll32": "val"}}]}
+            },
+        )
+
+    def test_nested_obj_in_list(self):
+        self._project(
+            "nesteddict.nestedlist[1].ll22.ll31",
+            result={"nesteddict": {"nestedlist": [{"ll22": {"ll31": "val"}}]}},
+        )
+
+    def test_list_unknown_indexes(self):
+        self._project("nesteddict.nestedlist[25]", result={})
+
+    def test_multiple_projections(self):
+        self._project(
+            "nesteddict.nestedlist[1].ll22,rootlist[0]",
+            result={
+                "nesteddict": {
+                    "nestedlist": [{"ll22": {"ll31": "val", "ll32": "val"}}]
+                },
+                "rootlist": [{"ll21": {"ll31": "val", "ll32": "val"}}],
+            },
+        )

--- a/tests/test_dynamodb/models/test_utilities.py
+++ b/tests/test_dynamodb/models/test_utilities.py
@@ -1,0 +1,75 @@
+from moto.dynamodb.models.utilities import find_nested_key
+
+
+class TestFindDictionaryKeys:
+    def setup(self):
+        self.item = {
+            "simplestring": "val",
+            "nesteddict": {
+                "level21": {"level3.1": "val", "level3.2": "val"},
+                "level22": {"level3.1": "val", "level3.2": "val"},
+                "nestedlist": [
+                    {"ll21": {"ll3.1": "val", "ll3.2": "val"}},
+                    {"ll22": {"ll3.1": "val", "ll3.2": "val"}},
+                ],
+            },
+            "rootlist": [
+                {"ll21": {"ll3.1": "val", "ll3.2": "val"}},
+                {"ll22": {"ll3.1": "val", "ll3.2": "val"}},
+            ],
+        }
+
+    def test_find_nothing(self):
+        assert find_nested_key([""], self.item) == {}
+
+    def test_find_unknown_key(self):
+        assert find_nested_key(["unknown"], self.item) == {}
+
+    def test_project_single_key_string(self):
+        assert find_nested_key(["simplestring"], self.item) == {"simplestring": "val"}
+
+    def test_project_single_key_dict(self):
+        assert find_nested_key(["nesteddict"], self.item) == {
+            "nesteddict": {
+                "level21": {"level3.1": "val", "level3.2": "val"},
+                "level22": {"level3.1": "val", "level3.2": "val"},
+                "nestedlist": [
+                    {"ll21": {"ll3.1": "val", "ll3.2": "val"}},
+                    {"ll22": {"ll3.1": "val", "ll3.2": "val"}},
+                ],
+            }
+        }
+
+    def test_project_nested_key(self):
+        assert find_nested_key(["nesteddict", "level21"], self.item) == {
+            "nesteddict": {"level21": {"level3.1": "val", "level3.2": "val"}}
+        }
+
+    def test_project_multi_level_nested_key(self):
+        assert find_nested_key(["nesteddict", "level21", "level3.2"], self.item) == {
+            "nesteddict": {"level21": {"level3.2": "val"}}
+        }
+
+    def test_project_nested_key__partial_fix(self):
+        assert find_nested_key(["nesteddict", "levelunknown"], self.item) == {}
+
+    def test_project_nested_key__partial_fix2(self):
+        assert find_nested_key(["nesteddict", "unknown", "unknown2"], self.item) == {}
+
+    def test_list_index(self):
+        assert find_nested_key(["rootlist[0]"], self.item) == {
+            "rootlist": [{"ll21": {"ll3.1": "val", "ll3.2": "val"}}]
+        }
+
+    def test_nested_list_index(self):
+        assert find_nested_key(["nesteddict", "nestedlist[1]"], self.item) == {
+            "nesteddict": {"nestedlist": [{"ll22": {"ll3.1": "val", "ll3.2": "val"}}]}
+        }
+
+    def test_nested_obj_in_list(self):
+        assert find_nested_key(
+            ["nesteddict", "nestedlist[1]", "ll22", "ll3.1"], self.item
+        ) == {"nesteddict": {"nestedlist": [{"ll22": {"ll3.1": "val"}}]}}
+
+    def test_list_unknown_indexes(self):
+        assert find_nested_key(["nesteddict", "nestedlist[25]"], self.item) == {}

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -895,7 +895,10 @@ def test_nested_projection_expression_using_get_item_with_attr_expression():
             "nested": {
                 "level1": {"id": "id1", "att": "irrelevant"},
                 "level2": {"id": "id2", "include": "all"},
-                "level3": {"id": "irrelevant"},
+                "level3": {
+                    "id": "irrelevant",
+                    "children": [{"Name": "child_a"}, {"Name": "child_b"}],
+                },
             },
             "foo": "bar",
         }
@@ -926,10 +929,20 @@ def test_nested_projection_expression_using_get_item_with_attr_expression():
             "nested": {
                 "level1": {"id": "id1", "att": "irrelevant"},
                 "level2": {"id": "id2", "include": "all"},
-                "level3": {"id": "irrelevant"},
+                "level3": {
+                    "id": "irrelevant",
+                    "children": [{"Name": "child_a"}, {"Name": "child_b"}],
+                },
             },
         }
     )
+
+    # Test a get_item retrieving children
+    result = table.get_item(
+        Key={"forum_name": "key1"},
+        ProjectionExpression="nested.level3.children[0].Name",
+    )["Item"]
+    result.should.equal({"nested": {"level3": {"children": [{"Name": "child_a"}]}}})
 
 
 @mock_dynamodb
@@ -3400,7 +3413,6 @@ def test_query_catches_when_no_filters():
 
 @mock_dynamodb
 def test_invalid_transact_get_items():
-
     dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
     dynamodb.create_table(
         TableName="test1",


### PR DESCRIPTION
Improves ProjectionExpressions in scan/query/get_item operations.

The old method would create a copy of the Item and then remove unwanted keys, acting as a filter.
That makes it difficult to filter lists, especially if there are multiple expressions acting on the same list (`listkey[0].a,listkey[1].a`).

This PR introduces a new approach that works the other way around: it recreates a new dictionary containing _just_ the value specified by the expression: `{"listkey": [..]}`.
These partial dictionaries are merged together afterwards to create the final result.

Fixes #6360 