### PR TITLE
CloudWatch: Apply startTime and endTime similarly to AWS

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -651,6 +651,17 @@ class CloudWatchBackend(BaseBackend):
         end_time: datetime,
         scan_by: str = "TimestampAscending",
     ) -> List[Dict[str, Any]]:
+        start_time = start_time.replace(microsecond=0)
+        end_time = end_time.replace(microsecond=0)
+
+        if start_time > end_time:
+            raise ValidationError(
+                "The parameter EndTime must be greater than StartTime."
+            )
+        if start_time == end_time:
+            raise ValidationError(
+                "The parameter StartTime must not equal parameter EndTime."
+            )
 
         period_data = [
             md for md in self.get_all_metrics() if start_time <= md.timestamp < end_time
@@ -731,6 +742,14 @@ class CloudWatchBackend(BaseBackend):
         dimensions: List[Dict[str, str]],
         unit: Optional[str] = None,
     ) -> List[Statistics]:
+        start_time = start_time.replace(microsecond=0)
+        end_time = end_time.replace(microsecond=0)
+
+        if start_time >= end_time:
+            raise InvalidParameterValue(
+                "The parameter StartTime must be less than the parameter EndTime."
+            )
+
         period_delta = timedelta(seconds=period)
         filtered_data = [
             md


### PR DESCRIPTION
Hi, I've noticed several small differences in handling `startTime` and `endTime` in `GetMetricsData` and `GetMetricsStatistics` compared to AWS (based on docs and my experience).

Summary:

1. Metrics timestamps in AWS seem to fully disregard miliseconds (docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html) - i.e. metric recorded in `2023-06-08T09:04:37.431Z` should be accessible even using `startTime` of `2023-06-08T09:04:37.000Z` --> solved by setting microsecond field of each timestamp to `0`.
2. AWS tends to throw exceptions when `startTime` and `endTime` are either equal or `endTime` is greater than `startTime` --> added exception throwing.
3. Added test cases.