### PR TITLE
Add missing/new availability zones

### DIFF
--- a/moto/ec2/models/availability_zones_and_regions.py
+++ b/moto/ec2/models/availability_zones_and_regions.py
@@ -76,6 +76,7 @@ class RegionsAndZonesBackend:
         "ap-south-1": [
             Zone(region_name="ap-south-1", name="ap-south-1a", zone_id="aps1-az1"),
             Zone(region_name="ap-south-1", name="ap-south-1b", zone_id="aps1-az3"),
+            Zone(region_name="ap-south-1", name="ap-south-1c", zone_id="aps1-az2"),
         ],
         "eu-west-3": [
             Zone(region_name="eu-west-3", name="eu-west-3a", zone_id="euw3-az1"),
@@ -160,11 +161,13 @@ class RegionsAndZonesBackend:
         ],
         "sa-east-1": [
             Zone(region_name="sa-east-1", name="sa-east-1a", zone_id="sae1-az1"),
+            Zone(region_name="sa-east-1", name="sa-east-1b", zone_id="sae1-az2"),
             Zone(region_name="sa-east-1", name="sa-east-1c", zone_id="sae1-az3"),
         ],
         "ca-central-1": [
             Zone(region_name="ca-central-1", name="ca-central-1a", zone_id="cac1-az1"),
             Zone(region_name="ca-central-1", name="ca-central-1b", zone_id="cac1-az2"),
+            Zone(region_name="ca-central-1", name="ca-central-1d", zone_id="cac1-az4"),
         ],
         "ap-southeast-1": [
             Zone(
@@ -248,6 +251,7 @@ class RegionsAndZonesBackend:
             Zone(region_name="us-west-2", name="us-west-2a", zone_id="usw2-az2"),
             Zone(region_name="us-west-2", name="us-west-2b", zone_id="usw2-az1"),
             Zone(region_name="us-west-2", name="us-west-2c", zone_id="usw2-az3"),
+            Zone(region_name="us-west-2", name="us-west-2d", zone_id="usw2-az4"),
         ],
         "me-south-1": [
             Zone(region_name="me-south-1", name="me-south-1a", zone_id="mes1-az1"),


### PR DESCRIPTION
## Motivation
We found cases where LocalStack users where unable to do a create_subnet for existing availability zones. This led to a investigation of missing zones.

## Changes
* Add found missing availability zones

## Notes
Due to my AWS account not being activated for certain regions, I was unable to check some regions: af-south-1, ap-east-1, ap-southeast-3, eu-south-1, me-south-1, cn-north-1, cn-northwest-1, us-gov-west-1, us-gov-east-1


## Script
I created a little script to find missing zones:

```python
#!/usr/bin/env python3

import dataclasses

import boto3

@dataclasses.dataclass
class Zone:
    region_name: str
    name: str
    zone_id: str

def check_zones(defined_zones: dict[str, list[Zone]]):
    for region, zones in defined_zones.items():
        print(f"Processing region {region}")
        zone_names = [zone.name for zone in zones]
        try:
            ec2_client = boto3.client("ec2", region_name=region)
            retrieved_zones = ec2_client.describe_availability_zones()["AvailabilityZones"]
        except Exception as e:
            print(f"ERROR: Cannot access region {region}: {e}")
            continue
        for zone in retrieved_zones:
            if zone["ZoneType"] == "availability-zone":
                if zone["ZoneName"] not in zone_names:
                    print(f"MISSING: Region: {region}, ZoneName: {zone['ZoneName']}, ZoneId: {zone['ZoneId']}")
                    print(f'Zone(region_name="{region}", name="{zone["ZoneName"]}", zone_id="{zone["ZoneId"]}"),')


if __name__ == "__main__":
    check_zones({})
```

the empty dict must be the zones dict from availability_zones_and_regions.py. The dataclass just some mock to make it standalone.
It is not sophisticated, but worked for the usecase. 