### PR TITLE
Cloudfront: correct create_invalidation API response when supplying a single path

### DIFF
--- a/moto/cloudfront/responses.py
+++ b/moto/cloudfront/responses.py
@@ -14,7 +14,7 @@ class CloudFrontResponse(BaseResponse):
         super().__init__(service_name="cloudfront")
 
     def _get_xml_body(self) -> Dict[str, Any]:
-        return xmltodict.parse(self.body, dict_constructor=dict)
+        return xmltodict.parse(self.body, dict_constructor=dict, force_list="Path")
 
     @property
     def backend(self) -> CloudFrontBackend:

--- a/tests/test_cloudfront/test_cloudfront_invalidation.py
+++ b/tests/test_cloudfront/test_cloudfront_invalidation.py
@@ -5,7 +5,36 @@ import sure  # noqa # pylint: disable=unused-import
 
 
 @mock_cloudfront
-def test_create_invalidation():
+def test_create_invalidation_with_single_path():
+    client = boto3.client("cloudfront", region_name="us-west-1")
+    config = scaffold.example_distribution_config("ref")
+    resp = client.create_distribution(DistributionConfig=config)
+    dist_id = resp["Distribution"]["Id"]
+
+    resp = client.create_invalidation(
+        DistributionId=dist_id,
+        InvalidationBatch={
+            "Paths": {"Quantity": 1, "Items": ["/path1"]},
+            "CallerReference": "ref2",
+        },
+    )
+
+    resp.should.have.key("Location")
+    resp.should.have.key("Invalidation")
+
+    resp["Invalidation"].should.have.key("Id")
+    resp["Invalidation"].should.have.key("Status").equals("COMPLETED")
+    resp["Invalidation"].should.have.key("CreateTime")
+    resp["Invalidation"].should.have.key("InvalidationBatch").equals(
+        {
+            "Paths": {"Quantity": 1, "Items": ["/path1"]},
+            "CallerReference": "ref2",
+        }
+    )
+
+
+@mock_cloudfront
+def test_create_invalidation_with_multiple_paths():
     client = boto3.client("cloudfront", region_name="us-west-1")
     config = scaffold.example_distribution_config("ref")
     resp = client.create_distribution(DistributionConfig=config)


### PR DESCRIPTION
Fixes #6386

Using the `force_list` parameter ensures that path items are always encapsulated in a list, even if only a single path is supplied.