### PR TITLE
Fix SES V2 Responses

### DIFF
--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -58,6 +58,7 @@ class BotocoreStubber:
             try:
                 recorder._record_request(request)
 
+                request.headers["X-Moto-EventName"] = event_name
                 status, headers, body = response_callback(
                     request, request.url, request.headers
                 )

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -237,7 +237,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         """
         use_raw_body: Use incoming bytes if True, encode to string otherwise
         """
-        event_name: Optional[str] = None
+        event_name: str = ""
         if "X-Moto-EventName" in headers:
             event_name = headers["X-Moto-EventName"]
             del headers["X-Moto-EventName"]
@@ -1002,7 +1002,7 @@ def to_str(value: Any, spec: Dict[str, Any]) -> str:
     elif vtype == "string":
         return str(value)
     elif vtype == "blob":
-        return base64.b64decode(value)
+        return base64.b64decode(value).decode("utf-8")
     elif value is None:
         return "null"
     else:

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -331,7 +331,7 @@ class SESBackend(BaseBackend):
                         )
 
     def send_raw_email(
-        self, source: str, destinations: List[str], raw_data: str
+        self, source: Optional[str], destinations: List[str], raw_data: str
     ) -> RawMessage:
         if source is not None:
             _, source_email_address = parseaddr(source)

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -32,7 +32,6 @@ RECIPIENT_LIMIT = 50
 
 
 class SESFeedback(BaseModel):
-
     BOUNCE = "Bounce"
     COMPLAINT = "Complaint"
     DELIVERY = "Delivery"
@@ -351,6 +350,7 @@ class SESBackend(BaseBackend):
                 raise MessageRejectedError(
                     f"Did not have authority to send from email {source_email_address}"
                 )
+            source = source_email_address
 
         for header in "TO", "CC", "BCC":
             recipient_count += sum(
@@ -416,7 +416,6 @@ class SESBackend(BaseBackend):
     def create_configuration_set_event_destination(
         self, configuration_set_name: str, event_destination: Dict[str, Any]
     ) -> None:
-
         if self.config_set.get(configuration_set_name) is None:
             raise ConfigurationSetDoesNotExist("Invalid Configuration Set Name.")
 

--- a/tests/test_sesv2/test_sesv2.py
+++ b/tests/test_sesv2/test_sesv2.py
@@ -70,6 +70,31 @@ def test_send_raw_email(ses_v1):  # pylint: disable=redefined-outer-name
 
 
 @mock_sesv2
+def test_send_raw_email2(ses_v1):  # pylint: disable=redefined-outer-name
+    # Setup
+    conn = boto3.client("sesv2", region_name="us-east-1")
+    message = get_raw_email()
+    message["Subject"] = "Test-2"
+    destination = {
+        "ToAddresses": [x.strip() for x in message["To"].split(",")],
+    }
+    kwargs = dict(
+        FromEmailAddress=message["From"],
+        Destination=destination,
+        Content={"Raw": {"Data": message.as_bytes()}},
+    )
+
+    # Execute
+    ses_v1.verify_email_identity(EmailAddress="test@example.com")
+    conn.send_email(**kwargs)
+
+    # Verify
+    send_quota = ses_v1.get_send_quota()
+    sent_count = int(send_quota["SentLast24Hours"])
+    assert sent_count == 2
+
+
+@mock_sesv2
 def test_create_contact_list():
     # Setup
     conn = boto3.client("sesv2", region_name="us-east-1")

--- a/tests/test_sesv2/test_sesv2.py
+++ b/tests/test_sesv2/test_sesv2.py
@@ -75,12 +75,7 @@ def test_send_raw_email2(ses_v1):  # pylint: disable=redefined-outer-name
     conn = boto3.client("sesv2", region_name="us-east-1")
     message = get_raw_email()
     message["Subject"] = "Test-2"
-    destination = {
-        "ToAddresses": [x.strip() for x in message["To"].split(",")],
-    }
     kwargs = dict(
-        FromEmailAddress=message["From"],
-        Destination=destination,
         Content={"Raw": {"Data": message.as_bytes()}},
     )
 


### PR DESCRIPTION
I was getting an error when calling `send_email` with certain raw message data using SES V2 (the current `master` branch test case seems to luckily pass without it happening).
I have tried to find the cause, and found that SES V2 uses `"protocol": "rest-json"`, so the body contains JSON, but the current `SESV2Response` parses it as a query string. This made `self.data` a strange dict, and [it was forced to use `json.loads` to retrieve the data](https://github.com/getmoto/moto/pull/6259/files#diff-4d53d2456ab2314d10a9f59631b895debb9ace766f76890603b6c585a3293c47R100). Here the raw message contains base64 encoding, so when the `=` padding is added, it gets split in parse as a query string!

To avoid this parse failure, I have changed to allow deserialization to the correct schema by adding a `aws_service_spec` value.
However, I noticed that SES V2 does not include headers like `X-Amz-Target`, so it is not possible to determine the method name (event name). In `BotocoreStubber.__call__`, the `event_name` was received, but it was not passed to callback; I wanted to add `event_name` as an argument to the callback function, but that would be too big an interface change. As a desperate measure, I temporarily included it in the headers so that it could be retrieved by `BaseResponse.setup_class`.

Other changes are included to accommodate the use of raw data in `send_email`, since it is not necessary to specify the `FromEmailAddress` or `Destination`.
