### PR TITLE
SESv2: send_email(): raw emails are send as JSON

### DIFF
--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -181,7 +181,6 @@ class EmailResponse(BaseResponse):
         return template.render()
 
     def set_identity_notification_topic(self) -> str:
-
         identity = self.querystring.get("Identity")[0]  # type: ignore
         not_type = self.querystring.get("NotificationType")[0]  # type: ignore
         sns_topic = self.querystring.get("SnsTopic")  # type: ignore
@@ -212,7 +211,6 @@ class EmailResponse(BaseResponse):
         return template.render(name=configuration_set_name)
 
     def create_configuration_set_event_destination(self) -> str:
-
         configuration_set_name = self._get_param("ConfigurationSetName")  # type: ignore
         is_configuration_event_enabled = self.querystring.get(
             "EventDestination.Enabled"


### PR DESCRIPTION
Before we would use query-parameters to get the arguments - but the query-parameters parser sometimes get confused if the body contains a `=`. Considering the parameters are send as JSON, we can just parse the body directly.

The actual message is base64 encoded, so we now decode the message before handing it off to the backend.

Because the message is now in proper email format, we can read and store the `source` and `destinations` of the email (with a few modifications)