### PR TITLE
Lambda: delete_layer_version() now also accepts an ARN

### DIFF
--- a/moto/awslambda/exceptions.py
+++ b/moto/awslambda/exceptions.py
@@ -1,4 +1,5 @@
 from moto.core.exceptions import JsonRESTError
+from typing import Any
 
 
 class LambdaClientError(JsonRESTError):
@@ -61,6 +62,16 @@ class UnknownLayerException(LambdaClientError):
 
     def __init__(self) -> None:
         super().__init__("ResourceNotFoundException", "Cannot find layer")
+
+
+class UnknownLayerVersionException(LambdaClientError):
+    code = 404
+
+    def __init__(self, arns: Any) -> None:
+        super().__init__(
+            "ResourceNotFoundException",
+            f"One or more LayerVersion does not exist {arns}",
+        )
 
 
 class UnknownPolicyException(LambdaClientError):

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -80,10 +80,12 @@ class LambdaResponse(BaseResponse):
 
     def layers_version(self, request: Any, full_url: str, headers: Any) -> TYPE_RESPONSE:  # type: ignore[return]
         self.setup_class(request, full_url, headers)
+        layer_name = unquote(self.path.split("/")[-3])
+        layer_version = self.path.split("/")[-1]
         if request.method == "DELETE":
-            return self._delete_layer_version()
+            return self._delete_layer_version(layer_name, layer_version)
         elif request.method == "GET":
-            return self._get_layer_version()
+            return self._get_layer_version(layer_name, layer_version)
 
     def layers_versions(self, request: Any, full_url: str, headers: Any) -> TYPE_RESPONSE:  # type: ignore[return]
         self.setup_class(request, full_url, headers)
@@ -492,17 +494,13 @@ class LambdaResponse(BaseResponse):
         layers = self.backend.list_layers()
         return 200, {}, json.dumps({"Layers": layers})
 
-    def _delete_layer_version(self) -> TYPE_RESPONSE:
-        layer_name = self.path.split("/")[-3]
-        layer_version = self.path.split("/")[-1]
-
+    def _delete_layer_version(
+        self, layer_name: str, layer_version: str
+    ) -> TYPE_RESPONSE:
         self.backend.delete_layer_version(layer_name, layer_version)
         return 200, {}, "{}"
 
-    def _get_layer_version(self) -> TYPE_RESPONSE:
-        layer_name = self.path.split("/")[-3]
-        layer_version = self.path.split("/")[-1]
-
+    def _get_layer_version(self, layer_name: str, layer_version: str) -> TYPE_RESPONSE:
         layer = self.backend.get_layer_version(layer_name, layer_version)
         return 200, {}, json.dumps(layer.get_layer_version())
 

--- a/moto/awslambda/urls.py
+++ b/moto/awslambda/urls.py
@@ -27,7 +27,7 @@ url_paths = {
     r"{0}/(?P<api_version>[^/]+)/functions/(?P<function_name>[\w_:%-]+)/url/?$": response.function_url_config,
     r"{0}/(?P<api_version>[^/]+)/layers$": response.list_layers,
     r"{0}/(?P<api_version>[^/]+)/layers/$": response.list_layers,
-    r"{0}/(?P<api_version>[^/]+)/layers/(?P<layer_name>[\w_-]+)/versions$": response.layers_versions,
-    r"{0}/(?P<api_version>[^/]+)/layers/(?P<layer_name>[\w_-]+)/versions/$": response.layers_versions,
-    r"{0}/(?P<api_version>[^/]+)/layers/(?P<layer_name>[\w_-]+)/versions/(?P<layer_version>[\w_-]+)$": response.layers_version,
+    r"{0}/(?P<api_version>[^/]+)/layers/(?P<layer_name>.+)/versions$": response.layers_versions,
+    r"{0}/(?P<api_version>[^/]+)/layers/(?P<layer_name>.+)/versions/$": response.layers_versions,
+    r"{0}/(?P<api_version>[^/]+)/layers/(?P<layer_name>.+)/versions/(?P<layer_version>[\w_-]+)$": response.layers_version,
 }


### PR DESCRIPTION
Fixes #6400 

The `get_layer_version` receives the same fix, so the `LayerName`-parameter can be both a Name and an ARN.

This PR also fixes the error format when creating a function with a non-existing layer. 
Before it would throw a generic `ValueError`. When running tests in ServerMode, `boto3` would constantly retry the request in case the `ValueError` was temporary, resulting in a very slow test (+8 seconds).

Moto now throws a regular `ClientError`, which means `boto3` now immediately understands it's a failure - without having to retry.