### PR TITLE
Feat: Support All AWS Partitions

### DIFF
--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -195,14 +195,10 @@ class AccountSpecificBackend(Dict[str, SERVICE_BACKEND]):
         self.regions = []
         if use_boto3_regions:
             sess = Session()
-            self.regions.extend(sess.get_available_regions(service_name))
             for partition in sess.get_available_partitions():
-                if partition != "aws":
-                    self.regions.extend(
-                        sess.get_available_regions(
-                            service_name, partition_name=partition
-                        )
-                    )
+                self.regions.extend(
+                    sess.get_available_regions(service_name, partition_name=partition)
+                )
         self.regions.extend(additional_regions or [])
         self._id = str(uuid4())
 

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -55,11 +55,13 @@ class BaseBackend:
         urls = {}
         for url_base in url_bases:
             # The default URL_base will look like: http://service.[..].amazonaws.com/...
-            # This extension ensures support for the China, ISO, & ISOB regions
+            # This extension ensures support for the China & ISO regions
             alt_dns_suffixes = {
                 "cn": "amazonaws.com.cn",
                 "iso": "c2s.ic.gov",
                 "isob": "sc2s.sgov.gov",
+                "isoe": "cloud.adc-e.uk",
+                "isof": "csp.hci.ic.gov",
             }
 
             for url_path, handler in unformatted_paths.items():

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -55,13 +55,20 @@ class BaseBackend:
         urls = {}
         for url_base in url_bases:
             # The default URL_base will look like: http://service.[..].amazonaws.com/...
-            # This extension ensures support for the China regions
-            cn_url_base = re.sub(r"amazonaws\\?.com$", "amazonaws.com.cn", url_base)
+            # This extension ensures support for the China, ISO, & ISOB regions
+            alt_dns_suffixes = {
+                "cn": "amazonaws.com.cn",
+                "iso": "c2s.ic.gov",
+                "isob": "sc2s.sgov.gov",
+            }
+
             for url_path, handler in unformatted_paths.items():
                 url = url_path.format(url_base)
                 urls[url] = handler
-                cn_url = url_path.format(cn_url_base)
-                urls[cn_url] = handler
+                for dns_suffix in alt_dns_suffixes.values():
+                    alt_url_base = re.sub(r"amazonaws\\?.com$", dns_suffix, url_base)
+                    alt_url = url_path.format(alt_url_base)
+                    urls[alt_url] = handler
 
         return urls
 

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -196,12 +196,13 @@ class AccountSpecificBackend(Dict[str, SERVICE_BACKEND]):
         if use_boto3_regions:
             sess = Session()
             self.regions.extend(sess.get_available_regions(service_name))
-            self.regions.extend(
-                sess.get_available_regions(service_name, partition_name="aws-us-gov")
-            )
-            self.regions.extend(
-                sess.get_available_regions(service_name, partition_name="aws-cn")
-            )
+            for partition in sess.get_available_partitions():
+                if partition != "aws":
+                    self.regions.extend(
+                        sess.get_available_regions(
+                            service_name, partition_name=partition
+                        )
+                    )
         self.regions.extend(additional_regions or [])
         self._id = str(uuid4())
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -25,7 +25,7 @@ _lambda_region = "us-west-2"
 boto3.setup_default_session(region_name=_lambda_region)
 
 
-@pytest.mark.parametrize("region", ["us-west-2", "cn-northwest-1"])
+@pytest.mark.parametrize("region", ["us-west-2", "cn-northwest-1", "us-isob-east-1"])
 @mock_lambda
 def test_lambda_regions(region):
     client = boto3.client("lambda", region_name=region)

--- a/tests/test_stepfunctions/test_stepfunctions.py
+++ b/tests/test_stepfunctions/test_stepfunctions.py
@@ -888,7 +888,9 @@ def test_state_machine_get_execution_history_contains_expected_success_events_wh
     execution_history["events"].should.equal(expected_events)
 
 
-@pytest.mark.parametrize("test_region", ["us-west-2", "cn-northwest-1"])
+@pytest.mark.parametrize(
+    "test_region", ["us-west-2", "cn-northwest-1", "us-isob-east-1"]
+)
 @mock_stepfunctions
 def test_stepfunction_regions(test_region):
     client = boto3.client("stepfunctions", region_name=test_region)

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -707,7 +707,7 @@ def test_federation_token_with_too_long_policy():
     )
 
 
-@pytest.mark.parametrize("region", ["us-west-2", "cn-northwest-1"])
+@pytest.mark.parametrize("region", ["us-west-2", "cn-northwest-1", "us-isob-east-1"])
 @mock_sts
 def test_sts_regions(region):
     client = boto3.client("sts", region_name=region)


### PR DESCRIPTION
This PR extends support of moto to all AWS Partitions.

One can see all Partitions, Regions, and DNS Suffixes with: `curl https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/endpoints.json | jq '.partitions[] | [.partitionName, .partition, .regions, .dnsSuffix]'`
