### PR TITLE
EC2: Return appropriate error when calling EC2.Client.replace_route() with missing route

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -444,6 +444,14 @@ class InvalidParameterValueErrorTagSpotFleetRequest(EC2ClientError):
         )
 
 
+class InvalidParameterValueErrorReplaceRoute(EC2ClientError):
+    def __init__(self, cidr: str):
+        super().__init__(
+            "InvalidParameterValue",
+            f"There is no route defined for '{cidr}' in the route table. Use CreateRoute instead.",
+        )
+
+
 class EmptyTagSpecError(EC2ClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -448,6 +448,11 @@ class RouteBackend:
         interface_id: Optional[str] = None,
         vpc_peering_connection_id: Optional[str] = None,
     ) -> Route:
+        cidr = destination_cidr_block
+        if destination_ipv6_cidr_block:
+            cidr = destination_ipv6_cidr_block
+        if destination_prefix_list_id:
+            cidr = destination_prefix_list_id
         route_table = self.get_route_table(route_table_id)
         route_id = generate_route_id(
             route_table.id, destination_cidr_block, destination_ipv6_cidr_block
@@ -455,11 +460,6 @@ class RouteBackend:
         try:
             route = route_table.routes[route_id]
         except KeyError:
-            cidr = (
-                destination_cidr_block
-                if destination_cidr_block
-                else destination_ipv6_cidr_block
-            )
             # This should be 'raise InvalidRouteError(route_table_id, cidr)' in
             # line with the delete_route() equivalent, but for some reason AWS
             # returns InvalidParameterValue instead in this case.

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -643,6 +643,18 @@ def test_routes_replace():
     ex.value.response["ResponseMetadata"].should.have.key("RequestId")
     ex.value.response["Error"]["Code"].should.equal("InvalidRouteTableID.NotFound")
 
+    with pytest.raises(ClientError) as ex:
+        client.replace_route(
+            RouteTableId=main_route_table.id,
+            DestinationCidrBlock="1.1.1.1/32",
+            NetworkInterfaceId=eni.id,
+        )
+    ex.value.response["ResponseMetadata"]["HTTPStatusCode"].should.equal(400)
+    ex.value.response["ResponseMetadata"].should.have.key("RequestId")
+    # This should be 'InvalidRoute.NotFound' in line with the delete_route()
+    # equivalent, but for some reason AWS returns InvalidParameterValue instead.
+    ex.value.response["Error"]["Code"].should.equal("InvalidParameterValue")
+
 
 @mock_ec2
 def test_routes_already_exist():


### PR DESCRIPTION
Currently the `EC2.Client.replace_route()` API does not error if a missing route is given, which is inconsistent with AWS behaviour.

The expected error code is `InvalidRoute.NotFound`, in line with what's returned from `delete_route()` and similar cases such as `InvalidRouteTable.NotFound` being returned if an invalid route table ID is given. However, AWS current behaviour is to return `InvalidParameterValue` instead, so that's what this PR gets moto to do (the [docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ReplaceRoute.html) are vague about what error code to expect, but this has been manually checked). This issue has been raised with AWS via a case (unfortunately no public link available), but there is not yet agreement to fix this.