### PR TITLE
pyparsing 3.1.0 support, remove experimental warning on Glue partition filtering

### DIFF
--- a/moto/glue/utils.py
+++ b/moto/glue/utils.py
@@ -15,12 +15,18 @@ from pyparsing import (
     Suppress,
     Word,
     alphanums,
-    delimited_list,
     exceptions,
     infix_notation,
     one_of,
     pyparsing_common,
 )
+
+try:
+    # TODO import directly when depending on pyparsing>=3.1.0
+    from pyparsing import DelimitedList
+except ImportError:
+    # delimited_list is deprecated in favor of DelimitedList in pyparsing 3.1.0
+    from pyparsing import delimited_list as DelimitedList
 
 from .exceptions import (
     InvalidInputException,
@@ -279,7 +285,7 @@ class _PartitionFilterExpressionCache:
         string <<= QuotedString(quote_char="'", esc_quote="''") | lpar + string + rpar  # type: ignore
 
         literal = (number | string).set_name("literal")
-        literal_list = delimited_list(literal, min=1).set_name("list")
+        literal_list = DelimitedList(literal, min=1).set_name("list")
 
         bin_op = one_of("<> >= <= > < =").set_name("binary op")
 

--- a/moto/glue/utils.py
+++ b/moto/glue/utils.py
@@ -1,7 +1,6 @@
 import abc
 import operator
 import re
-import warnings
 from datetime import date, datetime
 from itertools import repeat
 from typing import Any, Dict, List, Optional, Union
@@ -352,7 +351,6 @@ class PartitionFilter:
         if expression is None:
             return True
 
-        warnings.warn("Expression filtering is experimental")
         versions = list(self.fake_table.versions.values())
         return expression.eval(
             part_keys=versions[-1].get("PartitionKeys", []),

--- a/moto/glue/utils.py
+++ b/moto/glue/utils.py
@@ -26,7 +26,7 @@ try:
     from pyparsing import DelimitedList
 except ImportError:
     # delimited_list is deprecated in favor of DelimitedList in pyparsing 3.1.0
-    from pyparsing import delimited_list as DelimitedList
+    from pyparsing import delimited_list as DelimitedList  # type: ignore[assignment]
 
 from .exceptions import (
     InvalidInputException,

--- a/tests/test_glue/test_partition_filter.py
+++ b/tests/test_glue/test_partition_filter.py
@@ -346,12 +346,11 @@ def test_get_partition_expression_warnings_and_exceptions():
 
     kwargs = {"DatabaseName": database_name, "TableName": table_name}
 
-    with pytest.warns(match="Expression filtering is experimental"):
-        response = client.get_partitions(**kwargs, Expression="string_col = 'test'")
-        partitions = response["Partitions"]
-        partitions.should.have.length_of(1)
-        partition = partitions[0]
-        partition["Values"].should.equal(["test", "int", "3.14"])
+    response = client.get_partitions(**kwargs, Expression="string_col = 'test'")
+    partitions = response["Partitions"]
+    partitions.should.have.length_of(1)
+    partition = partitions[0]
+    partition["Values"].should.equal(["test", "int", "3.14"])
 
     with pytest.raises(ClientError) as exc:
         client.get_partitions(**kwargs, Expression="float_col = 3.14")


### PR DESCRIPTION
Pyparsing 3.1.0 was released (https://github.com/pyparsing/pyparsing/releases/tag/3.1.0) and has added `DelimitedList` in favor of `delimited_list`. This PR handles the announced future deprecation.

Also, the experimental warning on Glue partition filtering is removed. I use this excessively in my tests and found no issues, so I think this is safe to do.