### PR TITLE
add support for maintenance window targets

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6744,7 +6744,7 @@
 - [ ] delete_resource_policy
 - [ ] deregister_managed_instance
 - [ ] deregister_patch_baseline_for_patch_group
-- [ ] deregister_target_from_maintenance_window
+- [X] deregister_target_from_maintenance_window
 - [ ] deregister_task_from_maintenance_window
 - [ ] describe_activations
 - [ ] describe_association
@@ -6767,7 +6767,7 @@
 - [ ] describe_maintenance_window_execution_tasks
 - [ ] describe_maintenance_window_executions
 - [ ] describe_maintenance_window_schedule
-- [ ] describe_maintenance_window_targets
+- [X] describe_maintenance_window_targets
 - [ ] describe_maintenance_window_tasks
 - [X] describe_maintenance_windows
 - [ ] describe_maintenance_windows_for_target
@@ -6828,7 +6828,7 @@
 - [ ] put_resource_policy
 - [ ] register_default_patch_baseline
 - [ ] register_patch_baseline_for_patch_group
-- [ ] register_target_with_maintenance_window
+- [X] register_target_with_maintenance_window
 - [ ] register_task_with_maintenance_window
 - [X] remove_tags_from_resource
 - [ ] reset_service_setting

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1,5 +1,4 @@
 import re
-import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Iterator, Optional, Tuple
 from typing import DefaultDict
@@ -973,7 +972,7 @@ class FakeMaintenanceWindowTarget:
 
     @staticmethod
     def generate_id() -> str:
-        return str(uuid.uuid4())
+        return str(random.uuid4())
 
 
 def _maintenance_window_target_filter_match(

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Iterator, Optional, Tuple
 from typing import DefaultDict
@@ -941,6 +942,48 @@ def _valid_parameter_data_type(data_type: str) -> bool:
     return data_type in ("text", "aws:ec2:image")
 
 
+class FakeMaintenanceWindowTarget:
+    def __init__(
+        self,
+        window_id: str,
+        resource_type: str,
+        targets: List[Dict[str, Any]],
+        owner_information: Optional[str],
+        name: Optional[str],
+        description: Optional[str],
+    ):
+        self.window_id = window_id
+        self.window_target_id = self.generate_id()
+        self.resource_type = resource_type
+        self.targets = targets
+        self.name = name
+        self.description = description
+        self.owner_information = owner_information
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "WindowId": self.window_id,
+            "WindowTargetId": self.window_target_id,
+            "ResourceType": self.resource_type,
+            "Targets": self.targets,
+            "OwnerInformation": "",
+            "Name": self.name,
+            "Description": self.description,
+        }
+
+    @staticmethod
+    def generate_id() -> str:
+        return str(uuid.uuid4())
+
+
+def _maintenance_window_target_filter_match(
+    filters: Optional[List[Dict[str, Any]]], target: FakeMaintenanceWindowTarget
+) -> bool:
+    if not filters and target:
+        return True
+    return False
+
+
 class FakeMaintenanceWindow:
     def __init__(
         self,
@@ -964,6 +1007,7 @@ class FakeMaintenanceWindow:
         self.schedule_offset = schedule_offset
         self.start_date = start_date
         self.end_date = end_date
+        self.targets: Dict[str, FakeMaintenanceWindowTarget] = {}
 
     def to_json(self) -> Dict[str, Any]:
         return {
@@ -2249,6 +2293,54 @@ class SimpleSystemManagerBackend(BaseBackend):
         Assumes the provided BaselineId exists. No error handling has been implemented yet.
         """
         del self.baselines[baseline_id]
+
+    def register_target_with_maintenance_window(
+        self,
+        window_id: str,
+        resource_type: str,
+        targets: List[Dict[str, Any]],
+        owner_information: Optional[str],
+        name: Optional[str],
+        description: Optional[str],
+    ) -> str:
+        """
+        Registers a target with a maintenance window. No error handling has been implemented yet.
+        """
+        window = self.get_maintenance_window(window_id)
+
+        target = FakeMaintenanceWindowTarget(
+            window_id,
+            resource_type,
+            targets,
+            owner_information=owner_information,
+            name=name,
+            description=description,
+        )
+        window.targets[target.window_target_id] = target
+        return target.window_target_id
+
+    def deregister_target_from_maintenance_window(
+        self, window_id: str, window_target_id: str
+    ) -> None:
+        """
+        Deregisters a target from a maintenance window. No error handling has been implemented yet.
+        """
+        window = self.get_maintenance_window(window_id)
+        del window.targets[window_target_id]
+
+    def describe_maintenance_window_targets(
+        self, window_id: str, filters: Optional[List[Dict[str, Any]]]
+    ) -> List[FakeMaintenanceWindowTarget]:
+        """
+        Describes all targets for a maintenance window. No error handling has been implemented yet.
+        """
+        window = self.get_maintenance_window(window_id)
+        targets = [
+            target
+            for target in window.targets.values()
+            if _maintenance_window_target_filter_match(filters, target)
+        ]
+        return targets
 
 
 ssm_backends = BackendDict(SimpleSystemManagerBackend, "ssm")

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -441,6 +441,36 @@ class SimpleSystemManagerResponse(BaseResponse):
         window = self.ssm_backend.get_maintenance_window(window_id)
         return json.dumps(window.to_json())
 
+    def register_target_with_maintenance_window(self) -> str:
+        window_target_id = self.ssm_backend.register_target_with_maintenance_window(
+            window_id=self._get_param("WindowId"),
+            resource_type=self._get_param("ResourceType"),
+            targets=self._get_param("Targets"),
+            owner_information=self._get_param("OwnerInformation"),
+            name=self._get_param("Name"),
+            description=self._get_param("Description"),
+        )
+        return json.dumps({"WindowTargetId": window_target_id})
+
+    def describe_maintenance_window_targets(self) -> str:
+        window_id = self._get_param("WindowId")
+        filters = self._get_param("Filters", [])
+        targets = [
+            target.to_json()
+            for target in self.ssm_backend.describe_maintenance_window_targets(
+                window_id, filters
+            )
+        ]
+        return json.dumps({"Targets": targets})
+
+    def deregister_target_from_maintenance_window(self) -> str:
+        window_id = self._get_param("WindowId")
+        window_target_id = self._get_param("WindowTargetId")
+        self.ssm_backend.deregister_target_from_maintenance_window(
+            window_id, window_target_id
+        )
+        return "{}"
+
     def describe_maintenance_windows(self) -> str:
         filters = self._get_param("Filters", None)
         windows = [


### PR DESCRIPTION
This PR adds support for the next operations:

- [x] register_target_with_maintenance_window
- [x] describe_maintenance_window_targets
- [x] deregister_target_from_maintenance_window