### PR TITLE
add GroupId to SecurityGroupRules

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -558,8 +558,11 @@ class SecurityGroupBackend:
             )
         rules = []
         for group in matches:
-            rules.extend(group.ingress_rules)
-            rules.extend(group.egress_rules)
+            group_rules = {"group_id": group.group_id, "rules": []}
+            group_rules["rules"].extend(group.ingress_rules)
+            group_rules["rules"].extend(group.egress_rules)
+            if len(group_rules["rules"]) > 0:
+                rules.append(group_rules)
 
         return rules
 

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -550,7 +550,7 @@ class SecurityGroupBackend:
 
     def describe_security_group_rules(
         self, group_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[SecurityRule]:
+    ) -> List[dict[str, List[SecurityRule]]]:
         matches = self.describe_security_groups(group_ids=group_ids, filters=filters)
         if not matches:
             raise InvalidSecurityGroupNotFoundError(

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -550,19 +550,19 @@ class SecurityGroupBackend:
 
     def describe_security_group_rules(
         self, group_ids: Optional[List[str]] = None, filters: Any = None
-    ) -> List[dict[str, List[SecurityRule]]]:
+    ) -> Dict[str, List[SecurityRule]]:
         matches = self.describe_security_groups(group_ids=group_ids, filters=filters)
         if not matches:
             raise InvalidSecurityGroupNotFoundError(
                 "No security groups found matching the filters provided."
             )
-        rules = []
+        rules = {}
         for group in matches:
-            group_rules = {"group_id": group.group_id, "rules": []}
-            group_rules["rules"].extend(group.ingress_rules)
-            group_rules["rules"].extend(group.egress_rules)
-            if len(group_rules["rules"]) > 0:
-                rules.append(group_rules)
+            group_rules = []
+            group_rules.extend(group.ingress_rules)
+            group_rules.extend(group.egress_rules)
+            if group_rules:
+                rules[group.group_id] = group_rules
 
         return rules
 

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -254,22 +254,25 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
 <DescribeSecurityGroupRulesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>{{ request_id }}</requestId>
   <securityGroupRuleSet>
-    {% for rule in rules %}
-    <item>
-        {% if rule.from_port is not none %}
-        <fromPort>{{ rule.from_port }}</fromPort>
-        {% endif %}
-        {% if rule.to_port is not none %}
-          <toPort>{{ rule.to_port }}</toPort>
-        {% endif %}
-        {% if rule.ip_ranges %}
-          <cidrIpv4>{{ rule.ip_ranges[0]['CidrIp'] }}</cidrIpv4>
-        {% endif %}
-        <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
-        <groupOwnerId>{{ rule.owner_id }}</groupOwnerId>
-        <isEgress>{{ 'true' if rule.is_egress else 'false' }}</isEgress>
-        <securityGroupRuleId>{{ rule.id }}</securityGroupRuleId>
-    </item>
+    {% for group in rules %}
+        {% for rule in group.rules %}
+            <item>
+                {% if rule.from_port is not none %}
+                <fromPort>{{ rule.from_port }}</fromPort>
+                {% endif %}
+                {% if rule.to_port is not none %}
+                  <toPort>{{ rule.to_port }}</toPort>
+                {% endif %}
+                {% if rule.ip_ranges %}
+                  <cidrIpv4>{{ rule.ip_ranges[0]['CidrIp'] }}</cidrIpv4>
+                {% endif %}
+                <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
+                <groupId>{{ group.group_id }}</groupId>
+                <groupOwnerId>{{ rule.owner_id }}</groupOwnerId>
+                <isEgress>{{ 'true' if rule.is_egress else 'false' }}</isEgress>
+                <securityGroupRuleId>{{ rule.id }}</securityGroupRuleId>
+            </item>
+        {% endfor %}
     {% endfor %}
   </securityGroupRuleSet>
 </DescribeSecurityGroupRulesResponse>"""

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -254,8 +254,8 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
 <DescribeSecurityGroupRulesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
   <requestId>{{ request_id }}</requestId>
   <securityGroupRuleSet>
-    {% for group in rules %}
-        {% for rule in group.rules %}
+    {% for group, rule_list in rules.items() %}
+        {% for rule in rule_list %}
             <item>
                 {% if rule.from_port is not none %}
                 <fromPort>{{ rule.from_port }}</fromPort>
@@ -267,7 +267,7 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
                   <cidrIpv4>{{ rule.ip_ranges[0]['CidrIp'] }}</cidrIpv4>
                 {% endif %}
                 <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
-                <groupId>{{ group.group_id }}</groupId>
+                <groupId>{{ group }}</groupId>
                 <groupOwnerId>{{ rule.owner_id }}</groupOwnerId>
                 <isEgress>{{ 'true' if rule.is_egress else 'false' }}</isEgress>
                 <securityGroupRuleId>{{ rule.id }}</securityGroupRuleId>

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -586,6 +586,7 @@ def test_create_and_describe_security_grp_rule():
     assert rules[0]["IsEgress"] is True
     assert rules[0]["IpProtocol"] == "-1"
     assert rules[0]["CidrIpv4"] == "0.0.0.0/0"
+    assert "GroupId" in rules[0]
 
 
 @mock_ec2


### PR DESCRIPTION
There is a small parity issue within the operation `describe-security-group-rules` ([aws-examples-link](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-group-rules.html#examples)) as it is missing the field `GroupId`. This appeared due to a ticket within [localstack](https://github.com/localstack/localstack/issues/8528), which very nicely describes the issue.

This PR is a quick draft to resolve this - I'm not particularly familiar with ec2 or moto (:smile:) and haven't added a test to this yet. something like `assert "GroupId" in rules[0]` [here](https://github.com/getmoto/moto/blob/dab6318f90dba1fdbb758603879e430e038a3c85/tests/test_ec2/test_security_groups.py#L589)? thx for any hints 
