### PR TITLE
RDS: Automated snapshots now have the appropriate SnapshotType

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -5318,7 +5318,7 @@
 
 ## rds
 <details>
-<summary>38% implemented</summary>
+<summary>39% implemented</summary>
 
 - [ ] add_role_to_db_cluster
 - [ ] add_role_to_db_instance
@@ -5329,9 +5329,9 @@
 - [ ] backtrack_db_cluster
 - [X] cancel_export_task
 - [ ] copy_db_cluster_parameter_group
-- [ ] copy_db_cluster_snapshot
+- [X] copy_db_cluster_snapshot
 - [ ] copy_db_parameter_group
-- [ ] copy_db_snapshot
+- [X] copy_db_snapshot
 - [ ] copy_option_group
 - [ ] create_blue_green_deployment
 - [ ] create_custom_db_engine_version

--- a/docs/docs/services/rds.rst
+++ b/docs/docs/services/rds.rst
@@ -34,9 +34,9 @@ rds
 - [ ] backtrack_db_cluster
 - [X] cancel_export_task
 - [ ] copy_db_cluster_parameter_group
-- [ ] copy_db_cluster_snapshot
+- [X] copy_db_cluster_snapshot
 - [ ] copy_db_parameter_group
-- [ ] copy_db_snapshot
+- [X] copy_db_snapshot
 - [ ] copy_option_group
 - [ ] create_blue_green_deployment
 - [ ] create_custom_db_engine_version

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -312,7 +312,7 @@ class RDSResponse(BaseResponse):
         db_snapshot_identifier = self._get_param("DBSnapshotIdentifier")
         tags = self.unpack_list_params("Tags", "Tag")
         snapshot = self.backend.create_db_snapshot(
-            db_instance_identifier, db_snapshot_identifier, tags
+            db_instance_identifier, db_snapshot_identifier, tags=tags
         )
         template = self.response_template(CREATE_SNAPSHOT_TEMPLATE)
         return template.render(snapshot=snapshot)
@@ -321,7 +321,7 @@ class RDSResponse(BaseResponse):
         source_snapshot_identifier = self._get_param("SourceDBSnapshotIdentifier")
         target_snapshot_identifier = self._get_param("TargetDBSnapshotIdentifier")
         tags = self.unpack_list_params("Tags", "Tag")
-        snapshot = self.backend.copy_database_snapshot(
+        snapshot = self.backend.copy_db_snapshot(
             source_snapshot_identifier, target_snapshot_identifier, tags
         )
         template = self.response_template(COPY_SNAPSHOT_TEMPLATE)
@@ -642,7 +642,7 @@ class RDSResponse(BaseResponse):
         db_snapshot_identifier = self._get_param("DBClusterSnapshotIdentifier")
         tags = self.unpack_list_params("Tags", "Tag")
         snapshot = self.backend.create_db_cluster_snapshot(
-            db_cluster_identifier, db_snapshot_identifier, tags
+            db_cluster_identifier, db_snapshot_identifier, tags=tags
         )
         template = self.response_template(CREATE_CLUSTER_SNAPSHOT_TEMPLATE)
         return template.render(snapshot=snapshot)
@@ -655,7 +655,7 @@ class RDSResponse(BaseResponse):
             "TargetDBClusterSnapshotIdentifier"
         )
         tags = self.unpack_list_params("Tags", "Tag")
-        snapshot = self.backend.copy_cluster_snapshot(
+        snapshot = self.backend.copy_db_cluster_snapshot(
             source_snapshot_identifier, target_snapshot_identifier, tags
         )
         template = self.response_template(COPY_CLUSTER_SNAPSHOT_TEMPLATE)

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -309,9 +309,10 @@ def test_delete_db_cluster_do_snapshot():
         DBClusterIdentifier="cluster-id", FinalDBSnapshotIdentifier="final-snapshot"
     )
     client.describe_db_clusters()["DBClusters"].should.have.length_of(0)
-    snapshots = client.describe_db_cluster_snapshots()["DBClusterSnapshots"]
-    snapshots[0]["DBClusterIdentifier"].should.equal("cluster-id")
-    snapshots[0]["DBClusterSnapshotIdentifier"].should.equal("final-snapshot")
+    snapshot = client.describe_db_cluster_snapshots()["DBClusterSnapshots"][0]
+    assert snapshot["DBClusterIdentifier"] == "cluster-id"
+    assert snapshot["DBClusterSnapshotIdentifier"] == "final-snapshot"
+    assert snapshot["SnapshotType"] == "automated"
 
 
 @mock_rds
@@ -470,9 +471,10 @@ def test_create_db_cluster_snapshot():
         DBClusterIdentifier="db-primary-1", DBClusterSnapshotIdentifier="g-1"
     ).get("DBClusterSnapshot")
 
-    snapshot.get("Engine").should.equal("postgres")
-    snapshot.get("DBClusterIdentifier").should.equal("db-primary-1")
-    snapshot.get("DBClusterSnapshotIdentifier").should.equal("g-1")
+    assert snapshot["Engine"] == "postgres"
+    assert snapshot["DBClusterIdentifier"] == "db-primary-1"
+    assert snapshot["DBClusterSnapshotIdentifier"] == "g-1"
+    assert snapshot["SnapshotType"] == "manual"
     result = conn.list_tags_for_resource(ResourceName=snapshot["DBClusterSnapshotArn"])
     result["TagList"].should.equal([])
 


### PR DESCRIPTION
SnapshotType is set to `manual` for snapshots created by the user, and set to `automated` for snapshots created when a cluster is deleted.
This applies to both DatabaseSnapshots and ClusterSnapshots.

The `snapshot-type`-filter has also been fixed.

This PR also removes some duplicate validation when copying a snapshot. We now just call the `create..`-method, instead of duplicating the entire logic on copy.

Fixes #6419 