### PR TITLE
Fix service name for ACM backend

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -550,4 +550,4 @@ class AWSCertificateManagerBackend(BaseBackend):
         return certificate, certificate_chain, private_key
 
 
-acm_backends = BackendDict(AWSCertificateManagerBackend, "ec2")
+acm_backends = BackendDict(AWSCertificateManagerBackend, "acm")


### PR DESCRIPTION
This PR fixes the service name of the `BackendDict` for `acm` (it currently has `ec2` instead).
 
I wondered if there is a rationale behind this or if that's simply a mistake.