### PR TITLE
Lambda: create list_aliases functionality

### DIFF
--- a/moto/awslambda/exceptions.py
+++ b/moto/awslambda/exceptions.py
@@ -32,7 +32,12 @@ class PreconditionFailedException(JsonRESTError):
 
     def __init__(self, message: str):
         super().__init__("PreconditionFailedException", message)
+    
+class ConflictException(LambdaClientError):
+    code = 409
 
+    def __init__(self, message: str):
+        super().__init__("ConflictException", message)
 
 class UnknownAliasException(LambdaClientError):
     code = 404

--- a/moto/awslambda/exceptions.py
+++ b/moto/awslambda/exceptions.py
@@ -32,12 +32,14 @@ class PreconditionFailedException(JsonRESTError):
 
     def __init__(self, message: str):
         super().__init__("PreconditionFailedException", message)
-    
+
+
 class ConflictException(LambdaClientError):
     code = 409
 
     def __init__(self, message: str):
         super().__init__("ConflictException", message)
+
 
 class UnknownAliasException(LambdaClientError):
     code = 404

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1177,7 +1177,7 @@ class LambdaStorage(object):
         for config in self._functions[name]["versions"]:
             if str(config.version) == version:
                 return config
-    
+
         return None
 
     def _get_function_aliases(self, function_name: str) -> Dict[str, LambdaAlias]:
@@ -1209,7 +1209,7 @@ class LambdaStorage(object):
         if name in aliases:
             arn = f"arn:aws:lambda:{self.region_name}:{self.account_id}:function:{function_name}:{name}"
             raise ConflictException(f"Alias already exists: {arn}")
-    
+
         alias = LambdaAlias(
             account_id=self.account_id,
             region=self.region_name,
@@ -1233,7 +1233,7 @@ class LambdaStorage(object):
         alias = self.get_alias(name, function_name)
         alias.update(description, function_version, routing_config)
         return alias
-    
+
     def get_function_by_name(
         self, name: str, qualifier: Optional[str] = None
     ) -> Optional[LambdaFunction]:
@@ -1249,7 +1249,7 @@ class LambdaStorage(object):
         found_version = self._get_version(name, qualifier)
         if found_version:
             return found_version
-        
+
         aliases = self._get_function_aliases(name)
 
         if qualifier in aliases:
@@ -1376,9 +1376,8 @@ class LambdaStorage(object):
                     and not self._functions[name]["latest"]
                 ):
                     del self._functions[name]
-        
+
         self._aliases[function.function_arn] = {}
-        
 
     def all(self) -> Iterable[LambdaFunction]:
         result = []

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1256,6 +1256,8 @@ class LambdaStorage(object):
             alias = aliases[qualifier]
             return self._get_version(name, alias.function_version)
 
+        return None
+
     def list_versions_by_function(self, name: str) -> Iterable[LambdaFunction]:
         if name not in self._functions:
             return []

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1231,6 +1231,10 @@ class LambdaStorage(object):
         routing_config: str,
     ) -> LambdaAlias:
         alias = self.get_alias(name, function_name)
+
+        # errors if new function version doesn't exist
+        self.get_function_by_name_or_arn(function_name, function_version)
+
         alias.update(description, function_version, routing_config)
         return alias
 

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1204,7 +1204,7 @@ class LambdaStorage(object):
         description: str,
         routing_config: str,
     ) -> LambdaAlias:
-        fn = self.get_function_by_name_or_arn(function_name)
+        fn = self.get_function_by_name_or_arn(function_name, function_version)
         aliases = self._get_function_aliases(function_name)
         if name in aliases:
             arn = f"arn:aws:lambda:{self.region_name}:{self.account_id}:function:{function_name}:{name}"

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -959,6 +959,117 @@ def test_list_versions_by_function():
 
 @mock_lambda
 @mock_s3
+def test_list_aliases():
+    bucket_name = str(uuid4())
+    s3_conn = boto3.client("s3", _lambda_region)
+    s3_conn.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": _lambda_region},
+    )
+
+    zip_content = get_test_zip_file2()
+    s3_conn.put_object(Bucket=bucket_name, Key="test.zip", Body=zip_content)
+    conn = boto3.client("lambda", _lambda_region)
+    function_name = str(uuid4())[0:6]
+    function_name2 = str(uuid4())[0:6]
+
+    conn.create_function(
+        FunctionName=function_name,
+        Runtime="python2.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"S3Bucket": bucket_name, "S3Key": "test.zip"},
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    conn.create_function(
+        FunctionName=function_name2,
+        Runtime="python2.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"S3Bucket": bucket_name, "S3Key": "test.zip"},
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    first_version = conn.publish_version(FunctionName=function_name)["Version"]
+
+    conn.create_alias(
+        FunctionName=function_name,
+        Name="alias1",
+        FunctionVersion=first_version,
+    )
+
+    conn.update_function_code(FunctionName=function_name, ZipFile=get_test_zip_file1())
+    second_version = conn.publish_version(FunctionName=function_name)["Version"]
+
+    conn.create_alias(
+        FunctionName=function_name,
+        Name="alias2",
+        FunctionVersion=second_version,
+    )
+    
+    conn.create_alias(
+        FunctionName=function_name,
+        Name="alias0",
+        FunctionVersion=second_version,
+    )
+
+
+    aliases = conn.list_aliases(FunctionName=function_name)
+    assert len(aliases["Aliases"]) == 3
+
+    # should be ordered by their alias name (as per SDK response)
+    assert (
+        aliases["Aliases"][0]["AliasArn"]
+        == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name}:alias0"
+    )
+    assert (
+        aliases["Aliases"][0]["FunctionVersion"]
+        == second_version
+    )
+    
+    assert (
+        aliases["Aliases"][1]["AliasArn"]
+        == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name}:alias1"
+    )
+    assert (
+        aliases["Aliases"][1]["FunctionVersion"]
+        == first_version
+    )
+    
+    assert (
+        aliases["Aliases"][2]["AliasArn"]
+        == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name}:alias2"
+    )
+    assert (
+        aliases["Aliases"][2]["FunctionVersion"]
+        == second_version
+    )
+
+    res = conn.publish_version(FunctionName=function_name2)
+    conn.create_alias(
+        FunctionName=function_name2,
+        Name="alias1",
+        FunctionVersion=res["Version"],
+    )
+
+    aliases = conn.list_aliases(FunctionName=function_name2)
+
+    assert len(aliases["Aliases"]) == 1
+    assert (
+        aliases["Aliases"][0]["AliasArn"]
+        == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name2}:alias1"
+    )
+
+
+@mock_lambda
+@mock_s3
 def test_create_function_with_already_exists():
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1013,13 +1013,12 @@ def test_list_aliases():
         Name="alias2",
         FunctionVersion=second_version,
     )
-    
+
     conn.create_alias(
         FunctionName=function_name,
         Name="alias0",
         FunctionVersion=second_version,
     )
-
 
     aliases = conn.list_aliases(FunctionName=function_name)
     assert len(aliases["Aliases"]) == 3
@@ -1029,28 +1028,19 @@ def test_list_aliases():
         aliases["Aliases"][0]["AliasArn"]
         == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name}:alias0"
     )
-    assert (
-        aliases["Aliases"][0]["FunctionVersion"]
-        == second_version
-    )
-    
+    assert aliases["Aliases"][0]["FunctionVersion"] == second_version
+
     assert (
         aliases["Aliases"][1]["AliasArn"]
         == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name}:alias1"
     )
-    assert (
-        aliases["Aliases"][1]["FunctionVersion"]
-        == first_version
-    )
-    
+    assert aliases["Aliases"][1]["FunctionVersion"] == first_version
+
     assert (
         aliases["Aliases"][2]["AliasArn"]
         == f"arn:aws:lambda:us-west-2:{ACCOUNT_ID}:function:{function_name}:alias2"
     )
-    assert (
-        aliases["Aliases"][2]["FunctionVersion"]
-        == second_version
-    )
+    assert aliases["Aliases"][2]["FunctionVersion"] == second_version
 
     res = conn.publish_version(FunctionName=function_name2)
     conn.create_alias(

--- a/tests/test_awslambda/test_lambda_alias.py
+++ b/tests/test_awslambda/test_lambda_alias.py
@@ -296,15 +296,21 @@ def test_update_alias():
         Handler="lambda_function.lambda_handler",
         Code={"ZipFile": get_test_zip_file1()},
     )
-
+    
     client.create_alias(
         FunctionName=function_name, Name="alias1", FunctionVersion="$LATEST"
     )
+    
+    client.update_function_code(
+        FunctionName=function_name, ZipFile=get_test_zip_file2()
+    )
+
+    new_version = client.publish_version(FunctionName=function_name)["Version"]
 
     resp = client.update_alias(
         FunctionName=function_name,
         Name="alias1",
-        FunctionVersion="1",
+        FunctionVersion=new_version,
         Description="updated desc",
     )
 
@@ -313,10 +319,40 @@ def test_update_alias():
         == f"arn:aws:lambda:us-east-2:{ACCOUNT_ID}:function:{function_name}:alias1"
     )
     assert resp["Name"] == "alias1"
-    assert resp["FunctionVersion"] == "1"
+    assert resp["FunctionVersion"] == new_version
     assert resp["Description"] == "updated desc"
     assert "RevisionId" in resp
 
+@mock_lambda
+def test_update_alias_errors_if_version_doesnt_exist():
+    client = boto3.client("lambda", region_name="us-east-2")
+    function_name = str(uuid4())[0:6]
+
+    client.create_function(
+        FunctionName=function_name,
+        Runtime="python3.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file1()},
+    )
+
+    client.create_alias(
+        FunctionName=function_name, Name="alias1", FunctionVersion="$LATEST"
+    )
+
+    with pytest.raises(ClientError) as exc:
+        client.update_alias(
+            FunctionName=function_name,
+            Name="alias1",
+            FunctionVersion="1",
+            Description="updated desc",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
+    assert (
+        err["Message"]
+        == f"Function not found: arn:aws:lambda:us-east-2:{ACCOUNT_ID}:function:{function_name}:1"
+    )
 
 @mock_lambda
 def test_update_alias_routingconfig():

--- a/tests/test_awslambda/test_lambda_alias.py
+++ b/tests/test_awslambda/test_lambda_alias.py
@@ -150,11 +150,12 @@ def test_get_alias():
     assert resp["Description"] == ""
     assert "RevisionId" in resp
 
+
 @mock_lambda
 def test_aliases_are_unique_per_function():
     client = boto3.client("lambda", region_name="us-west-1")
     function_name = str(uuid4())[0:6]
-    function_name2= str(uuid4())[0:6]
+    function_name2 = str(uuid4())[0:6]
 
     client.create_function(
         FunctionName=function_name,
@@ -177,23 +178,28 @@ def test_aliases_are_unique_per_function():
     client.create_alias(
         FunctionName=function_name2, Name="alias1", FunctionVersion="$LATEST"
     )
-    
-    client.update_function_code(FunctionName=function_name, ZipFile=get_test_zip_file2())
-    client.update_function_code(FunctionName=function_name2, ZipFile=get_test_zip_file2())
-    
+
+    client.update_function_code(
+        FunctionName=function_name, ZipFile=get_test_zip_file2()
+    )
+    client.update_function_code(
+        FunctionName=function_name2, ZipFile=get_test_zip_file2()
+    )
+
     res = client.publish_version(FunctionName=function_name)
-    
+
     with pytest.raises(ClientError) as exc:
         client.create_alias(
             FunctionName=function_name, Name="alias1", FunctionVersion=res["Version"]
         )
-    
+
     err = exc.value.response["Error"]
     assert err["Code"] == "ConflictException"
     assert (
         err["Message"]
         == f"Alias already exists: arn:aws:lambda:us-west-1:{ACCOUNT_ID}:function:{function_name}:alias1"
     )
+
 
 @mock_lambda
 def test_get_alias_using_function_arn():

--- a/tests/test_awslambda/test_lambda_alias.py
+++ b/tests/test_awslambda/test_lambda_alias.py
@@ -296,11 +296,11 @@ def test_update_alias():
         Handler="lambda_function.lambda_handler",
         Code={"ZipFile": get_test_zip_file1()},
     )
-    
+
     client.create_alias(
         FunctionName=function_name, Name="alias1", FunctionVersion="$LATEST"
     )
-    
+
     client.update_function_code(
         FunctionName=function_name, ZipFile=get_test_zip_file2()
     )
@@ -322,6 +322,7 @@ def test_update_alias():
     assert resp["FunctionVersion"] == new_version
     assert resp["Description"] == "updated desc"
     assert "RevisionId" in resp
+
 
 @mock_lambda
 def test_update_alias_errors_if_version_doesnt_exist():
@@ -353,6 +354,7 @@ def test_update_alias_errors_if_version_doesnt_exist():
         err["Message"]
         == f"Function not found: arn:aws:lambda:us-east-2:{ACCOUNT_ID}:function:{function_name}:1"
     )
+
 
 @mock_lambda
 def test_update_alias_routingconfig():

--- a/tests/test_awslambda/test_lambda_alias.py
+++ b/tests/test_awslambda/test_lambda_alias.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from .utilities import (
     get_role_name,
     get_test_zip_file1,
+    get_test_zip_file2,
 )
 
 # See our Development Tips on writing tests for hints on how to write good tests:
@@ -149,6 +150,50 @@ def test_get_alias():
     assert resp["Description"] == ""
     assert "RevisionId" in resp
 
+@mock_lambda
+def test_aliases_are_unique_per_function():
+    client = boto3.client("lambda", region_name="us-west-1")
+    function_name = str(uuid4())[0:6]
+    function_name2= str(uuid4())[0:6]
+
+    client.create_function(
+        FunctionName=function_name,
+        Runtime="python3.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file1()},
+    )
+    client.create_function(
+        FunctionName=function_name2,
+        Runtime="python3.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file1()},
+    )
+
+    client.create_alias(
+        FunctionName=function_name, Name="alias1", FunctionVersion="$LATEST"
+    )
+    client.create_alias(
+        FunctionName=function_name2, Name="alias1", FunctionVersion="$LATEST"
+    )
+    
+    client.update_function_code(FunctionName=function_name, ZipFile=get_test_zip_file2())
+    client.update_function_code(FunctionName=function_name2, ZipFile=get_test_zip_file2())
+    
+    res = client.publish_version(FunctionName=function_name)
+    
+    with pytest.raises(ClientError) as exc:
+        client.create_alias(
+            FunctionName=function_name, Name="alias1", FunctionVersion=res["Version"]
+        )
+    
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ConflictException"
+    assert (
+        err["Message"]
+        == f"Alias already exists: arn:aws:lambda:us-west-1:{ACCOUNT_ID}:function:{function_name}:alias1"
+    )
 
 @mock_lambda
 def test_get_alias_using_function_arn():


### PR DESCRIPTION
- Creates the [list_aliases](https://boto3.amazonaws.com/v1/documentation/api/1.26.85/reference/services/lambda/client/list_aliases.html) functionality
- Redesign internal storage of aliases to correct mistaken implementation (Duplicate alias names could be created under the same lambda pointing to different versions)
- Adds tests for new functionality
- Worth noting I've not included functionality to filter by "version", can be implemented if needed