### PR TITLE
Add type field to error response

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -46,7 +46,7 @@ class RESTError(HTTPException):
     request_id_tag_name = "RequestId"
 
     # When this field is set, the `Type` field will be included in the response
-    sender_fault = False
+    sender_fault = True
 
     templates = {
         "single_error": SINGLE_ERROR_RESPONSE,

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -18,7 +18,7 @@ WRAPPED_SINGLE_ERROR_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
     <Error>
         <Code>{{error_type}}</Code>
         <Message><![CDATA[{{message}}]]></Message>
-        {% if sender_fault %}
+        {% if include_type_sender %}
         <Type>Sender</Type>
         {% endif %}
         {% block extra %}{% endblock %}
@@ -46,7 +46,8 @@ class RESTError(HTTPException):
     request_id_tag_name = "RequestId"
 
     # When this field is set, the `Type` field will be included in the response
-    sender_fault = True
+    # This indicates that the fault lies with the client
+    include_type_sender = True
 
     templates = {
         "single_error": SINGLE_ERROR_RESPONSE,
@@ -67,7 +68,7 @@ class RESTError(HTTPException):
                 error_type=error_type,
                 message=message,
                 request_id_tag=self.request_id_tag_name,
-                sender_fault=self.sender_fault,
+                include_type_sender=self.include_type_sender,
                 **kwargs,
             )
             self.content_type = "application/xml"

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -1,10 +1,15 @@
 from typing import Any, Optional
 from moto.core.exceptions import RESTError
 
+SNS_ERROR_WITH_TYPE = """{% extends 'wrapped_single_error' %}
+{% block extra %}<Type>Sender</Type>{% endblock %}
+"""
+
 
 class SNSException(RESTError):
     def __init__(self, *args: Any, **kwargs: Any):
-        kwargs["template"] = "wrapped_single_error"
+        self.templates["sns_error_with_type"] = SNS_ERROR_WITH_TYPE
+        kwargs["template"] = "sns_error_with_type"
         super().__init__(*args, **kwargs)
 
 

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -10,7 +10,6 @@ class SNSException(RESTError):
 
 class SNSNotFoundError(SNSException):
     code = 404
-    sender_fault = True
 
     def __init__(self, message: str, template: Optional[str] = None):
         super().__init__("NotFound", message, template=template)
@@ -23,7 +22,6 @@ class TopicNotFound(SNSNotFoundError):
 
 class ResourceNotFoundError(SNSException):
     code = 404
-    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__("ResourceNotFound", "Resource does not exist")
@@ -31,7 +29,6 @@ class ResourceNotFoundError(SNSException):
 
 class DuplicateSnsEndpointError(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("DuplicateEndpoint", message)
@@ -39,7 +36,6 @@ class DuplicateSnsEndpointError(SNSException):
 
 class SnsEndpointDisabled(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("EndpointDisabled", message)
@@ -47,7 +43,6 @@ class SnsEndpointDisabled(SNSException):
 
 class SNSInvalidParameter(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("InvalidParameter", message)
@@ -55,7 +50,6 @@ class SNSInvalidParameter(SNSException):
 
 class InvalidParameterValue(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("InvalidParameterValue", message)
@@ -63,7 +57,6 @@ class InvalidParameterValue(SNSException):
 
 class TagLimitExceededError(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__(
@@ -74,6 +67,7 @@ class TagLimitExceededError(SNSException):
 
 class InternalError(SNSException):
     code = 500
+    sender_fault = False
 
     def __init__(self, message: str):
         super().__init__("InternalFailure", message)
@@ -81,7 +75,6 @@ class InternalError(SNSException):
 
 class TooManyEntriesInBatchRequest(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__(
@@ -92,7 +85,6 @@ class TooManyEntriesInBatchRequest(SNSException):
 
 class BatchEntryIdsNotDistinct(SNSException):
     code = 400
-    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__(

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -67,7 +67,7 @@ class TagLimitExceededError(SNSException):
 
 class InternalError(SNSException):
     code = 500
-    sender_fault = False
+    include_type_sender = False
 
     def __init__(self, message: str):
         super().__init__("InternalFailure", message)

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -1,20 +1,16 @@
 from typing import Any, Optional
 from moto.core.exceptions import RESTError
 
-SNS_ERROR_WITH_TYPE = """{% extends 'wrapped_single_error' %}
-{% block extra %}<Type>Sender</Type>{% endblock %}
-"""
-
 
 class SNSException(RESTError):
     def __init__(self, *args: Any, **kwargs: Any):
-        self.templates["sns_error_with_type"] = SNS_ERROR_WITH_TYPE
-        kwargs["template"] = "sns_error_with_type"
+        kwargs["template"] = "wrapped_single_error"
         super().__init__(*args, **kwargs)
 
 
 class SNSNotFoundError(SNSException):
     code = 404
+    sender_fault = True
 
     def __init__(self, message: str, template: Optional[str] = None):
         super().__init__("NotFound", message, template=template)
@@ -27,6 +23,7 @@ class TopicNotFound(SNSNotFoundError):
 
 class ResourceNotFoundError(SNSException):
     code = 404
+    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__("ResourceNotFound", "Resource does not exist")
@@ -34,6 +31,7 @@ class ResourceNotFoundError(SNSException):
 
 class DuplicateSnsEndpointError(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("DuplicateEndpoint", message)
@@ -41,6 +39,7 @@ class DuplicateSnsEndpointError(SNSException):
 
 class SnsEndpointDisabled(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("EndpointDisabled", message)
@@ -48,6 +47,7 @@ class SnsEndpointDisabled(SNSException):
 
 class SNSInvalidParameter(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("InvalidParameter", message)
@@ -55,6 +55,7 @@ class SNSInvalidParameter(SNSException):
 
 class InvalidParameterValue(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self, message: str):
         super().__init__("InvalidParameterValue", message)
@@ -62,6 +63,7 @@ class InvalidParameterValue(SNSException):
 
 class TagLimitExceededError(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__(
@@ -79,6 +81,7 @@ class InternalError(SNSException):
 
 class TooManyEntriesInBatchRequest(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__(
@@ -89,6 +92,7 @@ class TooManyEntriesInBatchRequest(SNSException):
 
 class BatchEntryIdsNotDistinct(SNSException):
     code = 400
+    sender_fault = True
 
     def __init__(self) -> None:
         super().__init__(

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -148,6 +148,7 @@ def test_create_topic_in_multiple_regions():
     err = exc.value.response["Error"]
     assert err["Code"] == "NotFound"
     assert err["Message"] == "Topic does not exist"
+    assert err["Type"] == "Sender"
 
 
 @mock_sns
@@ -538,6 +539,7 @@ def test_create_fifo_topic():
             "Fifo Topic names must end with .fifo and must be made up of only uppercase and lowercase ASCII letters, "
             "numbers, underscores, and hyphens, and must be between 1 and 256 characters long."
         )
+        err.response["Error"]["Type"].should.equal("Sender")
 
     try:
         conn.create_topic(Name="test_topic.fifo")


### PR DESCRIPTION
AWS error responses have a field called `Type` which indicates where the blame for the error lies. There is little documentation on this, but HTTP 4xx errors seem to have this field set to `Sender`.

This PR introduces support for this field. To start with, SNS errors are correctly mapped.

The other two templates do not contain the field:
- `SINGLE_ERROR_RESPONSE`: Used for S3 response, see <https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html>
- `ERROR_RESPONSE`: Used for EC2 response, see <https://github.com/boto/botocore/blob/82f6e194716e36c838fc016eddc4a2ef8e449ec4/botocore/parsers.py#L614>

Also see: <https://github.com/boto/botocore/blob/82f6e194716e36c838fc016eddc4a2ef8e449ec4/tests/unit/test_parsers.py#L1200-L1271>