### PR TITLE
CF:create_distribution() - fix config with single alias

### DIFF
--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -148,6 +148,8 @@ class DistributionConfig:
         self.aliases = ((config.get("Aliases") or {}).get("Items") or {}).get(
             "CNAME"
         ) or []
+        if isinstance(self.aliases, str):
+            self.aliases = [self.aliases]
         self.comment = config.get("Comment") or ""
         self.default_cache_behavior = DefaultCacheBehaviour(
             config["DefaultCacheBehavior"]


### PR DESCRIPTION
If there is only 1 alias, it would be serialized as a string (`"alias1"`), instead of as a list (`["alias1"]`). 

When generating the response, we expect a list of aliases to iterate over. So if we're iterating over a string instead, Moto would return `Aliases=["a", "l", "i", "a", "s"]` instead