### PR TITLE
EC2: fix DescribeLaunchTemplateVersions default response

### DIFF
--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -156,8 +156,10 @@ class LaunchTemplates(EC2BaseResponse):
         template_id = self._get_param("LaunchTemplateId")
         if name:
             template = self.ec2_backend.get_launch_template_by_name(name)
-        if template_id:
+        elif template_id:
             template = self.ec2_backend.get_launch_template(template_id)
+        else:
+            template = None
 
         max_results = self._get_int_param("MaxResults", 15)
         versions = self._get_multi_param("LaunchTemplateVersion")
@@ -182,7 +184,7 @@ class LaunchTemplates(EC2BaseResponse):
         versions_node = ElementTree.SubElement(tree, "launchTemplateVersionSet")
 
         ret_versions = []
-        if versions and (name or template_id):
+        if versions and template is not None:
             for v in versions:
                 if str(v).lower() == "$latest" or "$default":
                     tv = template.get_version(v)
@@ -200,7 +202,7 @@ class LaunchTemplates(EC2BaseResponse):
         elif max_version:
             vMax = max_version
             ret_versions = template.versions[:vMax]
-        elif name or template_id:
+        elif template is not None:
             ret_versions = template.versions
 
         ret_versions = ret_versions[:max_results]

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -182,7 +182,7 @@ class LaunchTemplates(EC2BaseResponse):
         versions_node = ElementTree.SubElement(tree, "launchTemplateVersionSet")
 
         ret_versions = []
-        if versions:
+        if versions and (name or template_id):
             for v in versions:
                 if str(v).lower() == "$latest" or "$default":
                     tv = template.get_version(v)

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -200,7 +200,7 @@ class LaunchTemplates(EC2BaseResponse):
         elif max_version:
             vMax = max_version
             ret_versions = template.versions[:vMax]
-        else:
+        elif name or template_id:
             ret_versions = template.versions
 
         ret_versions = ret_versions[:max_results]

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -140,6 +140,10 @@ def test_describe_launch_template_versions_by_name_when_absent():
 
         cli.describe_launch_template_versions(LaunchTemplateName=template_name)
 
+    # test default response
+    resp = cli.describe_launch_template_versions()
+    assert resp["LaunchTemplateVersions"] == []
+
 
 @mock_ec2
 def test_create_launch_template_version():

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -144,6 +144,10 @@ def test_describe_launch_template_versions_by_name_when_absent():
     resp = cli.describe_launch_template_versions()
     assert resp["LaunchTemplateVersions"] == []
 
+    # test using $Latest version
+    resp = cli.describe_launch_template_versions(Versions=["$Latest"])
+    assert resp["LaunchTemplateVersions"] == []
+
 
 @mock_ec2
 def test_create_launch_template_version():


### PR DESCRIPTION
The default response of ec2's DescribeLaunchTemplateVersions fails due to the variable `template` being referenced without assignment [here](https://github.com/getmoto/moto/blob/db002cb95813255a083ed4af24eb68ae3224f31e/moto/ec2/responses/launch_templates.py#L204). The default should be an empty list. This came to light because of an issue report in [localstack](https://github.com/localstack/localstack/issues/8606).
Granted, this is rather an ugly quick fix, but it seems to work. Alternatively the default could be to create an empty launch template? (Open to adjust if you could give me some guidance what would be a more sensible approach here)