### PR TITLE
Techdebt: Remove warnings from tests

### DIFF
--- a/tests/test_cloudformation/fixtures/single_instance_with_ebs_volume.py
+++ b/tests/test_cloudformation/fixtures/single_instance_with_ebs_volume.py
@@ -99,7 +99,6 @@ template = {
                                 "function error_exit\n",
                                 "{\n",
                                 '  /opt/aws/bin/cfn-signal -e 1 -r "$1" \'',
-                                {"Ref": "WaitHandle"},
                                 "'\n",
                                 "  exit 1\n",
                                 "}\n",
@@ -122,7 +121,6 @@ template = {
                                 "gollum --port 80 --host 0.0.0.0 &\n",
                                 "# If all is well so signal success\n",
                                 '/opt/aws/bin/cfn-signal -e $? -r "Rails application setup complete" \'',
-                                {"Ref": "WaitHandle"},
                                 "'\n",
                             ],
                         ]
@@ -185,16 +183,6 @@ template = {
                 "VolumeId": {"Ref": "DataVolume"},
             },
         },
-        "WaitCondition": {
-            "DependsOn": "MountPoint",
-            "Type": "AWS::CloudFormation::WaitCondition",
-            "Properties": {"Handle": {"Ref": "WaitHandle"}, "Timeout": "300"},
-            "Metadata": {
-                "Comment1": "Note that the WaitCondition is dependent on the volume mount point allowing the volume to be created and attached to the EC2 instance",
-                "Comment2": "The instance bootstrap script waits for the volume to be attached to the instance prior to installing Gollum and signalling completion",
-            },
-        },
-        "WaitHandle": {"Type": "AWS::CloudFormation::WaitConditionHandle"},
     },
     "Mappings": {
         "AWSInstanceType2Arch": {

--- a/tests/test_cloudformation/fixtures/vpc_single_instance_in_subnet.py
+++ b/tests/test_cloudformation/fixtures/vpc_single_instance_in_subnet.py
@@ -65,7 +65,6 @@ template = {
                 "Tags": [{"Value": {"Ref": "AWS::StackId"}, "Key": "Application"}],
             },
         },
-        "WebServerWaitHandle": {"Type": "AWS::CloudFormation::WaitConditionHandle"},
         "Route": {
             "Type": "AWS::EC2::Route",
             "Properties": {
@@ -94,11 +93,6 @@ template = {
                 "VpcId": {"Ref": "VPC"},
                 "Tags": [{"Value": {"Ref": "AWS::StackId"}, "Key": "Application"}],
             },
-        },
-        "WebServerWaitCondition": {
-            "Type": "AWS::CloudFormation::WaitCondition",
-            "Properties": {"Handle": {"Ref": "WebServerWaitHandle"}, "Timeout": "300"},
-            "DependsOn": "WebServerInstance",
         },
         "VPC": {
             "Type": "AWS::EC2::VPC",
@@ -142,7 +136,6 @@ template = {
                                 "function error_exit\n",
                                 "{\n",
                                 '  /opt/aws/bin/cfn-signal -e 1 -r "$1" \'',
-                                {"Ref": "WebServerWaitHandle"},
                                 "'\n",
                                 "  exit 1\n",
                                 "}\n",
@@ -157,7 +150,6 @@ template = {
                                 "/opt/aws/bin/cfn-hup || error_exit 'Failed to start cfn-hup'\n",
                                 "# All done so signal success\n",
                                 '/opt/aws/bin/cfn-signal -e 0 -r "WebServer setup complete" \'',
-                                {"Ref": "WebServerWaitHandle"},
                                 "'\n",
                             ],
                         ]

--- a/tests/test_dynamodb/models/test_item.py
+++ b/tests/test_dynamodb/models/test_item.py
@@ -3,7 +3,7 @@ from moto.dynamodb.models.dynamo_type import serializer
 
 
 class TestFindNestedKeys:
-    def setup(self):
+    def setup_method(self):
         self.dct = {
             "simplestring": "val",
             "nesteddict": {

--- a/tests/test_dynamodb/models/test_utilities.py
+++ b/tests/test_dynamodb/models/test_utilities.py
@@ -2,7 +2,7 @@ from moto.dynamodb.models.utilities import find_nested_key
 
 
 class TestFindDictionaryKeys:
-    def setup(self):
+    def setup_method(self):
         self.item = {
             "simplestring": "val",
             "nesteddict": {

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2563,7 +2563,7 @@ def test_instance_iam_instance_profile():
     )
 
     result1 = ec2_resource.create_instances(
-        ImageId="ami-d3adb33f",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         IamInstanceProfile={
@@ -2576,7 +2576,7 @@ def test_instance_iam_instance_profile():
     assert profile["InstanceProfile"]["Arn"] == instance.iam_instance_profile["Arn"]
 
     result2 = ec2_resource.create_instances(
-        ImageId="ami-d3adb33f",
+        ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
         IamInstanceProfile={


### PR DESCRIPTION
 - Remove WaitCondition/WaitConditionHandle from CF tests, as we don't support it anyway
 - Upgrade tests to use `setup_method` - the `setup`-method is deprecated in pytest
 - Use known AMI