### PR TITLE
ECR: add CreateRepository name validation

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -30,6 +30,9 @@ from moto.moto_api._internal import mock_random as random
 from moto.utilities.tagging_service import TaggingService
 
 ECR_REPOSITORY_ARN_PATTERN = "^arn:(?P<partition>[^:]+):ecr:(?P<region>[^:]+):(?P<account_id>[^:]+):repository/(?P<repo_name>.*)$"
+ECR_REPOSITORY_NAME_PATTERN = (
+    "(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*"
+)
 
 EcrRepositoryArn = namedtuple(
     "EcrRepositoryArn", ["partition", "region", "account_id", "repo_name"]
@@ -465,6 +468,12 @@ class ECRBackend(BaseBackend):
     ) -> Repository:
         if self.repositories.get(repository_name):
             raise RepositoryAlreadyExistsException(repository_name, self.account_id)
+
+        match = re.fullmatch(ECR_REPOSITORY_NAME_PATTERN, repository_name)
+        if not match:
+            raise InvalidParameterException(
+                f"Invalid parameter at 'repositoryName' failed to satisfy constraint: 'must satisfy regular expression '{ECR_REPOSITORY_NAME_PATTERN}'"
+            )
 
         repository = Repository(
             account_id=self.account_id,

--- a/tests/test_ecr/test_ecr_boto3.py
+++ b/tests/test_ecr/test_ecr_boto3.py
@@ -157,6 +157,19 @@ def test_create_repository_error_already_exists():
 
 
 @mock_ecr
+def test_create_repository_error_name_validation():
+    client = boto3.client("ecr", region_name="eu-central-1")
+    repo_name = "tesT"
+
+    with pytest.raises(ClientError) as e:
+        client.create_repository(repositoryName=repo_name)
+
+    ex = e.value
+    ex.operation_name.should.equal("CreateRepository")
+    ex.response["Error"]["Code"].should.contain("InvalidParameterException")
+
+
+@mock_ecr
 def test_describe_repositories():
     client = boto3.client("ecr", region_name="us-east-1")
     _ = client.create_repository(repositoryName="test_repository1")


### PR DESCRIPTION
This is a small fix to add name validation for the `repository-name` within ECR's `create-repository`.
Currently there is no name validation during the creation - but the [documentation](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepository.html#API_CreateRepository_RequestSyntax) states that it needs to follow a regex pattern. I found this through a [localstack issue](https://github.com/localstack/localstack/issues/8051).