### PR TITLE
SSM: Fix bad state caused by invalid PutParameter request

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -2062,7 +2062,11 @@ class SimpleSystemManagerBackend(BaseBackend):
                     "formed as a mix of letters, numbers and the following 3 symbols .-_"
                 )
             raise ValidationException(invalid_prefix_error)
-        if not parameter_type and not overwrite and not (name in self._parameters and self._parameters[name]):
+        if (
+            not parameter_type
+            and not overwrite
+            and not (name in self._parameters and self._parameters[name])
+        ):
             raise ValidationException(
                 "A parameter type is required when you create a parameter."
             )

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -2062,7 +2062,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                     "formed as a mix of letters, numbers and the following 3 symbols .-_"
                 )
             raise ValidationException(invalid_prefix_error)
-        if not parameter_type and not overwrite and not self._parameters[name]:
+        if not parameter_type and not overwrite and not (name in self._parameters and self._parameters[name]):
             raise ValidationException(
                 "A parameter type is required when you create a parameter."
             )

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -448,6 +448,9 @@ def test_put_parameter_no_type():
         == "A parameter type is required when you create a parameter."
     )
 
+    # Ensure backend state is consistent
+    assert client.describe_parameters()
+
 
 @mock_ssm
 def test_update_parameter():


### PR DESCRIPTION
This PR fixes an issue where if PutParameter is called without parameter type, it creates an invalid state within SSM. Consequently, all calls to DescribeParameters break.

It is caused by peeking into a default dict which creates an empty list, which itself is the invalid state.

```
$ awslocal ssm put-parameter --name foo --value bar

An error occurred (ValidationException) when calling the PutParameter operation: A parameter type is required when you create a parameter.
```

```
$ awslocal ssm describe-parameters

An error occurred (InternalError) when calling the DescribeParameters operation (reached max retries: 4): exception while calling ssm.DescribeParameters: Traceback (most recent call last):
  File "/home/viren/repo/localstack/localstack/aws/chain.py", line 90, in handle
    handler(self, self.context, response)
  File "/home/viren/repo/localstack/localstack/aws/handlers/service.py", line 123, in __call__
    handler(chain, context, response)
  File "/home/viren/repo/localstack/localstack/aws/handlers/service.py", line 93, in __call__
    skeleton_response = self.skeleton.invoke(context)
  File "/home/viren/repo/localstack/localstack/aws/skeleton.py", line 154, in invoke
    return self.dispatch_request(context, instance)
  File "/home/viren/repo/localstack/localstack/aws/skeleton.py", line 166, in dispatch_request
    result = handler(context, instance) or {}
  File "/home/viren/repo/localstack/localstack/aws/forwarder.py", line 67, in _call
    return fallthrough_handler(context, req)
  File "/home/viren/repo/localstack/localstack/services/moto.py", line 83, in _proxy_moto
    return call_moto(context)
  File "/home/viren/repo/localstack/localstack/services/moto.py", line 46, in call_moto
    return dispatch_to_backend(context, dispatch_to_moto, include_response_metadata)
  File "/home/viren/repo/localstack/localstack/aws/forwarder.py", line 120, in dispatch_to_backend
    http_response = http_request_dispatcher(context)
  File "/home/viren/repo/localstack/localstack/services/moto.py", line 111, in dispatch_to_moto
    response = dispatch(request, request.url, request.headers)
  File "/home/viren/repo/moto-ext/moto/core/responses.py", line 231, in dispatch
    return cls()._dispatch(*args, **kwargs)
  File "/home/viren/repo/moto-ext/moto/core/responses.py", line 375, in _dispatch
    return self.call_action()
  File "/home/viren/repo/moto-ext/moto/core/responses.py", line 464, in call_action
    response = method()
  File "/home/viren/repo/moto-ext/moto/ssm/responses.py", line 250, in describe_parameters
    result = self.ssm_backend.describe_parameters(filters, parameter_filters)
  File "/home/viren/repo/moto-ext/moto/ssm/models.py", line 1565, in describe_parameters
    ssm_parameter: Parameter = self.get_parameter(param_name)  # type: ignore[assignment]
  File "/home/viren/repo/moto-ext/moto/ssm/models.py", line 1927, in get_parameter
    return self._parameters[name][-1]
IndexError: list index out of range
```

Related: https://github.com/getmoto/moto/pull/6436