### PR TITLE
S3: fixed tagging

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1923,7 +1923,7 @@ class S3Response(BaseResponse):
 
         tags = {}
         for tag in parsed_xml["Tagging"]["TagSet"]["Tag"]:
-            tags[tag["Key"]] = tag["Value"]
+            tags[tag["Key"]] = tag["Value"] or ""
 
         return tags
 

--- a/tests/test_s3/test_s3_tagging.py
+++ b/tests/test_s3/test_s3_tagging.py
@@ -69,6 +69,7 @@ def test_put_bucket_tagging():
             "TagSet": [
                 {"Key": "TagOne", "Value": "ValueOne"},
                 {"Key": "TagTwo", "Value": "ValueTwo"},
+                {"Key": "TagThree", "Value": ""}
             ]
         },
     )
@@ -222,6 +223,7 @@ def test_put_object_tagging():
             "TagSet": [
                 {"Key": "item1", "Value": "foo"},
                 {"Key": "item2", "Value": "bar"},
+                {"Key": "item3", "Value": ""},
             ]
         },
     )

--- a/tests/test_s3/test_s3_tagging.py
+++ b/tests/test_s3/test_s3_tagging.py
@@ -69,7 +69,7 @@ def test_put_bucket_tagging():
             "TagSet": [
                 {"Key": "TagOne", "Value": "ValueOne"},
                 {"Key": "TagTwo", "Value": "ValueTwo"},
-                {"Key": "TagThree", "Value": ""}
+                {"Key": "TagThree", "Value": ""},
             ]
         },
     )


### PR DESCRIPTION
## Fixed
- S3 bucket and object tagging can accept empty values.

## Related Issue
- https://github.com/localstack/localstack/issues/8598

## Related PR
- https://github.com/localstack/localstack/pull/8638