### PR TITLE
EMR: fix handling of Properties for job flows

### DIFF
--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -820,7 +820,14 @@ DESCRIBE_JOB_FLOWS_TEMPLATE = """<DescribeJobFlowsResponse xmlns="http://elastic
                   <member>{{ arg | escape }}</member>
                   {% endfor %}
                 </Args>
-                <Properties/>
+                <Properties>
+                {% for key, val in step.properties.items() %}
+                  <member>
+                    <Key>{{ key }}</Key>
+                    <Value>{{ val | escape }}</Value>
+                  </member>
+                {% endfor %}
+                </Properties>
               </HadoopJarStep>
               <Name>{{ step.name | escape }}</Name>
             </StepConfig>
@@ -852,10 +859,10 @@ DESCRIBE_STEP_TEMPLATE = """<DescribeStepResponse xmlns="http://elasticmapreduce
         <MainClass/>
         <Properties>
           {% for key, val in step.properties.items() %}
-          <member>
+          <entry>
             <key>{{ key }}</key>
             <value>{{ val | escape }}</value>
-          </member>
+          </entry>
           {% endfor %}
         </Properties>
       </Config>
@@ -1180,10 +1187,10 @@ LIST_STEPS_TEMPLATE = """<ListStepsResponse xmlns="http://elasticmapreduce.amazo
           <MainClass/>
           <Properties>
             {% for key, val in step.properties.items() %}
-            <member>
+            <entry>
               <key>{{ key }}</key>
               <value>{{ val | escape }}</value>
-            </member>
+            </entry>
             {% endfor %}
           </Properties>
         </Config>

--- a/moto/emr/utils.py
+++ b/moto/emr/utils.py
@@ -33,15 +33,23 @@ def steps_from_query_string(
     steps = []
     for step in querystring_dict:
         step["jar"] = step.pop("hadoop_jar_step._jar")
-        step["properties"] = dict(
-            (o["Key"], o["Value"]) for o in step.get("properties", [])
-        )
         step["args"] = []
         idx = 1
         keyfmt = "hadoop_jar_step._args.member.{0}"
         while keyfmt.format(idx) in step:
             step["args"].append(step.pop(keyfmt.format(idx)))
             idx += 1
+
+        idx = 1
+        keyfmt_prop = "hadoop_jar_step._properties.member.{0}._key"
+        properties = {}
+        while keyfmt_prop.format(idx) in step:
+            key = keyfmt_prop.format(idx)
+            value = key.replace("_key", "_value")
+            properties[step.pop(key)] = step.pop(value)
+            idx += 1
+
+        step["properties"] = properties
         steps.append(step)
     return steps
 

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -944,6 +944,9 @@ def test_steps():
                     "aggregate",
                 ],
                 "Jar": "command-runner.jar",
+                "Properties": [
+                    {"Key": "mapred.tasktracker.map.tasks.maximum", "Value": "2"}
+                ],
             },
             "Name": "My wordcount example",
         },
@@ -963,6 +966,10 @@ def test_steps():
                     "aggregate",
                 ],
                 "Jar": "command-runner.jar",
+                "Properties": [
+                    {"Key": "mapred.reduce.tasks", "Value": "0"},
+                    {"Key": "stream.map.output.field.separator", "Value": "."},
+                ],
             },
             "Name": "My wordcount example2",
         },


### PR DESCRIPTION
This PR fixes parsing issues for the `Properties` field for `run_job_flow` and `add_job_flow_steps`. 
Enhanced the test to use the `Properties` and fixed response templates.