### PR TITLE
Fix: SQS BatchRequestTooLong exception

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -884,15 +884,8 @@ class SQSBackend(BaseBackend):
         ):
             raise InvalidBatchEntryId()
 
-        body_length = next(
-            (
-                len(entry["MessageBody"])
-                for entry in entries.values()
-                if len(entry["MessageBody"]) > MAXIMUM_MESSAGE_LENGTH
-            ),
-            False,
-        )
-        if body_length:
+        body_length = sum(len(entry["MessageBody"]) for entry in entries.values())
+        if body_length > MAXIMUM_MESSAGE_LENGTH:
             raise BatchRequestTooLong(body_length)
 
         duplicate_id = self._get_first_duplicate_id(


### PR DESCRIPTION
When sending messages in batch to AWS SQS a `BatchRequestTooLong` is thrown by AWS if the length of all the messages put together is greater than the AWS limit. See AWS documentation [here](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html#:~:text=Status%20Code%3A%20400-,BatchRequestTooLong,-The%20length%20of).

This PR fixes the logic that determines if a `BatchRequestTooLong` exception should be thrown. Prior to this PR, a `BatchRequestTooLong` exception is thrown only if a message in the batch of messages to be sent is greater than the AWS limit. After this PR, an exception will be thrown if the sum of all the messages exceeds the AWS limit.