### PR TITLE
Fix code scanning alerts

### DIFF
--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -110,9 +110,9 @@ backend_url_patterns = [
     ),
     (
         "meteringmarketplace",
-        re.compile("https?://metering.marketplace.(.+).amazonaws.com"),
+        re.compile("https?://metering.marketplace\\.(.+)\\.amazonaws.com"),
     ),
-    ("meteringmarketplace", re.compile("https?://aws-marketplace.(.+).amazonaws.com")),
+    ("meteringmarketplace", re.compile("https?://aws-marketplace\\.(.+)\\.amazonaws.com")),
     ("mq", re.compile("https?://mq\\.(.+)\\.amazonaws\\.com")),
     ("opsworks", re.compile("https?://opsworks\\.us-east-1\\.amazonaws.com")),
     ("organizations", re.compile("https?://organizations\\.(.+)\\.amazonaws\\.com")),

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -112,7 +112,10 @@ backend_url_patterns = [
         "meteringmarketplace",
         re.compile("https?://metering.marketplace\\.(.+)\\.amazonaws.com"),
     ),
-    ("meteringmarketplace", re.compile("https?://aws-marketplace\\.(.+)\\.amazonaws.com")),
+    (
+        "meteringmarketplace",
+        re.compile("https?://aws-marketplace\\.(.+)\\.amazonaws.com"),
+    ),
     ("mq", re.compile("https?://mq\\.(.+)\\.amazonaws\\.com")),
     ("opsworks", re.compile("https?://opsworks\\.us-east-1\\.amazonaws.com")),
     ("organizations", re.compile("https?://organizations\\.(.+)\\.amazonaws\\.com")),

--- a/moto/glue/glue_schema_registry_constants.py
+++ b/moto/glue/glue_schema_registry_constants.py
@@ -39,7 +39,7 @@ SCHEMA_VERSION_ID_PATTERN = re.compile(
     r"^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
 )
 MIN_SCHEMA_VERSION_ID_LENGTH = 36
-SCHEMA_VERSION_METADATA_PATTERN = re.compile(r"^[a-zA-Z0-9+-=._./@]+$")
+SCHEMA_VERSION_METADATA_PATTERN = re.compile(r"^[a-zA-Z0-9+=._/@-]+$")
 MAX_SCHEMA_VERSION_METADATA_ALLOWED = 10
 MAX_SCHEMA_VERSION_METADATA_LENGTH = 128
 METADATA_KEY = "MetadataKey"

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1981,7 +1981,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                 label.startswith("aws")
                 or label.startswith("ssm")
                 or label[:1].isdigit()
-                or not re.match(r"^[a-zA-z0-9_\.\-]*$", label)
+                or not re.match(r"^[a-zA-Z0-9_\.\-]*$", label)
             ):
                 invalid_labels.append(label)
                 continue


### PR DESCRIPTION
The two range-based regexs were clearly incorrect.  The unescaped periods in the `meteringmarketplace` urls seem like an oversight, unless those urls work in some unique way I'm not understanding.