### PR TITLE
Cloudfront: update_distribution() now supports DefaultRootObject

### DIFF
--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -104,10 +104,8 @@ class CustomOriginConfig:
         self.keep_alive = config.get("OriginKeepaliveTimeout") or 5
         self.protocol_policy = config.get("OriginProtocolPolicy")
         self.read_timeout = config.get("OriginReadTimeout") or 30
-        self.ssl_protocols = (
-            config.get("OriginSslProtocols", {}).get("Items", {}).get("SslProtocol")
-            or []
-        )
+        protocols = config.get("OriginSslProtocols", {}).get("Items") or {}
+        self.ssl_protocols = protocols.get("SslProtocol") or []
 
 
 class Origin:
@@ -356,15 +354,20 @@ class CloudFrontBackend(BaseBackend):
             raise NoSuchDistribution
         dist = self.distributions[_id]
 
-        aliases = dist_config["Aliases"]["Items"]["CNAME"]
+        if dist_config.get("Aliases", {}).get("Items") is not None:
+            aliases = dist_config["Aliases"]["Items"]["CNAME"]
+            dist.distribution_config.aliases = aliases
         origin = dist_config["Origins"]["Items"]["Origin"]
         dist.distribution_config.config = dist_config
-        dist.distribution_config.aliases = aliases
         dist.distribution_config.origins = (
             [Origin(o) for o in origin]
             if isinstance(origin, list)
             else [Origin(origin)]
         )
+        if dist_config.get("DefaultRootObject") is not None:
+            dist.distribution_config.default_root_object = dist_config[
+                "DefaultRootObject"
+            ]
         self.distributions[_id] = dist
         dist.advance()
         return dist, dist.location, dist.etag

--- a/tests/test_cloudfront/test_cloudfront.py
+++ b/tests/test_cloudfront/test_cloudfront.py
@@ -223,3 +223,27 @@ def test_update_distribution_dist_config_not_set():
     assert typename == "ParamValidationError"
     error_str = 'botocore.exceptions.ParamValidationError: Parameter validation failed:\nMissing required parameter in input: "DistributionConfig"'
     assert error.exconly() == error_str
+
+
+@mock_cloudfront
+def test_update_default_root_object():
+    client = boto3.client("cloudfront", region_name="us-east-1")
+
+    config = scaffold.minimal_dist_custom_config("sth")
+    dist = client.create_distribution(DistributionConfig=config)
+
+    dist_id = dist["Distribution"]["Id"]
+    root_object = "index.html"
+    dist_config = client.get_distribution_config(Id=dist_id)
+
+    # Update the default root object
+    dist_config["DistributionConfig"]["DefaultRootObject"] = root_object
+
+    client.update_distribution(
+        DistributionConfig=dist_config["DistributionConfig"],
+        Id=dist_id,
+        IfMatch=dist_config["ETag"],
+    )
+
+    dist_config = client.get_distribution_config(Id=dist_id)
+    assert dist_config["DistributionConfig"]["DefaultRootObject"] == "index.html"


### PR DESCRIPTION
Fixes #6546 

Also fixes a bug where `update` fails when no `Aliases` or `OriginSslProtocols` are provided