### PR TITLE
DynamoDB: Support sending nested items to ESM's

### DIFF
--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -302,7 +302,14 @@ class Item(BaseModel):
     def to_json(self) -> Dict[str, Any]:
         attributes = {}
         for attribute_key, attribute in self.attrs.items():
-            attributes[attribute_key] = {attribute.type: attribute.value}
+            if isinstance(attribute.value, dict):
+                attr_value = {
+                    key: value.to_regular_json()
+                    for key, value in attribute.value.items()
+                }
+                attributes[attribute_key] = {attribute.type: attr_value}
+            else:
+                attributes[attribute_key] = {attribute.type: attribute.value}
 
         return {"Attributes": attributes}
 

--- a/tests/test_awslambda/test_lambda_eventsourcemapping.py
+++ b/tests/test_awslambda/test_lambda_eventsourcemapping.py
@@ -136,7 +136,8 @@ def test_invoke_function_from_dynamodb_put():
     assert response["EventSourceArn"] == table["TableDescription"]["LatestStreamArn"]
     assert response["State"] == "Enabled"
 
-    dynamodb.put_item(TableName=table_name, Item={"id": {"S": "item 1"}})
+    item_to_create = {"id": {"S": "item 1"}, "data": {"M": {"nested": {"S": "stuff"}}}}
+    dynamodb.put_item(TableName=table_name, Item=item_to_create)
 
     expected_msg = "get_test_zip_file3 success"
     log_group = f"/aws/lambda/{function_name}"
@@ -144,6 +145,9 @@ def test_invoke_function_from_dynamodb_put():
 
     assert msg_showed_up, (
         expected_msg + " was not found after a DDB insert. All logs: " + str(all_logs)
+    )
+    assert any(
+        [json.dumps(item_to_create, separators=(",", ":")) in msg for msg in all_logs]
     )
 
 


### PR DESCRIPTION
Calling `to_json` on a nested item (i.e., a DynamoDB Item that contains a Map) currently throws an error:

`TypeError: Object of type DynamoType is not JSON serializable`