### PR TITLE
[Bug fix] Add required deduplication_id parameter to sns:PublishBatch

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -1043,6 +1043,7 @@ class SNSBackend(BaseBackend):
                     subject=entry.get("Subject"),
                     message_attributes=entry.get("MessageAttributes", {}),
                     group_id=entry.get("MessageGroupId"),
+                    deduplication_id=entry.get("MessageDeduplicationId"),
                 )
                 successful.append({"MessageId": message_id, "Id": entry["Id"]})
             except Exception as e:


### PR DESCRIPTION
This fixes a bug when publishing to an SNS FifoTopic. Currently any message published to a FifoTopic results in the following error:

> The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly
