### PR TITLE
CloudWatch: get_metric_data() now support (simple) Expressions

### DIFF
--- a/moto/cloudwatch/metric_data_expression_parser.py
+++ b/moto/cloudwatch/metric_data_expression_parser.py
@@ -1,0 +1,13 @@
+from typing import Any, Dict, List, Tuple, SupportsFloat
+
+
+def parse_expression(
+    expression: str, results: List[Dict[str, Any]]
+) -> Tuple[List[SupportsFloat], List[str]]:
+    values: List[SupportsFloat] = []
+    timestamps: List[str] = []
+    for result in results:
+        if result.get("id") == expression:
+            values.extend(result["vals"])
+            timestamps.extend(result["timestamps"])
+    return values, timestamps

--- a/tests/test_cloudwatch/test_cloudwatch_expression_parser.py
+++ b/tests/test_cloudwatch/test_cloudwatch_expression_parser.py
@@ -1,0 +1,40 @@
+from moto.cloudwatch.metric_data_expression_parser import parse_expression
+
+
+def test_simple_expression():
+    result_from_previous_queries = [
+        {
+            "id": "totalBytes",
+            "label": "metric Sum",
+            "vals": [25.0],
+            "timestamps": ["timestamp1"],
+        }
+    ]
+    res = parse_expression("totalBytes", result_from_previous_queries)
+    assert res == ([25.0], ["timestamp1"])
+
+
+def test_missing_expression():
+    result_from_previous_queries = [
+        {
+            "id": "totalBytes",
+            "label": "metric Sum",
+            "vals": [25.0],
+            "timestamps": ["timestamp1"],
+        }
+    ]
+    res = parse_expression("unknown", result_from_previous_queries)
+    assert res == ([], [])
+
+
+def test_complex_expression():
+    result_from_previous_queries = [
+        {
+            "id": "totalBytes",
+            "label": "metric Sum",
+            "vals": [25.0],
+            "timestamps": ["timestamp1"],
+        }
+    ]
+    res = parse_expression("totalBytes/10", result_from_previous_queries)
+    assert res == ([], [])

--- a/tests/test_cloudwatch/test_cloudwatch_expressions.py
+++ b/tests/test_cloudwatch/test_cloudwatch_expressions.py
@@ -1,0 +1,70 @@
+import boto3
+import pytest
+
+from botocore.exceptions import ClientError
+from datetime import datetime, timedelta, timezone
+from moto import mock_cloudwatch
+
+
+@mock_cloudwatch
+def test_get_metric_data__no_metric_data_or_expression():
+    utc_now = datetime.now(tz=timezone.utc)
+    cloudwatch = boto3.client("cloudwatch", "eu-west-1")
+    with pytest.raises(ClientError) as exc:
+        cloudwatch.get_metric_data(
+            MetricDataQueries=[{"Id": "result1", "Label": "e1"}],
+            StartTime=utc_now - timedelta(minutes=5),
+            EndTime=utc_now,
+            ScanBy="TimestampDescending",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+    assert (
+        err["Message"]
+        == "The parameter MetricDataQueries.member.1.MetricStat is required.\n"
+    )
+
+
+@mock_cloudwatch
+def test_get_metric_data_with_simple_expression():
+    utc_now = datetime.now(tz=timezone.utc)
+    cloudwatch = boto3.client("cloudwatch", "eu-west-1")
+    namespace = "my_namespace/"
+    cloudwatch.put_metric_data(
+        Namespace=namespace,
+        MetricData=[
+            {
+                "MetricName": "metric",
+                "Value": 25,
+                "Unit": "Bytes",
+            },
+        ],
+    )
+    # get_metric_data 1
+    results = cloudwatch.get_metric_data(
+        MetricDataQueries=[
+            {
+                "Id": "result1",
+                "Expression": "totalBytes",
+                "Label": "e1",
+            },
+            {
+                "Id": "totalBytes",
+                "MetricStat": {
+                    "Metric": {"Namespace": namespace, "MetricName": "metric"},
+                    "Period": 60,
+                    "Stat": "Sum",
+                    "Unit": "Bytes",
+                },
+                "ReturnData": False,
+            },
+        ],
+        StartTime=utc_now - timedelta(minutes=5),
+        EndTime=utc_now + timedelta(minutes=5),
+        ScanBy="TimestampDescending",
+    )["MetricDataResults"]
+    #
+    assert len(results) == 1
+    assert results[0]["Id"] == "result1"
+    assert results[0]["Label"] == "e1"
+    assert results[0]["Values"] == [25.0]


### PR DESCRIPTION
Fixes #3323 

Biggest fix: Moto no longer throws a KeyError when `MetricStat` is not supplied.
If neither `MetricStat` or `Expression` are supplied, we throw an error (in line with AWS)

Expression support:
Currently only supports for extremely simple use cases, where the entire expression consists of the `Id` of another Query.
Once people request support for more complicated expressions, we can always extend this.