### PR TITLE
ResourceGroupsTaggingAPI: Support Glue resources

### DIFF
--- a/scripts/dependency_test.sh
+++ b/scripts/dependency_test.sh
@@ -33,7 +33,7 @@ valid_service() {
   # Verify whether this is a valid service
   # We'll ignore metadata folders, and folders that test generic Moto behaviour
   # We'll also ignore CloudFormation, as it will always depend on other services
-  local ignore_moto_folders="core instance_metadata __pycache__ templates cloudformation moto_api moto_server resourcegroupstaggingapi packages utilities s3bucket_path"
+  local ignore_moto_folders="core instance_metadata __pycache__ templates cloudformation moto_api moto_server packages utilities s3bucket_path"
   if echo $ignore_moto_folders | grep -q "$1"; then
     return 1
   else

--- a/setup.cfg
+++ b/setup.cfg
@@ -179,6 +179,17 @@ redshiftdata =
 rekognition =
 resourcegroups =
 resourcegroupstaggingapi =
+    python-jose[cryptography]>=3.1.0,<4.0.0
+    ecdsa!=0.15
+    docker>=3.0.0
+    graphql-core
+    PyYAML>=5.1
+    cfn-lint>=0.40.0
+    sshpubkeys>=3.1.0
+    openapi-spec-validator>=0.2.8
+    pyparsing>=3.0.7
+    jsondiff>=1.1.2
+    py-partiql-parser==0.3.6
 route53 =
 route53resolver = sshpubkeys>=3.1.0
 s3 =

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_glue.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_glue.py
@@ -1,0 +1,55 @@
+import boto3
+
+from moto import mock_glue, mock_resourcegroupstaggingapi
+from moto.core import DEFAULT_ACCOUNT_ID
+from uuid import uuid4
+
+
+@mock_glue
+@mock_resourcegroupstaggingapi
+def test_glue_jobs():
+    glue = boto3.client("glue", region_name="us-west-1")
+    job_name = glue.create_job(
+        Name=str(uuid4()),
+        Role="test_role",
+        Command=dict(Name="test_command"),
+        Tags={"k1": "v1"},
+    )["Name"]
+    job_arn = f"arn:aws:glue:us-west-1:{DEFAULT_ACCOUNT_ID}:job/{job_name}"
+
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-1")
+    resources = rtapi.get_resources(ResourceTypeFilters=["glue"])[
+        "ResourceTagMappingList"
+    ]
+    assert resources == [
+        {"ResourceARN": job_arn, "Tags": [{"Key": "k1", "Value": "v1"}]}
+    ]
+
+    resources = rtapi.get_resources(ResourceTypeFilters=["glue:job"])[
+        "ResourceTagMappingList"
+    ]
+    assert resources == [
+        {"ResourceARN": job_arn, "Tags": [{"Key": "k1", "Value": "v1"}]}
+    ]
+
+    resources = rtapi.get_resources(TagFilters=[{"Key": "k1", "Values": ["v1"]}])[
+        "ResourceTagMappingList"
+    ]
+    assert resources == [
+        {"ResourceARN": job_arn, "Tags": [{"Key": "k1", "Value": "v1"}]}
+    ]
+
+    resources = rtapi.get_resources(ResourceTypeFilters=["glue:table"])[
+        "ResourceTagMappingList"
+    ]
+    assert resources == []
+
+    resources = rtapi.get_resources(ResourceTypeFilters=["ec2"])[
+        "ResourceTagMappingList"
+    ]
+    assert resources == []
+
+    assert rtapi.get_tag_keys()["TagKeys"] == ["k1"]
+
+    assert rtapi.get_tag_values(Key="k1")["TagValues"] == ["v1"]
+    assert rtapi.get_tag_values(Key="unknown")["TagValues"] == []


### PR DESCRIPTION
Fixes #5931 

This PR also adds (almost) all dependencies for `moto[resourcegroupstaggingapi]`, as they were missing until now.
Test run that validates these dependencies are enough: https://github.com/bblommers/moto/actions/runs/5708608444