### PR TITLE
Techdebt: Ensure we only access endpoint services list after creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-only:
 	pytest -sv -rs --cov=moto --cov-report xml ./tests/ $(TEST_EXCLUDE)
 	# https://github.com/aws/aws-xray-sdk-python/issues/196 - Run these tests separately without Coverage enabled
 	pytest -sv -rs ./tests/test_xray
-	MOTO_CALL_RESET_API=false pytest -rs --cov=moto --cov-report xml --cov-append -n 4 $(PARALLEL_TESTS)
+	MOTO_CALL_RESET_API=false pytest -sv --cov=moto --cov-report xml --cov-append -n 4 $(PARALLEL_TESTS)
 
 test: lint test-only
 


### PR DESCRIPTION
The tests have been failing after #6617:
`The Vpc Endpoint Service 'com.amazonaws.us-west-1.config' does not exist`

I assume that is because the `_collect_default_endpoint_services` is called by multiple requests in parallel. 

1. `request 1`: creates `DEFAULT_VPC_ENDPOINT_SERVICES` for a single backend
2. `request 2`: comes in and sees that `DEFAULT_VPC_ENDPOINT_SERVICES` is not none, so it returns the half-filled list
3. `request 1`: continues filling up the list

I couldn't reproduce this locally of course, that would be too easy. But a lock around the creation of the list would ensure that `request 2` only has access to the full list:

1. `request 1`: creates `DEFAULT_VPC_ENDPOINT_SERVICES` for a single backend
2. `request 2`: comes in, but has to wait
3. `request 1`: continues filling up the list
4. `request 2`: now has access to the full list
