### PR TITLE
awslambda: `create_function()` should fail on duplicate

### DIFF
--- a/moto/awslambda/exceptions.py
+++ b/moto/awslambda/exceptions.py
@@ -14,6 +14,14 @@ class CrossAccountNotAllowed(LambdaClientError):
         )
 
 
+class FunctionAlreadyExists(LambdaClientError):
+    code = 409
+
+    def __init__(self, function_name: str) -> None:
+        message = f"Function already exist: {function_name}"
+        super().__init__("ResourceConflictException", message)
+
+
 class InvalidParameterValueException(LambdaClientError):
     def __init__(self, message: str):
         super().__init__("InvalidParameterValueException", message)

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote
 from moto.core.utils import path_url
 from moto.utilities.aws_headers import amz_crc32, amzn_request_id
 from moto.core.responses import BaseResponse, TYPE_RESPONSE
-from .exceptions import FunctionAlreadyExists
+from .exceptions import FunctionAlreadyExists, UnknownFunctionException
 from .models import lambda_backends, LambdaBackend
 
 
@@ -320,7 +320,7 @@ class LambdaResponse(BaseResponse):
         function_name = self.json_body["FunctionName"].rsplit(":", 1)[-1]
         try:
             self.backend.get_function(function_name, None)
-        except:
+        except UnknownFunctionException:
             fn = self.backend.create_function(self.json_body)
             config = fn.get_configuration(on_create=True)
             return 201, {}, json.dumps(config)

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -6,6 +6,7 @@ from urllib.parse import unquote
 from moto.core.utils import path_url
 from moto.utilities.aws_headers import amz_crc32, amzn_request_id
 from moto.core.responses import BaseResponse, TYPE_RESPONSE
+from .exceptions import FunctionAlreadyExists
 from .models import lambda_backends, LambdaBackend
 
 
@@ -323,20 +324,7 @@ class LambdaResponse(BaseResponse):
             fn = self.backend.create_function(self.json_body)
             config = fn.get_configuration(on_create=True)
             return 201, {}, json.dumps(config)
-        payload = json.dumps(
-            {
-                "Type": "User",
-                "message": f"Function already exist: {function_name}",
-            }
-        ).encode("utf-8")
-        return (
-            409,
-            {
-                "x-amzn-ErrorType": "ResourceConflictException",
-                "Content-Length": str(len(payload)),
-            },
-            payload,
-        )
+        raise FunctionAlreadyExists(function_name)
 
     def _create_function_url_config(self) -> TYPE_RESPONSE:
         function_name = unquote(self.path.split("/")[-2])

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1205,19 +1205,20 @@ def test_create_function_with_already_exists():
         Publish=True,
     )
 
-    response = conn.create_function(
-        FunctionName=function_name,
-        Runtime="python2.7",
-        Role=get_role_name(),
-        Handler="lambda_function.lambda_handler",
-        Code={"S3Bucket": bucket_name, "S3Key": "test.zip"},
-        Description="test lambda function",
-        Timeout=3,
-        MemorySize=128,
-        Publish=True,
-    )
+    with pytest.raises(ClientError) as exc:
+        conn.create_function(
+            FunctionName=function_name,
+            Runtime="python2.7",
+            Role=get_role_name(),
+            Handler="lambda_function.lambda_handler",
+            Code={"S3Bucket": bucket_name, "S3Key": "test.zip"},
+            Description="test lambda function",
+            Timeout=3,
+            MemorySize=128,
+            Publish=True,
+        )
 
-    assert response["FunctionName"] == function_name
+        assert exc.value.response["Error"]["Code"] == "ResourceConflictException"
 
 
 @mock_lambda

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1218,7 +1218,7 @@ def test_create_function_with_already_exists():
             Publish=True,
         )
 
-        assert exc.value.response["Error"]["Code"] == "ResourceConflictException"
+    assert exc.value.response["Error"]["Code"] == "ResourceConflictException"
 
 
 @mock_lambda

--- a/tests/test_awslambda/test_lambda_layers.py
+++ b/tests/test_awslambda/test_lambda_layers.py
@@ -115,6 +115,7 @@ def test_get_lambda_layers():
     assert result["LayerVersions"] == []
 
     # Test create function with non existant layer version
+    function_name = str(uuid4())[0:6]  # Must be different than above
     with pytest.raises(ClientError) as exc:
         conn.create_function(
             FunctionName=function_name,


### PR DESCRIPTION
In real life, `lambda:CreateFunction` fails if the caller attempts to create a function that already exists. Accurately model this behavior.

Yes, the actual AWS response really is written in broken English. ;-)