### PR TITLE
Lambda: model concurrency limits for `put_function_concurrency()`

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2042,7 +2042,7 @@ class LambdaBackend(BaseBackend):
             reserved_concurrency
         )
         for fnx in self.list_functions():
-            if fnx.reserved_concurrency and fnx.name != function_name:
+            if fnx.reserved_concurrency and fnx.function_name != function_name:
                 available -= int(fnx.reserved_concurrency)
         if available < 100:
             raise InvalidParameterValueException(

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1688,3 +1688,56 @@ def test_put_function_concurrency_failure():
     # No reservation should have been set
     response = conn.get_function_concurrency(FunctionName=function_name)
     assert "ReservedConcurrentExecutions" not in response
+
+
+@mock_lambda
+def test_put_function_concurrency_i_can_has_math():
+    conn = boto3.client("lambda", _lambda_region)
+    zip_content = get_test_zip_file1()
+    function_name_1 = str(uuid4())[0:6]
+    function_name_2 = str(uuid4())[0:6]
+    conn.create_function(
+        FunctionName=function_name_1,
+        Runtime="python2.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": zip_content},
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+    conn.create_function(
+        FunctionName=function_name_2,
+        Runtime="python2.7",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": zip_content},
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    response = conn.put_function_concurrency(
+        FunctionName=function_name_1, ReservedConcurrentExecutions=600
+    )
+    assert response["ReservedConcurrentExecutions"] == 600
+    response = conn.put_function_concurrency(
+        FunctionName=function_name_2, ReservedConcurrentExecutions=100
+    )
+    assert response["ReservedConcurrentExecutions"] == 100
+
+    # Increasing function 1's limit should succeed, e.g. 700 + 100 <= 900
+    response = conn.put_function_concurrency(
+        FunctionName=function_name_1, ReservedConcurrentExecutions=700
+    )
+    assert response["ReservedConcurrentExecutions"] == 700
+
+    # Increasing function 2's limit shoulf fail, e.g. 700 + 201 > 900
+    with pytest.raises(ClientError) as exc:
+        conn.put_function_concurrency(
+            FunctionName=function_name_2, ReservedConcurrentExecutions=201
+        )
+
+        assert exc.value.response["Error"]["Code"] == "InvalidParameterValueException"


### PR DESCRIPTION
In real life, AWS lambda does not allow unbounded concurrency. Refine behavior of `put_function_concurrency()` to provide an approximation of the correct behavior:

* The AWS default limit of 1,000 concurrent lambda instances per account and region can be overridden with the `MOTO_LAMBDA_CONCURRENCY_QUOTA` environment variable, if needed;
* If cumulative reservations result in fewer than 100 unreserved instances (i.e. by default, 900 reserved instances) then an `InvalidParameterValueException` is raised and no change is made;
* The simulation applies the limit across all defined functions (rather than only functions in the same account and region) -- my judgment is that this distinction is unimportant in nearly all test scenarios (and previous behavior can be obtained by redefining the quota to some really huge number sufficient to accommodate all functions under test)