### PR TITLE
awslambda: enforce concurrency quota in `put_function_concurrency()`

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2034,20 +2034,30 @@ class LambdaBackend(BaseBackend):
     def put_function_concurrency(
         self, function_name: str, reserved_concurrency: str
     ) -> str:
-        # Actual lambda restricts concurrency to 1000 (default) per region/account
-        # across all functions; we approximate that behavior by summing across all
-        # functions (hopefully all in the same account and region) and allowing the
-        # caller to simulate an increased quota.
-        available = int(os.environ.get("MOTO_LAMBDA_CONCURRENCY_QUOTA", "1000")) - int(
-            reserved_concurrency
-        )
-        for fnx in self.list_functions():
-            if fnx.reserved_concurrency and fnx.function_name != function_name:
-                available -= int(fnx.reserved_concurrency)
-        if available < 100:
-            raise InvalidParameterValueException(
-                "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [100]."
-            )
+        """Establish concurrency limit/reservations for a function
+
+        Actual lambda restricts concurrency to 1000 (default) per region/account
+        across all functions; we approximate that behavior by summing across all
+        functions (hopefully all in the same account and region) and allowing the
+        caller to simulate an increased quota.
+
+        By default, no quota is enforced in order to preserve compatibility with
+        existing code that assumes it can do as many things as it likes. To model
+        actual AWS behavior, define the MOTO_LAMBDA_CONCURRENCY_QUOTA environment
+        variable prior to testing.
+        """
+
+        quota: Optional[str] = os.environ.get("MOTO_LAMBDA_CONCURRENCY_QUOTA")
+        if quota is not None:
+            # Enforce concurrency limits as described above
+            available = int(quota) - int(reserved_concurrency)
+            for fnx in self.list_functions():
+                if fnx.reserved_concurrency and fnx.function_name != function_name:
+                    available -= int(fnx.reserved_concurrency)
+            if available < 100:
+                raise InvalidParameterValueException(
+                    "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [100]."
+                )
 
         fn = self.get_function(function_name)
         fn.reserved_concurrency = reserved_concurrency

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2042,7 +2042,7 @@ class LambdaBackend(BaseBackend):
             reserved_concurrency
         )
         for fnx in self.list_functions():
-            if fnx.reserved_concurrency and fnx.name != function_name:
+            if fnx.reserved_concurrency and fnx.function_name != function_name:
                 available -= int(fnx.reserved_concurrency)
         if available < 100:
             raise InvalidParameterValueException(

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1639,6 +1639,7 @@ def test_get_role_name_utility_race_condition():
 
 
 @mock_lambda
+@mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_success():
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -1641,6 +1641,10 @@ def test_get_role_name_utility_race_condition():
 @mock_lambda
 @mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_success():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest(
+            "Envars not easily set in server mode, feature off by default, skipping..."
+        )
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
     function_name = str(uuid4())[0:6]
@@ -1691,6 +1695,10 @@ def test_put_function_concurrency_not_enforced():
 @mock_lambda
 @mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_failure():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest(
+            "Envars not easily set in server mode, feature off by default, skipping..."
+        )
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
     function_name = str(uuid4())[0:6]
@@ -1721,6 +1729,10 @@ def test_put_function_concurrency_failure():
 @mock_lambda
 @mock.patch.dict(os.environ, {"MOTO_LAMBDA_CONCURRENCY_QUOTA": "1000"})
 def test_put_function_concurrency_i_can_has_math():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest(
+            "Envars not easily set in server mode, feature off by default, skipping..."
+        )
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
     function_name_1 = str(uuid4())[0:6]


### PR DESCRIPTION
In real life, AWS lambda does not allow unbounded concurrency. Refine behavior of `put_function_concurrency()` to provide an approximation of the correct behavior:

* By default, no concurrency limits are enforced (old behavior);
* If environment variable `MOTO_LAMBDA_CONCURRENCY_QUOTA` is defined (to a positive integer), then enforcement is enabled (use 1000 to match the AWS default limit);
* If cumulative reservations result in fewer than 100 unreserved instances (i.e. by default, 900 reserved instances) then an `InvalidParameterValueException` is raised and no change is made;
* The simulation applies the limit across all defined functions (rather than only functions in the same account and region) -- my judgment is that this distinction is unimportant in nearly all test scenarios (and previous behavior can be obtained by redefining the quota to some really huge number sufficient to accommodate all functions under test)