### PR TITLE
KMS: Validate key specs

### DIFF
--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 from enum import Enum
 import io
 import os

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from typing import Any, Dict, Tuple
+from enum import Enum
 import io
 import os
 import struct
@@ -46,6 +47,28 @@ RESERVED_ALIASE_TARGET_KEY_IDS = {
 }
 
 RESERVED_ALIASES = list(RESERVED_ALIASE_TARGET_KEY_IDS.keys())
+
+
+class KeySpec(str, Enum):
+    # Asymmetric key specs
+    RSA_2048 = "RSA_2048"
+    RSA_3072 = "RSA_3072"
+    RSA_4096 = "RSA_4096"
+    ECC_NIST_P256 = "ECC_NIST_P256"
+    ECC_NIST_P384 = "ECC_NIST_P384"
+    ECC_NIST_P512 = "ECC_NIST_P521"
+    ECC_SECG_P256K1 = "ECC_SECG_P256K1"
+    SM2 = "SM2"  # China Regions only
+    # Symmetric key specs
+    SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT"
+    HMAC224 = "HMAC_224"
+    HMAC_256 = "HMAC_256"
+    HMAC_284 = "HMAC_384"
+    HMAC_512 = "HMAC_512"
+
+    @classmethod
+    def key_specs(self) -> List[str]:
+        return [item.value for item in KeySpec]
 
 
 def generate_key_id(multi_region: bool = False) -> str:

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -55,13 +55,13 @@ class KeySpec(str, Enum):
     RSA_3072 = "RSA_3072"
     RSA_4096 = "RSA_4096"
     ECC_NIST_P256 = "ECC_NIST_P256"
+    ECC_SECG_P256K1 = "ECC_SECG_P256K1"
     ECC_NIST_P384 = "ECC_NIST_P384"
     ECC_NIST_P512 = "ECC_NIST_P521"
-    ECC_SECG_P256K1 = "ECC_SECG_P256K1"
     SM2 = "SM2"  # China Regions only
     # Symmetric key specs
     SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT"
-    HMAC224 = "HMAC_224"
+    HMAC_224 = "HMAC_224"
     HMAC_256 = "HMAC_256"
     HMAC_284 = "HMAC_384"
     HMAC_512 = "HMAC_512"

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -68,7 +68,7 @@ class KeySpec(str, Enum):
 
     @classmethod
     def key_specs(self) -> List[str]:
-        return [item.value for item in KeySpec]
+        return sorted([item.value for item in KeySpec])
 
 
 def generate_key_id(multi_region: bool = False) -> str:

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -43,6 +43,21 @@ def test_create_key_without_description():
 
 
 @mock_kms
+def test_create_key_with_invalid_key_spec():
+    conn = boto3.client("kms", region_name="us-east-1")
+    unsupported_key_spec = "NotSupportedKeySpec"
+    with pytest.raises(ClientError) as ex:
+        conn.create_key(Policy="my policy", KeySpec=unsupported_key_spec)
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert err["Message"] == (
+        "1 validation error detected: Value '{key_spec}' at 'KeySpec' failed "
+        "to satisfy constraint: Member must satisfy enum value set: "
+        "['ECC_NIST_P256', 'ECC_NIST_P384', 'ECC_NIST_P521', 'ECC_SECG_P256K1', 'HMAC_224', 'HMAC_256', 'HMAC_384', 'HMAC_512', 'RSA_2048', 'RSA_3072', 'RSA_4096', 'SM2', 'SYMMETRIC_DEFAULT']"
+    ).format(key_spec=unsupported_key_spec)
+
+
+@mock_kms
 def test_create_key():
     conn = boto3.client("kms", region_name="us-east-1")
     key = conn.create_key(


### PR DESCRIPTION
- Adding string Enum of supported kms key specs (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kms/client/create_key.html)
- Adding a method to validate that a given key spec is supported or not.