### PR TITLE
Techdebt: Re-add an ignore for mypy

### DIFF
--- a/moto/core/versions.py
+++ b/moto/core/versions.py
@@ -3,7 +3,7 @@ from moto.utilities.distutils_version import LooseVersion
 try:
     from importlib.metadata import version
 except ImportError:
-    from importlib_metadata import version
+    from importlib_metadata import version  # type: ignore[no-redef]
 
 
 RESPONSES_VERSION = version("responses")


### PR DESCRIPTION
(new contributor here)

I just unrolled the [Development Installation](http://docs.getmoto.org/en/latest/docs/contributing/installation.html) guide that states python 3.x as requirement.

My workstation runs python3.11, I created a dedicated venv. When running the `make test` on master (as of writing at c8b5470e25012477f817a619e88f9ad1bea08bbe) I came across a mypy error:
```
$ mypy --install-types --non-interactive
moto/core/versions.py:6:5: error: Name "version" already defined (possibly by an import)  [no-redef]
``` 

I was able to reproduce the same issue in the CI by running the lint suite with python3.11 [with a one-line edit](https://github.com/ajoga/moto/commit/5543db1a644c553d1b3c56d56f8b584f8c1a23b0) : https://github.com/ajoga/moto/actions/runs/5842743552/job/15844189693 

Using git-bisect I found that e26cfe7dc677360f03964f33385b04a8c1c063d4 introduced this failure ; this PR offers to put it back.