### PR TITLE
Docs: refactor document for server mode (TestThreadedMotoServer)

### DIFF
--- a/docs/docs/server_mode.rst
+++ b/docs/docs/server_mode.rst
@@ -83,8 +83,7 @@ See the following example:
 
             in_mem_client = boto3.client("s3")
             buckets = in_mem_client.list_buckets()["Buckets"]
-            [b["Name"] for b in buckets].should.equal(["test"])
-
+            self.assertEqual([b["Name"] for b in buckets], ["test"])
 This example shows it is possible to create state using the TreadedMotoServer, and access that state using the usual decorators.  :raw-html:`<br />`
 Note that the decorators will destroy any resources on start, so make sure to not accidentally destroy any resources created by the ThreadedMotoServer that should be kept.
 


### PR DESCRIPTION
There is a disused method shown in `docs/docs/server_mode.rst`, which is `.should.equal`

it is better that using `assertEqual` instead of `.should.equal`

# before
<img width="1312" alt="image" src="https://github.com/getmoto/moto/assets/28383935/62cd6021-9af2-4e41-86c8-4d4da6401ff7">

# after
<img width="1367" alt="image" src="https://github.com/getmoto/moto/assets/28383935/9aa415a7-6785-4173-b7af-e63046a46472">


