### PR TITLE
Docker image is now based on Python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,16 @@ jobs:
         grep ${{ env.VERSION }} CHANGELOG.md || { echo "Ensure that the CHANGELOG contains an entry for ${{ env.VERSION }}" ; exit 1; }
     - name: Set version number
       run: python update_version_from_git.py ${{ env.VERSION }}
-    - name: Build
+    - name: Build Python
       run: python -m build
+    - name: Build Docker release
+      run: |
+        docker build -t motoserver/moto . --tag moto:${{ env.VERSION }}
+    - name: Test Docker release
+      run: |
+        docker run -p 5000:5000 --name moto motoserver/moto &
+        TEST_SERVER_MODE=true pytest -sv tests/test_core tests/test_s3
+        docker stop moto
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -46,9 +54,6 @@ jobs:
       run: |
         git tag ${{ env.VERSION }}
         git push origin ${{ env.VERSION }}
-    - name: Build Docker release
-      run: |
-        docker build -t motoserver/moto . --tag moto:${{ env.VERSION }}
     # Required to get the correct Digest
     # See https://github.com/docker/build-push-action/issues/461
     - name: Set up QEMU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Moto Changelog
 ==============
 
+4.2.0
+------
+Docker Digest for 4.2.0: <autopopulateddigest>
+
+    General:
+        The Docker image is now based on Python 3.11 (instead of 3.7)
+
 4.1.15
 ------
 Docker Digest for 4.1.15: _sha256:eb63b1e0cbbd757e4596844e6ac1865660cbf8e358203b79e5404d57de94dd69_

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.11-slim
 
 ADD . /moto/
 ENV PYTHONUNBUFFERED 1

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -210,7 +210,7 @@ mock_all = MockAll
 # logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 __title__ = "moto"
-__version__ = "4.1.16.dev"
+__version__ = "4.2.0.dev"
 
 
 try:


### PR DESCRIPTION
Long time coming - but this was blocked by #6602 until now

Should provide a significant speedup across the board.