### PR TITLE
S3: add granting logging perms using bucket policy

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1259,7 +1259,7 @@ class FakeBucket(CloudFormationModel):
                 "The target bucket for logging does not exist."
             )
 
-        target_prefix = bucket_backend.buckets.get(logging_config["TargetPrefix"])
+        target_prefix = self.logging.get("TargetPrefix", None)
         has_policy_permissions = self._log_permissions_enabled_policy(
             target_bucket=target_bucket, target_prefix=target_prefix
         )

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -54,7 +54,7 @@ from .cloud_formation import cfn_to_api_encryption, is_replacement_update
 from . import notifications
 from .select_object_content import parse_query
 from .utils import _VersionedKeyStore, CaseInsensitiveDict
-from .utils import ARCHIVE_STORAGE_CLASSES, STORAGE_CLASS
+from .utils import ARCHIVE_STORAGE_CLASSES, STORAGE_CLASS, LOGGING_SERVICE_PRINCIPAL
 from ..events.notifications import send_notification as events_send_notification
 from ..settings import get_s3_default_key_buffer_size, S3_UPLOAD_PART_MIN_SIZE
 
@@ -1195,22 +1195,38 @@ class FakeBucket(CloudFormationModel):
     def delete_cors(self) -> None:
         self.cors = []
 
-    def set_logging(
-        self, logging_config: Optional[Dict[str, Any]], bucket_backend: "S3Backend"
-    ) -> None:
-        if not logging_config:
-            self.logging = {}
-            return
+    @staticmethod
+    def _log_permissions_enabled_policy(
+        target_bucket: "FakeBucket", target_prefix: Optional[str]
+    ) -> bool:
+        target_bucket_policy = target_bucket.policy
+        if target_bucket_policy:
+            target_bucket_policy_json = json.loads(target_bucket_policy.decode())
+            for stmt in target_bucket_policy_json["Statement"]:
+                if (
+                    stmt.get("Principal", {}).get("Service")
+                    != LOGGING_SERVICE_PRINCIPAL
+                ):
+                    continue
+                if stmt.get("Effect", "") != "Allow":
+                    continue
+                if "s3:PutObject" not in stmt.get("Action", []):
+                    continue
+                if (
+                    stmt.get("Resource")
+                    != f"arn:aws:s3:::{target_bucket.name}/{target_prefix if target_prefix else ''}*"
+                    and stmt.get("Resource") != f"arn:aws:s3:::{target_bucket.name}/*"
+                    and stmt.get("Resource") != f"arn:aws:s3:::{target_bucket.name}"
+                ):
+                    continue
+                return True
 
-        # Target bucket must exist in the same account (assuming all moto buckets are in the same account):
-        if not bucket_backend.buckets.get(logging_config["TargetBucket"]):
-            raise InvalidTargetBucketForLogging(
-                "The target bucket for logging does not exist."
-            )
+        return False
 
-        # Does the target bucket have the log-delivery WRITE and READ_ACP permissions?
+    @staticmethod
+    def _log_permissions_enabled_acl(target_bucket: "FakeBucket") -> bool:
         write = read_acp = False
-        for grant in bucket_backend.buckets[logging_config["TargetBucket"]].acl.grants:  # type: ignore
+        for grant in target_bucket.acl.grants:  # type: ignore
             # Must be granted to: http://acs.amazonaws.com/groups/s3/LogDelivery
             for grantee in grant.grantees:
                 if grantee.uri == "http://acs.amazonaws.com/groups/s3/LogDelivery":
@@ -1225,20 +1241,39 @@ class FakeBucket(CloudFormationModel):
                         or "FULL_CONTROL" in grant.permissions
                     ):
                         read_acp = True
-
                     break
 
-        if not write or not read_acp:
+        return write and read_acp
+
+    def set_logging(
+        self, logging_config: Optional[Dict[str, Any]], bucket_backend: "S3Backend"
+    ) -> None:
+        if not logging_config:
+            self.logging = {}
+            return
+
+        # Target bucket must exist in the same account (assuming all moto buckets are in the same account):
+        target_bucket = bucket_backend.buckets.get(logging_config["TargetBucket"])
+        if not target_bucket:
             raise InvalidTargetBucketForLogging(
-                "You must give the log-delivery group WRITE and READ_ACP"
-                " permissions to the target bucket"
+                "The target bucket for logging does not exist."
+            )
+
+        target_prefix = bucket_backend.buckets.get(logging_config["TargetPrefix"])
+        has_policy_permissions = self._log_permissions_enabled_policy(
+            target_bucket=target_bucket, target_prefix=target_prefix
+        )
+        has_acl_permissions = self._log_permissions_enabled_acl(
+            target_bucket=target_bucket
+        )
+        if not (has_policy_permissions or has_acl_permissions):
+            raise InvalidTargetBucketForLogging(
+                "You must either provide the necessary permissions to the logging service using a bucket "
+                "policy or give the log-delivery group WRITE and READ_ACP permissions to the target bucket"
             )
 
         # Buckets must also exist within the same region:
-        if (
-            bucket_backend.buckets[logging_config["TargetBucket"]].region_name
-            != self.region_name
-        ):
+        if target_bucket.region_name != self.region_name:
             raise CrossLocationLoggingProhibitted()
 
         # Checks pass -- set the logging config:

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -36,6 +36,7 @@ STORAGE_CLASS = [
     "ONEZONE_IA",
     "INTELLIGENT_TIERING",
 ] + ARCHIVE_STORAGE_CLASSES
+LOGGING_SERVICE_PRINCIPAL = "logging.s3.amazonaws.com"
 
 
 def bucket_name_from_url(url: str) -> Optional[str]:  # type: ignore

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -3,10 +3,12 @@ import json
 import boto3
 import pytest
 from botocore.client import ClientError
+from unittest import SkipTest
 from unittest.mock import patch
 
 
 from moto import mock_s3
+from moto import settings
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.s3 import s3_backends
 from moto.s3.models import FakeBucket
@@ -272,6 +274,9 @@ def test_log_file_is_created():
 
 @mock_s3
 def test_invalid_bucket_logging_when_permissions_are_false():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = "mybucket"
     log_bucket = "logbucket"
@@ -295,6 +300,9 @@ def test_invalid_bucket_logging_when_permissions_are_false():
 
 @mock_s3
 def test_valid_bucket_logging_when_permissions_are_true():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = "mybucket"
     log_bucket = "logbucket"

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -329,6 +329,9 @@ def test_valid_bucket_logging_when_permissions_are_true():
 
 @mock_s3
 def test_bucket_policy_not_set():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
 
@@ -346,6 +349,9 @@ def test_bucket_policy_not_set():
 
 @mock_s3
 def test_bucket_policy_principal():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
 
@@ -398,6 +404,9 @@ def test_bucket_policy_principal():
 
 @mock_s3
 def test_bucket_policy_effect():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
 
@@ -449,6 +458,9 @@ def test_bucket_policy_effect():
 
 @mock_s3
 def test_bucket_policy_action():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
 
@@ -498,6 +510,9 @@ def test_bucket_policy_action():
 
 @mock_s3
 def test_bucket_policy_resource():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't patch permission logic in ServerMode")
+
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_backend = s3_backends[DEFAULT_ACCOUNT_ID]["global"]
 


### PR DESCRIPTION
**Context**
Related issue: https://github.com/getmoto/moto/issues/6659

This PR enables for moto s3 buckets to enable logging if they have an appropriate bucket policy set (in addition to the existing logic that enables this if an appropriate ACL is set)

**Testing**
Added to existing unit tests.