### PR TITLE
Logs: Support two subscription filters

### DIFF
--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -371,11 +371,9 @@ class LogsResponse(BaseResponse):
     def describe_subscription_filters(self) -> str:
         log_group_name = self._get_param("logGroupName")
 
-        subscription_filters = self.logs_backend.describe_subscription_filters(
-            log_group_name
-        )
+        _filters = self.logs_backend.describe_subscription_filters(log_group_name)
 
-        return json.dumps({"subscriptionFilters": subscription_filters})
+        return json.dumps({"subscriptionFilters": [f.to_json() for f in _filters]})
 
     def put_subscription_filter(self) -> str:
         log_group_name = self._get_param("logGroupName")

--- a/tests/test_logs/test_integration.py
+++ b/tests/test_logs/test_integration.py
@@ -62,7 +62,7 @@ def test_put_subscription_filter_update():
     sub_filter["filterPattern"] = ""
 
     # when
-    # to update an existing subscription filter the 'filerName' must be identical
+    # to update an existing subscription filter the 'filterName' must be identical
     client_logs.put_subscription_filter(
         logGroupName=log_group_name,
         filterName="test",
@@ -82,11 +82,17 @@ def test_put_subscription_filter_update():
     sub_filter["filterPattern"] = "[]"
 
     # when
-    # only one subscription filter can be associated with a log group
+    # only two subscription filters can be associated with a log group
+    client_logs.put_subscription_filter(
+        logGroupName=log_group_name,
+        filterName="test-2",
+        filterPattern="[]",
+        destinationArn=function_arn,
+    )
     with pytest.raises(ClientError) as e:
         client_logs.put_subscription_filter(
             logGroupName=log_group_name,
-            filterName="test-2",
+            filterName="test-3",
             filterPattern="",
             destinationArn=function_arn,
         )


### PR DESCRIPTION
Fixes #6713 

SubscriptionFilters are now a first-class citizen, as part of the `LogGroup`-model:
 - They have their own model, instead of being a regular dict
 - put_log_events() requests the list of subscription filters when necessary (instead of `LogStream` having to keep a reference to the ARN/filter name)