### PR TITLE
Core: Allow request decompression

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -3,6 +3,7 @@ import inspect
 import re
 import unicodedata
 from botocore.exceptions import ClientError
+from gzip import decompress
 from typing import Any, Optional, List, Callable, Dict, Tuple
 from urllib.parse import urlparse, unquote
 from .common_types import TYPE_RESPONSE
@@ -416,3 +417,7 @@ def _unquote_hex_characters(path: str) -> str:
         )
         char_offset += (combo_end - combo_start) + len(character) - 1
     return path
+
+
+def gzip_decompress(body: bytes) -> bytes:
+    return decompress(body)

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -158,6 +158,11 @@ def parse_key_name(pth: str) -> str:
 class S3Response(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="s3")
+        # Whatever format requests come in, we should never touch them
+        # There are some nuances here - this decision should be method-specific, instead of service-specific
+        # E.G.: we don't want to touch put_object(), but we might have to decompress put_object_configuration()
+        # Taking the naive approach to never decompress anything from S3 for now
+        self.allow_request_decompression = False
 
     def get_safe_path_from_url(self, url: ParseResult) -> str:
         return self.get_safe_path(url.path)


### PR DESCRIPTION
Fixes #6692 

This PR enable support for request compression, coming to an SDK near you. It is a very naive and simple approach, but I intend to fine-tune this as necessary when compression arrives in boto3.