### PR TITLE
ResourceGroupsTaggingAPI: tag_resource() for RDS resources

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -221,6 +221,10 @@ class Cluster:
         )
 
     @property
+    def arn(self) -> str:
+        return self.db_cluster_arn
+
+    @property
     def db_cluster_arn(self) -> str:
         return f"arn:aws:rds:{self.region_name}:{self.account_id}:cluster:{self.db_cluster_identifier}"
 
@@ -462,6 +466,10 @@ class ClusterSnapshot(BaseModel):
         )
 
     @property
+    def arn(self) -> str:
+        return self.snapshot_arn
+
+    @property
     def snapshot_arn(self) -> str:
         return f"arn:aws:rds:{self.cluster.region_name}:{self.cluster.account_id}:cluster-snapshot:{self.snapshot_id}"
 
@@ -644,6 +652,10 @@ class Database(CloudFormationModel):
         self.enabled_cloudwatch_logs_exports = (
             kwargs.get("enable_cloudwatch_logs_exports") or []
         )
+
+    @property
+    def arn(self) -> str:
+        return self.db_instance_arn
 
     @property
     def db_instance_arn(self) -> str:
@@ -1090,6 +1102,10 @@ class DatabaseSnapshot(BaseModel):
         self.created_at = iso_8601_datetime_with_milliseconds(
             datetime.datetime.utcnow()
         )
+
+    @property
+    def arn(self) -> str:
+        return self.snapshot_arn
 
     @property
     def snapshot_arn(self) -> str:

--- a/moto/resourcegroupstaggingapi/responses.py
+++ b/moto/resourcegroupstaggingapi/responses.py
@@ -58,21 +58,15 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
 
         return json.dumps(response)
 
-    # These methods are all thats left to be implemented
-    # the response is already set up, all thats needed is
-    # the respective model function to be implemented.
-    #
-    # def tag_resources(self):
-    #     resource_arn_list = self._get_list_prefix("ResourceARNList.member")
-    #     tags = self._get_param("Tags")
-    #     failed_resources_map = self.backend.tag_resources(
-    #         resource_arn_list=resource_arn_list,
-    #         tags=tags,
-    #     )
-    #
-    #     # failed_resources_map should be {'resource': {'ErrorCode': str, 'ErrorMessage': str, 'StatusCode': int}}
-    #     return json.dumps({'FailedResourcesMap': failed_resources_map})
-    #
+    def tag_resources(self) -> str:
+        resource_arns = self._get_param("ResourceARNList")
+        tags = self._get_param("Tags")
+        failed_resources = self.backend.tag_resources(
+            resource_arns=resource_arns, tags=tags
+        )
+
+        return json.dumps({"FailedResourcesMap": failed_resources})
+
     # def untag_resources(self):
     #     resource_arn_list = self._get_list_prefix("ResourceARNList.member")
     #     tag_keys = self._get_list_prefix("TagKeys.member")

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_rds.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_rds.py
@@ -1,0 +1,71 @@
+import boto3
+import unittest
+
+from moto import mock_rds
+from moto import mock_resourcegroupstaggingapi
+
+
+@mock_rds
+@mock_resourcegroupstaggingapi
+class TestRdsTagging(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rds = boto3.client("rds", region_name="us-west-2")
+        self.rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+        self.resources_tagged = []
+        self.resources_untagged = []
+        for i in range(3):
+            database = self.rds.create_db_instance(
+                DBInstanceIdentifier=f"db-instance-{i}",
+                Engine="postgres",
+                DBInstanceClass="db.m1.small",
+                CopyTagsToSnapshot=bool(i),
+                Tags=[{"Key": "test", "Value": f"value-{i}"}] if i else [],
+            ).get("DBInstance")
+            snapshot = self.rds.create_db_snapshot(
+                DBInstanceIdentifier=database["DBInstanceIdentifier"],
+                DBSnapshotIdentifier=f"snapshot-{i}",
+            ).get("DBSnapshot")
+            group = self.resources_tagged if i else self.resources_untagged
+            group.append(database["DBInstanceArn"])
+            group.append(snapshot["DBSnapshotArn"])
+
+    def test_get_resources_rds(self):
+        def assert_response(response, expected_count, resource_type=None):
+            results = response.get("ResourceTagMappingList", [])
+            assert len(results) == expected_count
+            for item in results:
+                arn = item["ResourceARN"]
+                assert arn in self.resources_tagged
+                assert arn not in self.resources_untagged
+                if resource_type:
+                    assert f":{resource_type}:" in arn
+
+        resp = self.rtapi.get_resources(ResourceTypeFilters=["rds"])
+        assert_response(resp, 4)
+        resp = self.rtapi.get_resources(ResourceTypeFilters=["rds:db"])
+        assert_response(resp, 2, resource_type="db")
+        resp = self.rtapi.get_resources(ResourceTypeFilters=["rds:snapshot"])
+        assert_response(resp, 2, resource_type="snapshot")
+        resp = self.rtapi.get_resources(
+            TagFilters=[{"Key": "test", "Values": ["value-1"]}]
+        )
+        assert_response(resp, 2)
+
+    def test_tag_resources_rds(self):
+        # WHEN
+        # we tag resources
+        self.rtapi.tag_resources(
+            ResourceARNList=self.resources_tagged,
+            Tags={"key1": "value1", "key2": "value2"},
+        )
+
+        # THEN
+        # we can retrieve the tags using the RDS API
+        def get_tags(arn):
+            return self.rds.list_tags_for_resource(ResourceName=arn)["TagList"]
+
+        for arn in self.resources_tagged:
+            assert {"Key": "key1", "Value": "value1"} in get_tags(arn)
+            assert {"Key": "key2", "Value": "value2"} in get_tags(arn)
+        for arn in self.resources_untagged:
+            assert get_tags(arn) == []

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -6,7 +6,6 @@ from botocore.client import ClientError
 from moto import mock_ec2
 from moto import mock_elbv2
 from moto import mock_kms
-from moto import mock_rds
 from moto import mock_resourcegroupstaggingapi
 from moto import mock_s3
 from moto import mock_lambda
@@ -223,7 +222,6 @@ def test_get_resources_ecs():
     assert task_two not in resp["ResourceTagMappingList"][0]["ResourceARN"]
 
 
-@mock_rds
 @mock_ec2
 @mock_resourcegroupstaggingapi
 def test_get_resources_ec2():
@@ -588,49 +586,6 @@ def test_multiple_tag_filters():
     assert instance_2_id not in results[0]["ResourceARN"]
 
 
-@mock_rds
-@mock_resourcegroupstaggingapi
-def test_get_resources_rds():
-    client = boto3.client("rds", region_name="us-west-2")
-    resources_tagged = []
-    resources_untagged = []
-    for i in range(3):
-        database = client.create_db_instance(
-            DBInstanceIdentifier=f"db-instance-{i}",
-            Engine="postgres",
-            DBInstanceClass="db.m1.small",
-            CopyTagsToSnapshot=bool(i),
-            Tags=[{"Key": "test", "Value": f"value-{i}"}] if i else [],
-        ).get("DBInstance")
-        snapshot = client.create_db_snapshot(
-            DBInstanceIdentifier=database["DBInstanceIdentifier"],
-            DBSnapshotIdentifier=f"snapshot-{i}",
-        ).get("DBSnapshot")
-        group = resources_tagged if i else resources_untagged
-        group.append(database["DBInstanceArn"])
-        group.append(snapshot["DBSnapshotArn"])
-
-    def assert_response(response, expected_count, resource_type=None):
-        results = response.get("ResourceTagMappingList", [])
-        assert len(results) == expected_count
-        for item in results:
-            arn = item["ResourceARN"]
-            assert arn in resources_tagged
-            assert arn not in resources_untagged
-            if resource_type:
-                assert f":{resource_type}:" in arn
-
-    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
-    resp = rtapi.get_resources(ResourceTypeFilters=["rds"])
-    assert_response(resp, 4)
-    resp = rtapi.get_resources(ResourceTypeFilters=["rds:db"])
-    assert_response(resp, 2, resource_type="db")
-    resp = rtapi.get_resources(ResourceTypeFilters=["rds:snapshot"])
-    assert_response(resp, 2, resource_type="snapshot")
-    resp = rtapi.get_resources(TagFilters=[{"Key": "test", "Values": ["value-1"]}])
-    assert_response(resp, 2)
-
-
 @mock_lambda
 @mock_resourcegroupstaggingapi
 @mock_iam
@@ -717,3 +672,17 @@ def test_get_resources_lambda():
 
     resp = rtapi.get_resources(TagFilters=[{"Key": "Shape", "Values": ["rectangle"]}])
     assert_response(resp, [rectangle_arn])
+
+
+@mock_resourcegroupstaggingapi
+def test_tag_resources_for_unknown_service():
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+    missing_resources = rtapi.tag_resources(
+        ResourceARNList=["arn:aws:service_x"], Tags={"key1": "k", "key2": "v"}
+    )["FailedResourcesMap"]
+
+    assert "arn:aws:service_x" in missing_resources
+    assert (
+        missing_resources["arn:aws:service_x"]["ErrorCode"]
+        == "InternalServiceException"
+    )


### PR DESCRIPTION
Fixes #6688 

Also refactors the `_get_resource_generator` in ResourceGroupTaggingAPI, as it is the same logic across all RDS resource types.