### PR TITLE
KMS: Add `RSASSA_PKCS1_V1_5_SHA_256, 384, 512` signing algorithms

### DIFF
--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1170,7 +1170,14 @@ def test_sign_and_verify_ignoring_grant_tokens():
     list(
         itertools.product(
             ["RSA_2048", "RSA_3072", "RSA_4096"],
-            ["RSASSA_PSS_SHA_256", "RSASSA_PSS_SHA_384", "RSASSA_PSS_SHA_512"],
+            [
+                "RSASSA_PSS_SHA_256",
+                "RSASSA_PSS_SHA_384",
+                "RSASSA_PSS_SHA_512",
+                "RSASSA_PKCS1_V1_5_SHA_256",
+                "RSASSA_PKCS1_V1_5_SHA_384",
+                "RSASSA_PKCS1_V1_5_SHA_512",
+            ],
         )
     ),
 )


### PR DESCRIPTION
Adding the following signing algorithms and unittests.
- `RSASSA_PKCS1_V1_5_SHA_256`
- `RSASSA_PKCS1_V1_5_SHA_384`
- `RSASSA_PKCS1_V1_5_SHA_512`

Refactoring that a methods to select padding and hash functions is extracted.