### PR TITLE
KMS: Add signing by ECDSA Private key

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -167,12 +167,12 @@ class Key(CloudFormationModel):
             return None  # type: ignore[return-value]
         elif self.key_spec in KeySpec.ecc_key_specs():
             if self.key_spec == KeySpec.ECC_NIST_P384:
-                return [SigningAlgorithm.ECDSA_SHA_384]
-            elif self.key_spec == KeySpec.ECC_NIST_P512:
-                return [SigningAlgorithm.ECDSA_SHA_512]
+                return [SigningAlgorithm.ECDSA_SHA_384.value]
+            elif self.key_spec == KeySpec.ECC_NIST_P521:
+                return [SigningAlgorithm.ECDSA_SHA_512.value]
             else:
                 # key_spec is 'ECC_NIST_P256' or 'ECC_SECG_P256K1'
-                return [SigningAlgorithm.ECDSA_SHA_256]
+                return [SigningAlgorithm.ECDSA_SHA_256.value]
         elif self.key_spec in KeySpec.rsa_key_specs():
             return SigningAlgorithm.rsa_signing_algorithms()
         elif self.key_spec == KeySpec.SM2:

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives._asymmetric import AsymmetricPadding
-from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives.asymmetric import rsa, padding, ec
 
 
 from .exceptions import (
@@ -62,7 +62,7 @@ class KeySpec(str, Enum):
     ECC_NIST_P256 = "ECC_NIST_P256"
     ECC_SECG_P256K1 = "ECC_SECG_P256K1"
     ECC_NIST_P384 = "ECC_NIST_P384"
-    ECC_NIST_P512 = "ECC_NIST_P521"
+    ECC_NIST_P521 = "ECC_NIST_P521"
     SM2 = "SM2"  # China Regions only
     # Symmetric key specs
     SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT"
@@ -165,6 +165,16 @@ def validate_signing_algorithm(
         )
 
 
+def validate_key_spec(target_key_spec: str, valid_key_specs: List[str]) -> None:
+    if target_key_spec not in valid_key_specs:
+        raise ValidationException(
+            (
+                "1 validation error detected: Value at 'key_spec' failed "
+                "to satisfy constraint: Member must satisfy enum value set: {valid_key_specs}"
+            ).format(valid_key_specs=valid_key_specs)
+        )
+
+
 class RSAPrivateKey(AbstractPrivateKey):
     # See https://docs.aws.amazon.com/kms/latest/cryptographic-details/crypto-primitives.html
     __supported_key_sizes = [2048, 3072, 4096]
@@ -237,6 +247,57 @@ class RSAPrivateKey(AbstractPrivateKey):
         )
 
 
+class ECDSAPrivateKey(AbstractPrivateKey):
+    def __init__(self, key_spec: str):
+        validate_key_spec(key_spec, KeySpec.ecc_key_specs())
+
+        if key_spec == KeySpec.ECC_NIST_P256:
+            curve = ec.SECP256R1()  # type: ec.EllipticCurve
+            valid_signing_algorithms = ["ECDSA_SHA_256"]  # type: List[str]
+        elif key_spec == KeySpec.ECC_SECG_P256K1:
+            curve = ec.SECP256K1()
+            valid_signing_algorithms = ["ECDSA_SHA_256"]
+        elif key_spec == KeySpec.ECC_NIST_P384:
+            curve = ec.SECP384R1()
+            valid_signing_algorithms = ["ECDSA_SHA_384"]
+        else:
+            curve = ec.SECP521R1()
+            valid_signing_algorithms = ["ECDSA_SHA_512"]
+
+        self.private_key = ec.generate_private_key(curve)
+        self.valid_signing_algorithms = valid_signing_algorithms
+
+    def __hash_algorithm(self, signing_algorithm: str) -> hashes.HashAlgorithm:
+        if signing_algorithm == SigningAlgorithm.ECDSA_SHA_256:
+            algorithm = hashes.SHA256()  # type: Any
+        elif signing_algorithm == SigningAlgorithm.ECDSA_SHA_384:
+            algorithm = hashes.SHA384()
+        else:
+            algorithm = hashes.SHA512()
+        return algorithm
+
+    def sign(self, message: bytes, signing_algorithm: str) -> bytes:
+        validate_signing_algorithm(signing_algorithm, self.valid_signing_algorithms)
+        hash_algorithm = self.__hash_algorithm(signing_algorithm)
+        return self.private_key.sign(message, ec.ECDSA(hash_algorithm))
+
+    def verify(self, message: bytes, signature: bytes, signing_algorithm: str) -> bool:
+        validate_signing_algorithm(signing_algorithm, self.valid_signing_algorithms)
+        hash_algorithm = self.__hash_algorithm(signing_algorithm)
+        public_key = self.private_key.public_key()
+        try:
+            public_key.verify(signature, message, ec.ECDSA(hash_algorithm))
+            return True
+        except InvalidSignature:
+            return False
+
+    def public_key(self) -> bytes:
+        return self.private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+
 def generate_private_key(key_spec: str) -> AbstractPrivateKey:
     """Generate a private key to be used on asymmetric sign/verify."""
     if key_spec == KeySpec.RSA_2048:
@@ -245,6 +306,8 @@ def generate_private_key(key_spec: str) -> AbstractPrivateKey:
         return RSAPrivateKey(key_size=3072)
     elif key_spec == KeySpec.RSA_4096:
         return RSAPrivateKey(key_size=4096)
+    elif key_spec in KeySpec.ecc_key_specs():
+        return ECDSAPrivateKey(key_spec)
     else:
         return RSAPrivateKey(key_size=2048)
 

--- a/tests/test_kms/test_utils.py
+++ b/tests/test_kms/test_utils.py
@@ -20,6 +20,7 @@ from moto.kms.utils import (
     KeySpec,
     SigningAlgorithm,
     RSAPrivateKey,
+    ECDSAPrivateKey,
 )
 
 ENCRYPTION_CONTEXT_VECTORS = [
@@ -103,6 +104,15 @@ def test_RSAPrivateKey_invalid_key_size():
     assert (
         ex.value.message
         == "1 validation error detected: Value at 'key_size' failed to satisfy constraint: Member must satisfy enum value set: [2048, 3072, 4096]"
+    )
+
+
+def test_ECDSAPrivateKey_invalid_key_spec():
+    with pytest.raises(ValidationException) as ex:
+        _ = ECDSAPrivateKey(key_spec="InvalidKeySpec")
+    assert (
+        ex.value.message
+        == "1 validation error detected: Value at 'key_spec' failed to satisfy constraint: Member must satisfy enum value set: ['ECC_NIST_P256', 'ECC_NIST_P384', 'ECC_NIST_P521', 'ECC_SECG_P256K1']"
     )
 
 


### PR DESCRIPTION
- Adding ECDSA Private key and implementing signing and verification message.
- Adding unit tests:
  - 1. A message is successfully signed and verified.
  - 1. A message is successfully signed but verification fails.
  - 2. Signing fails becauase of an invalid signing algorithm for key spec.