### PR TITLE
EC2: Add missing transitGatewayArn field for CreateTransitGatewayResponse

### DIFF
--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -46,6 +46,10 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
     def owner_id(self) -> str:
         return self.ec2_backend.account_id
 
+    @property
+    def arn(self) -> str:
+        return f"arn:aws:ec2:{self.ec2_backend.region_name}:{self.ec2_backend.account_id}:transit-gateway/{self.id}"
+
     @staticmethod
     def cloudformation_name_type() -> str:
         return ""

--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -66,7 +66,7 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "TransitGateway":
         from ..models import ec2_backends
 

--- a/moto/ec2/responses/transit_gateways.py
+++ b/moto/ec2/responses/transit_gateways.py
@@ -64,7 +64,7 @@ CREATE_TRANSIT_GATEWAY_RESPONSE = """<CreateTransitGatewayResponse xmlns="http:/
     <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
     <transitGateway>
         <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
-        <transitGatewayArn>arn:aws:ec2:us-east-1:{{ transit_gateway.owner_id }}:transit-gateway/{{ transit_gateway.id }}</transitGatewayArn>
+        <transitGatewayArn>{{ transit_gateway.arn }}</transitGatewayArn>
         <ownerId>{{ transit_gateway.owner_id }}</ownerId>
         <description>{{ transit_gateway.description or '' }}</description>
         <createTime>{{ transit_gateway.create_time }}</createTime>
@@ -123,7 +123,7 @@ DESCRIBE_TRANSIT_GATEWAY_RESPONSE = """<DescribeTransitGatewaysResponse xmlns="h
                     </item>
                 {% endfor %}
             </tagSet>
-            <transitGatewayArn>arn:aws:ec2:us-east-1:{{ transit_gateway.owner_id }}:transit-gateway/{{ transit_gateway.id }}</transitGatewayArn>
+            <transitGatewayArn>{{ transit_gateway.arn }}</transitGatewayArn>
             <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
         </item>
     {% endfor %}
@@ -167,7 +167,7 @@ MODIFY_TRANSIT_GATEWAY_RESPONSE = """<ModifyTransitGatewaysResponse xmlns="http:
                 </item>
             {% endfor %}
         </tagSet>
-        <transitGatewayArn>arn:aws:ec2:us-east-1:{{ transit_gateway.owner_id }}:transit-gateway/{{ transit_gateway.id }}</transitGatewayArn>
+        <transitGatewayArn>{{ transit_gateway.arn }}</transitGatewayArn>
         <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
     </item>
     </transitGatewaySet>

--- a/moto/ec2/responses/transit_gateways.py
+++ b/moto/ec2/responses/transit_gateways.py
@@ -64,6 +64,7 @@ CREATE_TRANSIT_GATEWAY_RESPONSE = """<CreateTransitGatewayResponse xmlns="http:/
     <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
     <transitGateway>
         <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
+        <transitGatewayArn>arn:aws:ec2:us-east-1:{{ transit_gateway.owner_id }}:transit-gateway/{{ transit_gateway.id }}</transitGatewayArn>
         <ownerId>{{ transit_gateway.owner_id }}</ownerId>
         <description>{{ transit_gateway.description or '' }}</description>
         <createTime>{{ transit_gateway.create_time }}</createTime>

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -25,7 +25,7 @@ def test_create_transit_gateway():
     assert gateway["TransitGatewayId"].startswith("tgw-")
     assert (
         gateway["TransitGatewayArn"]
-        == f"arn:aws:ec2:us-east-1:{ACCOUNT_ID}:transit-gateway/{gateway['TransitGatewayId']}"
+        == f"arn:aws:ec2:us-west-1:{ACCOUNT_ID}:transit-gateway/{gateway['TransitGatewayId']}"
     )
     assert gateway["State"] == "available"
     assert gateway["OwnerId"] == ACCOUNT_ID
@@ -54,7 +54,7 @@ def test_create_transit_gateway():
     assert "CreationTime" in gateways[0]
     assert (
         gateways[0]["TransitGatewayArn"]
-        == f"arn:aws:ec2:us-east-1:{ACCOUNT_ID}:transit-gateway/{gateway['TransitGatewayId']}"
+        == f"arn:aws:ec2:us-west-1:{ACCOUNT_ID}:transit-gateway/{gateway['TransitGatewayId']}"
     )
     assert (
         gateways[0]["Options"]["AssociationDefaultRouteTableId"]

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -23,6 +23,10 @@ def test_create_transit_gateway():
     )
     gateway = response["TransitGateway"]
     assert gateway["TransitGatewayId"].startswith("tgw-")
+    assert (
+        gateway["TransitGatewayArn"]
+        == f"arn:aws:ec2:us-east-1:{ACCOUNT_ID}:transit-gateway/{gateway['TransitGatewayId']}"
+    )
     assert gateway["State"] == "available"
     assert gateway["OwnerId"] == ACCOUNT_ID
     assert gateway["Description"] == "my first gateway"

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -61,7 +61,6 @@ def test_create_transit_gateway():
         == gateways[0]["Options"]["PropagationDefaultRouteTableId"]
     )
     del gateways[0]["CreationTime"]
-    del gateways[0]["TransitGatewayArn"]
     del gateways[0]["Options"]["AssociationDefaultRouteTableId"]
     assert gateway == gateways[0]
 


### PR DESCRIPTION
Fixes a small parity issue with AWS. Here's an link to the [examples](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-transit-gateway.html#examples) and I also tried it out against actual AWS and it does indeed populate the ARN on create.

This also fixes this bug https://github.com/localstack/localstack/issues/9042 in `localstack`