### PR TITLE
Fix memory leak when comparing requests

### DIFF
--- a/moto/core/responses_custom_registry.py
+++ b/moto/core/responses_custom_registry.py
@@ -26,9 +26,11 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
         self._registered.clear()
 
     def find(self, request: Any) -> Tuple[Optional[responses.BaseResponse], List[str]]:
-        all_possibles = responses._default_mock._registry.registered
         # We don't have to search through all possible methods - only the ones registered for this particular method
-        all_possibles.extend(self._registered[request.method])
+        all_possibles = (
+            responses._default_mock._registry.registered
+            + self._registered[request.method]
+        )
         found = []
         match_failed_reasons = []
         for response in all_possibles:


### PR DESCRIPTION
An attempt to fix https://github.com/getmoto/moto/issues/6763

The issue with:
```python
all_possibles = responses._default_mock._registry.registered
all_possibles.extend(self._registered[request.method])
```
is that the original `all_possibles` gets mutated and keeps growing bigger and bigger.

We verified that behaviour in our project which uses moto.
`all_possibles = responses._default_mock._registry.registered + self._registered[request.method]` gives us a new list each time, instead of mutating the original.

This `.extend()` code exists in versions >= 4.1.13

This is what v4.1.12 does:
https://github.com/getmoto/moto/blob/2543f9af73e5537c8517c78ca79bb03dd24e2a77/moto/core/responses_custom_registry.py#L20
