### PR TITLE
fix(secretsmanager): fix update of no-value initial secret

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -129,7 +129,9 @@ class FakeSecret:
         if self.default_version_id:
             # set old AWSCURRENT secret to AWSPREVIOUS
             previous_current_version_id = self.default_version_id
-            self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]
+            self.versions[previous_current_version_id]["version_stages"] = [
+                "AWSPREVIOUS"
+            ]
 
         self.versions[version_id] = secret_version
         self.default_version_id = version_id

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -126,9 +126,10 @@ class FakeSecret:
             if "AWSPREVIOUS" in old_version["version_stages"]:
                 old_version["version_stages"].remove("AWSPREVIOUS")
 
-        # set old AWSCURRENT secret to AWSPREVIOUS
-        previous_current_version_id = self.default_version_id
-        self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]  # type: ignore
+        if self.default_version_id:
+            # set old AWSCURRENT secret to AWSPREVIOUS
+            previous_current_version_id = self.default_version_id
+            self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]
 
         self.versions[version_id] = secret_version
         self.default_version_id = version_id

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -293,6 +293,22 @@ def test_create_secret_without_value():
 
 
 @mock_secretsmanager
+def test_create_secret_that_has_no_value_and_then_update():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+
+    conn.create_secret(Name="secret-no-value")
+
+    conn.update_secret(
+        SecretId="secret-no-value",
+        SecretString="barsecret",
+        Description="desc",
+    )
+
+    secret = conn.get_secret_value(SecretId="secret-no-value")
+    assert secret["SecretString"] == "barsecret"
+
+
+@mock_secretsmanager
 def test_update_secret_without_value():
     conn = boto3.client("secretsmanager", region_name="us-east-2")
     secret_name = f"secret-{str(uuid4())[0:6]}"


### PR DESCRIPTION
Fixes the updating of an initial no-value secret.

If a secret was initially created without a value, then subsequent updates causes a `KeyError: None` as `default_version_id` is `None`.

Noticed downstream on the latest Localstack build.