### PR TITLE
EC2: Support filtering transit gateways by tag

### DIFF
--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -4,7 +4,10 @@ from moto.core import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.utilities.utils import filter_resources, merge_multiple_dicts
 from .core import TaggedEC2Resource
-from ..utils import random_transit_gateway_id
+from ..utils import (
+    random_transit_gateway_id,
+    describe_tag_filter,
+)
 
 
 class TransitGateway(TaggedEC2Resource, CloudFormationModel):
@@ -123,6 +126,8 @@ class TransitGatewayBackend:
         result = transit_gateways
         if filters:
             result = filter_resources(transit_gateways, filters, attr_pairs)
+            result = describe_tag_filter(filters, result)
+
         return result
 
     def delete_transit_gateway(self, transit_gateway_id: str) -> TransitGateway:

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -119,6 +119,44 @@ def test_describe_transit_gateway_by_id():
 
 
 @mock_ec2
+def test_describe_transit_gateway_by_tags():
+    ec2 = boto3.client("ec2", region_name="us-west-1")
+    ec2.create_transit_gateway(
+        Description="my first gatway",
+        TagSpecifications=[
+            {
+                "ResourceType": "transit-gateway-route-table",
+                "Tags": [
+                    {"Key": "tag1", "Value": "val1"},
+                    {"Key": "tag2", "Value": "val2"},
+                ],
+            }
+        ],
+    )["TransitGateway"]
+    g2 = ec2.create_transit_gateway(Description="my second gatway")["TransitGateway"]
+    g2 = ec2.create_transit_gateway(
+        Description="my second gatway",
+        TagSpecifications=[
+            {
+                "ResourceType": "transit-gateway-route-table",
+                "Tags": [
+                    {"Key": "the-tag", "Value": "the-value"},
+                    {"Key": "tag2", "Value": "val2"},
+                ],
+            }
+        ],
+    )["TransitGateway"]
+    g2_id = g2["TransitGatewayId"]
+    ec2.create_transit_gateway(Description="my third gatway")["TransitGateway"]
+
+    my_gateway = ec2.describe_transit_gateways(
+        Filters=[{"Name": "tag:the-tag", "Values": ["the-value"]}]
+    )["TransitGateways"][0]
+    assert my_gateway["TransitGatewayId"] == g2_id
+    assert my_gateway["Description"] == "my second gatway"
+
+
+@mock_ec2
 def test_modify_transit_gateway():
     ec2 = boto3.client("ec2", region_name="us-west-1")
     g = ec2.create_transit_gateway(Description="my first gatway")["TransitGateway"]

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -111,9 +111,12 @@ def test_describe_transit_gateway_by_id():
     g2_id = g2["TransitGatewayId"]
     ec2.create_transit_gateway(Description="my third gatway")["TransitGateway"]
 
-    my_gateway = ec2.describe_transit_gateways(TransitGatewayIds=[g2_id])[
+    gateways = ec2.describe_transit_gateways(TransitGatewayIds=[g2_id])[
         "TransitGateways"
-    ][0]
+    ]
+    assert len(gateways) == 1
+
+    my_gateway = gateways[0]
     assert my_gateway["TransitGatewayId"] == g2_id
     assert my_gateway["Description"] == "my second gatway"
 
@@ -149,9 +152,13 @@ def test_describe_transit_gateway_by_tags():
     g2_id = g2["TransitGatewayId"]
     ec2.create_transit_gateway(Description="my third gatway")["TransitGateway"]
 
-    my_gateway = ec2.describe_transit_gateways(
+    gateways = ec2.describe_transit_gateways(
         Filters=[{"Name": "tag:the-tag", "Values": ["the-value"]}]
-    )["TransitGateways"][0]
+    )["TransitGateways"]
+
+    assert len(gateways) == 1
+
+    my_gateway = gateways[0]
     assert my_gateway["TransitGatewayId"] == g2_id
     assert my_gateway["Description"] == "my second gatway"
 


### PR DESCRIPTION
Noticed transit gateways can't be filtered by tags, which is supported in AWS. Wasn't really sure how to do this, since there are several ways to do filters in the different models. Let me know if this isn't the right way to do it.