### PR TITLE
fix secretsmanager PutSecretValue on empty secret

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -126,9 +126,10 @@ class FakeSecret:
             if "AWSPREVIOUS" in old_version["version_stages"]:
                 old_version["version_stages"].remove("AWSPREVIOUS")
 
-        # set old AWSCURRENT secret to AWSPREVIOUS
-        previous_current_version_id = self.default_version_id
-        self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]  # type: ignore
+        # set old AWSCURRENT secret to AWSPREVIOUS if there is one
+        if self.default_version_id in self.versions:
+            previous_current_version_id = self.default_version_id
+            self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]  # type: ignore
 
         self.versions[version_id] = secret_version
         self.default_version_id = version_id

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -337,6 +337,27 @@ def test_update_secret_without_value():
 
 
 @mock_secretsmanager
+def test_create_secret_without_value_and_put_value():
+    conn = boto3.client("secretsmanager", region_name="us-east-2")
+    secret_name = f"secret-{str(uuid4())[0:6]}"
+
+    create = conn.create_secret(Name=secret_name)
+    assert set(create.keys()) == {"ARN", "Name", "ResponseMetadata"}
+
+    put_secret_value = conn.put_secret_value(
+        SecretId=secret_name, SecretString="example-string-to-protect"
+    )
+    assert set(put_secret_value.keys()) == {
+        "ARN",
+        "Name",
+        "VersionId",
+        "VersionStages",
+        "ResponseMetadata",
+    }
+    assert put_secret_value["VersionStages"] == ["AWSCURRENT"]
+
+
+@mock_secretsmanager
 def test_delete_secret():
     conn = boto3.client("secretsmanager", region_name="us-west-2")
 


### PR DESCRIPTION
Hello! It seems a case has been missed with #6720, when a secret would be created empty then updated with `PutSecretValue`. This would raise a `KeyError`:
```python
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/moto/secretsmanager/models.py", line 131, in reset_default_version
    self.versions[previous_current_version_id]["version_stages"] = ["AWSPREVIOUS"]  # type: ignore
KeyError: None
```

I don't know `secretsmanager` too well, but maybe when creating an empty secret, it does not create a version? 
So I've added a check to see if there was a previous version before trying to override it as `AWSPREVIOUS`. 

Added a test case checking this specific case. 

This issue was reported in the LocalStack Slack with `cdktf`, I was able to reproduce against LocalStack with a stripped down Terraform file:
### `main.tf`
```hcl
resource "aws_secretsmanager_secret" "example" {
  name = "example"
}

resource "aws_secretsmanager_secret_version" "example-version" {
  secret_id     = aws_secretsmanager_secret.example.id
  secret_string = "example-string-to-protect"
}
```