### PR TITLE
DynamoDB: key_condition_expression cannot contain a literal value

### DIFF
--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -150,11 +150,11 @@ def parse_expression(
             # hashkey = :id and sortkey = :sk
             #                                ^
             if current_stage == EXPRESSION_STAGES.KEY_VALUE:
-                key_values.append(
-                    expression_attribute_values.get(
-                        current_phrase, {"S": current_phrase}
+                if current_phrase not in expression_attribute_values:
+                    raise MockValidationException(
+                        "Invalid condition in KeyConditionExpression: Multiple attribute names used in one condition"
                     )
-                )
+                key_values.append(expression_attribute_values[current_phrase])
                 results.append((key_name, comparison, key_values))
                 break
         if crnt_char == "(":

--- a/tests/test_dynamodb/models/test_key_condition_expression_parser.py
+++ b/tests/test_dynamodb/models/test_key_condition_expression_parser.py
@@ -31,21 +31,6 @@ class TestHashKey:
             )
         assert exc.value.message == "Query condition missed key schema element: job_id"
 
-    def test_unknown_hash_value(self):
-        # TODO: is this correct? I'd assume that this should throw an error instead
-        # Revisit after test in exceptions.py passes
-        kce = "job_id = :unknown"
-        eav = {":id": {"S": "asdasdasd"}}
-        desired_hash_key, comparison, range_values = parse_expression(
-            expression_attribute_values=eav,
-            key_condition_expression=kce,
-            schema=self.schema,
-            expression_attribute_names=dict(),
-        )
-        assert desired_hash_key == {"S": ":unknown"}
-        assert comparison is None
-        assert range_values == []
-
 
 class TestHashAndRangeKey:
     schema = [
@@ -185,9 +170,8 @@ class TestHashAndRangeKey:
         ],
     )
     def test_brackets(self, expr):
-        eav = {":id": "pk", ":sk1": "19", ":sk2": "21"}
         desired_hash_key, comparison, range_values = parse_expression(
-            expression_attribute_values=eav,
+            expression_attribute_values={":id": "pk", ":sk": "19"},
             key_condition_expression=expr,
             schema=self.schema,
             expression_attribute_names=dict(),

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -1977,15 +1977,6 @@ def test_query_missing_expr_names():
     assert resp["Count"] == 1
     assert resp["Items"][0]["client"]["S"] == "test1"
 
-    resp = client.query(
-        TableName="test1",
-        KeyConditionExpression=":name=test2",
-        ExpressionAttributeNames={":name": "client"},
-    )
-
-    assert resp["Count"] == 1
-    assert resp["Items"][0]["client"]["S"] == "test2"
-
 
 # https://github.com/getmoto/moto/issues/2328
 @mock_dynamodb


### PR DESCRIPTION
Fixes #6781 

Verified against AWS