### PR TITLE
IAM validation: Now supports SSM requests

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -149,6 +149,7 @@ class ActionAuthenticatorMixin(object):
                 method=self.method,  # type: ignore[attr-defined]
                 path=path,
                 data=self.data,  # type: ignore[attr-defined]
+                body=self.body,  # type: ignore[attr-defined]
                 headers=self.headers,  # type: ignore[attr-defined]
             )
             iam_request.check_signature()


### PR DESCRIPTION
Fixes #6782 

**Change 1: Interrogate the headers to find the Action**

Until now, IAM validation only had (verified) support for requests that contained the Action in the body:
`Action=RunInstances&...`

SSM uses the `X-Amz-Target`-header to send this information, so we need to use that instead, if it exists.

**Change 2: Differentiate between `body` and `data`**

The `IAMRequestBase`-class now contains two different attributes that contain request information:
 - `data` - a dictionary of the key=value pairs described in the body + querystring + some headers
 - `body` - the raw body

Until now, we used the `data`-attribute to calculate the signature of the incoming request, but that is not guaranteed to be the same as the body. That's why we're now sending the (unchanged) `body` along as well, just to ensure the calculation is correct.