### PR TITLE
Athena: make statement type dependent on query command

### DIFF
--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -55,11 +55,15 @@ class AthenaResponse(BaseResponse):
     def get_query_execution(self) -> str:
         exec_id = self._get_param("QueryExecutionId")
         execution = self.athena_backend.get_query_execution(exec_id)
+        ddl_commands = ("ALTER", "CREATE", "DESCRIBE", "DROP", "MSCK", "SHOW")
+        statement_type = "DML"
+        if execution.query.upper().startswith(ddl_commands):
+            statement_type = "DDL"
         result = {
             "QueryExecution": {
                 "QueryExecutionId": exec_id,
                 "Query": execution.query,
-                "StatementType": "DDL",
+                "StatementType": statement_type,
                 "ResultConfiguration": execution.config,
                 "QueryExecutionContext": execution.context,
                 "Status": {

--- a/tests/test_athena/test_athena.py
+++ b/tests/test_athena/test_athena.py
@@ -140,7 +140,7 @@ def test_get_query_execution():
     #
     assert details["QueryExecutionId"] == exex_id
     assert details["Query"] == query
-    assert details["StatementType"] == "DDL"
+    assert details["StatementType"] == "DML"
     assert details["ResultConfiguration"]["OutputLocation"] == location
     assert details["QueryExecutionContext"]["Database"] == database
     assert details["Status"]["State"] == "SUCCEEDED"


### PR DESCRIPTION
Fixes #6776 

Simple fix that checks the first command in the sql query and determines the statement type. I based the list of commands off of this page from the AWS Athena docs: [https://docs.aws.amazon.com/athena/latest/ug/ddl-reference.html](https://docs.aws.amazon.com/athena/latest/ug/ddl-reference.html)
