### PR TITLE
Return proper metadata when replicating a KMS key

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -322,14 +322,16 @@ class KmsBackend(BaseBackend):
     #
     # In our implementation with just create a copy of all the properties once without any protection from change,
     # as the exact implementation is currently infeasible.
-    def replicate_key(self, key_id: str, replica_region: str) -> None:
+    def replicate_key(self, key_id: str, replica_region: str) -> Key:
         # Using copy() instead of deepcopy(), as the latter results in exception:
         #    TypeError: cannot pickle '_cffi_backend.FFI' object
         # Since we only update top level properties, copy() should suffice.
         replica_key = copy(self.keys[key_id])
         replica_key.region = replica_region
+        replica_key.arn = replica_key.arn.replace(self.region_name, replica_region)
         to_region_backend = kms_backends[self.account_id][replica_region]
         to_region_backend.keys[replica_key.id] = replica_key
+        return replica_key
 
     def update_key_description(self, key_id: str, description: str) -> None:
         key = self.keys[self.get_key_id(key_id)]

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -128,11 +128,17 @@ class KmsResponse(BaseResponse):
         )
         return json.dumps(key.to_dict())
 
-    def replicate_key(self) -> None:
+    def replicate_key(self) -> str:
         key_id = self._get_param("KeyId")
         self._validate_key_id(key_id)
         replica_region = self._get_param("ReplicaRegion")
-        self.kms_backend.replicate_key(key_id, replica_region)
+        replica_key = self.kms_backend.replicate_key(key_id, replica_region)
+        return json.dumps(
+            {
+                "ReplicaKeyMetadata": replica_key.to_dict()["KeyMetadata"],
+                "ReplicaPolicy": replica_key.generate_default_policy(),
+            }
+        )
 
     def update_key_description(self) -> str:
         """https://docs.aws.amazon.com/kms/latest/APIReference/API_UpdateKeyDescription.html"""

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -171,11 +171,15 @@ def test_replicate_key():
         to_region_client.describe_key(KeyId=key_id)
 
     with mock.patch.object(rsa, "generate_private_key", return_value=""):
-        from_region_client.replicate_key(
+        replica_response = from_region_client.replicate_key(
             KeyId=key_id, ReplicaRegion=region_to_replicate_to
         )
     to_region_client.describe_key(KeyId=key_id)
     from_region_client.describe_key(KeyId=key_id)
+
+    assert "ReplicaKeyMetadata" in replica_response
+    assert region_to_replicate_to in replica_response["ReplicaKeyMetadata"]["Arn"]
+    assert "ReplicaPolicy" in replica_response
 
 
 @mock_kms


### PR DESCRIPTION
We're unit testing some of our KMS interactions and found moto to not return the proper response that AWS would. I updated the code and UTs to reflect a standard boto3 `replicate_key` call. 

- [x] Feature is added
- [x] The linter is happy
- [x] Tests are ~added~ updated
- [x] All tests pass, existing and new

The response previously looked like:
```json
{'ResponseMetadata': {'HTTPHeaders': {'date': 'Fri, 08 Sep 2023 04:28:56 GMT',
                                      'server': 'amazon.com'},
                      'HTTPStatusCode': 200,
                      'RetryAttempts': 0}}
```
Now it looks like: 
```json
{'ReplicaKeyMetadata': {'AWSAccountId': '123456789012',
                        'Arn': 'arn:aws:kms:us-east-1:123456789012:key/mrk-1959ffd9-9e1e-432a-892f-8dbb04833b4d',
                        'CreationDate': datetime.datetime(2023, 9, 8, 4, 5, 35, 351574, tzinfo=tzlocal()),
                        'CustomerMasterKeySpec': 'ECC_NIST_P256',
                        'Description': 'JWT signing key',
                        'Enabled': True,
                        'KeyId': 'mrk-1959ffd9-9e1e-432a-892f-8dbb04833b4d',
                        'KeyManager': 'CUSTOMER',
                        'KeySpec': 'ECC_NIST_P256',
                        'KeyState': 'Enabled',
                        'KeyUsage': 'SIGN_VERIFY',
                        'MultiRegion': True,
                        'Origin': 'AWS_KMS',
                        'SigningAlgorithms': ['ECDSA_SHA_256']},
 'ReplicaPolicy': '{"Version": "2012-10-17", "Id": "key-default-1", '
                  '"Statement": [{"Sid": "Enable IAM User Permissions", '
                  '"Effect": "Allow", "Principal": {"AWS": '
                  '"arn:aws:iam::123456789012:root"}, "Action": "kms:*", '
                  '"Resource": "*"}]}',
 'ResponseMetadata': {'HTTPHeaders': {'date': 'Fri, 08 Sep 2023 04:05:35 GMT',
                                      'server': 'amazon.com'},
                      'HTTPStatusCode': 200,
                      'RetryAttempts': 0}}
```