### PR TITLE
STS: verify that a role exists to allow sts:AssumeRole

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -148,6 +148,14 @@ class AccessDeniedError(RESTError):
             "AccessDenied", f"User: {user_arn} is not authorized to perform: {action}"
         )
 
+class AccessDeniedOnResourceError(RESTError):
+    code = 403
+
+    def __init__(self, user_arn: str, action: str, resource: str):
+        super().__init__(
+            "AccessDenied", f"User: {user_arn} is not authorized to perform: {action} on resource: {resource}"
+        )
+
 
 class AuthFailureError(RESTError):
     code = 401

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -43,6 +43,7 @@ class TokenResponse(BaseResponse):
         policy = self.querystring.get("Policy", [None])[0]
         duration = int(self.querystring.get("DurationSeconds", [3600])[0])
         external_id = self.querystring.get("ExternalId", [None])[0]
+        access_key_id = self.get_access_key()
 
         role = self.backend.assume_role(
             role_session_name=role_session_name,
@@ -50,6 +51,7 @@ class TokenResponse(BaseResponse):
             policy=policy,
             duration=duration,
             external_id=external_id,
+            access_key_id=access_key_id
         )
         template = self.response_template(ASSUME_ROLE_RESPONSE)
         return template.render(role=role)


### PR DESCRIPTION
Hey,

I started this PR by writing the test case, as I found odd that it was possible to `assume_role()` with a non-existing IAM role.

Then I tried to fix it, but:

- it's becoming to feel like ["by design" that this check does not exist to begin with](https://github.com/ajoga/moto/blob/4e81d4e29bb75b5014691a8074c89cab7c083687/moto/sts/models.py#L101)
- Given that assuming a role that does not exist yields an AccessDenied error, I wonder if the logic that check that the role can be assume should be instead in moto.iam.access_control.IAMRequestBase.check_action_permitted() ?

I'm pushing this code now as a draft to open the discussion, can you help me contributing to this or let me know if this does not make sense?