### PR TITLE
IAM validation: Resource is now processed during authorization

### DIFF
--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -408,6 +408,8 @@ class IAMPolicyStatement:
             if self.is_unknown_principal(self._statement.get("Principal")):
                 return PermissionResult.NEUTRAL
             same_resource = self._check_element_matches("Resource", resource)
+            if not same_resource:
+                return PermissionResult.NEUTRAL
             if self._statement["Effect"] == "Allow" and same_resource:
                 return PermissionResult.PERMITTED
             else:  # Deny

--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -380,7 +380,7 @@ class IAMPolicy:
                     permitted = True
         else:  # dict
             iam_policy_statement = IAMPolicyStatement(self._policy_json["Statement"])
-            return iam_policy_statement.is_action_permitted(action)
+            return iam_policy_statement.is_action_permitted(action, resource)
 
         if permitted:
             return PermissionResult.PERMITTED

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -13,6 +13,11 @@ class TokenResponse(BaseResponse):
     def backend(self) -> STSBackend:
         return sts_backends[self.current_account]["global"]
 
+    def _determine_resource(self) -> str:
+        if "AssumeRole" in self.querystring.get("Action", []):
+            return self.querystring.get("RoleArn")[0]  # type: ignore[index]
+        return "*"
+
     def get_session_token(self) -> str:
         duration = int(self.querystring.get("DurationSeconds", [43200])[0])
         token = self.backend.get_session_token(duration=duration)


### PR DESCRIPTION
This PR uses the validation logic to validate the resource attribute of the principal-attached policies during `sts:AssumeRole`

It relates to the discussion in https://github.com/getmoto/moto/pull/6793#issuecomment-1712505836

What do you think of this draft @bblommers ? I implemented following your directions. I don't have enough experience to make an alternative proposition, and what you offered makes sense. It feels like it's going to be rather intense to implement each map of (service, method) to the corresponding resource attribute, but I don't see an alternative. 

If it looks good for you, I'll include in this PR the logic in TokenResponse._determine_resource() for every actions already supported for STS before submitting it as PR.

It's breaking some tests and there's one I've looked into I don't get:

> FAILED tests/test_s3/test_s3_bucket_policy.py::TestBucketPolicy::test_block_or_allow_get_object[kwargs2-403] - Failed: DID NOT RAISE <class 'botocore.exceptions.ClientError'>

On the previous commit that works, with a breakpoint at this line, I don't understand how the exception raises correctly ? https://github.com/ajoga/moto/blob/fa9aa95156d1e11a3c5a2e06ab8b085ae98c2c1f/tests/test_s3/test_s3_bucket_policy.py#L68 

When I compare my commit that breaks the test and the previous one that does not, I see no difference.

Also, do you see other tests cases needed?

I'll close the initial PR