### PR TITLE
Core: Mocked ACCESS_KEY values now adhere to AWS guidelines

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -56,8 +56,8 @@ class BaseMockAWS(ContextManager["BaseMockAWS"]):
         self.backends_for_urls.extend(default_backends)
 
         self.FAKE_KEYS = {
-            "AWS_ACCESS_KEY_ID": "foobar_key",
-            "AWS_SECRET_ACCESS_KEY": "foobar_secret",
+            "AWS_ACCESS_KEY_ID": "FOOBARKEY",
+            "AWS_SECRET_ACCESS_KEY": "FOOBARSECRET",
         }
         self.ORIG_KEYS: Dict[str, Optional[str]] = {}
         self.default_session_mock = patch("boto3.DEFAULT_SESSION", None)

--- a/tests/test_core/test_environ_patching.py
+++ b/tests/test_core/test_environ_patching.py
@@ -7,7 +7,7 @@ KEY = "AWS_ACCESS_KEY_ID"
 def test_aws_keys_are_patched():
     with mock_ec2():
         patched_value = os.environ[KEY]
-        assert patched_value == "foobar_key"
+        assert patched_value == "FOOBARKEY"
 
 
 def test_aws_keys_can_be_none():
@@ -25,7 +25,7 @@ def test_aws_keys_can_be_none():
         # Verify that the os.environ[KEY] is patched
         with mock_s3():
             patched_value = os.environ[KEY]
-            assert patched_value == "foobar_key"
+            assert patched_value == "FOOBARKEY"
         # Verify that the os.environ[KEY] is unpatched, and reverts to None
         assert os.environ.get(KEY) is None
     finally:


### PR DESCRIPTION
Fixes #6805 

> DynamoDB local version 2.0.0 and greater AWS_ACCESS_KEY_ID can contain only letters (A–Z, a–z) and numbers (0–9). 
>

Little odd that DynamoDB local cares about that, but it is the format that AWS uses for their access keys/secrets - so it makes sense to follow this.