### PR TITLE
ELBv2: added validation for target group

### DIFF
--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -184,3 +184,8 @@ class InvalidStatusCodeActionTypeError(ELBClientError):
 class InvalidLoadBalancerActionException(ELBClientError):
     def __init__(self, msg: str):
         super().__init__("InvalidLoadBalancerAction", msg)
+
+
+class ValidationError(ELBClientError):
+    def __init__(self, msg: str):
+        super().__init__("ValidationError", msg)

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1093,13 +1093,13 @@ Member must satisfy regular expression pattern: {expression}"
                     param = "VPC ID" if param == "vpc_id" else param.lower()
                     raise ValidationError(f"A {param} must be specified")
 
-        if vpc_id := kwargs.get("vpc_id"):
+        if kwargs.get("vpc_id"):
             from moto.ec2.exceptions import InvalidVPCIdError
 
             try:
-                self.ec2_backend.get_vpc(vpc_id)
+                self.ec2_backend.get_vpc(kwargs.get("vpc_id"))
             except InvalidVPCIdError:
-                raise ValidationError(f"The VPC ID '{vpc_id}' is not found")
+                raise ValidationError(f"The VPC ID '{kwargs.get('vpc_id')}' is not found")
 
         kwargs_patch = {}
 

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -105,7 +105,6 @@ class FakeTargetGroup(CloudFormationModel):
         self.healthcheck_interval_seconds = healthcheck_interval_seconds or "30"
         self.healthcheck_timeout_seconds = healthcheck_timeout_seconds or "10"
         self.ip_address_type = ip_address_type or "ipv4"
-        self.healthcheck_timeout_seconds = healthcheck_timeout_seconds
         self.healthcheck_enabled = (
             healthcheck_enabled.lower() == "true"
             if healthcheck_enabled in ["true", "false"]
@@ -1158,12 +1157,18 @@ Member must satisfy regular expression pattern: {expression}"
 
         kwargs.update(kwargs_patch)
 
-        healthcheck_timeout_seconds = int(kwargs.get("healthcheck_timeout_seconds"))
-        healthcheck_interval_seconds = int(kwargs.get("healthcheck_interval_seconds"))
+        healthcheck_timeout_seconds = int(
+            str(kwargs.get("healthcheck_timeout_seconds"))
+        )
+        healthcheck_interval_seconds = int(
+            str(kwargs.get("healthcheck_interval_seconds"))
+        )
+
         if (
-            healthcheck_interval_seconds is not None
-            and healthcheck_timeout_seconds is not None
+            healthcheck_timeout_seconds is not None
+            and healthcheck_interval_seconds is not None
         ):
+
             if healthcheck_interval_seconds < healthcheck_timeout_seconds:
                 raise ValidationError(
                     "Health check interval must be greater than the timeout."
@@ -1617,11 +1622,11 @@ Member must satisfy regular expression pattern: {expression}"
         health_check_port: Optional[str] = None,
         health_check_path: Optional[str] = None,
         health_check_interval: Optional[str] = None,
-        health_check_timeout: Optional[int] = None,
+        health_check_timeout: Optional[str] = None,
         healthy_threshold_count: Optional[str] = None,
         unhealthy_threshold_count: Optional[str] = None,
         http_codes: Optional[str] = None,
-        health_check_enabled: Optional[str] = None,
+        health_check_enabled: Optional[bool] = None,
     ) -> FakeTargetGroup:
         target_group = self.target_groups.get(arn)
         if target_group is None:

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1158,10 +1158,10 @@ Member must satisfy regular expression pattern: {expression}"
         kwargs.update(kwargs_patch)
 
         healthcheck_timeout_seconds = int(
-            str(kwargs.get("healthcheck_timeout_seconds"))
+            str(kwargs.get("healthcheck_timeout_seconds") or "10")
         )
         healthcheck_interval_seconds = int(
-            str(kwargs.get("healthcheck_interval_seconds"))
+            str(kwargs.get("healthcheck_interval_seconds") or "30")
         )
 
         if (

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1099,7 +1099,9 @@ Member must satisfy regular expression pattern: {expression}"
             try:
                 self.ec2_backend.get_vpc(kwargs.get("vpc_id"))
             except InvalidVPCIdError:
-                raise ValidationError(f"The VPC ID '{kwargs.get('vpc_id')}' is not found")
+                raise ValidationError(
+                    f"The VPC ID '{kwargs.get('vpc_id')}' is not found"
+                )
 
         kwargs_patch = {}
 

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -197,6 +197,7 @@ class ELBV2Response(BaseResponse):
         unhealthy_threshold_count = self._get_param("UnhealthyThresholdCount")
         matcher = params.get("Matcher")
         target_type = params.get("TargetType")
+        ip_address_type = params.get("IpAddressType")
         tags = params.get("Tags")
 
         target_group = self.elbv2_backend.create_target_group(
@@ -214,6 +215,7 @@ class ELBV2Response(BaseResponse):
             healthy_threshold_count=healthy_threshold_count,
             unhealthy_threshold_count=unhealthy_threshold_count,
             matcher=matcher,
+            ip_address_type=ip_address_type,
             target_type=target_type,
             tags=tags,
         )
@@ -797,6 +799,7 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         <TargetGroupName>{{ target_group.name }}</TargetGroupName>
         {% if target_group.protocol %}
         <Protocol>{{ target_group.protocol }}</Protocol>
+        <ProtocolVersion>{{ target_group.protocol_version }}</ProtocolVersion>
         {% endif %}
         {% if target_group.port %}
         <Port>{{ target_group.port }}</Port>
@@ -804,14 +807,16 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         {% if target_group.vpc_id %}
         <VpcId>{{ target_group.vpc_id }}</VpcId>
         {% endif %}
-        <HealthCheckProtocol>{{ target_group.healthcheck_protocol }}</HealthCheckProtocol>
-        {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
+        {% if target_group.healthcheck_enabled %}
+            {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
+            <HealthCheckProtocol>{{ target_group.healthcheck_protocol or "None" }}</HealthCheckProtocol>
+        {% endif %}
         <HealthCheckPath>{{ target_group.healthcheck_path or '' }}</HealthCheckPath>
         <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>
         <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
-        <HealthCheckEnabled>{{ target_group.healthcheck_enabled and 'true' or 'false' }}</HealthCheckEnabled>
         <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
         <UnhealthyThresholdCount>{{ target_group.unhealthy_threshold_count }}</UnhealthyThresholdCount>
+        <HealthCheckEnabled>{{ target_group.healthcheck_enabled and 'true' or 'false' }}</HealthCheckEnabled>
         {% if target_group.matcher %}
         <Matcher>
           <HttpCode>{{ target_group.matcher['HttpCode'] }}</HttpCode>
@@ -820,6 +825,7 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         {% if target_group.target_type %}
         <TargetType>{{ target_group.target_type }}</TargetType>
         {% endif %}
+        <IpAddressType>{{ target_group.ip_address_type }}</IpAddressType>
       </member>
     </TargetGroups>
   </CreateTargetGroupResult>

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -185,7 +185,7 @@ class ELBV2Response(BaseResponse):
         name = params.get("Name")
         vpc_id = params.get("VpcId")
         protocol = params.get("Protocol")
-        protocol_version = params.get("ProtocolVersion", "HTTP1")
+        protocol_version = params.get("ProtocolVersion")
         port = params.get("Port")
         healthcheck_protocol = self._get_param("HealthCheckProtocol")
         healthcheck_port = self._get_param("HealthCheckPort")
@@ -196,7 +196,7 @@ class ELBV2Response(BaseResponse):
         healthy_threshold_count = self._get_param("HealthyThresholdCount")
         unhealthy_threshold_count = self._get_param("UnhealthyThresholdCount")
         matcher = params.get("Matcher")
-        target_type = params.get("TargetType")
+        target_type = params.get("TargetType", "instance")
         ip_address_type = params.get("IpAddressType")
         tags = params.get("Tags")
 
@@ -799,7 +799,9 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         <TargetGroupName>{{ target_group.name }}</TargetGroupName>
         {% if target_group.protocol %}
         <Protocol>{{ target_group.protocol }}</Protocol>
+        {% if target_group.protocol_version %}
         <ProtocolVersion>{{ target_group.protocol_version }}</ProtocolVersion>
+        {% endif %}
         {% endif %}
         {% if target_group.port %}
         <Port>{{ target_group.port }}</Port>
@@ -808,10 +810,16 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         <VpcId>{{ target_group.vpc_id }}</VpcId>
         {% endif %}
         {% if target_group.healthcheck_enabled %}
-            {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
-            <HealthCheckProtocol>{{ target_group.healthcheck_protocol or "None" }}</HealthCheckProtocol>
+        {% if target_group.healthcheck_port %}
+        <HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>
         {% endif %}
+        {% if target_group.healthcheck_protocol %}
+        <HealthCheckProtocol>{{ target_group.healthcheck_protocol or "None" }}</HealthCheckProtocol>
+        {% endif %}
+        {% endif %}
+        {% if target_group.healthcheck_path %}
         <HealthCheckPath>{{ target_group.healthcheck_path or '' }}</HealthCheckPath>
+        {% endif %}
         <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>
         <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
         <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
@@ -825,7 +833,9 @@ CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elast
         {% if target_group.target_type %}
         <TargetType>{{ target_group.target_type }}</TargetType>
         {% endif %}
+        {% if target_group.ip_address_type %}
         <IpAddressType>{{ target_group.ip_address_type }}</IpAddressType>
+        {% endif %}
       </member>
     </TargetGroups>
   </CreateTargetGroupResult>

--- a/tests/test_autoscaling/test_elbv2.py
+++ b/tests/test_autoscaling/test_elbv2.py
@@ -27,7 +27,7 @@ class TestAutoscalignELBv2(unittest.TestCase):
             HealthCheckPort="8080",
             HealthCheckPath="/",
             HealthCheckIntervalSeconds=5,
-            HealthCheckTimeoutSeconds=5,
+            HealthCheckTimeoutSeconds=3,
             HealthyThresholdCount=5,
             UnhealthyThresholdCount=2,
             Matcher={"HttpCode": "200"},

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -266,7 +266,7 @@ def test_create_listeners_without_port():
         HealthCheckPort="8080",
         HealthCheckPath="/",
         HealthCheckIntervalSeconds=5,
-        HealthCheckTimeoutSeconds=5,
+        HealthCheckTimeoutSeconds=3,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
@@ -445,7 +445,7 @@ def test_register_targets():
         HealthCheckPort="8080",
         HealthCheckPath="/",
         HealthCheckIntervalSeconds=5,
-        HealthCheckTimeoutSeconds=5,
+        HealthCheckTimeoutSeconds=3,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
@@ -551,7 +551,7 @@ def test_stopped_instance_target():
         HealthCheckProtocol="HTTP",
         HealthCheckPath="/",
         HealthCheckIntervalSeconds=5,
-        HealthCheckTimeoutSeconds=5,
+        HealthCheckTimeoutSeconds=3,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
@@ -580,7 +580,7 @@ def test_stopped_instance_target():
     target_health_description = response["TargetHealthDescriptions"][0]
 
     assert target_health_description["Target"] == target_dict
-    assert target_health_description["HealthCheckPort"] == str(target_group_port)
+    assert target_health_description["HealthCheckPort"] == "traffic-port"
     assert target_health_description["TargetHealth"] == {"State": "healthy"}
 
     instance.stop()
@@ -591,7 +591,7 @@ def test_stopped_instance_target():
     assert len(response["TargetHealthDescriptions"]) == 1
     target_health_description = response["TargetHealthDescriptions"][0]
     assert target_health_description["Target"] == target_dict
-    assert target_health_description["HealthCheckPort"] == str(target_group_port)
+    assert target_health_description["HealthCheckPort"] == "traffic-port"
     assert target_health_description["TargetHealth"] == {
         "State": "unused",
         "Reason": "Target.InvalidState",
@@ -634,7 +634,7 @@ def test_terminated_instance_target():
         HealthCheckProtocol="HTTP",
         HealthCheckPath="/",
         HealthCheckIntervalSeconds=5,
-        HealthCheckTimeoutSeconds=5,
+        HealthCheckTimeoutSeconds=3,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
@@ -663,7 +663,7 @@ def test_terminated_instance_target():
     target_health_description = response["TargetHealthDescriptions"][0]
 
     assert target_health_description["Target"] == target_dict
-    assert target_health_description["HealthCheckPort"] == str(target_group_port)
+    assert target_health_description["HealthCheckPort"] == "traffic-port"
     assert target_health_description["TargetHealth"] == {"State": "healthy"}
 
     instance.terminate()
@@ -772,7 +772,7 @@ def test_handle_listener_rules():
         HealthCheckPort="8080",
         HealthCheckPath="/",
         HealthCheckIntervalSeconds=5,
-        HealthCheckTimeoutSeconds=5,
+        HealthCheckTimeoutSeconds=3,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
@@ -1323,7 +1323,7 @@ def test_modify_listener_http_to_https():
         HealthCheckPort="8080",
         HealthCheckPath="/",
         HealthCheckIntervalSeconds=5,
-        HealthCheckTimeoutSeconds=5,
+        HealthCheckTimeoutSeconds=3,
         HealthyThresholdCount=5,
         UnhealthyThresholdCount=2,
         Matcher={"HttpCode": "200"},
@@ -1523,7 +1523,9 @@ def test_add_listener_certificate():
 
     load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
 
-    response = client.create_target_group(Name="a-target", Protocol="HTTPS", Port=8443)
+    response = client.create_target_group(
+        Name="a-target", Protocol="HTTPS", Port=8443, VpcId=vpc.id
+    )
     target_group_arn = response["TargetGroups"][0]["TargetGroupArn"]
 
     # HTTPS listener
@@ -1564,10 +1566,12 @@ def test_add_listener_certificate():
 @mock_elbv2
 @mock_ec2
 def test_forward_config_action():
-    response, _, _, _, _, conn = create_load_balancer()
+    response, vpc, _, _, _, conn = create_load_balancer()
     load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
 
-    response = conn.create_target_group(Name="a-target", Protocol="HTTPS", Port=8443)
+    response = conn.create_target_group(
+        Name="a-target", Protocol="HTTPS", Port=8443, VpcId=vpc.id
+    )
     target_group_arn = response["TargetGroups"][0]["TargetGroupArn"]
 
     action = {
@@ -1600,10 +1604,12 @@ def test_forward_config_action():
 @mock_elbv2
 @mock_ec2
 def test_forward_config_action__with_stickiness():
-    response, _, _, _, _, conn = create_load_balancer()
+    response, vpc, _, _, _, conn = create_load_balancer()
     load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
 
-    response = conn.create_target_group(Name="a-target", Protocol="HTTPS", Port=8443)
+    response = conn.create_target_group(
+        Name="a-target", Protocol="HTTPS", Port=8443, VpcId=vpc.id
+    )
     target_group_arn = response["TargetGroups"][0]["TargetGroupArn"]
 
     action = {

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -3176,8 +3176,6 @@ def test_message_delay_is_more_than_15_minutes():
 
     assert sorted([entry["Id"] for entry in response["Failed"]]) == ["id_2"]
 
-    # print(response)
-
     time.sleep(4)
 
     response = client.receive_message(


### PR DESCRIPTION
# Motivation
- This PR aims to make target group in parity with AWS.

# Added
- Parameter validation for `create_target_group`
- Default values for `create_target_group`
- Adjusted test cases accordingly
- Fixed `create_target_group` response

# Notes
- Related PR for AWS Validated Test Case: https://github.com/localstack/localstack-ext/pull/2064