### PR TITLE
ELBv2: fix parity in describe_target_group

### DIFF
--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -35,9 +35,7 @@ class SubnetNotFoundError(ELBClientError):
 
 class TargetGroupNotFoundError(ELBClientError):
     def __init__(self) -> None:
-        super().__init__(
-            "TargetGroupNotFound", "The specified target group does not exist."
-        )
+        super().__init__("TargetGroupNotFound", "One or more target groups not found")
 
 
 class TooManyTagsError(ELBClientError):

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1397,16 +1397,14 @@ Member must satisfy regular expression pattern: {expression}"
 
         if names:
             target_groups = [
-                next(
-                    (tg for tg in self.target_groups.values() if tg.name == name), None
-                )
+                next((tg for tg in self.target_groups.values() if tg.name == name))
                 for name in names
             ]
             if None in target_groups:
                 raise TargetGroupNotFoundError()
 
         if len(target_groups) == 0:
-            target_groups = self.target_groups.values()
+            target_groups = list(self.target_groups.values())
 
         return sorted(target_groups, key=lambda tg: tg.name)
 

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -1070,6 +1070,7 @@ DESCRIBE_TARGET_GROUPS_TEMPLATE = """<DescribeTargetGroupsResponse xmlns="http:/
         {% if target_group.vpc_id %}
         <VpcId>{{ target_group.vpc_id }}</VpcId>
         {% endif %}
+        <IpAddressType>{{ target_group.ip_address_type }}</IpAddressType>
         <HealthCheckProtocol>{{ target_group.healthcheck_protocol }}</HealthCheckProtocol>
         {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
         <HealthCheckPath>{{ target_group.healthcheck_path or '' }}</HealthCheckPath>


### PR DESCRIPTION
# Motivation
This PR fixes minor parity gaps with aws in `describe_target_groups` api

# Fixed
- sorting the list of target group before returning it
- multiple arguments in describe call raises an exception

# Added
- Added test cases for `describe_target_groups` api