### PR TITLE
Cognito: Limit user pool ID to 55 characters

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -382,7 +382,7 @@ DEFAULT_USER_POOL_CONFIG: Dict[str, Any] = {
 
 class CognitoIdpUserPool(BaseModel):
 
-    MAX_ID_LENGTH = 56
+    MAX_ID_LENGTH = 55
 
     def __init__(
         self, account_id: str, region: str, name: str, extended_config: Dict[str, Any]


### PR DESCRIPTION
Hello!

In this pull request (PR), I have made changes to ensure that the created user pool ID is limited to a maximum of 55 characters.

When using the ```MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY=HASH``` configuration, creating a user pool with ```create-user-pool``` resulted in an ID that was 56 characters long. 
According to [AWS documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolType.html#CognitoUserPools-Type-UserPoolType-Id), the maximum character limit for a user pool ID is 55 characters .

This poses an issue when Cognito client libraries check the character count of the user pool ID, using Moto's Cognito mock unusable for such scenarios. For example, [Amplify-JS allows user pool IDs of up to 55 characters](https://github.com/aws-amplify/amplify-js/blob/main/packages/amazon-cognito-identity-js/src/CognitoUserPool.js#L39).

Best regards.