### PR TITLE
DynamoDB: Fix projection expression with binary attribute

### DIFF
--- a/moto/dynamodb/models/utilities.py
+++ b/moto/dynamodb/models/utilities.py
@@ -14,7 +14,7 @@ def dynamo_json_dump(dynamo_object: Any) -> str:
 
 
 def bytesize(val: str) -> int:
-    return len(val.encode("utf-8"))
+    return len(val if isinstance(val, bytes) else val.encode("utf-8"))
 
 
 def find_nested_key(


### PR DESCRIPTION
Fixes #6815 

When receiving an item with a Binary value, the SDK's will base64-encode it before sending it over the wire. That means that Moto receives a JSON like this:
```
"B": "dmFsdWU="
```

Inside `DynamoType.to_regular_json()`, we use the builtin boto3 TypeSerializers to convert the item to a DynamoDB compliant object. That means converting it back to the original value, to make sure that the type (`B`) and value (bytes) align:
```
"B": b"value"
```
However, when calling `to_json()`, we want the dictionary that we can send back over the wire - which means converting it back into the base64-encoded version.

Bug was introduced with the introduction of `to_regular_json()` in #6375 