### PR TITLE
ELBv2: added validation for create_target_group() and set_ip_address_type()

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1104,6 +1104,14 @@ Member must satisfy regular expression pattern: {expression}"
                     param = "VPC ID" if param == "vpc_id" else param.lower()
                     raise ValidationError(f"A {param} must be specified")
 
+        if target_type == "lambda":
+            for param in ["protocol", "port", "vpc_id"]:
+                if kwargs.get(param) is not None:
+                    param = "VPC ID" if param == "vpc_id" else param.capitalize()
+                    raise ValidationError(
+                        f"{param} cannot be specified for target groups with target type 'lambda'"
+                    )
+
         if kwargs.get("vpc_id"):
             from moto.ec2.exceptions import InvalidVPCIdError
 
@@ -1568,10 +1576,10 @@ Member must satisfy regular expression pattern: {expression}"
         return modified_rules
 
     def set_ip_address_type(self, arn: str, ip_type: str) -> None:
-        if ip_type not in ("internal", "dualstack"):
+        if ip_type not in ("ipv4", "dualstack"):
             raise RESTError(
-                "InvalidParameterValue",
-                "IpAddressType must be either internal | dualstack",
+                "ValidationError",
+                f"1 validation error detected: Value '{ip_type}' at 'ipAddressType' failed to satisfy constraint: Member must satisfy enum value set: [ipv4, dualstack]",
             )
 
         balancer = self.load_balancers.get(arn)

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -1159,6 +1159,11 @@ def test_set_ip_address_type():
 
     client.set_ip_address_type(LoadBalancerArn=arn, IpAddressType="dualstack")
 
+    with pytest.raises(ClientError) as ex:
+        client.set_ip_address_type(LoadBalancerArn=arn, IpAddressType="internal")
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+
 
 @mock_elbv2
 @mock_ec2

--- a/tests/test_elbv2/test_elbv2_target_groups.py
+++ b/tests/test_elbv2/test_elbv2_target_groups.py
@@ -881,3 +881,36 @@ def test_create_target_group_validation_error():
     err = ex.value.response["Error"]
     assert err["Code"] == "ValidationError"
     assert err["Message"] == "Health check interval must be greater than the timeout."
+
+    with pytest.raises(ClientError) as ex:
+        elbv2.create_target_group(Name="a-target", TargetType="lambda", Port=8080)
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+    assert (
+        err["Message"]
+        == "Port cannot be specified for target groups with target type 'lambda'"
+    )
+
+    with pytest.raises(ClientError) as ex:
+        elbv2.create_target_group(
+            Name="a-target", TargetType="lambda", VpcId="non-existing"
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+    assert (
+        err["Message"]
+        == "VPC ID cannot be specified for target groups with target type 'lambda'"
+    )
+
+    with pytest.raises(ClientError) as ex:
+        elbv2.create_target_group(
+            Name="a-target",
+            TargetType="lambda",
+            Protocol="HTTP",
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+    assert (
+        err["Message"]
+        == "Protocol cannot be specified for target groups with target type 'lambda'"
+    )


### PR DESCRIPTION
# Fixed
- `create_target_group`: parameter validation added for `TargetType == 'lambda'`
- `set_ip_address_type `:  parameter validation added for ip address type

# Test
- Adjusted test case and added new scenarios