### PR TITLE
Update script that creates managed rule list used by Config

### DIFF
--- a/moto/config/resources/aws_managed_rules.json
+++ b/moto/config/resources/aws_managed_rules.json
@@ -1,7 +1,7 @@
 {
   "ManagedRules": {
     "ACCESS_KEYS_ROTATED": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "90",
@@ -10,10 +10,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::IAM::User",
       "Trigger type": "Periodic"
     },
     "ACCOUNT_PART_OF_ORGANIZATIONS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "MasterAccountId",
@@ -24,7 +25,7 @@
       "Trigger type": "Periodic"
     },
     "ACM_CERTIFICATE_EXPIRATION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "14",
@@ -37,13 +38,13 @@
       "Trigger type": "Configuration changes and Periodic"
     },
     "ACM_CERTIFICATE_RSA_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ACM::Certificate",
       "Trigger type": "Configuration changes"
     },
     "ALB_DESYNC_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "desyncMode",
@@ -55,18 +56,18 @@
       "Trigger type": "Configuration changes"
     },
     "ALB_HTTP_DROP_INVALID_HEADER_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ALB_HTTP_TO_HTTPS_REDIRECTION_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ALB_WAF_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "wafWebAclIds",
@@ -78,13 +79,13 @@
       "Trigger type": "Configuration changes"
     },
     "API_GWV2_ACCESS_LOGS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ApiGatewayV2::Stage",
       "Trigger type": "Configuration changes"
     },
     "API_GWV2_AUTHORIZATION_TYPE_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "authorizationType",
@@ -96,7 +97,7 @@
       "Trigger type": "Periodic"
     },
     "API_GW_ASSOCIATED_WITH_WAF": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "WebAclArns",
@@ -108,13 +109,13 @@
       "Trigger type": "Configuration changes"
     },
     "API_GW_CACHE_ENABLED_AND_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::ApiGateway::Stage",
       "Trigger type": "Configuration changes"
     },
     "API_GW_ENDPOINT_TYPE_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "endpointConfigurationTypes",
@@ -126,7 +127,7 @@
       "Trigger type": "Configuration changes"
     },
     "API_GW_EXECUTION_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan) Region",
       "Parameters": [
         {
           "Default": "ERROR,INFO",
@@ -139,7 +140,7 @@
       "Trigger type": "Configuration changes"
     },
     "API_GW_SSL_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
       "Parameters": [
         {
           "Name": "CertificateIDs",
@@ -151,7 +152,7 @@
       "Trigger type": "Configuration changes"
     },
     "API_GW_XRAY_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::ApiGateway::Stage",
       "Trigger type": "Configuration changes"
@@ -172,7 +173,7 @@
       "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
-          "Default": "tag-key",
+          "Default": "tag-key:tag-value,other-tag-key",
           "Name": "amisByTagKeyAndValue",
           "Optional": false,
           "Type": "StringMap"
@@ -182,7 +183,7 @@
       "Trigger type": "Configuration changes"
     },
     "APPSYNC_ASSOCIATED_WITH_WAF": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "wafWebAclARNs",
@@ -194,13 +195,13 @@
       "Trigger type": "Periodic"
     },
     "APPSYNC_CACHE_ENCRYPTION_AT_REST": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::AppSync::GraphQLApi",
       "Trigger type": "Periodic"
     },
     "APPSYNC_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "fieldLoggingLevel",
@@ -211,8 +212,14 @@
       "Resource Types": "AWS::AppSync::GraphQLApi",
       "Trigger type": "Configuration changes"
     },
+    "ATHENA_WORKGROUP_ENCRYPTED_AT_REST": {
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::Athena::WorkGroup",
+      "Trigger type": "Configuration changes"
+    },
     "AURORA_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -241,7 +248,7 @@
       "Trigger type": "Periodic"
     },
     "AURORA_MYSQL_BACKTRACKING_ENABLED": {
-      "AWS Region": "Only available in Asia Pacific (Mumbai), Europe (Paris), US East (Ohio), Europe (Ireland), Europe (Frankfurt), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "BacktrackWindowInHours",
@@ -253,7 +260,7 @@
       "Trigger type": "Configuration changes"
     },
     "AURORA_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -295,7 +302,7 @@
       "Trigger type": "Periodic"
     },
     "AUTOSCALING_CAPACITY_REBALANCING": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
@@ -307,31 +314,31 @@
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCHCONFIG_REQUIRES_IMDSV2": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::AutoScaling::LaunchConfiguration",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCH_CONFIG_HOP_LIMIT": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::AutoScaling::LaunchConfiguration",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCH_CONFIG_PUBLIC_IP_DISABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv) Region",
       "Parameters": [],
       "Resource Types": "AWS::AutoScaling::LaunchConfiguration",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCH_TEMPLATE": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_MULTIPLE_AZ": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "minAvailabilityZones",
@@ -343,13 +350,13 @@
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_MULTIPLE_INSTANCE_TYPES": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "BACKUP_PLAN_MIN_FREQUENCY_AND_MIN_RETENTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "1",
@@ -374,13 +381,13 @@
       "Trigger type": "Configuration changes"
     },
     "BACKUP_RECOVERY_POINT_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::Backup::RecoveryPoint",
       "Trigger type": "Configuration changes"
     },
     "BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "principalArnList",
@@ -392,7 +399,7 @@
       "Trigger type": "Configuration changes"
     },
     "BACKUP_RECOVERY_POINT_MINIMUM_RETENTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "35",
@@ -405,13 +412,13 @@
       "Trigger type": "Configuration changes"
     },
     "BEANSTALK_ENHANCED_HEALTH_REPORTING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticBeanstalk::Environment",
       "Trigger type": "Configuration changes"
     },
     "CLB_DESYNC_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "desyncMode",
@@ -423,7 +430,7 @@
       "Trigger type": "Configuration changes"
     },
     "CLB_MULTIPLE_AZ": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "minAvailabilityZones",
@@ -435,7 +442,7 @@
       "Trigger type": "Configuration changes"
     },
     "CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK": {
-      "AWS Region": "Only available in Asia Pacific (Mumbai), US East (Ohio), Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central) Region",
+      "AWS Region": "All supported AWS regions except Europe (Stockholm), Europe (Paris), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "cloudformationRoleArn",
@@ -447,7 +454,7 @@
       "Trigger type": "Configuration changes and Periodic"
     },
     "CLOUDFORMATION_STACK_NOTIFICATION_CHECK": {
-      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), Europe (Paris), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), Europe (Paris), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "snsTopic1",
@@ -532,6 +539,12 @@
       "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
+    "CLOUDFRONT_S3_ORIGIN_ACCESS_CONTROL_ENABLED": {
+      "AWS Region": "Only available in US East (N. Virginia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
+      "Trigger type": "Configuration changes"
+    },
     "CLOUDFRONT_S3_ORIGIN_NON_EXISTENT_BUCKET": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
@@ -563,7 +576,7 @@
       "Trigger type": "Configuration changes"
     },
     "CLOUDTRAIL_S3_DATAEVENTS_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "S3BucketNames",
@@ -574,7 +587,7 @@
       "Trigger type": "Periodic"
     },
     "CLOUDTRAIL_SECURITY_TRAIL_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
@@ -629,7 +642,7 @@
       "Trigger type": "Configuration changes"
     },
     "CLOUDWATCH_ALARM_ACTION_ENABLED_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::CloudWatch::Alarm",
       "Trigger type": "Configuration changes"
@@ -689,7 +702,7 @@
       "Trigger type": "Configuration changes"
     },
     "CLOUDWATCH_LOG_GROUP_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Israel (Tel Aviv), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "KmsKeyId",
@@ -742,18 +755,18 @@
       "Trigger type": "Periodic"
     },
     "CMK_BACKING_KEY_ROTATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Europe (Spain) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "CODEBUILD_PROJECT_ARTIFACT_ENCRYPTION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_ENVIRONMENT_PRIVILEGED_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "exemptedProjects",
@@ -765,13 +778,13 @@
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_ENVVAR_AWSCRED_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "s3BucketNames",
@@ -788,7 +801,7 @@
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_S3_LOGS_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "exemptedProjects",
@@ -800,19 +813,19 @@
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_SOURCE_REPO_URL_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEDEPLOY_AUTO_ROLLBACK_MONITOR_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::CodeDeploy::DeploymentGroup",
       "Trigger type": "Configuration changes"
     },
     "CODEDEPLOY_EC2_MINIMUM_HEALTHY_HOSTS_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "66",
@@ -831,7 +844,7 @@
       "Trigger type": "Configuration changes"
     },
     "CODEDEPLOY_LAMBDA_ALLATONCE_TRAFFIC_SHIFT_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::CodeDeploy::DeploymentGroup",
       "Trigger type": "Configuration changes"
@@ -861,8 +874,14 @@
       "Resource Types": "AWS::CodePipeline::Pipeline",
       "Trigger type": "Configuration changes"
     },
+    "CUSTOM_SCHEMA_REGISTRY_POLICY_ATTACHED": {
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::EventSchemas::Registry",
+      "Trigger type": "Periodic"
+    },
     "CW_LOGGROUP_RETENTION_PERIOD_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "LogGroupNames",
@@ -883,7 +902,7 @@
       "Trigger type": "Periodic"
     },
     "DB_INSTANCE_BACKUP_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "backupRetentionPeriod",
@@ -944,12 +963,36 @@
       "Trigger type": "Configuration changes"
     },
     "DMS_REPLICATION_NOT_PUBLIC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
+    "DOCDB_CLUSTER_BACKUP_RETENTION_CHECK": {
+      "AWS Region": "Only available in Asia Pacific (Mumbai), Europe (Paris), US East (Ohio), Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Europe (Milan), Asia Pacific (Tokyo), US West (Oregon), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central), China (Ningxia) Region",
+      "Parameters": [
+        {
+          "Name": "minimumBackupRetentionPeriod",
+          "Optional": true,
+          "Type": "int"
+        }
+      ],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "DOCDB_CLUSTER_ENCRYPTED": {
+      "AWS Region": "Only available in Asia Pacific (Mumbai), Europe (Paris), US East (Ohio), Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Europe (Milan), Asia Pacific (Tokyo), US West (Oregon), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central), China (Ningxia) Region",
+      "Parameters": [
+        {
+          "Name": "kmsKeyArns",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
     "DYNAMODB_AUTOSCALING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "minProvisionedReadCapacity",
@@ -986,13 +1029,13 @@
       "Trigger type": "Periodic"
     },
     "DYNAMODB_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Periodic"
     },
     "DYNAMODB_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1021,13 +1064,13 @@
       "Trigger type": "Periodic"
     },
     "DYNAMODB_PITR_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
       "Parameters": [],
       "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Configuration changes"
     },
     "DYNAMODB_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1069,7 +1112,7 @@
       "Trigger type": "Periodic"
     },
     "DYNAMODB_TABLE_ENCRYPTED_KMS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -1081,13 +1124,13 @@
       "Trigger type": "Configuration changes"
     },
     "DYNAMODB_TABLE_ENCRYPTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Europe (Spain), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Configuration changes"
     },
     "DYNAMODB_THROUGHPUT_LIMIT_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Europe (Spain) Region",
       "Parameters": [
         {
           "Default": "80",
@@ -1105,12 +1148,12 @@
       "Trigger type": "Periodic"
     },
     "EBS_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EBS_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1139,13 +1182,13 @@
       "Trigger type": "Periodic"
     },
     "EBS_OPTIMIZED_INSTANCE": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [],
       "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EBS_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1187,17 +1230,23 @@
       "Trigger type": "Periodic"
     },
     "EBS_SNAPSHOT_PUBLIC_RESTORABLE_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
+    "EC2_CLIENT_VPN_NOT_AUTHORIZE_ALL": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::EC2::ClientVpnEndpoint",
+      "Trigger type": "Periodic"
+    },
     "EC2_EBS_ENCRYPTION_BY_DEFAULT": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EC2_IMDSV2_CHECK": {
-      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
@@ -1209,13 +1258,13 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_MANAGED_BY_SSM": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Israel (Tel Aviv), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::Instance, AWS::SSM::ManagedInstanceInventory",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_MULTIPLE_ENI_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "NetworkInterfaceIds",
@@ -1227,13 +1276,13 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_NO_PUBLIC_IP": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_PROFILE_ATTACHED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "IamInstanceProfileArnList",
@@ -1245,7 +1294,7 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1274,7 +1323,7 @@
       "Trigger type": "Periodic"
     },
     "EC2_LAUNCH_TEMPLATE_PUBLIC_IP_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "exemptedLaunchTemplates",
@@ -1286,7 +1335,7 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_APPLICATIONS_BLACKLISTED": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "applicationNames",
@@ -1303,7 +1352,7 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_APPLICATIONS_REQUIRED": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "applicationNames",
@@ -1320,13 +1369,13 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_ASSOCIATION_COMPLIANCE_STATUS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::SSM::AssociationCompliance",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_INVENTORY_BLACKLISTED": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "inventoryNames",
@@ -1343,13 +1392,13 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_PATCH_COMPLIANCE_STATUS_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::SSM::PatchCompliance",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_PLATFORM_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "platformType",
@@ -1376,7 +1425,7 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_NO_AMAZON_KEY_PAIR": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
@@ -1388,7 +1437,7 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1430,19 +1479,19 @@
       "Trigger type": "Periodic"
     },
     "EC2_SECURITY_GROUP_ATTACHED_TO_ENI": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Osaka) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "EC2_SECURITY_GROUP_ATTACHED_TO_ENI_PERIODIC": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Periodic"
     },
     "EC2_STOPPED_INSTANCE": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Default": "30",
@@ -1454,7 +1503,7 @@
       "Trigger type": "Periodic"
     },
     "EC2_TOKEN_HOP_LIMIT_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "tokenHopLimit",
@@ -1466,13 +1515,13 @@
       "Trigger type": "Configuration changes"
     },
     "EC2_TRANSIT_GATEWAY_AUTO_VPC_ATTACH_DISABLED": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Mumbai), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Mumbai), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::TransitGateway",
       "Trigger type": "Configuration changes"
     },
     "EC2_VOLUME_INUSE_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "deleteOnTermination",
@@ -1484,49 +1533,49 @@
       "Trigger type": "Configuration changes"
     },
     "ECR_PRIVATE_IMAGE_SCANNING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECR::Repository",
       "Trigger type": "Periodic"
     },
     "ECR_PRIVATE_LIFECYCLE_POLICY_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECR::Repository",
       "Trigger type": "Configuration changes"
     },
     "ECR_PRIVATE_TAG_IMMUTABILITY_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECR::Repository",
       "Trigger type": "Configuration changes"
     },
     "ECS_AWSVPC_NETWORKING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_CONTAINERS_NONPRIVILEGED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_CONTAINERS_READONLY_ACCESS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_CONTAINER_INSIGHTS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::Cluster",
       "Trigger type": "Configuration changes"
     },
     "ECS_FARGATE_LATEST_PLATFORM_VERSION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "latestLinuxVersion",
@@ -1543,7 +1592,7 @@
       "Trigger type": "Configuration changes"
     },
     "ECS_NO_ENVIRONMENT_SECRETS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "secretKeys",
@@ -1555,31 +1604,31 @@
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_LOG_CONFIGURATION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_MEMORY_HARD_LIMIT": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_NONROOT_USER": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_PID_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Name": "SkipInactiveTaskDefinitions",
@@ -1591,7 +1640,7 @@
       "Trigger type": "Configuration changes"
     },
     "EFS_ACCESS_POINT_ENFORCE_ROOT_DIRECTORY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "approvedDirectories",
@@ -1603,7 +1652,7 @@
       "Trigger type": "Configuration changes"
     },
     "EFS_ACCESS_POINT_ENFORCE_USER_IDENTITY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "approvedUids",
@@ -1620,7 +1669,7 @@
       "Trigger type": "Configuration changes"
     },
     "EFS_ENCRYPTED_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "KmsKeyId",
@@ -1631,12 +1680,12 @@
       "Trigger type": "Periodic"
     },
     "EFS_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EFS_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1665,7 +1714,7 @@
       "Trigger type": "Periodic"
     },
     "EFS_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1713,13 +1762,13 @@
       "Trigger type": "Configuration changes"
     },
     "EKS_CLUSTER_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::EKS::Cluster",
       "Trigger type": "Periodic"
     },
     "EKS_CLUSTER_OLDEST_SUPPORTED_VERSION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "oldestVersionSupported",
@@ -1731,7 +1780,7 @@
       "Trigger type": "Configuration changes"
     },
     "EKS_CLUSTER_SUPPORTED_VERSION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "oldestVersionSupported",
@@ -1743,12 +1792,12 @@
       "Trigger type": "Configuration changes"
     },
     "EKS_ENDPOINT_NO_PUBLIC_ACCESS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), US West (N. California), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), US West (N. California), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EKS_SECRETS_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), US West (N. California), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), US West (N. California), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -1759,13 +1808,13 @@
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_AUTO_MINOR_VERSION_UPGRADE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElastiCache::CacheCluster",
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_RBAC_AUTH_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "allowedUserGroupIDs",
@@ -1777,7 +1826,7 @@
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_REDIS_CLUSTER_AUTOMATIC_BACKUP_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "15",
@@ -1790,13 +1839,13 @@
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_REPL_GRP_AUTO_FAILOVER_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElastiCache::ReplicationGroup",
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_REPL_GRP_ENCRYPTED_AT_REST": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "approvedKMSKeyIds",
@@ -1808,35 +1857,52 @@
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_REPL_GRP_ENCRYPTED_IN_TRANSIT": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElastiCache::ReplicationGroup",
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_REPL_GRP_REDIS_AUTH_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElastiCache::ReplicationGroup",
       "Trigger type": "Periodic"
     },
     "ELASTICACHE_SUBNET_GROUP_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElastiCache::CacheCluster",
       "Trigger type": "Periodic"
     },
+    "ELASTICACHE_SUPPORTED_ENGINE_VERSION": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "latestMemcachedVersion",
+          "Optional": false,
+          "Type": "String"
+        },
+        {
+          "Name": "latestRedisVersion",
+          "Optional": false,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::ElastiCache::CacheCluster",
+      "Trigger type": "Periodic"
+    },
     "ELASTICSEARCH_ENCRYPTED_AT_REST": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ELASTICSEARCH_IN_VPC_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ELASTICSEARCH_LOGS_TO_CLOUDWATCH": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "logTypes",
@@ -1848,13 +1914,13 @@
       "Trigger type": "Configuration changes"
     },
     "ELASTICSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::Elasticsearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "ELASTIC_BEANSTALK_LOGS_TO_CLOUDWATCH": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "RetentionInDays",
@@ -1871,7 +1937,7 @@
       "Trigger type": "Configuration changes"
     },
     "ELASTIC_BEANSTALK_MANAGED_UPDATES_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "UpdateLevel",
@@ -1883,7 +1949,7 @@
       "Trigger type": "Configuration changes"
     },
     "ELBV2_ACM_CERTIFICATE_REQUIRED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "AcmCertificatesAllowed",
@@ -1894,7 +1960,7 @@
       "Trigger type": "Periodic"
     },
     "ELBV2_MULTIPLE_AZ": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "minAvailabilityZones",
@@ -1906,19 +1972,19 @@
       "Trigger type": "Configuration changes"
     },
     "ELB_ACM_CERTIFICATE_REQUIRED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_CROSS_ZONE_LOAD_BALANCING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_CUSTOM_SECURITY_POLICY_SSL_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "sslProtocolsAndCiphers",
@@ -1930,13 +1996,13 @@
       "Trigger type": "Configuration changes"
     },
     "ELB_DELETION_PROTECTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Israel (Tel Aviv), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "s3BucketNames",
@@ -1948,7 +2014,7 @@
       "Trigger type": "Configuration changes"
     },
     "ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "predefinedPolicyName",
@@ -1960,13 +2026,13 @@
       "Trigger type": "Configuration changes"
     },
     "ELB_TLS_HTTPS_LISTENERS_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Osaka), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "EMR_KERBEROS_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "TicketLifetimeInHours",
@@ -1997,13 +2063,13 @@
       "Trigger type": "Periodic"
     },
     "EMR_MASTER_NO_PUBLIC_IP": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::EMR::Cluster",
       "Trigger type": "Periodic"
     },
     "ENCRYPTED_VOLUMES": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Name": "kmsId",
@@ -2015,7 +2081,7 @@
       "Trigger type": "Configuration changes"
     },
     "FMS_SHIELD_RESOURCE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "webACLId",
@@ -2052,7 +2118,7 @@
       "Trigger type": "Configuration changes"
     },
     "FMS_WEBACL_RESOURCE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "webACLId",
@@ -2084,7 +2150,7 @@
       "Trigger type": "Configuration changes"
     },
     "FMS_WEBACL_RULEGROUP_ASSOCIATION_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "ruleGroups",
@@ -2106,7 +2172,7 @@
       "Trigger type": "Configuration changes"
     },
     "FSX_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -2135,7 +2201,7 @@
       "Trigger type": "Periodic"
     },
     "FSX_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -2177,7 +2243,7 @@
       "Trigger type": "Periodic"
     },
     "GUARDDUTY_ENABLED_CENTRALIZED": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "CentralMonitoringAccount",
@@ -2188,7 +2254,7 @@
       "Trigger type": "Periodic"
     },
     "GUARDDUTY_NON_ARCHIVED_FINDINGS": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "30",
@@ -2212,7 +2278,7 @@
       "Trigger type": "Periodic"
     },
     "IAM_CUSTOMER_POLICY_BLOCKED_KMS_ACTIONS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "blockedActionsPatterns",
@@ -2229,13 +2295,13 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_GROUP_HAS_USERS_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::IAM::Group",
       "Trigger type": "Configuration changes"
     },
     "IAM_INLINE_POLICY_BLOCKED_KMS_ACTIONS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "blockedActionsPatterns",
@@ -2252,13 +2318,13 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_NO_INLINE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::IAM::User, AWS::IAM::Role, AWS::IAM::Group",
       "Trigger type": "Configuration changes"
     },
     "IAM_PASSWORD_POLICY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Default": "true",
@@ -2306,10 +2372,10 @@
       "Trigger type": "Periodic"
     },
     "IAM_POLICY_BLACKLISTED_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
-          "Default": "arn",
+          "Default": "arn:aws:iam::aws:policy/AdministratorAccess",
           "Name": "policyArns",
           "Optional": false,
           "Type": "CSV"
@@ -2324,7 +2390,7 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_POLICY_IN_USE": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "policyARN",
@@ -2340,7 +2406,7 @@
       "Trigger type": "Periodic"
     },
     "IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "excludePermissionBoundaryPolicy",
@@ -2352,7 +2418,7 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "excludePermissionBoundaryPolicy",
@@ -2364,7 +2430,7 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_ROLE_MANAGED_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "managedPolicyArns",
@@ -2376,12 +2442,12 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_ROOT_ACCESS_KEY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "IAM_USER_GROUP_MEMBERSHIP_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "groupNames",
@@ -2393,18 +2459,18 @@
       "Trigger type": "Configuration changes"
     },
     "IAM_USER_MFA_ENABLED": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "IAM_USER_NO_POLICIES_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::IAM::User",
       "Trigger type": "Configuration changes"
     },
     "IAM_USER_UNUSED_CREDENTIALS_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "90",
@@ -2416,13 +2482,13 @@
       "Trigger type": "Periodic"
     },
     "INCOMING_SSH_DISABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "INSTANCES_IN_VPC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "vpcId",
@@ -2434,7 +2500,7 @@
       "Trigger type": "Configuration changes"
     },
     "INTERNET_GATEWAY_AUTHORIZED_VPC_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "AuthorizedVpcIds",
@@ -2446,13 +2512,13 @@
       "Trigger type": "Configuration changes"
     },
     "KINESIS_STREAM_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::Kinesis::Stream",
       "Trigger type": "Configuration changes"
     },
     "KMS_CMK_NOT_SCHEDULED_FOR_DELETION": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyIds",
@@ -2464,7 +2530,7 @@
       "Trigger type": "Periodic"
     },
     "LAMBDA_CONCURRENCY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "ConcurrencyLimitLow",
@@ -2481,7 +2547,7 @@
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_DLQ_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "dlqArns",
@@ -2493,13 +2559,13 @@
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_FUNCTION_PUBLIC_ACCESS_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_FUNCTION_SETTINGS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "runtime",
@@ -2528,7 +2594,7 @@
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_INSIDE_VPC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "subnetIds",
@@ -2540,7 +2606,7 @@
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_VPC_MULTI_AZ_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "availabilityZones",
@@ -2551,13 +2617,31 @@
       "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
+    "MACIE_STATUS_CHECK": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::::Account",
+      "Trigger type": "Periodic"
+    },
     "MFA_ENABLED_FOR_IAM_CONSOLE_ACCESS": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
+    "MQ_AUTOMATIC_MINOR_VERSION_UPGRADE_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::AmazonMQ::Broker",
+      "Trigger type": "Periodic"
+    },
+    "MQ_CLOUDWATCH_AUDIT_LOGGING_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::AmazonMQ::Broker",
+      "Trigger type": "Periodic"
+    },
     "MQ_NO_PUBLIC_ACCESS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::AmazonMQ::Broker",
       "Trigger type": "Periodic"
@@ -2594,13 +2678,85 @@
       "Trigger type": "Periodic"
     },
     "NACL_NO_UNRESTRICTED_SSH_RDP": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::NetworkAcl",
       "Trigger type": "Configuration changes"
     },
+    "NEPTUNE_CLUSTER_BACKUP_RETENTION_CHECK": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "minimumBackupRetentionPeriod",
+          "Optional": true,
+          "Type": "int"
+        }
+      ],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_CLOUDWATCH_LOG_EXPORT_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_COPY_TAGS_TO_SNAPSHOT_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_DELETION_PROTECTION_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_ENCRYPTED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "KmsKeyArns",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_IAM_DATABASE_AUTHENTICATION": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_SNAPSHOT_ENCRYPTED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBClusterSnapshot",
+      "Trigger type": "Configuration changes"
+    },
+    "NEPTUNE_CLUSTER_SNAPSHOT_PUBLIC_PROHIBITED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBClusterSnapshot",
+      "Trigger type": "Configuration changes"
+    },
+    "NETFW_LOGGING_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "logType",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::NetworkFirewall::LoggingConfiguration",
+      "Trigger type": "Periodic"
+    },
     "NETFW_MULTI_AZ_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "availabilityZones",
@@ -2612,7 +2768,7 @@
       "Trigger type": "Configuration changes"
     },
     "NETFW_POLICY_DEFAULT_ACTION_FRAGMENT_PACKETS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "statelessFragmentDefaultActions",
@@ -2624,7 +2780,7 @@
       "Trigger type": "Configuration changes"
     },
     "NETFW_POLICY_DEFAULT_ACTION_FULL_PACKETS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "statelessDefaultActions",
@@ -2636,25 +2792,25 @@
       "Trigger type": "Configuration changes"
     },
     "NETFW_POLICY_RULE_GROUP_ASSOCIATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::NetworkFirewall::FirewallPolicy",
       "Trigger type": "Configuration changes"
     },
     "NETFW_STATELESS_RULE_GROUP_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::NetworkFirewall::RuleGroup",
       "Trigger type": "Configuration changes"
     },
     "NLB_CROSS_ZONE_LOAD_BALANCING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "NO_UNRESTRICTED_ROUTE_TO_IGW": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "routeTableIds",
@@ -2666,13 +2822,13 @@
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_ACCESS_CONTROL_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_AUDIT_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "cloudWatchLogsLogGroupArnList",
@@ -2684,19 +2840,19 @@
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_DATA_NODE_FAULT_TOLERANCE": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_ENCRYPTED_AT_REST": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_HTTPS_REQUIRED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "tlsPolicies",
@@ -2708,13 +2864,13 @@
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_IN_VPC_ONLY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_LOGS_TO_CLOUDWATCH": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "logTypes",
@@ -2726,19 +2882,19 @@
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "RDS_AUTOMATIC_MINOR_VERSION_UPGRADE_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_DEFAULT_ADMIN_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "validAdminUserNames",
@@ -2750,19 +2906,25 @@
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_DELETION_PROTECTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
+      "Trigger type": "Configuration changes"
+    },
+    "RDS_CLUSTER_ENCRYPTED_AT_REST": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_IAM_AUTHENTICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_MULTI_AZ_ENABLED": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
@@ -2774,7 +2936,7 @@
       "Trigger type": "Configuration changes"
     },
     "RDS_ENHANCED_MONITORING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "monitoringInterval",
@@ -2786,7 +2948,7 @@
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_DEFAULT_ADMIN_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "validAdminUserNames",
@@ -2798,7 +2960,7 @@
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_DELETION_PROTECTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "databaseEngines",
@@ -2810,24 +2972,24 @@
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_IAM_AUTHENTICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Hong Kong), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_PUBLIC_ACCESS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "RDS_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -2856,7 +3018,7 @@
       "Trigger type": "Periodic"
     },
     "RDS_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "additionalLogs",
@@ -2868,13 +3030,13 @@
       "Trigger type": "Configuration changes"
     },
     "RDS_MULTI_AZ_SUPPORT": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -2916,19 +3078,19 @@
       "Trigger type": "Periodic"
     },
     "RDS_SNAPSHOTS_PUBLIC_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBSnapshot, AWS::RDS::DBClusterSnapshot",
       "Trigger type": "Configuration changes"
     },
     "RDS_SNAPSHOT_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::RDS::DBSnapshot, AWS::RDS::DBClusterSnapshot",
       "Trigger type": "Configuration changes"
     },
     "RDS_STORAGE_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyId",
@@ -2940,7 +3102,7 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_AUDIT_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "bucketNames",
@@ -2952,7 +3114,7 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_BACKUP_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "MinRetentionPeriod",
@@ -2969,7 +3131,7 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_CONFIGURATION_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Middle East (UAE), Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [
         {
           "Default": "true",
@@ -2994,7 +3156,7 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_KMS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3006,7 +3168,7 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_MAINTENANCESETTINGS_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [
         {
           "Default": "true",
@@ -3030,13 +3192,13 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_PUBLIC_ACCESS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_DEFAULT_ADMIN_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "validAdminUserNames",
@@ -3048,7 +3210,7 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_DEFAULT_DB_NAME_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "validDatabaseNames",
@@ -3060,13 +3222,13 @@
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_ENHANCED_VPC_ROUTING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_REQUIRE_TLS_SSL": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Milan), Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
@@ -3140,7 +3302,7 @@
       "Trigger type": "Configuration changes"
     },
     "RESTRICTED_INCOMING_TRAFFIC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "20",
@@ -3171,23 +3333,28 @@
           "Name": "blockedPort5",
           "Optional": true,
           "Type": "int"
+        },
+        {
+          "Name": "blockedPorts",
+          "Optional": true,
+          "Type": "CSV"
         }
       ],
       "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "ROOT_ACCOUNT_HARDWARE_MFA_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ROOT_ACCOUNT_MFA_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "True",
@@ -3218,7 +3385,7 @@
       "Trigger type": "Configuration changes (current status not checked, only evaluated when changes generate new events)"
     },
     "S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS_PERIODIC": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "IgnorePublicAcls",
@@ -3241,16 +3408,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::::Account",
       "Trigger type": "Periodic"
     },
     "S3_BUCKET_ACL_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_BLACKLISTED_ACTIONS_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "blacklistedActionPattern",
@@ -3262,7 +3430,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_DEFAULT_LOCK_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "mode",
@@ -3274,7 +3442,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "excludedPublicBuckets",
@@ -3286,7 +3454,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "targetBucket",
@@ -3303,7 +3471,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_POLICY_GRANTEE_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "awsPrincipals",
@@ -3335,7 +3503,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_POLICY_NOT_MORE_PERMISSIVE": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "controlPolicy",
@@ -3347,19 +3515,19 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_PUBLIC_READ_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [],
       "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes and Periodic"
     },
     "S3_BUCKET_PUBLIC_WRITE_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [],
       "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes and Periodic"
     },
     "S3_BUCKET_REPLICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "ReplicationType",
@@ -3371,13 +3539,13 @@
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_SSL_REQUESTS_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Europe (Spain) Region",
       "Parameters": [],
       "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
@@ -3395,7 +3563,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_DEFAULT_ENCRYPTION_KMS": {
-      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Europe (Spain) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3407,7 +3575,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_EVENT_NOTIFICATIONS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "destinationArn",
@@ -3424,7 +3592,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3453,7 +3621,7 @@
       "Trigger type": "Periodic"
     },
     "S3_LIFECYCLE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "targetTransitionDays",
@@ -3485,7 +3653,7 @@
       "Trigger type": "Configuration changes"
     },
     "S3_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3527,7 +3695,7 @@
       "Trigger type": "Periodic"
     },
     "S3_VERSION_LIFECYCLE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "bucketNames",
@@ -3539,7 +3707,7 @@
       "Trigger type": "Configuration changes"
     },
     "SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3550,7 +3718,7 @@
       "Trigger type": "Periodic"
     },
     "SAGEMAKER_NOTEBOOK_INSTANCE_INSIDE_VPC": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "SubnetIds",
@@ -3562,7 +3730,7 @@
       "Trigger type": "Configuration changes"
     },
     "SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3573,13 +3741,13 @@
       "Trigger type": "Periodic"
     },
     "SAGEMAKER_NOTEBOOK_INSTANCE_ROOT_ACCESS_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::SageMaker::NotebookInstance",
       "Trigger type": "Configuration changes"
     },
     "SAGEMAKER_NOTEBOOK_NO_DIRECT_INTERNET_ACCESS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
@@ -3607,7 +3775,7 @@
       "Trigger type": "Configuration changes"
     },
     "SECRETSMANAGER_SECRET_PERIODIC_ROTATION": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "maxDaysSinceRotation",
@@ -3618,7 +3786,7 @@
       "Trigger type": "Periodic"
     },
     "SECRETSMANAGER_SECRET_UNUSED": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "unusedForDays",
@@ -3629,7 +3797,7 @@
       "Trigger type": "Periodic"
     },
     "SECRETSMANAGER_USING_CMK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3641,18 +3809,18 @@
       "Trigger type": "Configuration changes"
     },
     "SECURITYHUB_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "SECURITY_ACCOUNT_INFORMATION_PROVIDED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::::Account",
       "Trigger type": "Periodic"
     },
     "SERVICE_VPC_ENDPOINT_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Name": "serviceName",
@@ -3679,7 +3847,7 @@
       "Trigger type": "Periodic"
     },
     "SNS_ENCRYPTED_KMS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyIds",
@@ -3691,18 +3859,35 @@
       "Trigger type": "Configuration changes"
     },
     "SNS_TOPIC_MESSAGE_DELIVERY_NOTIFICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::SNS::Topic",
       "Trigger type": "Configuration changes"
     },
     "SSM_DOCUMENT_NOT_PUBLIC": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Israel (Tel Aviv) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
+    "STEP_FUNCTIONS_STATE_MACHINE_LOGGING_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "cloudWatchLogGroupArns",
+          "Optional": true,
+          "Type": "CSV"
+        },
+        {
+          "Name": "logLevel",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::StepFunctions::StateMachine",
+      "Trigger type": "Configuration changes"
+    },
     "STORAGEGATEWAY_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3731,7 +3916,7 @@
       "Trigger type": "Periodic"
     },
     "STORAGEGATEWAY_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3773,13 +3958,13 @@
       "Trigger type": "Periodic"
     },
     "SUBNET_AUTO_ASSIGN_PUBLIC_IP_DISABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::Subnet",
       "Trigger type": "Configuration changes"
     },
     "VIRTUALMACHINE_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3808,7 +3993,7 @@
       "Trigger type": "Periodic"
     },
     "VIRTUALMACHINE_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3850,13 +4035,13 @@
       "Trigger type": "Periodic"
     },
     "VPC_DEFAULT_SECURITY_GROUP_CLOSED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [],
       "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "VPC_FLOW_LOGS_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Name": "trafficType",
@@ -3867,13 +4052,13 @@
       "Trigger type": "Periodic"
     },
     "VPC_NETWORK_ACL_UNUSED_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::NetworkAcl",
       "Trigger type": "Configuration changes"
     },
     "VPC_PEERING_DNS_RESOLUTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "vpcIds",
@@ -3885,7 +4070,7 @@
       "Trigger type": "Configuration changes"
     },
     "VPC_SG_OPEN_ONLY_TO_AUTHORIZED_PORTS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Asia Pacific (Melbourne), Israel (Tel Aviv) Region",
       "Parameters": [
         {
           "Name": "authorizedTcpPorts",
@@ -3902,13 +4087,13 @@
       "Trigger type": "Configuration changes"
     },
     "VPC_VPN_2_TUNNELS_UP": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), China (Ningxia) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Osaka), Israel (Tel Aviv), China (Ningxia) Region",
       "Parameters": [],
       "Resource Types": "AWS::EC2::VPNConnection",
       "Trigger type": "Configuration changes"
     },
     "WAFV2_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "KinesisFirehoseDeliveryStreamArns",
@@ -3919,13 +4104,13 @@
       "Trigger type": "Periodic"
     },
     "WAFV2_RULEGROUP_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::WAFv2::RuleGroup",
       "Trigger type": "Configuration changes"
     },
     "WAFV2_WEBACL_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::WAFv2::WebACL",
       "Trigger type": "Configuration changes"
@@ -3960,19 +4145,19 @@
       "Trigger type": "Configuration changes"
     },
     "WAF_REGIONAL_RULEGROUP_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::WAFRegional::RuleGroup",
       "Trigger type": "Configuration changes"
     },
     "WAF_REGIONAL_RULE_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::WAFRegional::Rule",
       "Trigger type": "Configuration changes"
     },
     "WAF_REGIONAL_WEBACL_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), AWS GovCloud (US-East), AWS GovCloud (US-West), Israel (Tel Aviv), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Resource Types": "AWS::WAFRegional::WebACL",
       "Trigger type": "Configuration changes"

--- a/moto/config/resources/aws_managed_rules.json
+++ b/moto/config/resources/aws_managed_rules.json
@@ -1,7 +1,7 @@
 {
   "ManagedRules": {
     "ACCESS_KEYS_ROTATED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "90",
@@ -13,7 +13,7 @@
       "Trigger type": "Periodic"
     },
     "ACCOUNT_PART_OF_ORGANIZATIONS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "MasterAccountId",
@@ -24,7 +24,7 @@
       "Trigger type": "Periodic"
     },
     "ACM_CERTIFICATE_EXPIRATION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Osaka), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "14",
@@ -33,10 +33,17 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::ACM::Certificate",
+      "Trigger type": "Configuration changes and Periodic"
+    },
+    "ACM_CERTIFICATE_RSA_CHECK": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ACM::Certificate",
       "Trigger type": "Configuration changes"
     },
     "ALB_DESYNC_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "desyncMode",
@@ -44,20 +51,22 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ALB_HTTP_DROP_INVALID_HEADER_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ALB_HTTP_TO_HTTPS_REDIRECTION_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ALB_WAF_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "wafWebAclIds",
@@ -65,10 +74,29 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
+    "API_GWV2_ACCESS_LOGS_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ApiGatewayV2::Stage",
+      "Trigger type": "Configuration changes"
+    },
+    "API_GWV2_AUTHORIZATION_TYPE_CONFIGURED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "authorizationType",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::ApiGatewayV2::Route",
+      "Trigger type": "Periodic"
+    },
     "API_GW_ASSOCIATED_WITH_WAF": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "WebAclArns",
@@ -76,15 +104,17 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ApiGateway::Stage",
       "Trigger type": "Configuration changes"
     },
     "API_GW_CACHE_ENABLED_AND_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ApiGateway::Stage",
       "Trigger type": "Configuration changes"
     },
     "API_GW_ENDPOINT_TYPE_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "endpointConfigurationTypes",
@@ -92,10 +122,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::ApiGateway::RestApi",
       "Trigger type": "Configuration changes"
     },
     "API_GW_EXECUTION_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
       "Parameters": [
         {
           "Default": "ERROR,INFO",
@@ -104,10 +135,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::ApiGateway::Stage, AWS::ApiGatewayV2::Stage",
       "Trigger type": "Configuration changes"
     },
     "API_GW_SSL_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "CertificateIDs",
@@ -115,11 +147,13 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ApiGateway::Stage",
       "Trigger type": "Configuration changes"
     },
     "API_GW_XRAY_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ApiGateway::Stage",
       "Trigger type": "Configuration changes"
     },
     "APPROVED_AMIS_BY_ID": {
@@ -131,6 +165,7 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "APPROVED_AMIS_BY_TAG": {
@@ -143,10 +178,41 @@
           "Type": "StringMap"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
+      "Trigger type": "Configuration changes"
+    },
+    "APPSYNC_ASSOCIATED_WITH_WAF": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "wafWebAclARNs",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::AppSync::GraphQLApi",
+      "Trigger type": "Periodic"
+    },
+    "APPSYNC_CACHE_ENCRYPTION_AT_REST": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::AppSync::GraphQLApi",
+      "Trigger type": "Periodic"
+    },
+    "APPSYNC_LOGGING_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "fieldLoggingLevel",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::AppSync::GraphQLApi",
       "Trigger type": "Configuration changes"
     },
     "AURORA_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -171,10 +237,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Periodic"
     },
     "AURORA_MYSQL_BACKTRACKING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Europe (Stockholm), Middle East (Bahrain), Africa (Cape Town), South America (Sao Paulo) Region",
+      "AWS Region": "Only available in Asia Pacific (Mumbai), Europe (Paris), US East (Ohio), Europe (Ireland), Europe (Frankfurt), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "BacktrackWindowInHours",
@@ -182,10 +249,11 @@
           "Type": "double"
         }
       ],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "AURORA_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -223,40 +291,47 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Periodic"
     },
     "AUTOSCALING_CAPACITY_REBALANCING": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_GROUP_ELB_HEALTHCHECK_REQUIRED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Melbourne) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCHCONFIG_REQUIRES_IMDSV2": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::LaunchConfiguration",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCH_CONFIG_HOP_LIMIT": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::LaunchConfiguration",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCH_CONFIG_PUBLIC_IP_DISABLED": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::LaunchConfiguration",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_LAUNCH_TEMPLATE": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_MULTIPLE_AZ": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "minAvailabilityZones",
@@ -264,15 +339,17 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "AUTOSCALING_MULTIPLE_INSTANCE_TYPES": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::AutoScaling::AutoScalingGroup",
       "Trigger type": "Configuration changes"
     },
     "BACKUP_PLAN_MIN_FREQUENCY_AND_MIN_RETENTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "1",
@@ -293,15 +370,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::Backup::BackupPlan",
       "Trigger type": "Configuration changes"
     },
     "BACKUP_RECOVERY_POINT_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Backup::RecoveryPoint",
       "Trigger type": "Configuration changes"
     },
     "BACKUP_RECOVERY_POINT_MANUAL_DELETION_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "principalArnList",
@@ -309,10 +388,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Backup::BackupVault",
       "Trigger type": "Configuration changes"
     },
     "BACKUP_RECOVERY_POINT_MINIMUM_RETENTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "35",
@@ -321,15 +401,17 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::Backup::RecoveryPoint",
       "Trigger type": "Configuration changes"
     },
     "BEANSTALK_ENHANCED_HEALTH_REPORTING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticBeanstalk::Environment",
       "Trigger type": "Configuration changes"
     },
     "CLB_DESYNC_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "desyncMode",
@@ -337,10 +419,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "CLB_MULTIPLE_AZ": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "minAvailabilityZones",
@@ -348,10 +431,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFORMATION_STACK_DRIFT_DETECTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Europe (Paris), Europe (Stockholm), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "Only available in Asia Pacific (Mumbai), US East (Ohio), Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central) Region",
       "Parameters": [
         {
           "Name": "cloudformationRoleArn",
@@ -359,10 +443,11 @@
           "Type": "String"
         }
       ],
-      "Trigger type": "Configuration changes"
+      "Resource Types": "AWS::CloudFormation::Stack",
+      "Trigger type": "Configuration changes and Periodic"
     },
     "CLOUDFORMATION_STACK_NOTIFICATION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Europe (Paris), Europe (Stockholm), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), Europe (Paris), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "snsTopic1",
@@ -390,6 +475,7 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::CloudFormation::Stack",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_ACCESSLOGS_ENABLED": {
@@ -401,6 +487,7 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_ASSOCIATED_WITH_WAF": {
@@ -412,50 +499,71 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_CUSTOM_SSL_CERTIFICATE": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_DEFAULT_ROOT_OBJECT_CONFIGURED": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_NO_DEPRECATED_SSL_PROTOCOLS": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_ORIGIN_ACCESS_IDENTITY_ENABLED": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_ORIGIN_FAILOVER_ENABLED": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
+      "Trigger type": "Configuration changes"
+    },
+    "CLOUDFRONT_S3_ORIGIN_NON_EXISTENT_BUCKET": {
+      "AWS Region": "Only available in US East (N. Virginia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
+      "Trigger type": "Periodic"
+    },
+    "CLOUDFRONT_SECURITY_POLICY_CHECK": {
+      "AWS Region": "Only available in US East (N. Virginia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_SNI_ENABLED": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_TRAFFIC_TO_ORIGIN_ENCRYPTED": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDFRONT_VIEWER_POLICY_HTTPS": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudFront::Distribution",
       "Trigger type": "Configuration changes"
     },
     "CLOUDTRAIL_S3_DATAEVENTS_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "S3BucketNames",
@@ -466,7 +574,7 @@
       "Trigger type": "Periodic"
     },
     "CLOUDTRAIL_SECURITY_TRAIL_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
@@ -517,11 +625,13 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::CloudWatch::Alarm",
       "Trigger type": "Configuration changes"
     },
     "CLOUDWATCH_ALARM_ACTION_ENABLED_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CloudWatch::Alarm",
       "Trigger type": "Configuration changes"
     },
     "CLOUDWATCH_ALARM_RESOURCE_CHECK": {
@@ -575,10 +685,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::CloudWatch::Alarm",
       "Trigger type": "Configuration changes"
     },
     "CLOUDWATCH_LOG_GROUP_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "KmsKeyId",
@@ -631,17 +742,18 @@
       "Trigger type": "Periodic"
     },
     "CMK_BACKING_KEY_ROTATION_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "CODEBUILD_PROJECT_ARTIFACT_ENCRYPTION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_ENVIRONMENT_PRIVILEGED_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "exemptedProjects",
@@ -649,15 +761,17 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_ENVVAR_AWSCRED_CHECK": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "s3BucketNames",
@@ -670,10 +784,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_S3_LOGS_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "exemptedProjects",
@@ -681,20 +796,23 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEBUILD_PROJECT_SOURCE_REPO_URL_CHECK": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CodeBuild::Project",
       "Trigger type": "Configuration changes"
     },
     "CODEDEPLOY_AUTO_ROLLBACK_MONITOR_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CodeDeploy::DeploymentGroup",
       "Trigger type": "Configuration changes"
     },
     "CODEDEPLOY_EC2_MINIMUM_HEALTHY_HOSTS_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "66",
@@ -709,15 +827,17 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::CodeDeploy::DeploymentGroup",
       "Trigger type": "Configuration changes"
     },
     "CODEDEPLOY_LAMBDA_ALLATONCE_TRAFFIC_SHIFT_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::CodeDeploy::DeploymentGroup",
       "Trigger type": "Configuration changes"
     },
     "CODEPIPELINE_DEPLOYMENT_COUNT_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Europe (Stockholm), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "Only available in Asia Pacific (Mumbai), Europe (Paris), US East (Ohio), Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central) Region",
       "Parameters": [
         {
           "Name": "deploymentLimit",
@@ -725,10 +845,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::CodePipeline::Pipeline",
       "Trigger type": "Configuration changes"
     },
     "CODEPIPELINE_REGION_FANOUT_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Europe (Stockholm), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "Only available in Asia Pacific (Mumbai), Europe (Paris), US East (Ohio), Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Seoul), Europe (London), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney), Canada (Central) Region",
       "Parameters": [
         {
           "Default": "3",
@@ -737,10 +858,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::CodePipeline::Pipeline",
       "Trigger type": "Configuration changes"
     },
     "CW_LOGGROUP_RETENTION_PERIOD_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "LogGroupNames",
@@ -761,7 +883,7 @@
       "Trigger type": "Periodic"
     },
     "DB_INSTANCE_BACKUP_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "backupRetentionPeriod",
@@ -784,6 +906,7 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "DESIRED_INSTANCE_TENANCY": {
@@ -805,6 +928,7 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "DESIRED_INSTANCE_TYPE": {
@@ -816,15 +940,16 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "DMS_REPLICATION_NOT_PUBLIC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "DYNAMODB_AUTOSCALING_ENABLED": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "minProvisionedReadCapacity",
@@ -857,15 +982,17 @@
           "Type": "double"
         }
       ],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Periodic"
     },
     "DYNAMODB_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Periodic"
     },
     "DYNAMODB_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -890,15 +1017,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Periodic"
     },
     "DYNAMODB_PITR_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
       "Parameters": [],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Configuration changes"
     },
     "DYNAMODB_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -936,10 +1065,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Periodic"
     },
     "DYNAMODB_TABLE_ENCRYPTED_KMS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -947,15 +1077,17 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Configuration changes"
     },
     "DYNAMODB_TABLE_ENCRYPTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Europe (Stockholm), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Europe (Stockholm), Middle East (Bahrain), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::DynamoDB::Table",
       "Trigger type": "Configuration changes"
     },
     "DYNAMODB_THROUGHPUT_LIMIT_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "80",
@@ -973,12 +1105,12 @@
       "Trigger type": "Periodic"
     },
     "EBS_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EBS_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1003,15 +1135,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::Volume",
       "Trigger type": "Periodic"
     },
     "EBS_OPTIMIZED_INSTANCE": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EBS_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1049,35 +1183,39 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::Volume",
       "Trigger type": "Periodic"
     },
     "EBS_SNAPSHOT_PUBLIC_RESTORABLE_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EC2_EBS_ENCRYPTION_BY_DEFAULT": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EC2_IMDSV2_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_DETAILED_MONITORING_ENABLED": {
       "AWS Region": "All supported AWS regions",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_MANAGED_BY_SSM": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance, AWS::SSM::ManagedInstanceInventory",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_MULTIPLE_ENI_CHECK": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "NetworkInterfaceIds",
@@ -1085,15 +1223,17 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_NO_PUBLIC_IP": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_INSTANCE_PROFILE_ATTACHED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "IamInstanceProfileArnList",
@@ -1101,10 +1241,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1129,10 +1270,23 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Periodic"
     },
+    "EC2_LAUNCH_TEMPLATE_PUBLIC_IP_DISABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "exemptedLaunchTemplates",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::EC2::LaunchTemplate",
+      "Trigger type": "Configuration changes"
+    },
     "EC2_MANAGEDINSTANCE_APPLICATIONS_BLACKLISTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "applicationNames",
@@ -1145,10 +1299,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::SSM::ManagedInstanceInventory",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_APPLICATIONS_REQUIRED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "applicationNames",
@@ -1161,15 +1316,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::SSM::ManagedInstanceInventory",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_ASSOCIATION_COMPLIANCE_STATUS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::SSM::AssociationCompliance",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_INVENTORY_BLACKLISTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "inventoryNames",
@@ -1182,15 +1339,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::SSM::ManagedInstanceInventory",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_PATCH_COMPLIANCE_STATUS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::SSM::PatchCompliance",
       "Trigger type": "Configuration changes"
     },
     "EC2_MANAGEDINSTANCE_PLATFORM_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "platformType",
@@ -1213,20 +1372,23 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::SSM::ManagedInstanceInventory",
       "Trigger type": "Configuration changes"
     },
     "EC2_NO_AMAZON_KEY_PAIR": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_PARAVIRTUAL_INSTANCE_CHECK": {
       "AWS Region": "Only available in Europe (Ireland), Europe (Frankfurt), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1264,20 +1426,23 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Periodic"
     },
     "EC2_SECURITY_GROUP_ATTACHED_TO_ENI": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "EC2_SECURITY_GROUP_ATTACHED_TO_ENI_PERIODIC": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Periodic"
     },
     "EC2_STOPPED_INSTANCE": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
       "Parameters": [
         {
           "Default": "30",
@@ -1289,7 +1454,7 @@
       "Trigger type": "Periodic"
     },
     "EC2_TOKEN_HOP_LIMIT_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "tokenHopLimit",
@@ -1297,15 +1462,17 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "EC2_TRANSIT_GATEWAY_AUTO_VPC_ATTACH_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Mumbai), Middle East (Bahrain) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Mumbai), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::TransitGateway",
       "Trigger type": "Configuration changes"
     },
     "EC2_VOLUME_INUSE_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Name": "deleteOnTermination",
@@ -1313,50 +1480,70 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::EC2::Volume",
       "Trigger type": "Configuration changes"
     },
     "ECR_PRIVATE_IMAGE_SCANNING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
-      "Trigger type": "Configuration changes"
+      "Resource Types": "AWS::ECR::Repository",
+      "Trigger type": "Periodic"
     },
     "ECR_PRIVATE_LIFECYCLE_POLICY_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECR::Repository",
       "Trigger type": "Configuration changes"
     },
     "ECR_PRIVATE_TAG_IMMUTABILITY_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECR::Repository",
       "Trigger type": "Configuration changes"
     },
     "ECS_AWSVPC_NETWORKING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_CONTAINERS_NONPRIVILEGED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_CONTAINERS_READONLY_ACCESS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_CONTAINER_INSIGHTS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::Cluster",
       "Trigger type": "Configuration changes"
     },
     "ECS_FARGATE_LATEST_PLATFORM_VERSION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
-      "Parameters": [],
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "Parameters": [
+        {
+          "Name": "latestLinuxVersion",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "latestWindowsVersion",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::ECS::Service",
       "Trigger type": "Configuration changes"
     },
     "ECS_NO_ENVIRONMENT_SECRETS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "secretKeys",
@@ -1364,30 +1551,35 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_LOG_CONFIGURATION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_MEMORY_HARD_LIMIT": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_NONROOT_USER": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_PID_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "SkipInactiveTaskDefinitions",
@@ -1395,10 +1587,11 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::ECS::TaskDefinition",
       "Trigger type": "Configuration changes"
     },
     "EFS_ACCESS_POINT_ENFORCE_ROOT_DIRECTORY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "approvedDirectories",
@@ -1406,10 +1599,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EFS::AccessPoint",
       "Trigger type": "Configuration changes"
     },
     "EFS_ACCESS_POINT_ENFORCE_USER_IDENTITY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "approvedUids",
@@ -1422,10 +1616,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EFS::AccessPoint",
       "Trigger type": "Configuration changes"
     },
     "EFS_ENCRYPTED_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "KmsKeyId",
@@ -1436,12 +1631,12 @@
       "Trigger type": "Periodic"
     },
     "EFS_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EFS_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1466,10 +1661,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EFS::FileSystem",
       "Trigger type": "Periodic"
     },
     "EFS_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1507,15 +1703,23 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EFS::FileSystem",
       "Trigger type": "Periodic"
     },
     "EIP_ATTACHED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::EIP",
       "Trigger type": "Configuration changes"
     },
+    "EKS_CLUSTER_LOGGING_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::EKS::Cluster",
+      "Trigger type": "Periodic"
+    },
     "EKS_CLUSTER_OLDEST_SUPPORTED_VERSION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "oldestVersionSupported",
@@ -1523,10 +1727,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EKS::Cluster",
       "Trigger type": "Configuration changes"
     },
     "EKS_CLUSTER_SUPPORTED_VERSION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "oldestVersionSupported",
@@ -1534,15 +1739,16 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EKS::Cluster",
       "Trigger type": "Configuration changes"
     },
     "EKS_ENDPOINT_NO_PUBLIC_ACCESS": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), US West (N. California), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), US West (N. California), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "EKS_SECRETS_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), US West (N. California), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), US West (N. California), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -1552,8 +1758,26 @@
       ],
       "Trigger type": "Periodic"
     },
+    "ELASTICACHE_AUTO_MINOR_VERSION_UPGRADE_CHECK": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ElastiCache::CacheCluster",
+      "Trigger type": "Periodic"
+    },
+    "ELASTICACHE_RBAC_AUTH_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "allowedUserGroupIDs",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::ElastiCache::ReplicationGroup",
+      "Trigger type": "Periodic"
+    },
     "ELASTICACHE_REDIS_CLUSTER_AUTOMATIC_BACKUP_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "15",
@@ -1562,20 +1786,57 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::ElastiCache::CacheCluster, AWS::ElastiCache::ReplicationGroup",
+      "Trigger type": "Periodic"
+    },
+    "ELASTICACHE_REPL_GRP_AUTO_FAILOVER_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ElastiCache::ReplicationGroup",
+      "Trigger type": "Periodic"
+    },
+    "ELASTICACHE_REPL_GRP_ENCRYPTED_AT_REST": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "Parameters": [
+        {
+          "Name": "approvedKMSKeyIds",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::ElastiCache::ReplicationGroup",
+      "Trigger type": "Periodic"
+    },
+    "ELASTICACHE_REPL_GRP_ENCRYPTED_IN_TRANSIT": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ElastiCache::ReplicationGroup",
+      "Trigger type": "Periodic"
+    },
+    "ELASTICACHE_REPL_GRP_REDIS_AUTH_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ElastiCache::ReplicationGroup",
+      "Trigger type": "Periodic"
+    },
+    "ELASTICACHE_SUBNET_GROUP_CHECK": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::ElastiCache::CacheCluster",
       "Trigger type": "Periodic"
     },
     "ELASTICSEARCH_ENCRYPTED_AT_REST": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ELASTICSEARCH_IN_VPC_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ELASTICSEARCH_LOGS_TO_CLOUDWATCH": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "logTypes",
@@ -1583,15 +1844,34 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Elasticsearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "ELASTICSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Elasticsearch::Domain",
+      "Trigger type": "Configuration changes"
+    },
+    "ELASTIC_BEANSTALK_LOGS_TO_CLOUDWATCH": {
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "RetentionInDays",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "DeleteOnTerminate",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::ElasticBeanstalk::Environment",
       "Trigger type": "Configuration changes"
     },
     "ELASTIC_BEANSTALK_MANAGED_UPDATES_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "UpdateLevel",
@@ -1599,10 +1879,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::ElasticBeanstalk::Environment",
       "Trigger type": "Configuration changes"
     },
     "ELBV2_ACM_CERTIFICATE_REQUIRED": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "AcmCertificatesAllowed",
@@ -1613,7 +1894,7 @@
       "Trigger type": "Periodic"
     },
     "ELBV2_MULTIPLE_AZ": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "minAvailabilityZones",
@@ -1621,20 +1902,23 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_ACM_CERTIFICATE_REQUIRED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_CROSS_ZONE_LOAD_BALANCING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_CUSTOM_SECURITY_POLICY_SSL_CHECK": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "sslProtocolsAndCiphers",
@@ -1642,15 +1926,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_DELETION_PROTECTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "s3BucketNames",
@@ -1658,10 +1944,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer, AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_PREDEFINED_SECURITY_POLICY_SSL_CHECK": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "predefinedPolicyName",
@@ -1669,15 +1956,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "ELB_TLS_HTTPS_LISTENERS_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticLoadBalancing::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "EMR_KERBEROS_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "TicketLifetimeInHours",
@@ -1708,12 +1997,13 @@
       "Trigger type": "Periodic"
     },
     "EMR_MASTER_NO_PUBLIC_IP": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EMR::Cluster",
       "Trigger type": "Periodic"
     },
     "ENCRYPTED_VOLUMES": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan) Region",
       "Parameters": [
         {
           "Name": "kmsId",
@@ -1721,10 +2011,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::Volume",
       "Trigger type": "Configuration changes"
     },
     "FMS_SHIELD_RESOURCE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "webACLId",
@@ -1757,10 +2048,11 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::CloudFront::Distribution, AWS::ElasticLoadBalancingV2::LoadBalancer, AWS::WAFRegional::WebACL, AWS::EC2::EIP, AWS::ElasticLoadBalancing::LoadBalancer, AWS::ShieldRegional::Protection, AWS::Shield::Protection",
       "Trigger type": "Configuration changes"
     },
     "FMS_WEBACL_RESOURCE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Name": "webACLId",
@@ -1788,10 +2080,11 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::CloudFront::Distribution, AWS::ApiGateway::Stage, AWS::ElasticLoadBalancingV2::LoadBalancer, AWS::WAFRegional::WebACL",
       "Trigger type": "Configuration changes"
     },
     "FMS_WEBACL_RULEGROUP_ASSOCIATION_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Name": "ruleGroups",
@@ -1809,10 +2102,11 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::WAF::WebACL, AWS::WAFRegional::WebACL",
       "Trigger type": "Configuration changes"
     },
     "FSX_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1837,10 +2131,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::FSx::FileSystem",
       "Trigger type": "Periodic"
     },
     "FSX_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -1878,10 +2173,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::FSx::FileSystem",
       "Trigger type": "Periodic"
     },
     "GUARDDUTY_ENABLED_CENTRALIZED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "CentralMonitoringAccount",
@@ -1892,7 +2188,7 @@
       "Trigger type": "Periodic"
     },
     "GUARDDUTY_NON_ARCHIVED_FINDINGS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Middle East (Bahrain), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "30",
@@ -1916,7 +2212,7 @@
       "Trigger type": "Periodic"
     },
     "IAM_CUSTOMER_POLICY_BLOCKED_KMS_ACTIONS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "blockedActionsPatterns",
@@ -1929,15 +2225,17 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::IAM::Policy",
       "Trigger type": "Configuration changes"
     },
     "IAM_GROUP_HAS_USERS_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::IAM::Group",
       "Trigger type": "Configuration changes"
     },
     "IAM_INLINE_POLICY_BLOCKED_KMS_ACTIONS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "blockedActionsPatterns",
@@ -1950,15 +2248,17 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::IAM::Group, AWS::IAM::Role, AWS::IAM::User",
       "Trigger type": "Configuration changes"
     },
     "IAM_NO_INLINE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::IAM::User, AWS::IAM::Role, AWS::IAM::Group",
       "Trigger type": "Configuration changes"
     },
     "IAM_PASSWORD_POLICY": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Default": "true",
@@ -2006,7 +2306,7 @@
       "Trigger type": "Periodic"
     },
     "IAM_POLICY_BLACKLISTED_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "arn",
@@ -2020,10 +2320,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::IAM::User, AWS::IAM::Group, AWS::IAM::Role",
       "Trigger type": "Configuration changes"
     },
     "IAM_POLICY_IN_USE": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "policyARN",
@@ -2039,12 +2340,7 @@
       "Trigger type": "Periodic"
     },
     "IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS": {
-      "AWS Region": "All supported AWS regions",
-      "Parameters": [],
-      "Trigger type": "Configuration changes"
-    },
-    "IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "excludePermissionBoundaryPolicy",
@@ -2052,10 +2348,23 @@
           "Type": "boolean"
         }
       ],
+      "Resource Types": "AWS::IAM::Policy",
+      "Trigger type": "Configuration changes"
+    },
+    "IAM_POLICY_NO_STATEMENTS_WITH_FULL_ACCESS": {
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "excludePermissionBoundaryPolicy",
+          "Optional": true,
+          "Type": "boolean"
+        }
+      ],
+      "Resource Types": "AWS::IAM::Policy",
       "Trigger type": "Configuration changes"
     },
     "IAM_ROLE_MANAGED_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "managedPolicyArns",
@@ -2063,15 +2372,16 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::IAM::Role",
       "Trigger type": "Configuration changes"
     },
     "IAM_ROOT_ACCESS_KEY_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "IAM_USER_GROUP_MEMBERSHIP_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "groupNames",
@@ -2079,20 +2389,22 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::IAM::User",
       "Trigger type": "Configuration changes"
     },
     "IAM_USER_MFA_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "IAM_USER_NO_POLICIES_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::IAM::User",
       "Trigger type": "Configuration changes"
     },
     "IAM_USER_UNUSED_CREDENTIALS_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "90",
@@ -2104,12 +2416,13 @@
       "Trigger type": "Periodic"
     },
     "INCOMING_SSH_DISABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "INSTANCES_IN_VPC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "vpcId",
@@ -2117,10 +2430,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::Instance",
       "Trigger type": "Configuration changes"
     },
     "INTERNET_GATEWAY_AUTHORIZED_VPC_ONLY": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "AuthorizedVpcIds",
@@ -2128,15 +2442,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::InternetGateway",
       "Trigger type": "Configuration changes"
     },
     "KINESIS_STREAM_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Kinesis::Stream",
       "Trigger type": "Configuration changes"
     },
     "KMS_CMK_NOT_SCHEDULED_FOR_DELETION": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyIds",
@@ -2144,10 +2460,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::KMS::Key",
       "Trigger type": "Periodic"
     },
     "LAMBDA_CONCURRENCY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "ConcurrencyLimitLow",
@@ -2160,10 +2477,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_DLQ_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "dlqArns",
@@ -2171,15 +2489,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_FUNCTION_PUBLIC_ACCESS_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_FUNCTION_SETTINGS_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "runtime",
@@ -2204,10 +2524,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_INSIDE_VPC": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "subnetIds",
@@ -2215,10 +2536,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "LAMBDA_VPC_MULTI_AZ_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "availabilityZones",
@@ -2226,15 +2548,22 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::Lambda::Function",
       "Trigger type": "Configuration changes"
     },
     "MFA_ENABLED_FOR_IAM_CONSOLE_ACCESS": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
+    "MQ_NO_PUBLIC_ACCESS": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::AmazonMQ::Broker",
+      "Trigger type": "Periodic"
+    },
     "MULTI_REGION_CLOUD_TRAIL_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE) Region",
       "Parameters": [
         {
           "Name": "s3BucketName",
@@ -2265,12 +2594,25 @@
       "Trigger type": "Periodic"
     },
     "NACL_NO_UNRESTRICTED_SSH_RDP": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::NetworkAcl",
+      "Trigger type": "Configuration changes"
+    },
+    "NETFW_MULTI_AZ_ENABLED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "availabilityZones",
+          "Optional": true,
+          "Type": "int"
+        }
+      ],
+      "Resource Types": "AWS::NetworkFirewall::Firewall",
       "Trigger type": "Configuration changes"
     },
     "NETFW_POLICY_DEFAULT_ACTION_FRAGMENT_PACKETS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "statelessFragmentDefaultActions",
@@ -2278,10 +2620,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::NetworkFirewall::FirewallPolicy",
       "Trigger type": "Configuration changes"
     },
     "NETFW_POLICY_DEFAULT_ACTION_FULL_PACKETS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "statelessDefaultActions",
@@ -2289,25 +2632,29 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::NetworkFirewall::FirewallPolicy",
       "Trigger type": "Configuration changes"
     },
     "NETFW_POLICY_RULE_GROUP_ASSOCIATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::NetworkFirewall::FirewallPolicy",
       "Trigger type": "Configuration changes"
     },
     "NETFW_STATELESS_RULE_GROUP_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::NetworkFirewall::RuleGroup",
       "Trigger type": "Configuration changes"
     },
     "NLB_CROSS_ZONE_LOAD_BALANCING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Trigger type": "Configuration changes"
     },
     "NO_UNRESTRICTED_ROUTE_TO_IGW": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "routeTableIds",
@@ -2315,15 +2662,17 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::RouteTable",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_ACCESS_CONTROL_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_AUDIT_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "cloudWatchLogsLogGroupArnList",
@@ -2331,20 +2680,23 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_DATA_NODE_FAULT_TOLERANCE": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_ENCRYPTED_AT_REST": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_HTTPS_REQUIRED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "tlsPolicies",
@@ -2352,15 +2704,17 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_IN_VPC_ONLY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_LOGS_TO_CLOUDWATCH": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "logTypes",
@@ -2368,20 +2722,23 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "OPENSEARCH_NODE_TO_NODE_ENCRYPTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::OpenSearch::Domain",
       "Trigger type": "Configuration changes"
     },
     "RDS_AUTOMATIC_MINOR_VERSION_UPGRADE_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_DEFAULT_ADMIN_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Middle East (Bahrain), South America (Sao Paulo) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "validAdminUserNames",
@@ -2389,30 +2746,35 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_DELETION_PROTECTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka), Middle East (Bahrain), South America (Sao Paulo) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_IAM_AUTHENTICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Middle East (Bahrain), South America (Sao Paulo) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "RDS_CLUSTER_MULTI_AZ_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Middle East (Bahrain), South America (Sao Paulo) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), South America (Sao Paulo), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBCluster",
       "Trigger type": "Configuration changes"
     },
     "RDS_DB_SECURITY_GROUP_NOT_ALLOWED": {
       "AWS Region": "Only available in Europe (Ireland), South America (Sao Paulo), US East (N. Virginia), Asia Pacific (Tokyo), US West (Oregon), US West (N. California), Asia Pacific (Singapore), Asia Pacific (Sydney) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBSecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "RDS_ENHANCED_MONITORING_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "monitoringInterval",
@@ -2420,10 +2782,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_DEFAULT_ADMIN_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "validAdminUserNames",
@@ -2431,10 +2794,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_DELETION_PROTECTION_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "databaseEngines",
@@ -2442,25 +2806,28 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_IAM_AUTHENTICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Hong Kong), Asia Pacific (Jakarta), Asia Pacific (Osaka), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Hong Kong), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_INSTANCE_PUBLIC_ACCESS_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_IN_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "RDS_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -2485,10 +2852,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Periodic"
     },
     "RDS_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "additionalLogs",
@@ -2496,15 +2864,17 @@
           "Type": "StringMap"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_MULTI_AZ_SUPPORT": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "RDS_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -2542,20 +2912,23 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Periodic"
     },
     "RDS_SNAPSHOTS_PUBLIC_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBSnapshot, AWS::RDS::DBClusterSnapshot",
       "Trigger type": "Configuration changes"
     },
     "RDS_SNAPSHOT_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::RDS::DBSnapshot, AWS::RDS::DBClusterSnapshot",
       "Trigger type": "Configuration changes"
     },
     "RDS_STORAGE_ENCRYPTED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyId",
@@ -2563,10 +2936,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::RDS::DBInstance",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_AUDIT_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "bucketNames",
@@ -2574,10 +2948,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_BACKUP_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "MinRetentionPeriod",
@@ -2590,10 +2965,11 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_CONFIGURATION_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "true",
@@ -2614,10 +2990,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_KMS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -2625,10 +3002,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_MAINTENANCESETTINGS_CHECK": {
-      "AWS Region": "All supported AWS regions except Middle East (Bahrain) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "true",
@@ -2648,15 +3026,17 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_CLUSTER_PUBLIC_ACCESS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_DEFAULT_ADMIN_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "validAdminUserNames",
@@ -2664,10 +3044,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_DEFAULT_DB_NAME_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "validDatabaseNames",
@@ -2675,16 +3056,19 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_ENHANCED_VPC_ROUTING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REDSHIFT_REQUIRE_TLS_SSL": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::Redshift::Cluster",
       "Trigger type": "Configuration changes"
     },
     "REQUIRED_TAGS": {
@@ -2752,10 +3136,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::ACM::Certificate, AWS::AutoScaling::AutoScalingGroup, AWS::CloudFormation::Stack, AWS::CodeBuild::Project, AWS::DynamoDB::Table, AWS::EC2::CustomerGateway, AWS::EC2::Instance, AWS::EC2::InternetGateway, AWS::EC2::NetworkAcl, AWS::EC2::NetworkInterface, AWS::EC2::RouteTable, AWS::EC2::SecurityGroup, AWS::EC2::Subnet, AWS::EC2::Volume, AWS::EC2::VPC, AWS::EC2::VPNConnection, AWS::EC2::VPNGateway, AWS::ElasticLoadBalancing::LoadBalancer, AWS::ElasticLoadBalancingV2::LoadBalancer, AWS::RDS::DBInstance, AWS::RDS::DBSecurityGroup, AWS::RDS::DBSnapshot, AWS::RDS::DBSubnetGroup, AWS::RDS::EventSubscription, AWS::Redshift::Cluster, AWS::Redshift::ClusterParameterGroup, AWS::Redshift::ClusterSecurityGroup, AWS::Redshift::ClusterSnapshot, AWS::Redshift::ClusterSubnetGroup, AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "RESTRICTED_INCOMING_TRAFFIC": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "20",
@@ -2788,20 +3173,21 @@
           "Type": "int"
         }
       ],
+      "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "ROOT_ACCOUNT_HARDWARE_MFA_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "ROOT_ACCOUNT_MFA_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Middle East (UAE), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Middle East (Bahrain) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Default": "True",
@@ -2828,10 +3214,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::AccountPublicAccessBlock",
       "Trigger type": "Configuration changes (current status not checked, only evaluated when changes generate new events)"
     },
     "S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS_PERIODIC": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "IgnorePublicAcls",
@@ -2857,12 +3244,13 @@
       "Trigger type": "Periodic"
     },
     "S3_BUCKET_ACL_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_BLACKLISTED_ACTIONS_PROHIBITED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "blacklistedActionPattern",
@@ -2870,10 +3258,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_DEFAULT_LOCK_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "mode",
@@ -2881,10 +3270,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "excludedPublicBuckets",
@@ -2892,10 +3282,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "targetBucket",
@@ -2908,10 +3299,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_POLICY_GRANTEE_CHECK": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "awsPrincipals",
@@ -2939,10 +3331,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_POLICY_NOT_MORE_PERMISSIVE": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "controlPolicy",
@@ -2950,31 +3343,43 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_PUBLIC_READ_PROHIBITED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes and Periodic"
     },
     "S3_BUCKET_PUBLIC_WRITE_PROHIBITED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes and Periodic"
     },
     "S3_BUCKET_REPLICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions",
-      "Parameters": [],
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "ReplicationType",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_SSL_REQUESTS_ONLY": {
-      "AWS Region": "All supported AWS regions",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_BUCKET_VERSIONING_ENABLED": {
@@ -2986,10 +3391,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_DEFAULT_ENCRYPTION_KMS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -2997,10 +3403,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_EVENT_NOTIFICATIONS_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "destinationArn",
@@ -3013,10 +3420,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3041,10 +3449,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Periodic"
     },
     "S3_LIFECYCLE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "targetTransitionDays",
@@ -3072,10 +3481,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "S3_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3113,10 +3523,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Periodic"
     },
     "S3_VERSION_LIFECYCLE_POLICY_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "bucketNames",
@@ -3124,10 +3535,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::S3::Bucket",
       "Trigger type": "Configuration changes"
     },
     "SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3136,9 +3548,21 @@
         }
       ],
       "Trigger type": "Periodic"
+    },
+    "SAGEMAKER_NOTEBOOK_INSTANCE_INSIDE_VPC": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "SubnetIds",
+          "Optional": true,
+          "Type": "CSV"
+        }
+      ],
+      "Resource Types": "AWS::SageMaker::NotebookInstance",
+      "Trigger type": "Configuration changes"
     },
     "SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3148,29 +3572,42 @@
       ],
       "Trigger type": "Periodic"
     },
+    "SAGEMAKER_NOTEBOOK_INSTANCE_ROOT_ACCESS_CHECK": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::SageMaker::NotebookInstance",
+      "Trigger type": "Configuration changes"
+    },
     "SAGEMAKER_NOTEBOOK_NO_DIRECT_INTERNET_ACCESS": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
     "SECRETSMANAGER_ROTATION_ENABLED_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [
         {
           "Name": "maximumAllowedRotationFrequency",
           "Optional": true,
           "Type": "int"
+        },
+        {
+          "Name": "maximumAllowedRotationFrequencyInHours",
+          "Optional": true,
+          "Type": "int"
         }
       ],
+      "Resource Types": "AWS::SecretsManager::Secret",
       "Trigger type": "Configuration changes"
     },
     "SECRETSMANAGER_SCHEDULED_ROTATION_SUCCESS_CHECK": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions",
       "Parameters": [],
+      "Resource Types": "AWS::SecretsManager::Secret",
       "Trigger type": "Configuration changes"
     },
     "SECRETSMANAGER_SECRET_PERIODIC_ROTATION": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "maxDaysSinceRotation",
@@ -3181,7 +3618,7 @@
       "Trigger type": "Periodic"
     },
     "SECRETSMANAGER_SECRET_UNUSED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [
         {
           "Name": "unusedForDays",
@@ -3192,7 +3629,7 @@
       "Trigger type": "Periodic"
     },
     "SECRETSMANAGER_USING_CMK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
       "Parameters": [
         {
           "Name": "kmsKeyArns",
@@ -3200,15 +3637,22 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::SecretsManager::Secret",
       "Trigger type": "Configuration changes"
     },
     "SECURITYHUB_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
       "Trigger type": "Periodic"
     },
+    "SECURITY_ACCOUNT_INFORMATION_PROVIDED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), China (Ningxia) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::::Account",
+      "Trigger type": "Periodic"
+    },
     "SERVICE_VPC_ENDPOINT_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Name": "serviceName",
@@ -3216,6 +3660,12 @@
           "Type": "String"
         }
       ],
+      "Trigger type": "Periodic"
+    },
+    "SES_MALWARE_SCANNING_ENABLED": {
+      "AWS Region": "Only available in Europe (Ireland), US East (N. Virginia), US West (Oregon) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::SES::ReceiptRule",
       "Trigger type": "Periodic"
     },
     "SHIELD_ADVANCED_ENABLED_AUTORENEW": {
@@ -3229,7 +3679,7 @@
       "Trigger type": "Periodic"
     },
     "SNS_ENCRYPTED_KMS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "kmsKeyIds",
@@ -3237,11 +3687,13 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::SNS::Topic",
       "Trigger type": "Configuration changes"
     },
     "SNS_TOPIC_MESSAGE_DELIVERY_NOTIFICATION_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::SNS::Topic",
       "Trigger type": "Configuration changes"
     },
     "SSM_DOCUMENT_NOT_PUBLIC": {
@@ -3250,7 +3702,7 @@
       "Trigger type": "Periodic"
     },
     "STORAGEGATEWAY_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3275,43 +3727,11 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::StorageGateway::Volume",
       "Trigger type": "Periodic"
     },
-    "SUBNET_AUTO_ASSIGN_PUBLIC_IP_DISABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
-      "Parameters": [],
-      "Trigger type": "Configuration changes"
-    },
-    "VIRTUALMACHINE_LAST_BACKUP_RECOVERY_POINT_CREATED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
-      "Parameters": [
-        {
-          "Name": "resourceTags",
-          "Optional": true,
-          "Type": "String"
-        },
-        {
-          "Name": "resourceId",
-          "Optional": true,
-          "Type": "String"
-        },
-        {
-          "Default": "1",
-          "Name": "recoveryPointAgeValue",
-          "Optional": true,
-          "Type": "int"
-        },
-        {
-          "Default": "days",
-          "Name": "recoveryPointAgeUnit",
-          "Optional": true,
-          "Type": "String"
-        }
-      ],
-      "Trigger type": "Periodic"
-    },
-    "VIRTUALMACHINE_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+    "STORAGEGATEWAY_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "resourceTags",
@@ -3349,15 +3769,94 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::StorageGateway::Volume",
+      "Trigger type": "Periodic"
+    },
+    "SUBNET_AUTO_ASSIGN_PUBLIC_IP_DISABLED": {
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::EC2::Subnet",
+      "Trigger type": "Configuration changes"
+    },
+    "VIRTUALMACHINE_LAST_BACKUP_RECOVERY_POINT_CREATED": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "resourceTags",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "resourceId",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Default": "1",
+          "Name": "recoveryPointAgeValue",
+          "Optional": true,
+          "Type": "int"
+        },
+        {
+          "Default": "days",
+          "Name": "recoveryPointAgeUnit",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::BackupGateway::VirtualMachine",
+      "Trigger type": "Periodic"
+    },
+    "VIRTUALMACHINE_RESOURCES_PROTECTED_BY_BACKUP_PLAN": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [
+        {
+          "Name": "resourceTags",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "resourceId",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "crossRegionList",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "crossAccountList",
+          "Optional": true,
+          "Type": "String"
+        },
+        {
+          "Name": "maxRetentionDays",
+          "Optional": true,
+          "Type": "int"
+        },
+        {
+          "Name": "minRetentionDays",
+          "Optional": true,
+          "Type": "int"
+        },
+        {
+          "Name": "backupVaultLockCheck",
+          "Optional": true,
+          "Type": "String"
+        }
+      ],
+      "Resource Types": "AWS::BackupGateway::VirtualMachine",
       "Trigger type": "Periodic"
     },
     "VPC_DEFAULT_SECURITY_GROUP_CLOSED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "VPC_FLOW_LOGS_ENABLED": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Name": "trafficType",
@@ -3368,12 +3867,13 @@
       "Trigger type": "Periodic"
     },
     "VPC_NETWORK_ACL_UNUSED_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::NetworkAcl",
       "Trigger type": "Configuration changes"
     },
     "VPC_PEERING_DNS_RESOLUTION_CHECK": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "vpcIds",
@@ -3381,10 +3881,11 @@
           "Type": "CSV"
         }
       ],
+      "Resource Types": "AWS::EC2::VPCPeeringConnection",
       "Trigger type": "Configuration changes"
     },
     "VPC_SG_OPEN_ONLY_TO_AUTHORIZED_PORTS": {
-      "AWS Region": "All supported AWS regions except Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except Asia Pacific (Osaka), Asia Pacific (Melbourne) Region",
       "Parameters": [
         {
           "Name": "authorizedTcpPorts",
@@ -3397,15 +3898,17 @@
           "Type": "String"
         }
       ],
+      "Resource Types": "AWS::EC2::SecurityGroup",
       "Trigger type": "Configuration changes"
     },
     "VPC_VPN_2_TUNNELS_UP": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), Asia Pacific (Jakarta), Asia Pacific (Osaka), Middle East (Bahrain) Region",
+      "AWS Region": "All supported AWS regions except Middle East (Bahrain), China (Beijing), Asia Pacific (Jakarta), Asia Pacific (Osaka), Asia Pacific (Melbourne), China (Ningxia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::EC2::VPNConnection",
       "Trigger type": "Configuration changes"
     },
     "WAFV2_LOGGING_ENABLED": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka), Europe (Milan), Africa (Cape Town) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Africa (Cape Town), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), Europe (Milan), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [
         {
           "Name": "KinesisFirehoseDeliveryStreamArns",
@@ -3414,6 +3917,18 @@
         }
       ],
       "Trigger type": "Periodic"
+    },
+    "WAFV2_RULEGROUP_NOT_EMPTY": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::WAFv2::RuleGroup",
+      "Trigger type": "Configuration changes"
+    },
+    "WAFV2_WEBACL_NOT_EMPTY": {
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
+      "Parameters": [],
+      "Resource Types": "AWS::WAFv2::WebACL",
+      "Trigger type": "Configuration changes"
     },
     "WAF_CLASSIC_LOGGING_ENABLED": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
@@ -3429,31 +3944,37 @@
     "WAF_GLOBAL_RULEGROUP_NOT_EMPTY": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::WAF::RuleGroup",
       "Trigger type": "Configuration changes"
     },
     "WAF_GLOBAL_RULE_NOT_EMPTY": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::WAF::Rule",
       "Trigger type": "Configuration changes"
     },
     "WAF_GLOBAL_WEBACL_NOT_EMPTY": {
       "AWS Region": "Only available in US East (N. Virginia) Region",
       "Parameters": [],
+      "Resource Types": "AWS::WAF::WebACL",
       "Trigger type": "Configuration changes"
     },
     "WAF_REGIONAL_RULEGROUP_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta), Asia Pacific (Osaka) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Osaka), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::WAFRegional::RuleGroup",
       "Trigger type": "Configuration changes"
     },
     "WAF_REGIONAL_RULE_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::WAFRegional::Rule",
       "Trigger type": "Configuration changes"
     },
     "WAF_REGIONAL_WEBACL_NOT_EMPTY": {
-      "AWS Region": "All supported AWS regions except China (Beijing), China (Ningxia), AWS GovCloud (US-East), AWS GovCloud (US-West), Asia Pacific (Jakarta) Region",
+      "AWS Region": "All supported AWS regions except China (Beijing), Asia Pacific (Jakarta), Middle East (UAE), Asia Pacific (Hyderabad), Asia Pacific (Melbourne), AWS GovCloud (US-East), AWS GovCloud (US-West), Europe (Spain), China (Ningxia), Europe (Zurich) Region",
       "Parameters": [],
+      "Resource Types": "AWS::WAFRegional::WebACL",
       "Trigger type": "Configuration changes"
     }
   }

--- a/scripts/pull_down_aws_managed_rules.py
+++ b/scripts/pull_down_aws_managed_rules.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
-"""Download markdown files with AWS managed ConfigRule info and convert to JSON.
+"""Scrape web-based docs for AWS managed ConfigRule info and convert to JSON.
 
 Invocation:  ./pull_down_aws_managed_rules.py
+    - Install ../requirements-tests.txt packages to ensure the lxml package
+      is installed.
     - Execute from the moto/scripts directory.
-    - To track download progress, use the "-v" command line switch.
-    - MANAGED_RULES_OUTPUT_FILENAME is the variable containing the name of
-      the file that will be overwritten when this script is run.
+    - To track progress, use the "-v" command line switch.
+    - MANAGED_RULES_OUTPUT_FILENAME is the variable with the output filename.
+      The file is overwritten when this script is successfully run.
 
-    NOTE:  This script takes a while to download all the files.
+    NOTE:  This script takes a while to scrape all the web pages.  The
+    scraping could be parallelized, but since this script might only be
+    run once every couple of months, it wasn't worth the complexity.
 
 Summary:
-    The first markdown file is read to obtain the names of markdown files
-    for all the AWS managed config rules.  Then each of those markdown files
-    are read and info is extracted with the final results written to a JSON
-    file.
+    An initial web page is parsed to obtain the links for all the other
+    docs for AWS managed config rules.  Each of those links are parsed
+    and the needed info is written to a JSON file.
 
     The JSON output will look as follows:
 
@@ -31,6 +34,7 @@ Summary:
                             }
                     ],
                     "Trigger type": "Periodic"
+                    "Resource type:  "AWS::IAM::User"
                 },
             },
             ...
@@ -40,101 +44,102 @@ Summary:
 import argparse
 
 import json
-import re
 import sys
 
+from lxml import html
 import requests
 
 MANAGED_RULES_OUTPUT_FILENAME = "../moto/config/resources/aws_managed_rules.json"
 
-AWS_MARKDOWN_URL_START = (
-    "https://raw.githubusercontent.com/awsdocs/aws-config-developer-guide/"
-    "main/doc_source/"
+AWS_CONFIG_MANAGED_RULES_URL_START = (
+    "https://docs.aws.amazon.com/config/latest/developerguide/"
 )
 
-LIST_OF_MARKDOWNS_URL = "managed-rules-by-aws-config.md"
+LIST_OF_RULES_URL = "managed-rules-by-aws-config.html"
 
 
-def extract_param_info(line):
-    """Return dict containing parameter info extracted from line."""
-    # Examples of parameter definitions:
-    #   maxAccessKeyAgeType: intDefault: 90
-    #   IgnorePublicAcls \(Optional\)Type: StringDefault: True
-    #   MasterAccountId \(Optional\)Type: String
-    #   endpointConfigurationTypesType: String
+def extract_param_info(page_content):
+    """Return dict containing parameter info extracted from page.
 
-    values = re.split(r":\s?", line)
-    name = values[0]
-    param_type = values[1]
+    The info for each parameter is contained within a "dl" tag, with "dt"
+    tags providing the details.
+    """
+    param_info = []
+    dl_tags = page_content.xpath('//div[@class="variablelist"]//dl')
+    for dl_tag in dl_tags:
+        dt_tags = dl_tag.xpath(".//dt")
 
-    # If there is no Optional keyword, then sometimes there
-    # isn't a space between the parameter name and "Type".
-    name = re.sub("Type$", "", name)
+        params = {}
+        for dt_tag in dt_tags:
+            text = dt_tag.text_content()
+            if not text or text == "None":
+                continue
 
-    # Sometimes there isn't a space between the type and the
-    # word "Default".
-    if "Default" in param_type:
-        param_type = re.sub("Default$", "", param_type)
+            # This is the parameter name and not a key, value pair.
+            if ": " not in text:
+                if "Optional" in text:
+                    text = text.split()[0]
+                    params["Optional"] = True
+                else:
+                    params["Optional"] = False
+                params["Name"] = text
+                continue
 
-    optional = False
-    if "Optional" in line:
-        optional = True
-        # Remove "Optional" from the line.
-        name = name.split()[0]
+            key, value = text.split(": ")
+            params[key] = value
 
-    param_info = {
-        "Name": name,
-        "Optional": optional,
-        "Type": param_type,
-    }
-
-    # A default value isn't always provided.
-    if len(values) > 2:
-        param_info["Default"] = values[2]
+        if params:
+            param_info.append(params)
 
     return param_info
 
 
-def extract_managed_rule_info(lines):
-    """Return dict of qualifiers/rules extracted from a markdown file."""
+def extract_managed_rule_info(page_content):
+    """Return dict of qualifiers/rules extracted from web page.
+
+    An example of the html that's being processed:
+
+    <div id="main-content" class="awsui-util-container">
+    ...
+
+    <h1 class="topictitle" id="access-keys-rotated">access-keys-rotated</h1>
+    <p><b>Identifier:</b> ACCESS_KEYS_ROTATED</p>
+    <p><b>Resource Types:</b> AWS::IAM::User</p>
+    <p><b>Trigger type:</b> Periodic</p>
+    <p><b>AWS Region:</b> All supported AWS regions except Middle East (UAE),
+        Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Israel (Tel Aviv),
+        Europe (Spain), Europe (Zurich) Region</p>
+    <p><b>Parameters:</b></p>
+    <div class="variablelist">
+    <dl>
+        <dt><span class="term">maxAccessKeyAge</span></dt>
+        <dt><span class="term">Type: int</span></dt>
+        <dt><span class="term">Default: 90</span></dt>
+          <dd>
+             <p>Maximum number of days without rotation. Default 90.</p>
+          </dd>
+      </dl>
+
+    ...
+    </div>
+    """
     rule_info = {}
-    label_pattern = re.compile(r"(?:\*\*)(?P<label>[^\*].*)\:\*\*\s?(?P<value>.*)?")
+    paragraphs = page_content.xpath('//div[@id="main-content"]/descendant::p')
 
-    collecting_params = False
-    params = []
-    for line in lines:
-        if not line:
-            continue
-        line = line.replace("\\", "").strip()
-
-        # Parameters are listed in the lines following the label, so they
-        # require special processing.
-        if collecting_params:
-            # A new header marks the end of the parameters.
-            if line.startswith("##"):
-                rule_info["Parameters"] = params
-                break
-
-            if "Type: " in line:
-                params.append(extract_param_info(line))
+    for paragraph in paragraphs:
+        text = paragraph.text_content()
+        if ": " not in text:
             continue
 
-        # Check for a label starting with two asterisks.
-        matches = re.match(label_pattern, line)
-        if not matches:
+        parts = text.split(": ")
+        if len(parts) > 2:
             continue
 
-        # Look for "Identifier", "Trigger type", "AWS Region" and
-        # "Parameters" labels and store the values for all but parameters.
-        # Parameters values aren't on the same line as labels.
-        label = matches.group("label")
-        value = matches.group("value")
-        if label in ["Identifier", "Trigger type", "AWS Region", "Resource Types"]:
-            rule_info[label] = value
-        elif label == "Parameters":
-            collecting_params = True
-        else:
-            print(f"ERROR:  Unknown label: '{label}', line: '{line}'", file=sys.stderr)
+        if parts[0] in ["Identifier", "Trigger type", "AWS Region", "Resource Types"]:
+            rule_info[parts[0]] = parts[1]
+
+    # The parameters are in their own "div", so handle them separately.
+    rule_info["Parameters"] = extract_param_info(page_content)
     return rule_info
 
 
@@ -142,35 +147,33 @@ def process_cmdline_args():
     """Return parsed command line arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            f"Download AWS config rules and merge output to create the "
-            f"JSON file {MANAGED_RULES_OUTPUT_FILENAME}"
+            "Scrape web pages with AWS config rules and merge results to "
+            f"create the JSON file {MANAGED_RULES_OUTPUT_FILENAME}"
         )
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Report on progress of downloads"
+        "-v", "--verbose", action="store_true", help="Report on progress"
     )
     return parser.parse_args()
 
 
 def main():
-    """Create a JSON file containing info pulled from AWS markdown files."""
+    """Create a JSON file containing info pulled from AWS online docs."""
     args = process_cmdline_args()
 
-    # Get the markdown file with links to the markdown files for services.
-    req = requests.get(AWS_MARKDOWN_URL_START + LIST_OF_MARKDOWNS_URL)
+    # Get the list of links for all the services.
+    page = requests.get(AWS_CONFIG_MANAGED_RULES_URL_START + LIST_OF_RULES_URL)
+    tree = html.fromstring(page.content)
+    links = [x.lstrip("./") for x in tree.xpath('//div[@class="highlights"]//ul//a/@href')]
 
-    # Extract the list of all the markdown files on the page.
-    link_pattern = re.compile(r"\+ \[[^\]]+\]\(([^)]+)\)")
-    markdown_files = link_pattern.findall(req.text)
-
-    # For each of those markdown files, extract the id, region, trigger type
-    # and parameter information.
+    # From each linked page, extract the id, region, trigger type and parameter
+    # information.
     managed_rules = {"ManagedRules": {}}
-    for markdown_file in markdown_files:
+    for link in links:
         if args.verbose:
-            print(f"Downloading {markdown_file} ...")
-        req = requests.get(AWS_MARKDOWN_URL_START + markdown_file)
-        rules = extract_managed_rule_info(req.text.split("\n"))
+            print(f"Extracting from {link} ...")
+        page = requests.get(AWS_CONFIG_MANAGED_RULES_URL_START + link)
+        rules = extract_managed_rule_info(html.fromstring(page.content))
 
         rule_id = rules.pop("Identifier")
         managed_rules["ManagedRules"][rule_id] = rules

--- a/scripts/pull_down_aws_managed_rules.py
+++ b/scripts/pull_down_aws_managed_rules.py
@@ -47,7 +47,10 @@ import requests
 
 MANAGED_RULES_OUTPUT_FILENAME = "../moto/config/resources/aws_managed_rules.json"
 
-AWS_MARKDOWN_URL_START = "https://raw.githubusercontent.com/awsdocs/aws-config-developer-guide/main/doc_source/"
+AWS_MARKDOWN_URL_START = (
+    "https://raw.githubusercontent.com/awsdocs/aws-config-developer-guide/"
+    "main/doc_source/"
+)
 
 LIST_OF_MARKDOWNS_URL = "managed-rules-by-aws-config.md"
 
@@ -126,7 +129,7 @@ def extract_managed_rule_info(lines):
         # Parameters values aren't on the same line as labels.
         label = matches.group("label")
         value = matches.group("value")
-        if label in ["Identifier", "Trigger type", "AWS Region"]:
+        if label in ["Identifier", "Trigger type", "AWS Region", "Resource Types"]:
             rule_info[label] = value
         elif label == "Parameters":
             collecting_params = True


### PR DESCRIPTION
The script, `scripts/pull_down_aws_managed_rules.py`, used to download markdown files from an AWS repo.  Those markdown files contained info on managed rules, similar to what appears on AWS official documentation, but in a format that's easier to parse.  However, the repo containing markdown files was archived on June 15, 2023 as AWS doesn't want to maintain a separate list of the managed rules ([read their explanation here](https://aws.amazon.com/blogs/aws/retiring-the-aws-documentation-on-github/)).

So `scripts/pull_down_aws_managed_rules.py` has been updated to pull the managed rule info from AWS documentation websites and the parsed results (`moto/config/resources/aws_managed_rules.json`) has been updated to match that documentation.  The updates in the last year for manged rules appear to include adding another label, "Resource Types", changes to regions and a few new services.