### PR TITLE
Opensearch: Add the `list_domain_names` method support

### DIFF
--- a/docs/docs/services/opensearch.rst
+++ b/docs/docs/services/opensearch.rst
@@ -61,7 +61,7 @@ opensearch
 - [ ] get_package_version_history
 - [ ] get_upgrade_history
 - [ ] get_upgrade_status
-- [ ] list_domain_names
+- [x] list_domain_names
 - [ ] list_domains_for_package
 - [ ] list_instance_type_details
 - [ ] list_packages_for_domain

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -1,9 +1,9 @@
 import importlib
 import sys
 from contextlib import ContextDecorator
-from moto.core.models import BaseMockAWS
 from typing import Any, Callable, List, Optional, TypeVar
 
+from moto.core.models import BaseMockAWS
 
 TEST_METHOD = TypeVar("TEST_METHOD", bound=Callable[..., Any])
 
@@ -189,6 +189,7 @@ mock_xray = lazy_load(".xray", "mock_xray")
 mock_xray_client = lazy_load(".xray", "mock_xray_client")
 mock_wafv2 = lazy_load(".wafv2", "mock_wafv2")
 mock_textract = lazy_load(".textract", "mock_textract")
+mock_opensearch = lazy_load(".opensearch", "mock_opensearch", boto3_name="opensearch")
 
 
 class MockAll(ContextDecorator):

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -189,7 +189,6 @@ mock_xray = lazy_load(".xray", "mock_xray")
 mock_xray_client = lazy_load(".xray", "mock_xray_client")
 mock_wafv2 = lazy_load(".wafv2", "mock_wafv2")
 mock_textract = lazy_load(".textract", "mock_textract")
-mock_opensearch = lazy_load(".opensearch", "mock_opensearch", boto3_name="opensearch")
 
 
 class MockAll(ContextDecorator):

--- a/moto/es/urls.py
+++ b/moto/es/urls.py
@@ -10,6 +10,7 @@ url_paths = {
     "{0}/2015-01-01/domain$": ElasticsearchServiceResponse.list_domains,
     "{0}/2015-01-01/es/domain$": ElasticsearchServiceResponse.domains,
     "{0}/2015-01-01/es/domain/(?P<domainname>[^/]+)": ElasticsearchServiceResponse.domain,
+    "{0}/2021-01-01/domain$": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/compatibleVersions": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/domain": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/domain/(?P<domainname>[^/]+)": OpenSearchServiceResponse.dispatch,

--- a/moto/opensearch/exceptions.py
+++ b/moto/opensearch/exceptions.py
@@ -5,3 +5,10 @@ from moto.core.exceptions import JsonRESTError
 class ResourceNotFoundException(JsonRESTError):
     def __init__(self, name: str):
         super().__init__("ResourceNotFoundException", f"Domain not found: {name}")
+
+
+class EngineTypeNotFoundException(JsonRESTError):
+    def __init__(self, domain_name: str):
+        super().__init__(
+            "EngineTypeNotFoundException", f"Engine Type not found: {domain_name}"
+        )

--- a/moto/opensearch/models.py
+++ b/moto/opensearch/models.py
@@ -333,7 +333,10 @@ class OpenSearchServiceBackend(BaseBackend):
             if engine_type:
                 if engine_type in domain.engine_version:
                     domains.append(
-                        {"DomainName": domain.domain_name, "EngineType": engine_type}
+                        {
+                            "DomainName": domain.domain_name,
+                            "EngineType": engine_type.split("_")[0],
+                        }
                     )
                 else:
                     raise EngineTypeNotFoundException(domain.domain_name)

--- a/moto/opensearch/responses.py
+++ b/moto/opensearch/responses.py
@@ -2,6 +2,7 @@
 import json
 
 from moto.core.responses import BaseResponse
+
 from .models import opensearch_backends, OpenSearchServiceBackend
 
 
@@ -138,3 +139,10 @@ class OpenSearchServiceResponse(BaseResponse):
         tag_keys = self._get_param("TagKeys")
         self.opensearch_backend.remove_tags(arn, tag_keys)
         return "{}"
+
+    def list_domain_names(self) -> str:
+        engine_type = self._get_param("engineType")
+        domain_names = self.opensearch_backend.list_domain_names(
+            engine_type=engine_type,
+        )
+        return json.dumps(dict(DomainNames=domain_names))


### PR DESCRIPTION
Add the Opensearch `list_domain_names` method support. The pagination functionality hasn't been implemented yet, just the base configuration for listing all the domain names for Opensearch.