### PR TITLE
ECS: add pidMode validation for FARGATE

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1141,9 +1141,9 @@ class EC2ContainerServiceBackend(BaseBackend):
 
         if requires_compatibilities and "FARGATE" in requires_compatibilities:
             # TODO need more validation for Fargate
-            if pid_mode != "task":
+            if pid_mode and pid_mode != "task":
                 raise EcsClientException(
-                    "Tasks using the Fargate launch type do not support pidMode 'host'. The supported value for pidMode is 'task'."
+                    f"Tasks using the Fargate launch type do not support pidMode '{pid_mode}'. The supported value for pidMode is 'task'."
                 )
 
         if family in self.task_definitions:

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1139,7 +1139,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         ephemeral_storage: Optional[Dict[str, int]] = None,
     ) -> TaskDefinition:
 
-        if "FARGATE" in requires_compatibilities:
+        if requires_compatibilities and "FARGATE" in requires_compatibilities:
             # TODO need more validation for Fargate
             if pid_mode != "task":
                 raise EcsClientException(

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1138,6 +1138,14 @@ class EC2ContainerServiceBackend(BaseBackend):
         pid_mode: Optional[str] = None,
         ephemeral_storage: Optional[Dict[str, int]] = None,
     ) -> TaskDefinition:
+
+        if "FARGATE" in requires_compatibilities:
+            # TODO need more validation for Fargate
+            if pid_mode != "task":
+                raise EcsClientException(
+                    "Tasks using the Fargate launch type do not support pidMode 'host'. The supported value for pidMode is 'task'."
+                )
+
         if family in self.task_definitions:
             last_id = self._get_last_task_definition_revision_id(family)
             revision = (last_id or 0) + 1


### PR DESCRIPTION
ECS on FARGATE only allows `task` for pidMode
https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_definition_parameters.html