### PR TITLE
EC2: Cross-account VPC peering connections

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -632,21 +632,23 @@ class InvalidVPCRangeError(EC2ClientError):
         super().__init__("InvalidVpc.Range", f"The CIDR '{cidr_block}' is invalid.")
 
 
-# accept exception
+# Raised when attempting to accept a VPC peering connection request in own account but in the requester region
 class OperationNotPermitted2(EC2ClientError):
     def __init__(self, client_region: str, pcx_id: str, acceptor_region: str):
         super().__init__(
             "OperationNotPermitted",
-            f"Incorrect region ({client_region}) specified for this request.VPC peering connection {pcx_id} must be accepted in region {acceptor_region}",
+            f"Incorrect region ({client_region}) specified for this request. "
+            f"VPC peering connection {pcx_id} must be accepted in region {acceptor_region}",
         )
 
 
-# reject exception
+# Raised when attempting to reject a VPC peering connection request in own account but in the requester region
 class OperationNotPermitted3(EC2ClientError):
     def __init__(self, client_region: str, pcx_id: str, acceptor_region: str):
         super().__init__(
             "OperationNotPermitted",
-            f"Incorrect region ({client_region}) specified for this request.VPC peering connection {pcx_id} must be accepted or rejected in region {acceptor_region}",
+            f"Incorrect region ({client_region}) specified for this request. "
+            f"VPC peering connection {pcx_id} must be accepted or rejected in region {acceptor_region}",
         )
 
 
@@ -655,6 +657,15 @@ class OperationNotPermitted4(EC2ClientError):
         super().__init__(
             "OperationNotPermitted",
             f"The instance '{instance_id}' may not be terminated. Modify its 'disableApiTermination' instance attribute and try again.",
+        )
+
+
+# Raised when attempting to accept or reject a VPC peering connection request for a VPC not belonging to self
+class OperationNotPermitted5(EC2ClientError):
+    def __init__(self, account_id: str, pcx_id: str, operation: str):
+        super().__init__(
+            "OperationNotPermitted",
+            f"User ({account_id}) cannot {operation} peering {pcx_id}",
         )
 
 

--- a/moto/ec2/models/transit_gateway_attachments.py
+++ b/moto/ec2/models/transit_gateway_attachments.py
@@ -95,7 +95,7 @@ class TransitGatewayPeeringAttachment(TransitGatewayAttachment):
             "region": region_name,
             "transitGatewayId": transit_gateway_id,
         }
-        self.status = PeeringConnectionStatus()
+        self.status = PeeringConnectionStatus(accepter_id=peer_account_id)
 
 
 class TransitGatewayAttachmentBackend:

--- a/moto/ec2/models/transit_gateway_attachments.py
+++ b/moto/ec2/models/transit_gateway_attachments.py
@@ -342,5 +342,5 @@ class TransitGatewayAttachmentBackend:
             transit_gateway_attachment_id
         ]
         transit_gateway_attachment.state = "deleted"
-        transit_gateway_attachment.status.deleted()  # type: ignore[attr-defined]
+        transit_gateway_attachment.status.deleted(deleter_id=self.account_id)  # type: ignore[attr-defined]
         return transit_gateway_attachment

--- a/moto/ec2/models/vpc_peering_connections.py
+++ b/moto/ec2/models/vpc_peering_connections.py
@@ -150,7 +150,7 @@ class VPCPeeringConnectionBackend:
 
     def delete_vpc_peering_connection(self, vpc_pcx_id: str) -> VPCPeeringConnection:
         deleted = self.get_vpc_peering_connection(vpc_pcx_id)
-        deleted._status.deleted(deleter_id=self.account_id)
+        deleted._status.deleted(deleter_id=self.account_id)  # type: ignore[attr-defined]
         return deleted
 
     def accept_vpc_peering_connection(self, vpc_pcx_id: str) -> VPCPeeringConnection:
@@ -159,8 +159,8 @@ class VPCPeeringConnectionBackend:
         # validate cross-account acceptance
         req_account_id = vpc_pcx.vpc.owner_id
         acp_account_id = vpc_pcx.peer_vpc.owner_id
-        if req_account_id != acp_account_id and self.account_id != acp_account_id:
-            raise OperationNotPermitted5(self.account_id, vpc_pcx_id, "accept")
+        if req_account_id != acp_account_id and self.account_id != acp_account_id:  # type: ignore[attr-defined]
+            raise OperationNotPermitted5(self.account_id, vpc_pcx_id, "accept")  # type: ignore[attr-defined]
 
         # validate cross-region acceptance
         pcx_req_region = vpc_pcx.vpc.region
@@ -179,8 +179,8 @@ class VPCPeeringConnectionBackend:
         # validate cross-account rejection
         req_account_id = vpc_pcx.vpc.owner_id
         acp_account_id = vpc_pcx.peer_vpc.owner_id
-        if req_account_id != acp_account_id and self.account_id != acp_account_id:
-            raise OperationNotPermitted5(self.account_id, vpc_pcx_id, "reject")
+        if req_account_id != acp_account_id and self.account_id != acp_account_id:  # type: ignore[attr-defined]
+            raise OperationNotPermitted5(self.account_id, vpc_pcx_id, "reject")  # type: ignore[attr-defined]
 
         # validate cross-region acceptance
         pcx_req_region = vpc_pcx.vpc.region

--- a/moto/ec2/models/vpc_peering_connections.py
+++ b/moto/ec2/models/vpc_peering_connections.py
@@ -7,6 +7,7 @@ from ..exceptions import (
     InvalidVPCPeeringConnectionStateTransitionError,
     OperationNotPermitted2,
     OperationNotPermitted3,
+    OperationNotPermitted5,
 )
 from .core import TaggedEC2Resource
 from .vpcs import VPC
@@ -14,21 +15,24 @@ from ..utils import random_vpc_peering_connection_id
 
 
 class PeeringConnectionStatus:
-    def __init__(self, code: str = "initiating-request", message: str = ""):
+    def __init__(
+        self, accepter_id: str, code: str = "initiating-request", message: str = ""
+    ):
+        self.accepter_id = accepter_id
         self.code = code
         self.message = message
 
-    def deleted(self) -> None:
+    def deleted(self, deleter_id: str) -> None:
         self.code = "deleted"
-        self.message = "Deleted by {deleter ID}"
+        self.message = f"Deleted by {deleter_id}"
 
     def initiating(self) -> None:
         self.code = "initiating-request"
-        self.message = "Initiating Request to {accepter ID}"
+        self.message = f"Initiating Request to {self.accepter_id}"
 
     def pending(self) -> None:
         self.code = "pending-acceptance"
-        self.message = "Pending Acceptance by {accepter ID}"
+        self.message = f"Pending Acceptance by {self.accepter_id}"
 
     def accept(self) -> None:
         self.code = "active"
@@ -61,7 +65,7 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
         self.requester_options = self.DEFAULT_OPTIONS.copy()
         self.accepter_options = self.DEFAULT_OPTIONS.copy()
         self.add_tags(tags or {})
-        self._status = PeeringConnectionStatus()
+        self._status = PeeringConnectionStatus(accepter_id=peer_vpc.owner_id)
 
     @staticmethod
     def cloudformation_name_type() -> str:
@@ -79,7 +83,7 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> "VPCPeeringConnection":
         from ..models import ec2_backends
 
@@ -120,11 +124,15 @@ class VPCPeeringConnectionBackend:
         vpc_pcx = VPCPeeringConnection(self, vpc_pcx_id, vpc, peer_vpc, tags)
         vpc_pcx._status.pending()
         self.vpc_pcxs[vpc_pcx_id] = vpc_pcx
-        # insert cross region peering info
-        if vpc.ec2_backend.region_name != peer_vpc.ec2_backend.region_name:
-            for vpc_pcx_cx in peer_vpc.ec2_backend.get_vpc_pcx_refs():
-                if vpc_pcx_cx.region_name == peer_vpc.ec2_backend.region_name:
-                    vpc_pcx_cx.vpc_pcxs[vpc_pcx_id] = vpc_pcx
+        # insert cross-account/cross-region peering info
+        if vpc.owner_id != peer_vpc.owner_id or vpc.region != peer_vpc.region:
+            for backend in peer_vpc.ec2_backend.get_vpc_pcx_refs():
+                if (
+                    backend.account_id == peer_vpc.owner_id
+                    and backend.region_name == peer_vpc.region
+                ):
+                    backend.vpc_pcxs[vpc_pcx_id] = vpc_pcx
+
         return vpc_pcx
 
     def describe_vpc_peering_connections(
@@ -142,16 +150,24 @@ class VPCPeeringConnectionBackend:
 
     def delete_vpc_peering_connection(self, vpc_pcx_id: str) -> VPCPeeringConnection:
         deleted = self.get_vpc_peering_connection(vpc_pcx_id)
-        deleted._status.deleted()
+        deleted._status.deleted(deleter_id=self.account_id)
         return deleted
 
     def accept_vpc_peering_connection(self, vpc_pcx_id: str) -> VPCPeeringConnection:
         vpc_pcx = self.get_vpc_peering_connection(vpc_pcx_id)
-        # if cross region need accepter from another region
-        pcx_req_region = vpc_pcx.vpc.ec2_backend.region_name
-        pcx_acp_region = vpc_pcx.peer_vpc.ec2_backend.region_name
+
+        # validate cross-account acceptance
+        req_account_id = vpc_pcx.vpc.owner_id
+        acp_account_id = vpc_pcx.peer_vpc.owner_id
+        if req_account_id != acp_account_id and self.account_id != acp_account_id:
+            raise OperationNotPermitted5(self.account_id, vpc_pcx_id, "accept")
+
+        # validate cross-region acceptance
+        pcx_req_region = vpc_pcx.vpc.region
+        pcx_acp_region = vpc_pcx.peer_vpc.region
         if pcx_req_region != pcx_acp_region and self.region_name == pcx_req_region:  # type: ignore[attr-defined]
             raise OperationNotPermitted2(self.region_name, vpc_pcx.id, pcx_acp_region)  # type: ignore[attr-defined]
+
         if vpc_pcx._status.code != "pending-acceptance":
             raise InvalidVPCPeeringConnectionStateTransitionError(vpc_pcx.id)
         vpc_pcx._status.accept()
@@ -159,11 +175,19 @@ class VPCPeeringConnectionBackend:
 
     def reject_vpc_peering_connection(self, vpc_pcx_id: str) -> VPCPeeringConnection:
         vpc_pcx = self.get_vpc_peering_connection(vpc_pcx_id)
-        # if cross region need accepter from another region
-        pcx_req_region = vpc_pcx.vpc.ec2_backend.region_name
-        pcx_acp_region = vpc_pcx.peer_vpc.ec2_backend.region_name
+
+        # validate cross-account rejection
+        req_account_id = vpc_pcx.vpc.owner_id
+        acp_account_id = vpc_pcx.peer_vpc.owner_id
+        if req_account_id != acp_account_id and self.account_id != acp_account_id:
+            raise OperationNotPermitted5(self.account_id, vpc_pcx_id, "reject")
+
+        # validate cross-region acceptance
+        pcx_req_region = vpc_pcx.vpc.region
+        pcx_acp_region = vpc_pcx.peer_vpc.region
         if pcx_req_region != pcx_acp_region and self.region_name == pcx_req_region:  # type: ignore[attr-defined]
             raise OperationNotPermitted3(self.region_name, vpc_pcx.id, pcx_acp_region)  # type: ignore[attr-defined]
+
         if vpc_pcx._status.code != "pending-acceptance":
             raise InvalidVPCPeeringConnectionStateTransitionError(vpc_pcx.id)
         vpc_pcx._status.reject()

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -205,6 +205,10 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
     def owner_id(self) -> str:
         return self.ec2_backend.account_id
 
+    @property
+    def region(self) -> str:
+        return self.ec2_backend.region_name
+
     @staticmethod
     def cloudformation_name_type() -> str:
         return ""

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -3,21 +3,23 @@ from ._base_response import EC2BaseResponse
 
 class VPCPeeringConnections(EC2BaseResponse):
     def create_vpc_peering_connection(self) -> str:
-        peer_region = self._get_param("PeerRegion")
         tags = self._parse_tag_specification().get("vpc-peering-connection", {})
 
-        if peer_region == self.region or peer_region is None:
-            peer_vpc = self.ec2_backend.get_vpc(self._get_param("PeerVpcId"))
-        else:
-            from moto.ec2.models import ec2_backends
+        account_id = self._get_param("PeerOwnerId") or self.current_account
+        region_name = self._get_param("PeerRegion") or self.region
 
-            peer_vpc = ec2_backends[self.current_account][peer_region].get_vpc(
-                self._get_param("PeerVpcId")
-            )
         vpc = self.ec2_backend.get_vpc(self._get_param("VpcId"))
+
+        # Peer VPC could belong to another account or region
+        from moto.ec2.models import ec2_backends
+
+        peer_vpc = ec2_backends[account_id][region_name].get_vpc(
+            self._get_param("PeerVpcId")
+        )
+
         vpc_pcx = self.ec2_backend.create_vpc_peering_connection(vpc, peer_vpc, tags)
         template = self.response_template(CREATE_VPC_PEERING_CONNECTION_RESPONSE)
-        return template.render(account_id=self.current_account, vpc_pcx=vpc_pcx)
+        return template.render(vpc_pcx=vpc_pcx)
 
     def delete_vpc_peering_connection(self) -> str:
         vpc_pcx_id = self._get_param("VpcPeeringConnectionId")
@@ -31,13 +33,13 @@ class VPCPeeringConnections(EC2BaseResponse):
             vpc_peering_ids=ids
         )
         template = self.response_template(DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE)
-        return template.render(account_id=self.current_account, vpc_pcxs=vpc_pcxs)
+        return template.render(vpc_pcxs=vpc_pcxs)
 
     def accept_vpc_peering_connection(self) -> str:
         vpc_pcx_id = self._get_param("VpcPeeringConnectionId")
         vpc_pcx = self.ec2_backend.accept_vpc_peering_connection(vpc_pcx_id)
         template = self.response_template(ACCEPT_VPC_PEERING_CONNECTION_RESPONSE)
-        return template.render(account_id=self.current_account, vpc_pcx=vpc_pcx)
+        return template.render(vpc_pcx=vpc_pcx)
 
     def reject_vpc_peering_connection(self) -> str:
         vpc_pcx_id = self._get_param("VpcPeeringConnectionId")
@@ -68,39 +70,46 @@ CREATE_VPC_PEERING_CONNECTION_RESPONSE = """
 <CreateVpcPeeringConnectionResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
  <vpcPeeringConnection>
-  <vpcPeeringConnectionId>{{ vpc_pcx.id }}</vpcPeeringConnectionId>
-    <requesterVpcInfo>
-     <ownerId>{{ account_id }}</ownerId>
+   <vpcPeeringConnectionId>{{ vpc_pcx.id }}</vpcPeeringConnectionId>
+   <requesterVpcInfo>
+     <ownerId>{{ vpc_pcx.vpc.owner_id }}</ownerId>
+     <region>{{ vpc_pcx.vpc.region }}</region>
      <vpcId>{{ vpc_pcx.vpc.id }}</vpcId>
      <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
+     <cidrBlockSet></cidrBlockSet>
+     <ipv6CidrBlockSet></ipv6CidrBlockSet>
      <peeringOptions>
        <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.requester_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
        <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.requester_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
        <allowDnsResolutionFromRemoteVpc>{{ vpc_pcx.requester_options.AllowDnsResolutionFromRemoteVpc or '' }}</allowDnsResolutionFromRemoteVpc>
      </peeringOptions>
-    </requesterVpcInfo>
-    <accepterVpcInfo>
-      <ownerId>{{ account_id }}</ownerId>
-      <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
-      <peeringOptions>
-        <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.accepter_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
-        <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.accepter_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
-        <allowDnsResolutionFromRemoteVpc>{{ vpc_pcx.accepter_options.AllowDnsResolutionFromRemoteVpc or '' }}</allowDnsResolutionFromRemoteVpc>
-      </peeringOptions>
-    </accepterVpcInfo>
-    <status>
+   </requesterVpcInfo>
+   <accepterVpcInfo>
+     <ownerId>{{ vpc_pcx.peer_vpc.owner_id }}</ownerId>
+     <region>{{ vpc_pcx.peer_vpc.region }}</region>
+     <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
+     <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
+     <cidrBlockSet></cidrBlockSet>
+     <ipv6CidrBlockSet></ipv6CidrBlockSet>
+     <peeringOptions>
+       <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.accepter_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
+       <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.accepter_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
+       <allowDnsResolutionFromRemoteVpc>{{ vpc_pcx.accepter_options.AllowDnsResolutionFromRemoteVpc or '' }}</allowDnsResolutionFromRemoteVpc>
+     </peeringOptions>
+   </accepterVpcInfo>
+   <status>
      <code>initiating-request</code>
-     <message>Initiating Request to {accepter ID}</message>
-    </status>
-    <expirationTime>2014-02-18T14:37:25.000Z</expirationTime>
-    <tagSet>
-    {% for tag in vpc_pcx.get_tags() %}
-      <item>
-        <key>{{ tag.key }}</key>
-        <value>{{ tag.value }}</value>
-      </item>
-    {% endfor %}
-    </tagSet>
+     <message>Initiating Request to {{ vpc_pcx.peer_vpc.owner_id }}</message>
+   </status>
+   <expirationTime>2014-02-18T14:37:25.000Z</expirationTime>
+   <tagSet>
+   {% for tag in vpc_pcx.get_tags() %}
+     <item>
+       <key>{{ tag.key }}</key>
+       <value>{{ tag.value }}</value>
+     </item>
+   {% endfor %}
+   </tagSet>
  </vpcPeeringConnection>
 </CreateVpcPeeringConnectionResponse>
 """
@@ -113,10 +122,12 @@ DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
  <item>
   <vpcPeeringConnectionId>{{ vpc_pcx.id }}</vpcPeeringConnectionId>
     <requesterVpcInfo>
-     <ownerId>{{ account_id }}</ownerId>
+     <ownerId>{{ vpc_pcx.vpc.owner_id }}</ownerId>
+     <region>{{ vpc_pcx.vpc.region }}</region>
      <vpcId>{{ vpc_pcx.vpc.id }}</vpcId>
      <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
-     <region>{{ vpc_pcx.vpc.ec2_backend.region_name }}</region>
+     <cidrBlockSet></cidrBlockSet>
+     <ipv6CidrBlockSet></ipv6CidrBlockSet>
      <peeringOptions>
       <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.requester_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
       <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.requester_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
@@ -124,10 +135,12 @@ DESCRIBE_VPC_PEERING_CONNECTIONS_RESPONSE = """
      </peeringOptions>
     </requesterVpcInfo>
     <accepterVpcInfo>
-     <ownerId>{{ account_id }}</ownerId>
+     <ownerId>{{ vpc_pcx.peer_vpc.owner_id }}</ownerId>
+     <region>{{ vpc_pcx.peer_vpc.region }}</region>
      <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
      <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
-     <region>{{ vpc_pcx.peer_vpc.ec2_backend.region_name }}</region>
+     <cidrBlockSet></cidrBlockSet>
+     <ipv6CidrBlockSet></ipv6CidrBlockSet>
      <peeringOptions>
       <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.accepter_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
       <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.accepter_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
@@ -165,15 +178,25 @@ ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
   <vpcPeeringConnection>
     <vpcPeeringConnectionId>{{ vpc_pcx.id }}</vpcPeeringConnectionId>
     <requesterVpcInfo>
-      <ownerId>{{ account_id }}</ownerId>
-      <vpcId>{{ vpc_pcx.vpc.id }}</vpcId>
-      <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
-      <region>{{ vpc_pcx.vpc.ec2_backend.region_name }}</region>
+     <ownerId>{{ vpc_pcx.vpc.owner_id }}</ownerId>
+     <region>{{ vpc_pcx.vpc.region }}</region>
+     <vpcId>{{ vpc_pcx.vpc.id }}</vpcId>
+     <cidrBlock>{{ vpc_pcx.vpc.cidr_block }}</cidrBlock>
+     <cidrBlockSet></cidrBlockSet>
+     <ipv6CidrBlockSet></ipv6CidrBlockSet>
+     <peeringOptions>
+      <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.requester_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
+      <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.requester_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
+      <allowDnsResolutionFromRemoteVpc>{{ vpc_pcx.requester_options.AllowDnsResolutionFromRemoteVpc or '' }}</allowDnsResolutionFromRemoteVpc>
+     </peeringOptions>
     </requesterVpcInfo>
     <accepterVpcInfo>
-      <ownerId>{{ account_id }}</ownerId>
+      <ownerId>{{ vpc_pcx.peer_vpc.owner_id }}</ownerId>
+      <region>{{ vpc_pcx.peer_vpc.region }}</region>
       <vpcId>{{ vpc_pcx.peer_vpc.id }}</vpcId>
       <cidrBlock>{{ vpc_pcx.peer_vpc.cidr_block }}</cidrBlock>
+      <cidrBlockSet></cidrBlockSet>
+      <ipv6CidrBlockSet></ipv6CidrBlockSet>
       <peeringOptions>
         <allowEgressFromLocalClassicLinkToRemoteVpc>{{ vpc_pcx.accepter_options.AllowEgressFromLocalClassicLinkToRemoteVpc or '' }}</allowEgressFromLocalClassicLinkToRemoteVpc>
         <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.accepter_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>

--- a/moto/ec2/responses/vpc_peering_connections.py
+++ b/moto/ec2/responses/vpc_peering_connections.py
@@ -202,7 +202,6 @@ ACCEPT_VPC_PEERING_CONNECTION_RESPONSE = """
         <allowEgressFromLocalVpcToRemoteClassicLink>{{ vpc_pcx.accepter_options.AllowEgressFromLocalVpcToRemoteClassicLink or '' }}</allowEgressFromLocalVpcToRemoteClassicLink>
         <allowDnsResolutionFromRemoteVpc>{{ vpc_pcx.accepter_options.AllowDnsResolutionFromRemoteVpc or '' }}</allowDnsResolutionFromRemoteVpc>
       </peeringOptions>
-      <region>{{ vpc_pcx.peer_vpc.ec2_backend.region_name }}</region>
     </accepterVpcInfo>
     <status>
       <code>{{ vpc_pcx._status.code }}</code>

--- a/tests/test_ec2/test_vpc_peering.py
+++ b/tests/test_ec2/test_vpc_peering.py
@@ -1,3 +1,6 @@
+import os
+from unittest import mock
+
 import boto3
 import pytest
 
@@ -115,24 +118,45 @@ def test_vpc_peering_connections_delete_boto3():
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    assert vpc_pcx_usw1.status["Code"] == "initiating-request"
-    assert vpc_pcx_usw1.requester_vpc.id == vpc_usw1.id
-    assert vpc_pcx_usw1.accepter_vpc.id == vpc_apn1.id
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
+        )
+
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Code"] == "initiating-request"
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
+    # TODO add more assertions
+
     # test cross region vpc peering connection exist
-    vpc_pcx_apn1 = ec2_apn1.VpcPeeringConnection(vpc_pcx_usw1.id)
-    assert vpc_pcx_apn1.id == vpc_pcx_usw1.id
-    assert vpc_pcx_apn1.requester_vpc.id == vpc_usw1.id
-    assert vpc_pcx_apn1.accepter_vpc.id == vpc_apn1.id
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        vpc_pcx_apn1 = ec2_apn1.VpcPeeringConnection(vpc_pcx_usw1["VpcPeeringConnection"]["VpcPeeringConnectionId"])
+        assert vpc_pcx_apn1.id == vpc_pcx_usw1["VpcPeeringConnection"]["VpcPeeringConnectionId"]
+        assert vpc_pcx_apn1.requester_vpc.id == vpc_usw1.id
+        assert vpc_pcx_apn1.accepter_vpc.id == vpc_apn1.id
+
     # Quick check to verify the options have a default value
     accepter_options = vpc_pcx_apn1.accepter_vpc_info["PeeringOptions"]
     assert accepter_options["AllowDnsResolutionFromRemoteVpc"] is False
@@ -145,28 +169,47 @@ def test_vpc_peering_connections_cross_region():
 
 
 @mock_ec2
-def test_modify_vpc_peering_connections_accepter_only():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_modify_vpc_peering_connections_accepter_only(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    client = boto3.client("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        client = boto3.client("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    #
-    client.modify_vpc_peering_connection_options(
-        VpcPeeringConnectionId=vpc_pcx_usw1.id,
-        AccepterPeeringConnectionOptions={"AllowDnsResolutionFromRemoteVpc": True},
-    )
-    # Accepter options are different
-    vpc_pcx_usw1.reload()
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
+        )
+
+        # modify peering connection options
+        client.modify_vpc_peering_connection_options(
+            VpcPeeringConnectionId=vpc_pcx_usw1.id,
+            AccepterPeeringConnectionOptions={"AllowDnsResolutionFromRemoteVpc": True},
+        )
+
+        # Accepter options are different
+        vpc_pcx_usw1.reload()
+
     accepter_options = vpc_pcx_usw1.accepter_vpc_info["PeeringOptions"]
     assert accepter_options["AllowDnsResolutionFromRemoteVpc"] is True
     assert accepter_options["AllowEgressFromLocalClassicLinkToRemoteVpc"] is False
     assert accepter_options["AllowEgressFromLocalVpcToRemoteClassicLink"] is False
+
     # Requester options are untouched
     requester_options = vpc_pcx_usw1.requester_vpc_info["PeeringOptions"]
     assert requester_options["AllowDnsResolutionFromRemoteVpc"] is False
@@ -175,30 +218,47 @@ def test_modify_vpc_peering_connections_accepter_only():
 
 
 @mock_ec2
-def test_modify_vpc_peering_connections_requester_only():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_modify_vpc_peering_connections_requester_only(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    client = boto3.client("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        client = boto3.client("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    #
-    client.modify_vpc_peering_connection_options(
-        VpcPeeringConnectionId=vpc_pcx_usw1.id,
-        RequesterPeeringConnectionOptions={
-            "AllowEgressFromLocalVpcToRemoteClassicLink": True,
-        },
-    )
-    # Requester options are different
-    vpc_pcx_usw1.reload()
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
+        )
+        #
+        client.modify_vpc_peering_connection_options(
+            VpcPeeringConnectionId=vpc_pcx_usw1.id,
+            RequesterPeeringConnectionOptions={
+                "AllowEgressFromLocalVpcToRemoteClassicLink": True,
+            },
+        )
+        # Requester options are different
+        vpc_pcx_usw1.reload()
+
     requester_options = vpc_pcx_usw1.requester_vpc_info["PeeringOptions"]
     assert requester_options["AllowDnsResolutionFromRemoteVpc"] is False
     assert requester_options["AllowEgressFromLocalClassicLinkToRemoteVpc"] is False
     assert requester_options["AllowEgressFromLocalVpcToRemoteClassicLink"] is True
+
     # Accepter options are untouched
     accepter_options = vpc_pcx_usw1.accepter_vpc_info["PeeringOptions"]
     assert accepter_options["AllowDnsResolutionFromRemoteVpc"] is False
@@ -207,97 +267,159 @@ def test_modify_vpc_peering_connections_requester_only():
 
 
 @mock_ec2
-def test_modify_vpc_peering_connections_unknown_vpc():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_modify_vpc_peering_connections_unknown_vpc(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    client = boto3.client("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        client = boto3.client("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    #
-    with pytest.raises(ClientError) as ex:
-        client.modify_vpc_peering_connection_options(
-            VpcPeeringConnectionId="vpx-unknown", RequesterPeeringConnectionOptions={}
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
+
+        with pytest.raises(ClientError) as ex:
+            client.modify_vpc_peering_connection_options(
+                VpcPeeringConnectionId="vpx-unknown",
+                RequesterPeeringConnectionOptions={},
+            )
     err = ex.value.response["Error"]
     assert err["Code"] == "InvalidVpcPeeringConnectionId.NotFound"
     assert err["Message"] == "VpcPeeringConnectionID vpx-unknown does not exist."
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region_fail():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region_fail(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering wrong region with no vpc
     with pytest.raises(ClientError) as cm:
-        ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-2"
-        )
+        with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+            ec2_usw1.create_vpc_peering_connection(
+                VpcId=vpc_usw1.id,
+                PeerVpcId=vpc_apn1.id,
+                PeerRegion="ap-northeast-2",
+                PeerOwnerId=account2,
+            )
     assert cm.value.response["Error"]["Code"] == "InvalidVpcID.NotFound"
 
 
 @mock_ec2
-def test_describe_vpc_peering_connections_only_returns_requested_id():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_describe_vpc_peering_connections_only_returns_requested_id(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    vpc_pcx_usw2 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    # describe peering
-    ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
-    our_vpcx = [vpcx["VpcPeeringConnectionId"] for vpcx in retrieve_all(ec2_usw1)]
-    assert vpc_pcx_usw1.id in our_vpcx
-    assert vpc_pcx_usw2.id in our_vpcx
-    assert vpc_apn1.id not in our_vpcx
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2,
+        )
+        vpc_pcx_usw2 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2,
+        )
 
-    both_pcx = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id, vpc_pcx_usw2.id]
-    )["VpcPeeringConnections"]
-    assert len(both_pcx) == 2
+        # describe peering
+        ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+        our_vpcx = [vpcx["VpcPeeringConnectionId"] for vpcx in retrieve_all(ec2_usw1)]
 
-    one_pcx = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )["VpcPeeringConnections"]
-    assert len(one_pcx) == 1
+        assert vpc_pcx_usw1.id in our_vpcx
+        assert vpc_pcx_usw2.id in our_vpcx
+        assert vpc_apn1.id not in our_vpcx
+
+        both_pcx = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id, vpc_pcx_usw2.id]
+        )["VpcPeeringConnections"]
+        assert len(both_pcx) == 2
+
+        one_pcx = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )["VpcPeeringConnections"]
+        assert len(one_pcx) == 1
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region_accept():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region_accept(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+        )
+
     # accept peering from ap-northeast-1
-    ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
-    ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
-    acp_pcx_apn1 = ec2_apn1.accept_vpc_peering_connection(
-        VpcPeeringConnectionId=vpc_pcx_usw1.id
-    )
-    des_pcx_apn1 = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )
-    des_pcx_usw1 = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
+        acp_pcx_apn1 = ec2_apn1.accept_vpc_peering_connection(
+            VpcPeeringConnectionId=vpc_pcx_usw1.id
+        )
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+        des_pcx_apn1 = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )
+        des_pcx_usw1 = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )
+
     assert acp_pcx_apn1["VpcPeeringConnection"]["Status"]["Code"] == "active"
     assert (
         acp_pcx_apn1["VpcPeeringConnection"]["AccepterVpcInfo"]["Region"]
@@ -328,102 +450,190 @@ def test_vpc_peering_connections_cross_region_accept():
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region_reject():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region_reject(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+        )
+
     # reject peering from ap-northeast-1
-    ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
-    ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
-    rej_pcx_apn1 = ec2_apn1.reject_vpc_peering_connection(
-        VpcPeeringConnectionId=vpc_pcx_usw1.id
-    )
-    des_pcx_apn1 = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )
-    des_pcx_usw1 = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
+        rej_pcx_apn1 = ec2_apn1.reject_vpc_peering_connection(
+            VpcPeeringConnectionId=vpc_pcx_usw1.id
+        )
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+        des_pcx_apn1 = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )
+        des_pcx_usw1 = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )
     assert rej_pcx_apn1["Return"] is True
     assert des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Code"] == "rejected"
     assert des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Code"] == "rejected"
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region_delete():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region_delete(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    # reject peering from ap-northeast-1
-    ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
-    ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
-    del_pcx_apn1 = ec2_apn1.delete_vpc_peering_connection(
-        VpcPeeringConnectionId=vpc_pcx_usw1.id
-    )
-    des_pcx_apn1 = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )
-    des_pcx_usw1 = ec2_usw1.describe_vpc_peering_connections(
-        VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
-    )
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+        )
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        # reject peering from ap-northeast-1
+        ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
+        del_pcx_apn1 = ec2_apn1.delete_vpc_peering_connection(
+            VpcPeeringConnectionId=vpc_pcx_usw1.id
+        )
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+        des_pcx_apn1 = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )
+        des_pcx_usw1 = ec2_usw1.describe_vpc_peering_connections(
+            VpcPeeringConnectionIds=[vpc_pcx_usw1.id]
+        )
+
     assert del_pcx_apn1["Return"] is True
     assert des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Code"] == "deleted"
     assert des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Code"] == "deleted"
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region_accept_wrong_region():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region_accept_wrong_region(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+        )
 
     # accept wrong peering from us-west-1 which will raise error
-    ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
-    ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
-    with pytest.raises(ClientError) as cm:
-        ec2_usw1.accept_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
-    assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
-    exp_msg = f"Incorrect region (us-west-1) specified for this request.VPC peering connection {vpc_pcx_usw1.id} must be accepted in region ap-northeast-1"
-    assert cm.value.response["Error"]["Message"] == exp_msg
+    # only applicable for cross-region intra-account peering.
+    if account1 == account2:
+        with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+            ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+            with pytest.raises(ClientError) as cm:
+                ec2_usw1.accept_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+
+        assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
+        exp_msg = f"Incorrect region (us-west-1) specified for this request. VPC peering connection {vpc_pcx_usw1.id} must be accepted in region ap-northeast-1"
+        assert cm.value.response["Error"]["Message"] == exp_msg
+
+    # Ensure accepting peering from requester account raises
+    # only applicable for cross-region inter-account peering.
+    if account1 != account2:
+        with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+            ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+            with pytest.raises(ClientError) as cm:
+                ec2_usw1.accept_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+
+        assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
+        exp_msg = f"User ({account1}) cannot accept peering {vpc_pcx_usw1.id}"
+        assert cm.value.response["Error"]["Message"] == exp_msg
 
 
 @mock_ec2
-def test_vpc_peering_connections_cross_region_reject_wrong_region():
+@pytest.mark.parametrize(
+    "account1,account2",
+    [
+        pytest.param("111111111111", "111111111111", id="within account"),
+        pytest.param("111111111111", "222222222222", id="across accounts"),
+    ],
+)
+def test_vpc_peering_connections_cross_region_reject_wrong_region(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
-    ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
-    vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
-    ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
-    vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        ec2_usw1 = boto3.resource("ec2", region_name="us-west-1")
+        vpc_usw1 = ec2_usw1.create_vpc(CidrBlock="10.90.0.0/16")
+
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
+        ec2_apn1 = boto3.resource("ec2", region_name="ap-northeast-1")
+        vpc_apn1 = ec2_apn1.create_vpc(CidrBlock="10.20.0.0/16")
+
     # create peering
-    vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-        VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1"
-    )
-    # reject wrong peering from us-west-1 which will raise error
-    ec2_apn1 = boto3.client("ec2", region_name="ap-northeast-1")
-    ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
-    with pytest.raises(ClientError) as cm:
-        ec2_usw1.reject_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
-    assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
-    exp_msg = f"Incorrect region (us-west-1) specified for this request.VPC peering connection {vpc_pcx_usw1.id} must be accepted or rejected in region ap-northeast-1"
-    assert cm.value.response["Error"]["Message"] == exp_msg
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+        vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
+            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+        )
+
+    # reject wrong peering from us-west-1 which will raise error.
+    # only applicable for cross-region intra-account peering.
+    if account1 == account2:
+        with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+            ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+            with pytest.raises(ClientError) as cm:
+                ec2_usw1.reject_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+
+        assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
+        exp_msg = f"Incorrect region (us-west-1) specified for this request. VPC peering connection {vpc_pcx_usw1.id} must be accepted or rejected in region ap-northeast-1"
+        assert cm.value.response["Error"]["Message"] == exp_msg
+
+    # Ensure rejecting peering from requester account raises
+    # only applicable for cross-region inter-account peering.
+    if account1 != account2:
+        with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
+            ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
+            with pytest.raises(ClientError) as cm:
+                ec2_usw1.reject_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+
+        assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
+        exp_msg = f"User ({account1}) cannot reject peering {vpc_pcx_usw1.id}"
+        assert cm.value.response["Error"]["Message"] == exp_msg
 
 
 def retrieve_all(client):

--- a/tests/test_ec2/test_vpc_peering.py
+++ b/tests/test_ec2/test_vpc_peering.py
@@ -145,15 +145,26 @@ def test_vpc_peering_connections_cross_region(account1, account2):
             PeerOwnerId=account2,
         )
 
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Code"] == "initiating-request"
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Code"] == "initiating-request"
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
+    )
     # TODO add more assertions
 
     # test cross region vpc peering connection exist
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
-        vpc_pcx_apn1 = ec2_apn1.VpcPeeringConnection(vpc_pcx_usw1["VpcPeeringConnection"]["VpcPeeringConnectionId"])
-        assert vpc_pcx_apn1.id == vpc_pcx_usw1["VpcPeeringConnection"]["VpcPeeringConnectionId"]
+        vpc_pcx_apn1 = ec2_apn1.VpcPeeringConnection(
+            vpc_pcx_usw1["VpcPeeringConnection"]["VpcPeeringConnectionId"]
+        )
+        assert (
+            vpc_pcx_apn1.id
+            == vpc_pcx_usw1["VpcPeeringConnection"]["VpcPeeringConnectionId"]
+        )
         assert vpc_pcx_apn1.requester_vpc.id == vpc_usw1.id
         assert vpc_pcx_apn1.accepter_vpc.id == vpc_apn1.id
 
@@ -355,10 +366,16 @@ def test_describe_vpc_peering_connections_only_returns_requested_id(account1, ac
     # create peering
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
         vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2,
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
         vpc_pcx_usw2 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2,
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
 
         # describe peering
@@ -401,7 +418,10 @@ def test_vpc_peering_connections_cross_region_accept(account1, account2):
     # create peering
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
         vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
 
     # accept peering from ap-northeast-1
@@ -470,7 +490,10 @@ def test_vpc_peering_connections_cross_region_reject(account1, account2):
     # create peering
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
         vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
 
     # reject peering from ap-northeast-1
@@ -514,7 +537,10 @@ def test_vpc_peering_connections_cross_region_delete(account1, account2):
     # create peering
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
         vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
 
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
@@ -559,7 +585,10 @@ def test_vpc_peering_connections_cross_region_accept_wrong_region(account1, acco
     # create peering
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
         vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
 
     # accept wrong peering from us-west-1 which will raise error
@@ -568,7 +597,9 @@ def test_vpc_peering_connections_cross_region_accept_wrong_region(account1, acco
         with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
             ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
             with pytest.raises(ClientError) as cm:
-                ec2_usw1.accept_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+                ec2_usw1.accept_vpc_peering_connection(
+                    VpcPeeringConnectionId=vpc_pcx_usw1.id
+                )
 
         assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
         exp_msg = f"Incorrect region (us-west-1) specified for this request. VPC peering connection {vpc_pcx_usw1.id} must be accepted in region ap-northeast-1"
@@ -580,7 +611,9 @@ def test_vpc_peering_connections_cross_region_accept_wrong_region(account1, acco
         with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
             ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
             with pytest.raises(ClientError) as cm:
-                ec2_usw1.accept_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+                ec2_usw1.accept_vpc_peering_connection(
+                    VpcPeeringConnectionId=vpc_pcx_usw1.id
+                )
 
         assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
         exp_msg = f"User ({account1}) cannot accept peering {vpc_pcx_usw1.id}"
@@ -608,7 +641,10 @@ def test_vpc_peering_connections_cross_region_reject_wrong_region(account1, acco
     # create peering
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
         vpc_pcx_usw1 = ec2_usw1.create_vpc_peering_connection(
-            VpcId=vpc_usw1.id, PeerVpcId=vpc_apn1.id, PeerRegion="ap-northeast-1", PeerOwnerId=account2
+            VpcId=vpc_usw1.id,
+            PeerVpcId=vpc_apn1.id,
+            PeerRegion="ap-northeast-1",
+            PeerOwnerId=account2,
         )
 
     # reject wrong peering from us-west-1 which will raise error.
@@ -617,7 +653,9 @@ def test_vpc_peering_connections_cross_region_reject_wrong_region(account1, acco
         with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
             ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
             with pytest.raises(ClientError) as cm:
-                ec2_usw1.reject_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+                ec2_usw1.reject_vpc_peering_connection(
+                    VpcPeeringConnectionId=vpc_pcx_usw1.id
+                )
 
         assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
         exp_msg = f"Incorrect region (us-west-1) specified for this request. VPC peering connection {vpc_pcx_usw1.id} must be accepted or rejected in region ap-northeast-1"
@@ -629,7 +667,9 @@ def test_vpc_peering_connections_cross_region_reject_wrong_region(account1, acco
         with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
             ec2_usw1 = boto3.client("ec2", region_name="us-west-1")
             with pytest.raises(ClientError) as cm:
-                ec2_usw1.reject_vpc_peering_connection(VpcPeeringConnectionId=vpc_pcx_usw1.id)
+                ec2_usw1.reject_vpc_peering_connection(
+                    VpcPeeringConnectionId=vpc_pcx_usw1.id
+                )
 
         assert cm.value.response["Error"]["Code"] == "OperationNotPermitted"
         exp_msg = f"User ({account1}) cannot reject peering {vpc_pcx_usw1.id}"

--- a/tests/test_ec2/test_vpc_peering.py
+++ b/tests/test_ec2/test_vpc_peering.py
@@ -43,7 +43,7 @@ def test_vpc_peering_connections_get_all_boto3():
         if vpc_pcx["VpcPeeringConnectionId"] == vpc_pcx_id
     ][0]
     assert my_vpc_pcx["Status"]["Code"] == "pending-acceptance"
-    assert my_vpc_pcx["Status"]["Message"] == 'Pending Acceptance by 123456789012'
+    assert my_vpc_pcx["Status"]["Message"] == "Pending Acceptance by 123456789012"
 
 
 @mock_ec2
@@ -152,15 +152,38 @@ def test_vpc_peering_connections_cross_region(account1, account2):
     assert (
         vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Code"] == "initiating-request"
     )
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Message"] == f"Initiating Request to {account2}"
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["CidrBlock"] == '10.90.0.0/16'
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["OwnerId"] == account1
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["Region"] == 'us-west-1'
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["CidrBlock"] == '10.20.0.0/16'
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["OwnerId"] == account2
-    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["Region"] == 'ap-northeast-1'
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Message"]
+        == f"Initiating Request to {account2}"
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["CidrBlock"]
+        == "10.90.0.0/16"
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["OwnerId"] == account1
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["Region"]
+        == "us-west-1"
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["CidrBlock"]
+        == "10.20.0.0/16"
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["OwnerId"] == account2
+    )
+    assert (
+        vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["Region"]
+        == "ap-northeast-1"
+    )
 
     # test cross region vpc peering connection exist
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
@@ -591,10 +614,16 @@ def test_vpc_peering_connections_cross_region_delete(account1, account2):
 
     assert del_pcx_apn1["Return"] is True
     assert des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Code"] == "deleted"
-    assert des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Message"] == f"Deleted by {account2}"
+    assert (
+        des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Message"]
+        == f"Deleted by {account2}"
+    )
 
     assert des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Code"] == "deleted"
-    assert des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Message"] == f"Deleted by {account2}"
+    assert (
+        des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Message"]
+        == f"Deleted by {account2}"
+    )
 
 
 @mock_ec2

--- a/tests/test_ec2/test_vpc_peering.py
+++ b/tests/test_ec2/test_vpc_peering.py
@@ -6,7 +6,7 @@ import pytest
 
 from botocore.exceptions import ClientError
 
-from moto import mock_ec2
+from moto import mock_ec2, settings
 
 
 def create_vpx_pcx(ec2, client):
@@ -126,6 +126,9 @@ def test_vpc_peering_connections_delete_boto3():
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
 )
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
+)
 def test_vpc_peering_connections_cross_region(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
@@ -190,6 +193,9 @@ def test_vpc_peering_connections_cross_region(account1, account2):
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
 )
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
+)
 def test_modify_vpc_peering_connections_accepter_only(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
@@ -238,6 +244,9 @@ def test_modify_vpc_peering_connections_accepter_only(account1, account2):
         pytest.param("111111111111", "111111111111", id="within account"),
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
+)
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
 )
 def test_modify_vpc_peering_connections_requester_only(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
@@ -288,6 +297,9 @@ def test_modify_vpc_peering_connections_requester_only(account1, account2):
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
 )
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
+)
 def test_modify_vpc_peering_connections_unknown_vpc(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
@@ -326,6 +338,9 @@ def test_modify_vpc_peering_connections_unknown_vpc(account1, account2):
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
 )
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
+)
 def test_vpc_peering_connections_cross_region_fail(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
@@ -355,6 +370,9 @@ def test_vpc_peering_connections_cross_region_fail(account1, account2):
         pytest.param("111111111111", "111111111111", id="within account"),
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
+)
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
 )
 def test_describe_vpc_peering_connections_only_returns_requested_id(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
@@ -407,6 +425,9 @@ def test_describe_vpc_peering_connections_only_returns_requested_id(account1, ac
         pytest.param("111111111111", "111111111111", id="within account"),
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
+)
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
 )
 def test_vpc_peering_connections_cross_region_accept(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
@@ -480,6 +501,9 @@ def test_vpc_peering_connections_cross_region_accept(account1, account2):
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
 )
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
+)
 def test_vpc_peering_connections_cross_region_reject(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account1}):
@@ -526,6 +550,9 @@ def test_vpc_peering_connections_cross_region_reject(account1, account2):
         pytest.param("111111111111", "111111111111", id="within account"),
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
+)
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
 )
 def test_vpc_peering_connections_cross_region_delete(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
@@ -577,6 +604,9 @@ def test_vpc_peering_connections_cross_region_delete(account1, account2):
         pytest.param("111111111111", "111111111111", id="within account"),
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
+)
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
 )
 def test_vpc_peering_connections_cross_region_accept_wrong_region(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1
@@ -633,6 +663,9 @@ def test_vpc_peering_connections_cross_region_accept_wrong_region(account1, acco
         pytest.param("111111111111", "111111111111", id="within account"),
         pytest.param("111111111111", "222222222222", id="across accounts"),
     ],
+)
+@pytest.mark.skipif(
+    settings.TEST_SERVER_MODE, reason="Cannot set account ID in server mode"
 )
 def test_vpc_peering_connections_cross_region_reject_wrong_region(account1, account2):
     # create vpc in us-west-1 and ap-northeast-1

--- a/tests/test_ec2/test_vpc_peering.py
+++ b/tests/test_ec2/test_vpc_peering.py
@@ -43,6 +43,7 @@ def test_vpc_peering_connections_get_all_boto3():
         if vpc_pcx["VpcPeeringConnectionId"] == vpc_pcx_id
     ][0]
     assert my_vpc_pcx["Status"]["Code"] == "pending-acceptance"
+    assert my_vpc_pcx["Status"]["Message"] == 'Pending Acceptance by 123456789012'
 
 
 @mock_ec2
@@ -148,13 +149,15 @@ def test_vpc_peering_connections_cross_region(account1, account2):
     assert (
         vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Code"] == "initiating-request"
     )
-    assert (
-        vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
-    )
-    assert (
-        vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
-    )
-    # TODO add more assertions
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["Status"]["Message"] == f"Initiating Request to {account2}"
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["VpcId"] == vpc_usw1.id
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["CidrBlock"] == '10.90.0.0/16'
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["OwnerId"] == account1
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["RequesterVpcInfo"]["Region"] == 'us-west-1'
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["VpcId"] == vpc_apn1.id
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["CidrBlock"] == '10.20.0.0/16'
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["OwnerId"] == account2
+    assert vpc_pcx_usw1["VpcPeeringConnection"]["AccepterVpcInfo"]["Region"] == 'ap-northeast-1'
 
     # test cross region vpc peering connection exist
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account2}):
@@ -561,7 +564,10 @@ def test_vpc_peering_connections_cross_region_delete(account1, account2):
 
     assert del_pcx_apn1["Return"] is True
     assert des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Code"] == "deleted"
+    assert des_pcx_apn1["VpcPeeringConnections"][0]["Status"]["Message"] == f"Deleted by {account2}"
+
     assert des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Code"] == "deleted"
+    assert des_pcx_usw1["VpcPeeringConnections"][0]["Status"]["Message"] == f"Deleted by {account2}"
 
 
 @mock_ec2


### PR DESCRIPTION
AWS allows VPCs to be peered as long as their CIDR ranges do not overlap. Peering can happen within the same account/region or cross-account/region.

https://github.com/getmoto/moto/pull/2195 added VPC peering support across-regions.

This PR introduces VPC peering support across-accounts.

Exisiting tests have been parametrised to run all assertions within the same account and across accounts. 

Closes: https://github.com/localstack/localstack/issues/8550