### PR TITLE
elbv2: adds a new ssl policy

### DIFF
--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -146,7 +146,7 @@ SSL_POLICIES = [
             {"name": "ECDHE-RSA-AES256-GCM-SHA384", "priority": 9},
             {"name": "ECDHE-ECDSA-AES256-SHA384", "priority": 10},
             {"name": "ECDHE-RSA-AES256-SHA384", "priority": 11},
-            ],
+        ],
     },
 ]
 

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -131,6 +131,23 @@ SSL_POLICIES = [
             {"name": "ECDHE-RSA-AES256-GCM-SHA384", "priority": 4},
         ],
     },
+    {
+        "name": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+        "ssl_protocols": ["TLSv1.2", "TLSv1.3"],
+        "ciphers": [
+            {"name": "TLS_AES_128_GCM_SHA256", "priority": 1},
+            {"name": "TLS_AES_256_GCM_SHA384", "priority": 2},
+            {"name": "TLS_CHACHA20_POLY1305_SHA256", "priority": 3},
+            {"name": "ECDHE-ECDSA-AES128-GCM-SHA256", "priority": 4},
+            {"name": "ECDHE-RSA-AES128-GCM-SHA256", "priority": 5},
+            {"name": "ECDHE-ECDSA-AES128-SHA256", "priority": 6},
+            {"name": "ECDHE-RSA-AES128-SHA256", "priority": 7},
+            {"name": "ECDHE-ECDSA-AES256-GCM-SHA384", "priority": 8},
+            {"name": "ECDHE-RSA-AES256-GCM-SHA384", "priority": 9},
+            {"name": "ECDHE-ECDSA-AES256-SHA384", "priority": 10},
+            {"name": "ECDHE-RSA-AES256-SHA384", "priority": 11},
+            ],
+    },
 ]
 
 

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -1120,7 +1120,7 @@ def test_describe_ssl_policies():
     client = boto3.client("elbv2", region_name="eu-central-1")
 
     resp = client.describe_ssl_policies()
-    assert len(resp["SslPolicies"]) == 6
+    assert len(resp["SslPolicies"]) == 7
 
     resp = client.describe_ssl_policies(
         Names=["ELBSecurityPolicy-TLS-1-2-2017-01", "ELBSecurityPolicy-2016-08"]


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
This PR aims to add an SSL policy: `ELBSecurityPolicy-TLS13-1-2-2021-06` to `elbv2` service. 

<!-- What notable changes does this PR make? -->
## Changes
adds security policies with:
- TLS protocol 
- TLS ciphers 

