### PR TITLE
Fix tag specifications crash for EC2 resources

### DIFF
--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -7,7 +7,9 @@ class AmisResponse(EC2BaseResponse):
         name = self.querystring.get("Name")[0]  # type: ignore[index]
         description = self._get_param("Description", if_none="")
         instance_id = self._get_param("InstanceId")
-        tag_specifications = self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        tag_specifications = self._get_multi_param(
+            "TagSpecification", skip_result_conversion=True
+        )
 
         self.error_on_dryrun()
 

--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -7,7 +7,7 @@ class AmisResponse(EC2BaseResponse):
         name = self.querystring.get("Name")[0]  # type: ignore[index]
         description = self._get_param("Description", if_none="")
         instance_id = self._get_param("InstanceId")
-        tag_specifications = self._get_multi_param("TagSpecification")
+        tag_specifications = self._get_multi_param("TagSpecification", skip_result_conversion=True)
 
         self.error_on_dryrun()
 

--- a/moto/ec2/responses/carrier_gateways.py
+++ b/moto/ec2/responses/carrier_gateways.py
@@ -5,7 +5,7 @@ from ._base_response import EC2BaseResponse
 class CarrierGateway(EC2BaseResponse):
     def create_carrier_gateway(self) -> str:
         vpc_id = self._get_param("VpcId")
-        tag_param = self._get_multi_param("TagSpecification")
+        tag_param = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         tags = add_tag_specification(tag_param)
 
         carrier_gateway = self.ec2_backend.create_carrier_gateway(

--- a/moto/ec2/responses/carrier_gateways.py
+++ b/moto/ec2/responses/carrier_gateways.py
@@ -5,7 +5,9 @@ from ._base_response import EC2BaseResponse
 class CarrierGateway(EC2BaseResponse):
     def create_carrier_gateway(self) -> str:
         vpc_id = self._get_param("VpcId")
-        tag_param = self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        tag_param = self._get_multi_param(
+            "TagSpecification", skip_result_conversion=True
+        )
         tags = add_tag_specification(tag_param)
 
         carrier_gateway = self.ec2_backend.create_carrier_gateway(

--- a/moto/ec2/responses/egress_only_internet_gateways.py
+++ b/moto/ec2/responses/egress_only_internet_gateways.py
@@ -5,7 +5,7 @@ from moto.ec2.utils import add_tag_specification
 class EgressOnlyInternetGateway(EC2BaseResponse):
     def create_egress_only_internet_gateway(self) -> str:
         vpc_id = self._get_param("VpcId")
-        tag_param = self._get_multi_param("TagSpecification")
+        tag_param = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         tags = add_tag_specification(tag_param)
 
         egress_only_igw = self.ec2_backend.create_egress_only_internet_gateway(

--- a/moto/ec2/responses/egress_only_internet_gateways.py
+++ b/moto/ec2/responses/egress_only_internet_gateways.py
@@ -5,7 +5,9 @@ from moto.ec2.utils import add_tag_specification
 class EgressOnlyInternetGateway(EC2BaseResponse):
     def create_egress_only_internet_gateway(self) -> str:
         vpc_id = self._get_param("VpcId")
-        tag_param = self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        tag_param = self._get_multi_param(
+            "TagSpecification", skip_result_conversion=True
+        )
         tags = add_tag_specification(tag_param)
 
         egress_only_igw = self.ec2_backend.create_egress_only_internet_gateway(

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -6,7 +6,9 @@ class ElasticIPAddresses(EC2BaseResponse):
     def allocate_address(self) -> str:
         domain = self._get_param("Domain", if_none=None)
         reallocate_address = self._get_param("Address", if_none=None)
-        tag_param = self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        tag_param = self._get_multi_param(
+            "TagSpecification", skip_result_conversion=True
+        )
         tags = add_tag_specification(tag_param)
 
         self.error_on_dryrun()

--- a/moto/ec2/responses/elastic_ip_addresses.py
+++ b/moto/ec2/responses/elastic_ip_addresses.py
@@ -6,7 +6,7 @@ class ElasticIPAddresses(EC2BaseResponse):
     def allocate_address(self) -> str:
         domain = self._get_param("Domain", if_none=None)
         reallocate_address = self._get_param("Address", if_none=None)
-        tag_param = self._get_multi_param("TagSpecification")
+        tag_param = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         tags = add_tag_specification(tag_param)
 
         self.error_on_dryrun()

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -14,7 +14,9 @@ class ElasticNetworkInterfaces(EC2BaseResponse):
         groups = self._get_multi_param("SecurityGroupId")
         subnet = self.ec2_backend.get_subnet(subnet_id)
         description = self._get_param("Description")
-        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
+        tags = add_tag_specification(
+            self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        )
 
         self.error_on_dryrun()
 

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -14,7 +14,7 @@ class ElasticNetworkInterfaces(EC2BaseResponse):
         groups = self._get_multi_param("SecurityGroupId")
         subnet = self.ec2_backend.get_subnet(subnet_id)
         description = self._get_param("Description")
-        tags = add_tag_specification(self._get_multi_param("TagSpecification"))
+        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
 
         self.error_on_dryrun()
 

--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -45,7 +45,9 @@ class Fleets(EC2BaseResponse):
         valid_from = self._get_param("ValidFrom")
         valid_until = self._get_param("ValidUntil")
 
-        tag_specifications = self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        tag_specifications = self._get_multi_param(
+            "TagSpecification", skip_result_conversion=True
+        )
 
         request = self.ec2_backend.create_fleet(
             on_demand_options=on_demand_options,

--- a/moto/ec2/responses/fleets.py
+++ b/moto/ec2/responses/fleets.py
@@ -45,7 +45,7 @@ class Fleets(EC2BaseResponse):
         valid_from = self._get_param("ValidFrom")
         valid_until = self._get_param("ValidUntil")
 
-        tag_specifications = self._get_multi_param("TagSpecification")
+        tag_specifications = self._get_multi_param("TagSpecification", skip_result_conversion=True)
 
         request = self.ec2_backend.create_fleet(
             on_demand_options=on_demand_options,

--- a/moto/ec2/responses/nat_gateways.py
+++ b/moto/ec2/responses/nat_gateways.py
@@ -7,7 +7,9 @@ class NatGateways(EC2BaseResponse):
         subnet_id = self._get_param("SubnetId")
         allocation_id = self._get_param("AllocationId")
         connectivity_type = self._get_param("ConnectivityType")
-        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
+        tags = add_tag_specification(
+            self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        )
 
         nat_gateway = self.ec2_backend.create_nat_gateway(
             subnet_id=subnet_id,

--- a/moto/ec2/responses/nat_gateways.py
+++ b/moto/ec2/responses/nat_gateways.py
@@ -7,7 +7,7 @@ class NatGateways(EC2BaseResponse):
         subnet_id = self._get_param("SubnetId")
         allocation_id = self._get_param("AllocationId")
         connectivity_type = self._get_param("ConnectivityType")
-        tags = add_tag_specification(self._get_multi_param("TagSpecification"))
+        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
 
         nat_gateway = self.ec2_backend.create_nat_gateway(
             subnet_id=subnet_id,

--- a/moto/ec2/responses/network_acls.py
+++ b/moto/ec2/responses/network_acls.py
@@ -4,7 +4,7 @@ from ._base_response import EC2BaseResponse
 class NetworkACLs(EC2BaseResponse):
     def create_network_acl(self) -> str:
         vpc_id = self._get_param("VpcId")
-        tags = self._get_multi_param("TagSpecification")
+        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         if tags:
             tags = tags[0].get("Tag")
         network_acl = self.ec2_backend.create_network_acl(vpc_id, tags=tags)

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -11,7 +11,7 @@ class Subnets(EC2BaseResponse):
         ipv6_cidr_block = self._get_param("Ipv6CidrBlock")
         availability_zone = self._get_param("AvailabilityZone")
         availability_zone_id = self._get_param("AvailabilityZoneId")
-        tags = self._get_multi_param("TagSpecification")
+        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         if tags:
             tags = tags[0].get("Tag")
 

--- a/moto/ec2/responses/transit_gateways.py
+++ b/moto/ec2/responses/transit_gateways.py
@@ -5,7 +5,7 @@ class TransitGateways(EC2BaseResponse):
     def create_transit_gateway(self) -> str:
         description = self._get_param("Description") or None
         options = self._get_multi_param_dict("Options")
-        tags = self._get_multi_param("TagSpecification")
+        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         if tags:
             tags = tags[0].get("Tag")
 

--- a/moto/ec2/responses/vpc_service_configuration.py
+++ b/moto/ec2/responses/vpc_service_configuration.py
@@ -9,7 +9,7 @@ class VPCEndpointServiceConfiguration(EC2BaseResponse):
         if not gateway_lbs and not network_lbs:
             raise NoLoadBalancersProvided
 
-        tags = self._get_multi_param("TagSpecification")
+        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         if tags:
             tags = tags[0].get("Tag")
         acceptance_required = (

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -19,7 +19,7 @@ class VPCs(EC2BaseResponse):
 
     def create_vpc(self) -> str:
         cidr_block = self._get_param("CidrBlock")
-        tags = self._get_multi_param("TagSpecification")
+        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
         instance_tenancy = self._get_param("InstanceTenancy", if_none="default")
         amazon_provided_ipv6_cidr_block = self._get_param(
             "AmazonProvidedIpv6CidrBlock"
@@ -201,7 +201,7 @@ class VPCs(EC2BaseResponse):
         private_dns_enabled = self._get_bool_param("PrivateDnsEnabled", if_none=True)
         security_group_ids = self._get_multi_param("SecurityGroupId")
 
-        tags = add_tag_specification(self._get_multi_param("TagSpecification"))
+        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
         vpc_end_point = self.ec2_backend.create_vpc_endpoint(
             vpc_id=vpc_id,
             service_name=service_name,

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -201,7 +201,9 @@ class VPCs(EC2BaseResponse):
         private_dns_enabled = self._get_bool_param("PrivateDnsEnabled", if_none=True)
         security_group_ids = self._get_multi_param("SecurityGroupId")
 
-        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
+        tags = add_tag_specification(
+            self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        )
         vpc_end_point = self.ec2_backend.create_vpc_endpoint(
             vpc_id=vpc_id,
             service_name=service_name,

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -10,7 +10,9 @@ class VPNConnections(EC2BaseResponse):
         vgw_id = self._get_param("VpnGatewayId")
         tgw_id = self._get_param("TransitGatewayId")
         static_routes = self._get_param("StaticRoutesOnly")
-        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
+        tags = add_tag_specification(
+            self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        )
         vpn_connection = self.ec2_backend.create_vpn_connection(
             vpn_conn_type,
             cgw_id,

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -10,7 +10,7 @@ class VPNConnections(EC2BaseResponse):
         vgw_id = self._get_param("VpnGatewayId")
         tgw_id = self._get_param("TransitGatewayId")
         static_routes = self._get_param("StaticRoutesOnly")
-        tags = add_tag_specification(self._get_multi_param("TagSpecification"))
+        tags = add_tag_specification(self._get_multi_param("TagSpecification", skip_result_conversion=True))
         vpn_connection = self.ec2_backend.create_vpn_connection(
             vpn_conn_type,
             cgw_id,


### PR DESCRIPTION
It seems like moto mishandles tags for a some EC2 resources with the error `AttributeError: 'list' object has no attribute 'get'`.

Commands to reproduce:
```
awslocal ec2 create-vpc --cidr-block 10.0.0.0/16
awslocal ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block 10.0.20.0/20 --tag-specifications '{"Tags":[{"Key":"Name","Value":"ok"},{"Key":"Hello","Value":"World"}]}'
```

I could replicate this error for VPC, Subnets, and Route Tables and just fixed the other EC2 resources which had the same faulty pattern. 