### PR TITLE
EC2: Add validations for create_subnet tags

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -741,6 +741,14 @@ class GenericInvalidParameterValueError(EC2ClientError):
         )
 
 
+class InvalidParameter(EC2ClientError):
+    def __init__(self, message: str):
+        super().__init__(
+            "InvalidParameter",
+            message,
+        )
+
+
 class InvalidSubnetCidrBlockAssociationID(EC2ClientError):
     def __init__(self, association_id: str):
         super().__init__(

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -317,7 +317,7 @@ class SubnetBackend:
         ipv6_cidr_block: Optional[str] = None,
         availability_zone: Optional[str] = None,
         availability_zone_id: Optional[str] = None,
-        tags: Optional[dict[str, dict[str, str]]] = None,
+        tags: Optional[Dict[str, Dict[str, str]]] = None,
     ) -> Subnet:
 
         subnet_id = random_subnet_id()

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     InvalidAvailabilityZoneError,
     InvalidCIDRBlockParameterError,
     InvalidParameterValueError,
+    InvalidParameter,
     InvalidSubnetConflictError,
     InvalidSubnetIdError,
     InvalidSubnetRangeError,
@@ -310,6 +311,19 @@ class SubnetBackend:
             if subnet.default_for_az
         ][0]
 
+    def validate_tags(self, tags: List[dict[str, Any]]) -> None:
+        tags_dict = (
+            tags[0] if isinstance(tags, list) else tags
+        )  # awscli allows for a json string to be passed in
+        if "ResourceType" not in tags_dict:
+            raise InvalidParameter("Tag specification resource type must have a value")
+        if tags_dict["ResourceType"] != "subnet":
+            raise InvalidParameter(
+                f"'{tags_dict['ResourceType']}' is not a valid taggable resource type for this operation."
+            )
+        if "Tags" not in tags_dict:
+            raise InvalidParameter("Tag specification must have at least one tag")
+
     def create_subnet(
         self,
         vpc_id: str,
@@ -317,8 +331,13 @@ class SubnetBackend:
         ipv6_cidr_block: Optional[str] = None,
         availability_zone: Optional[str] = None,
         availability_zone_id: Optional[str] = None,
-        tags: Optional[List[Dict[str, str]]] = None,
+        tags: Optional[List[dict[str, Any]]] = None,
     ) -> Subnet:
+
+        if tags:
+            self.validate_tags(tags)
+            tags = tags[0].get("Tags")
+
         subnet_id = random_subnet_id()
         # Validate VPC exists and the supplied CIDR block is a subnet of the VPC's
         vpc = self.get_vpc(vpc_id)  # type: ignore[attr-defined]

--- a/moto/ec2/responses/_base_response.py
+++ b/moto/ec2/responses/_base_response.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from moto.core.responses import BaseResponse
-from ..exceptions import EmptyTagSpecError
+from ..exceptions import EmptyTagSpecError, InvalidParameter
 from ..utils import convert_tag_spec
 
 
@@ -17,12 +17,32 @@ class EC2BaseResponse(BaseResponse):
         # return {x1: y1, ...}
         return {f["Name"]: f["Value"] for f in _filters}
 
-    def _parse_tag_specification(self) -> Dict[str, Dict[str, str]]:
+    def _parse_tag_specification(
+        self, expected_type: Optional[str] = None
+    ) -> Dict[str, Dict[str, str]]:
         # [{"ResourceType": _type, "Tag": [{"Key": k, "Value": v}, ..]}]
-        tag_spec_set = self._get_multi_param("TagSpecification")
+        tag_spec_set = self._get_multi_param(
+            "TagSpecification", skip_result_conversion=True
+        )
         if not tag_spec_set:
-            tag_spec_set = self._get_multi_param("TagSpecifications")
-        # If we do not pass any Tags, this method will convert this to [_type] instead
+            tag_spec_set = self._get_multi_param(
+                "TagSpecifications", skip_result_conversion=True
+            )
+        if not tag_spec_set:
+            return {}
+
+        tags_dict = (
+            tag_spec_set[0] if isinstance(tag_spec_set, list) else tag_spec_set
+        )  # awscli allows for a json string to be passed and it should be allowed
+        if "ResourceType" not in tags_dict:
+            raise InvalidParameter("Tag specification resource type must have a value")
+        if expected_type and tags_dict["ResourceType"] != expected_type:
+            raise InvalidParameter(
+                f"'{tags_dict['ResourceType']}' is not a valid taggable resource type for this operation."
+            )
+        if "Tag" not in tags_dict:
+            raise InvalidParameter("Tag specification must have at least one tag")
+
         if isinstance(tag_spec_set, list) and any(
             [isinstance(spec, str) for spec in tag_spec_set]
         ):

--- a/moto/ec2/responses/_base_response.py
+++ b/moto/ec2/responses/_base_response.py
@@ -41,11 +41,8 @@ class EC2BaseResponse(BaseResponse):
                 f"'{tags_dict['ResourceType']}' is not a valid taggable resource type for this operation."
             )
         if "Tag" not in tags_dict:
-            raise InvalidParameter("Tag specification must have at least one tag")
-
-        if isinstance(tag_spec_set, list) and any(
-            [isinstance(spec, str) for spec in tag_spec_set]
-        ):
+            if tags_dict.get("ResourceType") == "subnet":
+                raise InvalidParameter("Tag specification must have at least one tag")
             raise EmptyTagSpecError
-        # {_type: {k: v, ..}}
+
         return convert_tag_spec(tag_spec_set)

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -11,7 +11,7 @@ class Subnets(EC2BaseResponse):
         ipv6_cidr_block = self._get_param("Ipv6CidrBlock")
         availability_zone = self._get_param("AvailabilityZone")
         availability_zone_id = self._get_param("AvailabilityZoneId")
-        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
+        tags = self._parse_tag_specification("subnet")
 
         if not availability_zone and not availability_zone_id:
             availability_zone = random.choice(

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -11,9 +11,7 @@ class Subnets(EC2BaseResponse):
         ipv6_cidr_block = self._get_param("Ipv6CidrBlock")
         availability_zone = self._get_param("AvailabilityZone")
         availability_zone_id = self._get_param("AvailabilityZoneId")
-        tags = self._get_multi_param("TagSpecification")
-        if tags:
-            tags = tags[0].get("Tag")
+        tags = self._get_multi_param("TagSpecification", skip_result_conversion=True)
 
         if not availability_zone and not availability_zone_id:
             availability_zone = random.choice(

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -517,6 +517,17 @@ def test_ec2_validate_subnet_tags():
         == "'snapshot' is not a valid taggable resource type for this operation."
     )
 
+    client.create_subnet(
+        VpcId=vpc_id,
+        CidrBlock="10.0.0.1/24",
+        TagSpecifications=[
+            {
+                "ResourceType": "subnet",
+                "Tags": [{"Key": "TEST_TAG", "Value": "TEST_VALUE"}],
+            }
+        ],
+    )
+
 
 def get_filter(tag_val):
     return [

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -470,7 +470,7 @@ def test_retrieve_resource_with_multiple_tags():
 
 @mock_ec2
 def test_ec2_validate_subnet_tags():
-    client = boto3.client("ec2")
+    client = boto3.client("ec2", region_name="us-west-1")
 
     # create vpc
     vpc = client.create_vpc(CidrBlock="10.0.0.0/16")


### PR DESCRIPTION
Wrong inputs are common among users and the crashing of the service instead of returning the correct error message confuse them. This PR adds some extra validations for the situation encountered in localstack/localstack#9195