### PR TITLE
cognito-idp: Use default values for unspecified settings in update_user_pool

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -399,22 +399,7 @@ class CognitoIdpUserPool(BaseModel):
         self.name = name
         self.status = None
 
-        self.extended_config = DEFAULT_USER_POOL_CONFIG.copy()
-        self.extended_config.update(extended_config or {})
-
-        message_template = self.extended_config.get("VerificationMessageTemplate")
-        if message_template and "SmsVerificationMessage" not in extended_config:
-            self.extended_config["SmsVerificationMessage"] = message_template.get(
-                "SmsMessage"
-            )
-        if message_template and "EmailVerificationSubject" not in extended_config:
-            self.extended_config["EmailVerificationSubject"] = message_template.get(
-                "EmailSubject"
-            )
-        if message_template and "EmailVerificationMessage" not in extended_config:
-            self.extended_config["EmailVerificationMessage"] = message_template.get(
-                "EmailMessage"
-            )
+        self.update_extended_config(extended_config)
 
         self.creation_date = utcnow()
         self.last_modified_date = utcnow()
@@ -471,6 +456,24 @@ class CognitoIdpUserPool(BaseModel):
             ),
             None,
         )
+
+    def update_extended_config(self, extended_config: Dict[str, Any]) -> None:
+        self.extended_config = DEFAULT_USER_POOL_CONFIG.copy()
+        self.extended_config.update(extended_config or {})
+
+        message_template = self.extended_config.get("VerificationMessageTemplate")
+        if message_template and "SmsVerificationMessage" not in extended_config:
+            self.extended_config["SmsVerificationMessage"] = message_template.get(
+                "SmsMessage"
+            )
+        if message_template and "EmailVerificationSubject" not in extended_config:
+            self.extended_config["EmailVerificationSubject"] = message_template.get(
+                "EmailSubject"
+            )
+        if message_template and "EmailVerificationMessage" not in extended_config:
+            self.extended_config["EmailVerificationMessage"] = message_template.get(
+                "EmailMessage"
+            )
 
     def _base_json(self) -> Dict[str, Any]:
         return {
@@ -978,7 +981,7 @@ class CognitoIdpBackend(BaseBackend):
         self, user_pool_id: str, extended_config: Dict[str, Any]
     ) -> None:
         user_pool = self.describe_user_pool(user_pool_id)
-        user_pool.extended_config = extended_config
+        user_pool.update_extended_config(extended_config)
 
     def delete_user_pool(self, user_pool_id: str) -> None:
         self.describe_user_pool(user_pool_id)

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -885,6 +885,12 @@ def test_update_user_pool():
         UserPoolId=user_pool_details["UserPool"]["Id"]
     )
     assert updated_user_pool_details["UserPool"]["Policies"] == new_policies
+    assert updated_user_pool_details["UserPool"]["AdminCreateUserConfig"] is not None
+    assert updated_user_pool_details["UserPool"]["EmailConfiguration"] is not None
+    assert (
+        updated_user_pool_details["UserPool"]["VerificationMessageTemplate"] is not None
+    )
+    assert updated_user_pool_details["UserPool"]["AccountRecoverySetting"] is not None
 
 
 @mock_cognitoidp


### PR DESCRIPTION
Hi!

In this PR, I've fixed the behavior of `update_user_pool`.

I discovered that `update_user_pool` overwrites default values even when the request doesn't contain those parameters.

However, the [AWS docs](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UpdateUserPool.html) state:

>If you don't provide a value for an attribute, Amazon Cognito sets it to its default value.

Therefore, I've added a method to extend the default config, ensuring that UserPool uses it during both creation and configuration updates.

Best regards.