### PR TITLE
Admin: Lakeformation: Fix test names

### DIFF
--- a/tests/test_lakeformation/test_resource_tags_integration.py
+++ b/tests/test_lakeformation/test_resource_tags_integration.py
@@ -359,3 +359,51 @@ def test_tag_lakeformation_columns(
             }
         }
     )
+
+
+@lakeformation_aws_verified
+def test_lf_tags(
+    bucket_name=None, db_name=None, table_name=None, column_name=None
+):  # pylint: disable=unused-argument
+    client = boto3.client("lakeformation", region_name="eu-west-2")
+    sts = boto3.client("sts", "eu-west-2")
+    account_id = sts.get_caller_identity()["Account"]
+
+    client.create_lf_tag(TagKey="tag1", TagValues=["1a", "1b", "1c"])
+    client.create_lf_tag(TagKey="tag2", TagValues=["2a", "2b"])
+    client.create_lf_tag(TagKey="tag3", TagValues=["3a", "3b"])
+
+    resp = client.get_lf_tag(TagKey="tag1")
+    assert resp["CatalogId"] == account_id
+    assert resp["TagKey"] == "tag1"
+    assert resp["TagValues"] == ["1a", "1b", "1c"]
+
+    client.update_lf_tag(TagKey="tag1", TagValuesToDelete=["1a", "1c"])
+
+    tags = client.list_lf_tags()["LFTags"]
+    assert set([x["CatalogId"] for x in tags]) == {account_id}
+    tag_keys = [x["TagKey"] for x in tags]
+    assert "tag1" in tag_keys
+    assert "tag2" in tag_keys
+    assert "tag3" in tag_keys
+
+    assert [x for x in tags if x["TagKey"] == "tag1"][0]["TagValues"] == ["1b"]
+    assert set([x for x in tags if x["TagKey"] == "tag2"][0]["TagValues"]) == {
+        "2a",
+        "2b",
+    }
+    assert set([x for x in tags if x["TagKey"] == "tag3"][0]["TagValues"]) == {
+        "3a",
+        "3b",
+    }
+
+    client.delete_lf_tag(TagKey="tag2")
+
+    tags = client.list_lf_tags()["LFTags"]
+    tag_keys = [x["TagKey"] for x in tags]
+    assert "tag1" in tag_keys
+    assert "tag3" in tag_keys
+    assert "tag2" not in tag_keys
+
+    client.delete_lf_tag(TagKey="tag1")
+    client.delete_lf_tag(TagKey="tag3")


### PR DESCRIPTION
These tests depend on multiple services (i.e., Glue and S3), and the names should therefore follow a specific convention (test_*integration.py). 

This will ensure that the DependencyTests know to ignore these.
https://github.com/getmoto/moto/blob/197e8710afcd311cf3845811dccdea7535711feb/scripts/dependency_test.sh#L8