### PR TITLE
Small documentation improvements for new developers

### DIFF
--- a/docs/docs/contributing/development_tips/tests.rst
+++ b/docs/docs/contributing/development_tips/tests.rst
@@ -33,7 +33,7 @@ To verify whether your tests pass in ServerMode, you can run the following comma
 
 .. sourcecode:: bash
 
-  moto_server
+  python moto/server.py
   TEST_SERVER_MODE=true pytest -sv tests/test_service/..
 
 

--- a/docs/docs/contributing/installation.rst
+++ b/docs/docs/contributing/installation.rst
@@ -36,13 +36,20 @@ With all dependencies installed, run the following command to run all the tests 
 
 Note that this may take awhile - there are many services, and each service will have a boatload of tests.
 
+You can also run the linting checks separately:
+
+.. code-block:: bash
+
+  make lint
+
 To verify all tests pass for a specific service, for example for `s3`, run these commands manually:
 
 .. code-block:: bash
 
-  ruff moto/s3
+  ruff moto/s3 tests/test_s3
   black --check moto/s3 tests/test_s3
-  pylint tests/test_s3
+  pylint moto/s3 tests/test_s3
+  mypy
   pytest -sv tests/test_s3
 
 If black fails, you can run the following command to automatically format the offending files:
@@ -76,7 +83,8 @@ Then standard development on Moto can proceed, for example:
 
 .. code-block:: bash
 
-  ruff moto/s3
+  ruff moto/s3 tests/test_s3
   black --check moto/s3 tests/test_s3
-  pylint tests/test_s3
+  pylint moto/s3 tests/test_s3
+  mypy
   pytest -sv tests/test_s3


### PR DESCRIPTION
So I recently read through the documentation and followed the instructions. And I think a few small things can be improved. Let me know if these suggestions are incorrect or if I missed something!

- When I run `moto_server` it starts the version installed by pip, and not the code that I'm actually working on. So I think in the instructions about running the ServerMode tests, `moto_server` should be replaced by `python moto/server.py`.
- I added a reference to the `make lint` target, because I think it may have helped me to prevent pushing code with linting errors.
- Likewise, I updated the section in the documentation for how to test one specific service. I referred to this a lot while writing code because these commands give quick feedback. And I was actually curious why `ruff` was only run on `moto` and `pylint` only on `tests`. Turns out the commands were just incomplete. :-D I also think it makes sense to include `mypy` in this list.

All these changes except the `moto_server` one are actually based on suggestions from @bblommers in https://github.com/getmoto/moto/pull/6894.