### PR TITLE
S3: Add paging to list_object_versions()

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1815,7 +1815,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         all_versions.sort(key=lambda r: (r.name, -unix_time_millis(r.last_modified)))
         last_name = None
 
-        def key_or_version_match(ver: FakeKey | FakeDeleteMarker) -> bool:
+        def key_or_version_match(ver: Union[FakeKey, FakeDeleteMarker]) -> bool:
             if key_marker is None:
                 return True
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1813,6 +1813,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         )
         # sort by name, revert last-modified-date
         all_versions.sort(key=lambda r: (r.name, -unix_time_millis(r.last_modified)))
+        last_name = None
 
         def key_or_version_match(ver: FakeKey | FakeDeleteMarker) -> bool:
             if key_marker is None:
@@ -1828,6 +1829,11 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             all_versions,
         ):
             name = version.name
+            # guaranteed to be sorted - so the first key with this name will be the latest
+            version.is_latest = name != last_name
+            if version.is_latest:
+                last_name = name
+
             # Filter for keys that start with prefix
             if not name.startswith(prefix):
                 continue

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -601,17 +601,31 @@ class S3Response(BaseResponse):
         elif "versions" in querystring:
             delimiter = querystring.get("delimiter", [None])[0]
             key_marker = querystring.get("key-marker", [None])[0]
+            max_keys = int(querystring.get("max-keys", [1000])[0])
             prefix = querystring.get("prefix", [""])[0]
+            version_id_marker = querystring.get("version-id-marker", [None])[0]
 
             bucket = self.backend.get_bucket(bucket_name)
             (
                 versions,
                 common_prefixes,
                 delete_markers,
+                next_key_marker,
+                next_version_id_marker,
             ) = self.backend.list_object_versions(
-                bucket_name, delimiter=delimiter, key_marker=key_marker, prefix=prefix
+                bucket_name,
+                delimiter=delimiter,
+                key_marker=key_marker,
+                max_keys=max_keys,
+                prefix=prefix,
+                version_id_marker=version_id_marker,
             )
             key_list = versions
+
+            is_truncated = False
+            if next_key_marker is not None:
+                is_truncated = True
+
             template = self.response_template(S3_BUCKET_GET_VERSIONS)
 
             return (
@@ -623,10 +637,12 @@ class S3Response(BaseResponse):
                     delete_marker_list=delete_markers,
                     bucket=bucket,
                     prefix=prefix,
-                    max_keys=1000,
+                    max_keys=max_keys,
                     delimiter=delimiter,
                     key_marker=key_marker,
-                    is_truncated="false",
+                    is_truncated=is_truncated,
+                    next_key_marker=next_key_marker,
+                    next_version_id_marker=next_version_id_marker,
                 ),
             )
         elif "encryption" in querystring:
@@ -2580,7 +2596,13 @@ S3_BUCKET_GET_VERSIONS = """<?xml version="1.0" encoding="UTF-8"?>
     <Delimiter>{{ delimiter }}</Delimiter>
     <KeyMarker>{{ key_marker or "" }}</KeyMarker>
     <MaxKeys>{{ max_keys }}</MaxKeys>
-    <IsTruncated>{{ is_truncated }}</IsTruncated>
+    {% if is_truncated %}
+    <IsTruncated>true</IsTruncated>
+    <NextKeyMarker>{{ next_key_marker }}</NextKeyMarker>
+    <NextVersionIdMarker>{{ next_version_id_marker }}</NextVersionIdMarker>
+    {% else %}
+    <IsTruncated>false</IsTruncated>
+    {% endif %}
     {% for key in key_list %}
     <Version>
         <Key>{{ key.name }}</Key>

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -640,6 +640,7 @@ class S3Response(BaseResponse):
                     max_keys=max_keys,
                     delimiter=delimiter,
                     key_marker=key_marker,
+                    version_id_marker=version_id_marker,
                     is_truncated=is_truncated,
                     next_key_marker=next_key_marker,
                     next_version_id_marker=next_version_id_marker,
@@ -2595,11 +2596,14 @@ S3_BUCKET_GET_VERSIONS = """<?xml version="1.0" encoding="UTF-8"?>
     {% endif %}
     <Delimiter>{{ delimiter }}</Delimiter>
     <KeyMarker>{{ key_marker or "" }}</KeyMarker>
+    <VersionIdMarker>{{ version_id_marker or "" }}</VersionIdMarker>
     <MaxKeys>{{ max_keys }}</MaxKeys>
     {% if is_truncated %}
     <IsTruncated>true</IsTruncated>
     <NextKeyMarker>{{ next_key_marker }}</NextKeyMarker>
+    {% if next_version_id_marker %}
     <NextVersionIdMarker>{{ next_version_id_marker }}</NextVersionIdMarker>
+    {% endif %}
     {% else %}
     <IsTruncated>false</IsTruncated>
     {% endif %}


### PR DESCRIPTION
This adds paging to list_object_versions(). The original motivation was to enable moto testing for an S3 point-in-time recovery tool, where proper handling of paging is important.

CC @bblommers