### PR TITLE
EC2: Add default DHCP options set for VPCs

### DIFF
--- a/moto/ec2/models/dhcp_options.py
+++ b/moto/ec2/models/dhcp_options.py
@@ -69,6 +69,11 @@ class DHCPOptionsSetBackend:
         dhcp_options.vpc = vpc
         vpc.dhcp_options = dhcp_options
 
+    def disassociate_dhcp_options(self, vpc: Any) -> None:
+        if vpc.dhcp_options:
+            vpc.dhcp_options.vpc = None
+        vpc.dhcp_options = None
+
     def create_dhcp_options(
         self,
         domain_name_servers: Optional[List[str]] = None,

--- a/moto/ec2/responses/dhcp_options.py
+++ b/moto/ec2/responses/dhcp_options.py
@@ -6,10 +6,13 @@ class DHCPOptions(EC2BaseResponse):
         dhcp_opt_id = self._get_param("DhcpOptionsId")
         vpc_id = self._get_param("VpcId")
 
-        dhcp_opt = self.ec2_backend.describe_dhcp_options([dhcp_opt_id])[0]
         vpc = self.ec2_backend.get_vpc(vpc_id)
 
-        self.ec2_backend.associate_dhcp_options(dhcp_opt, vpc)
+        if dhcp_opt_id == "default":
+            self.ec2_backend.disassociate_dhcp_options(vpc)
+        else:
+            dhcp_opt = self.ec2_backend.describe_dhcp_options([dhcp_opt_id])[0]
+            self.ec2_backend.associate_dhcp_options(dhcp_opt, vpc)
 
         template = self.response_template(ASSOCIATE_DHCP_OPTIONS_RESPONSE)
         return template.render()

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -374,7 +374,7 @@ CREATE_VPC_RESPONSE = """
               {% endfor %}
           </ipv6CidrBlockAssociationSet>
         {% endif %}
-      <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-1a2b3c4d2{% endif %}</dhcpOptionsId>
+      <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}default{% endif %}</dhcpOptionsId>
       <instanceTenancy>{{ vpc.instance_tenancy }}</instanceTenancy>
       <ownerId> {{ vpc.owner_id }}</ownerId>
       <tagSet>
@@ -475,7 +475,7 @@ DESCRIBE_VPCS_RESPONSE = """
               {% endfor %}
             </ipv6CidrBlockAssociationSet>
         {% endif %}
-        <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}dopt-7a8b9c2d{% endif %}</dhcpOptionsId>
+        <dhcpOptionsId>{% if vpc.dhcp_options %}{{ vpc.dhcp_options.id }}{% else %}default{% endif %}</dhcpOptionsId>
         <instanceTenancy>{{ vpc.instance_tenancy }}</instanceTenancy>
         <isDefault>{{ vpc.is_default }}</isDefault>
         <ownerId> {{ vpc.owner_id }}</ownerId>


### PR DESCRIPTION
AWS provides the `AssociateDhcpOptions` operation to associate a DHCP Options Set with a VPC.

There is no `DisassociateDhcpOptions` operation to remove a DHCP Options Set from a VPC. Instead, `DhcpOptionsId` must be set to `default` when calling `AssociateDhcpOptions` to achieve this.

This PR implements this capability.

See: <https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateDhcpOptions.html#API_AssociateDhcpOptions_RequestParameters>

Closes: https://github.com/localstack/localstack/issues/9222