### PR TITLE
EC2: Add support for ED25519 SSH key pairs

### DIFF
--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -8,11 +8,12 @@ from ..exceptions import (
     InvalidKeyPairFormatError,
 )
 from ..utils import (
-    random_key_pair,
+    generic_filter,
     public_key_fingerprint,
     public_key_parse,
-    generic_filter,
     random_key_pair_id,
+    random_ed25519_key_pair,
+    random_rsa_key_pair,
 )
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 
@@ -42,10 +43,14 @@ class KeyPairBackend:
     def __init__(self) -> None:
         self.keypairs: Dict[str, KeyPair] = {}
 
-    def create_key_pair(self, name: str) -> KeyPair:
+    def create_key_pair(self, name: str, key_type: str = "rsa") -> KeyPair:
         if name in self.keypairs:
             raise InvalidKeyPairDuplicateError(name)
-        keypair = KeyPair(name, **random_key_pair())
+        if key_type == "ed25519":
+            keypair = KeyPair(name, **random_ed25519_key_pair())
+        else:
+            keypair = KeyPair(name, **random_rsa_key_pair())
+
         self.keypairs[name] = keypair
         return keypair
 

--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -9,8 +9,8 @@ from ..exceptions import (
 )
 from ..utils import (
     random_key_pair,
-    rsa_public_key_fingerprint,
-    rsa_public_key_parse,
+    public_key_fingerprint,
+    public_key_parse,
     generic_filter,
     random_key_pair_id,
 )
@@ -77,11 +77,11 @@ class KeyPairBackend:
             raise InvalidKeyPairDuplicateError(key_name)
 
         try:
-            rsa_public_key = rsa_public_key_parse(public_key_material)
+            public_key = public_key_parse(public_key_material)
         except ValueError:
             raise InvalidKeyPairFormatError()
 
-        fingerprint = rsa_public_key_fingerprint(rsa_public_key)
+        fingerprint = public_key_fingerprint(public_key)
         keypair = KeyPair(
             key_name, material=public_key_material, fingerprint=fingerprint
         )

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -4,9 +4,9 @@ from ._base_response import EC2BaseResponse
 class KeyPairs(EC2BaseResponse):
     def create_key_pair(self) -> str:
         name = self._get_param("KeyName")
+        key_type = self._get_param("KeyType")
         self.error_on_dryrun()
-
-        keypair = self.ec2_backend.create_key_pair(name)
+        keypair = self.ec2_backend.create_key_pair(name, key_type)
         return self.response_template(CREATE_KEY_PAIR_RESPONSE).render(keypair=keypair)
 
     def delete_key_pair(self) -> str:

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -6,11 +6,12 @@ import ipaddress
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
-from typing import Any, Dict, List, Set, TypeVar, Tuple, Optional, Union
-
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PublicKey,
+    Ed25519PrivateKey,
+)
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.hazmat.primitives.serialization import load_ssh_public_key
+from typing import Any, Dict, List, Set, TypeVar, Tuple, Optional, Union
 
 from moto.core.utils import utcnow
 from moto.iam import iam_backends
@@ -556,7 +557,22 @@ def simple_aws_filter_to_re(filter_string: str) -> str:
     return tmp_filter
 
 
-def random_key_pair() -> Dict[str, str]:
+def random_ed25519_key_pair() -> Dict[str, str]:
+    private_key = Ed25519PrivateKey.generate()
+    private_key_material = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    fingerprint = public_key_fingerprint(private_key.public_key())
+
+    return {
+        "fingerprint": fingerprint,
+        "material": private_key_material.decode("ascii"),
+    }
+
+
+def random_rsa_key_pair() -> Dict[str, str]:
     private_key = rsa.generate_private_key(
         public_exponent=65537, key_size=2048, backend=default_backend()
     )
@@ -649,9 +665,10 @@ def generate_instance_identity_document(instance: Any) -> Dict[str, Any]:
     return document
 
 
-def public_key_parse(key_material: str) -> Union[RSAPublicKey, Ed25519PublicKey]:
+def public_key_parse(
+    key_material: Union[str, bytes]
+) -> Union[RSAPublicKey, Ed25519PublicKey]:
     # These imports take ~.5s; let's keep them local
-    # TODO remove sshpubkeys dep
     import sshpubkeys.exceptions
     from sshpubkeys.keys import SSHKey
 
@@ -659,21 +676,25 @@ def public_key_parse(key_material: str) -> Union[RSAPublicKey, Ed25519PublicKey]
         if not isinstance(key_material, bytes):
             key_material = key_material.encode("ascii")
 
-        decoded_key = base64.b64decode(key_material).decode("ascii")
-        public_key = SSHKey(decoded_key)
+        decoded_key = base64.b64decode(key_material)
+        public_key = SSHKey(decoded_key.decode("ascii"))
     except (sshpubkeys.exceptions.InvalidKeyException, UnicodeDecodeError):
         raise ValueError("bad key")
 
     if public_key.rsa:
         return public_key.rsa
 
+    # `cryptography` currently does not support RSA RFC4716/SSH2 format, otherwise we could get rid of `sshpubkeys` and
+    # simply use `load_ssh_public_key()`
     if public_key.key_type == b"ssh-ed25519":
-        return load_ssh_public_key(bytes(decoded_key, "ascii"))
+        return serialization.load_ssh_public_key(decoded_key)  # type: ignore[return-value]
 
     raise ValueError("bad key")
 
 
 def public_key_fingerprint(public_key: Union[RSAPublicKey, Ed25519PublicKey]) -> str:
+    # TODO: Use different fingerprint calculation methods based on key type and source
+    # see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/verify-keys.html#how-ec2-key-fingerprints-are-calculated
     key_data = public_key.public_bytes(
         encoding=serialization.Encoding.DER,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,

--- a/tests/test_ec2/helpers.py
+++ b/tests/test_ec2/helpers.py
@@ -1,14 +1,23 @@
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import rsa, ed25519
 
 
-def rsa_check_private_key(private_key_material):
+def check_private_key(private_key_material, key_type):
     assert isinstance(private_key_material, str)
 
-    private_key = serialization.load_pem_private_key(
-        data=private_key_material.encode("ascii"),
-        backend=default_backend(),
-        password=None,
-    )
-    assert isinstance(private_key, rsa.RSAPrivateKey)
+    if key_type == "rsa":
+        private_key = serialization.load_pem_private_key(
+            data=private_key_material.encode("ascii"),
+            backend=default_backend(),
+            password=None,
+        )
+        assert isinstance(private_key, rsa.RSAPrivateKey)
+    elif key_type == "ed25519":
+        private_key = serialization.load_ssh_private_key(
+            data=private_key_material.encode("ascii"),
+            password=None,
+        )
+        assert isinstance(private_key, ed25519.Ed25519PrivateKey)
+    else:
+        raise AssertionError("Bad private key")

--- a/tests/test_ec2/test_utils.py
+++ b/tests/test_ec2/test_utils.py
@@ -5,16 +5,19 @@ from pytest import raises
 
 from moto.ec2 import utils
 
-from .helpers import rsa_check_private_key
+from .helpers import check_private_key
 
 
 def test_random_key_pair():
-    key_pair = utils.random_key_pair()
-    rsa_check_private_key(key_pair["material"])
+    key_pair = utils.random_rsa_key_pair()
+    check_private_key(key_pair["material"], "rsa")
 
     # AWS uses MD5 fingerprints, which are 47 characters long, *not* SHA1
     # fingerprints with 59 characters.
     assert len(key_pair["fingerprint"]) == 47
+
+    key_pair = utils.random_ed25519_key_pair()
+    check_private_key(key_pair["material"], "ed25519")
 
 
 def test_random_ipv6_cidr():


### PR DESCRIPTION
This PR adds support for ED25519 SSH key pairs in EC2.

It is now possible to use the `KeyType` field in `CreateKeyPair`, as well as the ability to `ImportKeyPair` ED25519 keys.

See:
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateKeyPair.html
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportKeyPair.html
- https://github.com/localstack/localstack/issues/9237