### PR TITLE
Route53: add CallerReference to the GetHostedZone response

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -4,6 +4,8 @@ import itertools
 import re
 import string
 from collections import defaultdict
+from datetime import datetime
+
 from jinja2 import Template
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -34,6 +36,12 @@ ROUTE53_ID_CHOICE = string.ascii_uppercase + string.digits
 def create_route53_zone_id() -> str:
     # New ID's look like this Z1RWWTK7Y8UDDQ
     return "".join([random.choice(ROUTE53_ID_CHOICE) for _ in range(0, 15)])
+
+
+def create_route53_caller_reference() -> str:
+    timestamp = datetime.now().strftime("%H:%M:%S.%f")
+    random_string = "".join(random.choice(string.ascii_letters) for _ in range(6))
+    return f"{random_string} {timestamp}"
 
 
 class DelegationSet(BaseModel):
@@ -505,13 +513,14 @@ class Route53Backend(BaseBackend):
         self,
         name: str,
         private_zone: bool,
-        caller_reference: str,
+        caller_reference: Optional[str] = None,
         vpcid: Optional[str] = None,
         vpcregion: Optional[str] = None,
         comment: Optional[str] = None,
         delegation_set_id: Optional[str] = None,
     ) -> FakeZone:
         new_id = create_route53_zone_id()
+        caller_reference = caller_reference or create_route53_caller_reference()
         delegation_set = self.create_reusable_delegation_set(
             caller_reference=f"DelSet_{name}", delegation_set_id=delegation_set_id
         )

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -310,6 +310,7 @@ class FakeZone(CloudFormationModel):
         name: str,
         id_: str,
         private_zone: bool,
+        caller_reference: str,
         comment: Optional[str] = None,
         delegation_set: Optional[DelegationSet] = None,
     ):
@@ -318,6 +319,7 @@ class FakeZone(CloudFormationModel):
         self.vpcs: List[Dict[str, Any]] = []
         if comment is not None:
             self.comment = comment
+        self.caller_reference = caller_reference
         self.private_zone = private_zone
         self.rrsets: List[RecordSet] = []
         self.delegation_set = delegation_set
@@ -503,6 +505,7 @@ class Route53Backend(BaseBackend):
         self,
         name: str,
         private_zone: bool,
+        caller_reference: str,
         vpcid: Optional[str] = None,
         vpcregion: Optional[str] = None,
         comment: Optional[str] = None,
@@ -518,6 +521,7 @@ class Route53Backend(BaseBackend):
         new_zone = FakeZone(
             name,
             new_id,
+            caller_reference=caller_reference,
             private_zone=private_zone,
             comment=comment,
             delegation_set=delegation_set,

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -66,6 +66,7 @@ class Route53(BaseResponse):
                     vpcregion = zone_request["VPC"].get("VPCRegion", None)
 
             name = zone_request["Name"]
+            caller_reference = zone_request["CallerReference"]
 
             if name[-1] != ".":
                 name += "."
@@ -75,6 +76,7 @@ class Route53(BaseResponse):
                 name,
                 comment=comment,
                 private_zone=private_zone,
+                caller_reference=caller_reference,
                 vpcid=vpcid,
                 vpcregion=vpcregion,
                 delegation_set_id=delegation_set_id,
@@ -619,6 +621,7 @@ GET_HOSTED_ZONE_RESPONSE = """<GetHostedZoneResponse xmlns="https://route53.amaz
    <HostedZone>
       <Id>/hostedzone/{{ zone.id }}</Id>
       <Name>{{ zone.name }}</Name>
+        <CallerReference>{{ zone.caller_reference }}</CallerReference>
       <ResourceRecordSetCount>{{ zone.rrsets|count }}</ResourceRecordSetCount>
       <Config>
         {% if zone.comment %}

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -33,6 +33,19 @@ def test_create_hosted_zone():
 
 
 @mock_route53
+def test_get_hosted_zone():
+    conn = boto3.client("route53", region_name="us-east-1")
+    name = "testdns.aws.com."
+    caller_ref = str(hash("foo"))
+
+    zone = conn.create_hosted_zone(Name=name, CallerReference=caller_ref)["HostedZone"]
+
+    res = conn.get_hosted_zone(Id=zone["Id"])
+    assert res["HostedZone"]["Name"] == name
+    assert res["HostedZone"]["CallerReference"] == caller_ref
+
+
+@mock_route53
 def test_list_hosted_zones():
     conn = boto3.client("route53", region_name="us-east-1")
 


### PR DESCRIPTION
According to the response syntax of [`GetHostedZone`](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/route53/client/get_hosted_zone.html#Route53.Client.get_hosted_zone), the caller reference should be returned in the hosted zone object.

This PR fixes this behavior. 