### PR TITLE
S3: head_object() only returns 405 on DeleteMarkers when specifying VersionId

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -1,5 +1,9 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, TYPE_CHECKING
 from moto.core.exceptions import RESTError
+
+if TYPE_CHECKING:
+    from moto.s3.models import FakeDeleteMarker
+
 
 ERROR_WITH_BUCKET_NAME = """{% extends 'single_error' %}
 {% block extra %}<BucketName>{{ bucket }}</BucketName>{% endblock %}
@@ -561,8 +565,8 @@ class ObjectLockConfigurationNotFoundError(S3ClientError):
         )
 
 
-class MethodNotAllowed(S3ClientError):
-    code = 405
+class HeadOnDeleteMarker(Exception):
+    """Marker to indicate that we've called `head_object()` on a FakeDeleteMarker"""
 
-    def __init__(self) -> None:
-        super().__init__("MethodNotAllowed", "Method Not Allowed")
+    def __init__(self, marker: "FakeDeleteMarker"):
+        self.marker = marker

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -42,7 +42,7 @@ from moto.s3.exceptions import (
     MissingKey,
     InvalidNotificationDestination,
     MalformedXML,
-    MethodNotAllowed,
+    HeadOnDeleteMarker,
     InvalidStorageClass,
     InvalidTargetBucketForLogging,
     CrossLocationLoggingProhibitted,
@@ -2107,7 +2107,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             bucket_name, key_name, version_id, part_number, return_delete_marker=True
         )
         if isinstance(obj, FakeDeleteMarker):
-            raise MethodNotAllowed
+            raise HeadOnDeleteMarker(obj)
         return obj
 
     def get_object_acl(self, key: FakeKey) -> Optional[FakeAcl]:


### PR DESCRIPTION
Followup/Correction of #6889 

As @jagoodhand pointed out in https://github.com/getmoto/moto/issues/6837#issuecomment-1764206738, we should only return a 405 when calling `head_object()` on a DeleteMarker when the VersionId is specified. 
If `head_object()` is called without the VersionId, we should return a normal 404.

The existing test has been extended to verify this scenario, and passes when run against AWS.