### PR TITLE
Fix: SESV2 send_email with HTML body

### DIFF
--- a/moto/sesv2/responses.py
+++ b/moto/sesv2/responses.py
@@ -42,11 +42,16 @@ class SESV2Response(BaseResponse):
                 raw_data=base64.b64decode(content["Raw"]["Data"]).decode("utf-8"),
             )
         elif "Simple" in content:
+            content_body = content["Simple"]["Body"]
+            if "Html" in content_body:
+                body = content_body["Html"]["Data"]
+            else:
+                body = content_body["Text"]["Data"]
             message = self.sesv2_backend.send_email(  # type: ignore
                 source=from_email_address,
                 destinations=destination,
                 subject=content["Simple"]["Subject"]["Data"],
-                body=content["Simple"]["Body"]["Text"]["Data"],
+                body=body,
             )
         elif "Template" in content:
             raise NotImplementedError("Template functionality not ready")


### PR DESCRIPTION
Fix of #6909, part 2.

#6913 handled the case of "Text" body. The goal of this PR is to handle the "Html" body case.

Ref: see SES v2 [send_email](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sesv2/client/send_email.html).
Cc: @bblommers
