### PR TITLE
Admin: Update TF tests

### DIFF
--- a/.github/workflows/test_terraform.yml
+++ b/.github/workflows/test_terraform.yml
@@ -11,6 +11,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   test_service:
     needs: prepare_list
+    permissions:
+      actions: read
+      contents: read
     if: "!contains(github.event.pull_request.labels.*.name, 'java')"
     strategy:
       fail-fast: false
@@ -27,6 +30,11 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: tests/terraformtests/terraform-provider-aws/go.sum
+    - name: Go Dependencies
+      run: |
+        cd tests/terraformtests/terraform-provider-aws
+        go list -m -u all
+        cd ../../..
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -43,6 +51,10 @@ jobs:
     - name: Get original AWS service name
       id: get-service-name
       run: echo "servicename=$(python -c "print('${{ matrix.service }}'[:'${{ matrix.service }}'.index('|') if '|' in '${{ matrix.service }}' else len('${{ matrix.service }}')])")" >> $GITHUB_OUTPUT
+    - name: Collect Workflow Telemetry
+      uses: runforesight/workflow-telemetry-action@v1
     - name: Execute tests
+      env:
+        TF_LOG: "debug"
       run: |
         make terraformtests SERVICE_NAME=${{ steps.get-service-name.outputs.servicename }} TEST_NAMES=${{ steps.get-list.outputs.testlist }}

--- a/tests/terraformtests/bin/run_go_test
+++ b/tests/terraformtests/bin/run_go_test
@@ -14,6 +14,7 @@ PATCH="etc/0001-Patch-Hardcode-endpoints-to-local-server.patch"
 (git apply $pwd/etc/0006-CF-Reduce-wait-times.patch > /dev/null 2>&1 && echo "Patched CF") || echo "!! Not able to patch CF"
 (git apply $pwd/etc/0007-Comprehend-Reduce-wait-times.patch > /dev/null 2>&1 && echo "Patched Comprehend") || echo "!! Not able to patch Comprehend"
 (git apply $pwd/etc/0008-Patch-RDS-improvements.patch > /dev/null 2>&1 && echo "Patched RDS") || echo "!! Not able to patch RDS"
+(git apply $pwd/etc/0009-Patch-CloudFormation-delays.patch > /dev/null 2>&1 && echo "Patched CloudFormation") || echo "!! Not able to patch CloudFormation"
 )
 
 (
@@ -23,5 +24,5 @@ TF_ACC=1 \
   AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
   AWS_ALTERNATE_ACCESS_KEY_ID=test AWS_ALTERNATE_SECRET_ACCESS_KEY=test \
   AWS_THIRD_SECRET_ACCESS_KEY=test AWS_THIRD_ACCESS_KEY_ID=test \
-  go test ./internal/service/$1/ -v -timeout 60m -run $2
+  go test ./internal/service/$1/ -v -timeout 240m -run $2
 )

--- a/tests/terraformtests/etc/0001-Patch-Hardcode-endpoints-to-local-server.patch
+++ b/tests/terraformtests/etc/0001-Patch-Hardcode-endpoints-to-local-server.patch
@@ -1,21 +1,22 @@
-From 83f8df495c5fc187d925a7dd61f93d1fdc4f405b Mon Sep 17 00:00:00 2001
+From bf15437c8a30fc8b0afebf97a509d22d45da1e94 Mon Sep 17 00:00:00 2001
 From: Bert Blommers <info@bertblommers.nl>
-Date: Sun, 13 Aug 2023 21:16:30 +0000
-Subject: [PATCH] Patch endpoints to localhost:4566
+Date: Thu, 19 Oct 2023 22:22:07 +0000
+Subject: [PATCH] Patch hardcoded endpoints
 
 ---
- internal/conns/config.go      | 14 ++++++++++++++
+ internal/conns/config.go      | 16 ++++++++++++++++
  internal/provider/provider.go |  4 ++--
- 2 files changed, 16 insertions(+), 2 deletions(-)
+ 2 files changed, 18 insertions(+), 2 deletions(-)
 
 diff --git a/internal/conns/config.go b/internal/conns/config.go
-index 72c9cabde0..1f2e0d00e9 100644
+index b376ffacae..f41d4fee3f 100644
 --- a/internal/conns/config.go
 +++ b/internal/conns/config.go
-@@ -55,10 +55,24 @@ type Config struct {
+@@ -58,12 +58,28 @@ type Config struct {
  	UseFIPSEndpoint                bool
  }
 
++
 +// XXX: added by bblommers
 +func GetLocalEndpoints() map[string]string {
 +	const localEndpoint = "http://localhost:4566"
@@ -26,22 +27,25 @@ index 72c9cabde0..1f2e0d00e9 100644
 +	return localEndpoints
 +}
 +
++
  // ConfigureProvider configures the provided provider Meta (instance data).
  func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWSClient, diag.Diagnostics) {
  	var diags diag.Diagnostics
 
-+    // XXX: added by bblommers
+ 	ctx, logger := logging.NewTfLogger(ctx)
+
++	// XXX: added by bblommers
 +	// insert custom endpoints
 +	c.Endpoints = GetLocalEndpoints()
 +
  	awsbaseConfig := awsbase.Config{
  		AccessKey:                     c.AccessKey,
- 		APNInfo:                       StdUserAgentProducts(c.TerraformVersion),
+ 		AllowedAccountIds:             c.AllowedAccountIds,
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go
-index 88c6ea9538..cfe78c5549 100644
+index 0bcb6d6a98..78b088c68e 100644
 --- a/internal/provider/provider.go
 +++ b/internal/provider/provider.go
-@@ -452,13 +452,13 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
+@@ -462,13 +462,13 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
  		CustomCABundle:                 d.Get("custom_ca_bundle").(string),
  		EC2MetadataServiceEndpoint:     d.Get("ec2_metadata_service_endpoint").(string),
  		EC2MetadataServiceEndpointMode: d.Get("ec2_metadata_service_endpoint_mode").(string),
@@ -58,4 +62,5 @@ index 88c6ea9538..cfe78c5549 100644
  		SkipCredsValidation:            d.Get("skip_credentials_validation").(bool),
  		SkipRegionValidation:           d.Get("skip_region_validation").(bool),
 --
-2.25.1
+2.34.1
+

--- a/tests/terraformtests/etc/0006-CF-Reduce-wait-times.patch
+++ b/tests/terraformtests/etc/0006-CF-Reduce-wait-times.patch
@@ -1,29 +1,42 @@
-From c2981f42629c1dcb3756c13f243c8c52391f3677 Mon Sep 17 00:00:00 2001
+From 787080f8c3cac8d7c982843d3470b6ad1dc12985 Mon Sep 17 00:00:00 2001
 From: Bert Blommers <info@bertblommers.nl>
-Date: Sun, 13 Aug 2023 21:43:26 +0000
-Subject: [PATCH] Patch: CloudFront timings
+Date: Fri, 20 Oct 2023 18:31:37 +0000
+Subject: [PATCH] Patch CloudFront delays
 
 ---
- internal/service/cloudfront/distribution.go | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ internal/service/cloudfront/distribution.go | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/internal/service/cloudfront/distribution.go b/internal/service/cloudfront/distribution.go
-index 4870ca0f6d..8190b12231 100644
+index 7d66d22860..ac1c83b8e4 100644
 --- a/internal/service/cloudfront/distribution.go
 +++ b/internal/service/cloudfront/distribution.go
-@@ -1120,9 +1120,9 @@ func DistributionWaitUntilDeployed(ctx context.Context, id string, meta interfac
+@@ -1148,9 +1148,9 @@ func WaitDistributionDeployed(ctx context.Context, conn *cloudfront.CloudFront,
  		Pending:    []string{"InProgress"},
  		Target:     []string{"Deployed"},
- 		Refresh:    resourceWebDistributionStateRefreshFunc(ctx, id, meta),
+ 		Refresh:    distributionDeployRefreshFunc(ctx, conn, id),
 -		Timeout:    90 * time.Minute,
 -		MinTimeout: 15 * time.Second,
--		Delay:      1 * time.Minute,
+-		Delay:      30 * time.Second,
 +		Timeout:    90 * time.Second,
 +		MinTimeout: 2 * time.Second,
 +		Delay:      2 * time.Second,
  	}
 
  	_, err := stateConf.WaitForStateContext(ctx)
--- 
-2.25.1
+@@ -1162,9 +1162,9 @@ func WaitDistributionDeleted(ctx context.Context, conn *cloudfront.CloudFront, i
+ 		Pending:    []string{"InProgress", "Deployed"},
+ 		Target:     []string{},
+ 		Refresh:    distributionDeleteRefreshFunc(ctx, conn, id),
+-		Timeout:    90 * time.Minute,
+-		MinTimeout: 15 * time.Second,
+-		Delay:      15 * time.Second,
++		Timeout:    90 * time.Second,
++		MinTimeout: 2 * time.Second,
++		Delay:      2 * time.Second,
+ 	}
+
+ 	_, err := stateConf.WaitForStateContext(ctx)
+--
+2.34.1
 

--- a/tests/terraformtests/etc/0009-Patch-CloudFormation-delays.patch
+++ b/tests/terraformtests/etc/0009-Patch-CloudFormation-delays.patch
@@ -1,0 +1,43 @@
+From dc6ca47bf4fe94083559b8a3c824ab387bccebe6 Mon Sep 17 00:00:00 2001
+From: Bert Blommers <info@bertblommers.nl>
+Date: Fri, 20 Oct 2023 18:28:08 +0000
+Subject: [PATCH] Patch CloudFormation delays
+
+---
+ internal/service/cloudformation/stack.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/internal/service/cloudformation/stack.go b/internal/service/cloudformation/stack.go
+index e7ba19db9c..c18e5358c0 100644
+--- a/internal/service/cloudformation/stack.go
++++ b/internal/service/cloudformation/stack.go
+@@ -473,7 +473,7 @@ func WaitStackCreated(ctx context.Context, conn *cloudformation.CloudFormation,
+ 		},
+ 		Timeout:    timeout,
+ 		MinTimeout: minTimeout,
+-		Delay:      10 * time.Second,
++		Delay:      2 * time.Second,
+ 		Refresh:    statusStack(ctx, conn, name),
+ 	}
+ 
+@@ -535,7 +535,7 @@ func WaitStackUpdated(ctx context.Context, conn *cloudformation.CloudFormation,
+ 		},
+ 		Timeout:    timeout,
+ 		MinTimeout: minTimeout,
+-		Delay:      10 * time.Second,
++		Delay:      2 * time.Second,
+ 		Refresh:    statusStack(ctx, conn, name),
+ 	}
+ 
+@@ -576,7 +576,7 @@ func WaitStackDeleted(ctx context.Context, conn *cloudformation.CloudFormation,
+ 		},
+ 		Timeout:    timeout,
+ 		MinTimeout: minTimeout,
+-		Delay:      10 * time.Second,
++		Delay:      2 * time.Second,
+ 		Refresh:    statusStack(ctx, conn, name),
+ 	}
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
The existing tests were failing because of a Golang panic, `concurrent map writes`. There were no changes to the Moto and/or the TF tests themselves when this started, so it error occured presumably due to a `golang` dependency update.

Updating the TF to [latest](https://github.com/hashicorp/terraform-provider-aws/commit/b35c1b3529733ca7be22c640a29eda61ba624fd2) seems to 'solve' it - with the caveat that  tests now timeout, because they take 10+ times longer to execute.

The TF tests are [disabled](https://github.com/getmoto/moto/commit/531fdc7851ad1fa259c6298596343d6589f206ad) on master for now. 

I'll continue to try and figure out why these timeouts are happening. For now, I'll just close this PR, as there is no point in running the regular tests for every change - I'll just run the TF tests manually. When there is a solution, I'll reopen.