### PR TITLE
S3: fix unquoting of S3 object keys in DeleteObjects

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -363,6 +363,11 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         self.uri = full_url
 
         self.path = self.parsed_url.path
+        if self.is_werkzeug_request and "RAW_URI" in request.environ:
+            self.raw_path = urlparse(request.environ.get("RAW_URI")).path
+        else:
+            self.raw_path = self.path
+
         self.querystring = querystring
         self.data = querystring
         self.method = request.method

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1482,9 +1482,9 @@ class S3Response(BaseResponse):
                 if isinstance(copy_source, bytes):
                     copy_source = copy_source.decode("utf-8")
                 copy_source_parsed = urlparse(copy_source)
-                url_path = copy_source_parsed.path
-                # this path should not be decoded, as it is not encoded in the headers
-                src_bucket, src_key = url_path.lstrip("/").split("/", 1)
+                src_bucket, src_key = (
+                    unquote(copy_source_parsed.path).lstrip("/").split("/", 1)
+                )
                 src_version_id = parse_qs(copy_source_parsed.query).get(
                     "versionId", [None]  # type: ignore
                 )[0]

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Iterator, Union, Tuple, Optional, Type
 import urllib.parse
 
 from moto import settings
-from moto.core.versions import is_werkzeug_2_3_x
 from moto.core.utils import (
     extract_region_from_aws_authorization,
     str_to_rfc_1123_datetime,
@@ -1153,10 +1152,6 @@ class S3Response(BaseResponse):
             objects = [objects]
         if len(objects) == 0:
             raise MalformedXML()
-        if self.is_werkzeug_request and is_werkzeug_2_3_x():
-            for obj in objects:
-                if "Key" in obj:
-                    obj["Key"] = self.get_safe_path(obj["Key"])
 
         if authenticated:
             deleted_objects = self.backend.delete_objects(bucket_name, objects)

--- a/tests/test_core/test_utils.py
+++ b/tests/test_core/test_utils.py
@@ -7,7 +7,6 @@ from moto.core.utils import (
     unix_time,
     camelcase_to_pascal,
     pascal_to_camelcase,
-    _unquote_hex_characters,
 )
 
 
@@ -51,29 +50,3 @@ def test_camelcase_to_pascal(_input, expected):
 @freeze_time("2015-01-01 12:00:00")
 def test_unix_time():
     assert unix_time() == 1420113600.0
-
-
-@pytest.mark.parametrize(
-    "original_url,result",
-    [
-        ("some%3Fkey", "some?key"),
-        ("6T7\x159\x12\r\x08.txt", "6T7\x159\x12\r\x08.txt"),
-        ("foobar/the-unicode-%E2%98%BA-key", "foobar/the-unicode-☺-key"),
-        ("key-with%2Eembedded%2Eurl%2Eencoding", "key-with.embedded.url.encoding"),
-        # Can represent a single character
-        ("%E2%82%AC", "€"),
-        ("%2E", "."),
-        # Multiple chars in a row
-        ("%E2%82%AC%E2%82%AC", "€€"),
-        ("%2E%2E", ".."),
-    ],
-)
-def test_quote_characters(original_url, result):
-    assert _unquote_hex_characters(original_url) == result
-
-
-@pytest.mark.parametrize("original_path", ["%2F%2F", "s%2Fs%2Fs%2F"])
-def test_quote_characters__with_slashes(original_path):
-    # If the string contains slashes, we ignore them
-    # Werkzeug already takes care of those for us
-    assert _unquote_hex_characters(original_path) == original_path

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3425,7 +3425,10 @@ def test_delete_objects_percent_encoded():
     client.put_object(
         Bucket=bucket_name, Key=object_key_2, Body="percent encoded emoji"
     )
-    assert len(client.list_objects(Bucket=bucket_name)["Contents"]) == 2
+    list_objs = client.list_objects(Bucket=bucket_name)
+    assert len(list_objs["Contents"]) == 2
+    assert list_objs["Contents"][0]["Key"] == object_key_1
+    assert list_objs["Contents"][1]["Key"] == object_key_2
 
     delete_objects = client.delete_objects(
         Bucket=bucket_name,


### PR DESCRIPTION
As reported in https://github.com/localstack/localstack/issues/9428, moto is decoding the content of the `DeleteObjects` body, but those keys are not going through the URL encoding as they're in the XML, and should be used as is.

I've removed the `get_safe_path` call from `DeleteObjects` and added a test validating the behaviour, tested against AWS.

This devolved into a bit of a rabbit hole, as it seems fixing this still did not delete the keys, because they were saved with an emoji in the name where it should have been using the raw url encoded format like S3.

```python
object_key_emoji = "a/%F0%9F%98%80"
client.put_object(Bucket=bucket_name, Key=object_key_emoji, Body="emoji percent encoding")
```
Result of `ListObjects`:
```json
{
    "Contents": [
        {
            "ETag": "\"ec53baa61c0c0b736a567bdef59250f3\"",
            "Key": "a/😀",
        }
     ]
}
```

I've changed the `get_safe_path` util to make use of Werkzeug `RAW_URI`, as this contains the URI as received by the server. We can then use those proper values to construct the object key, and this circumvents all issue related to the key encoding. This is a rather big change, but if the tests are green, I believe this would be safe to do. 