### PR TITLE
AWSLambda: mark layers test as requiring docker

### DIFF
--- a/tests/test_awslambda/test_lambda_layers_invoked.py
+++ b/tests/test_awslambda/test_lambda_layers_invoked.py
@@ -4,6 +4,7 @@ import pkgutil
 from moto import mock_lambda
 from uuid import uuid4
 
+from tests.markers import requires_docker
 from .utilities import get_role_name, _process_lambda
 
 PYTHON_VERSION = "python3.11"
@@ -20,6 +21,7 @@ def lambda_handler(event, context):
     return _process_lambda(pfunc)
 
 
+@requires_docker
 @mock_lambda
 def test_invoke_local_lambda_layers():
     conn = boto3.client("lambda", _lambda_region)


### PR DESCRIPTION
Otherwise without docker it fails like this;

```
        msg = success_result["Payload"].read().decode("utf-8")
>       assert msg == '"2.31.0"'
E       assert "error runnin... directory'))" == '"2.31.0"'
E         - "2.31.0"
E         + error running docker: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
```