### PR TITLE
Up openapi-spec-validator version; swith to pytest-order

### DIFF
--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [ "3.11" ]
         responses-version: ["0.13.0", "0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
         werkzeug-version: ["2.0.1", "2.1.1", "2.2.2"]
-        openapi-spec-validator-version: ["0.4.0", "0.5.0"]
+        openapi-spec-validator-version: ["0.5.0"]
 
     steps:
     - name: Checkout repository

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -6,15 +6,11 @@ import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from openapi_spec_validator import validate_spec
 import requests
 import responses
 
-try:
-    from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
-except ImportError:
-    # OpenAPI Spec Validator < 0.5.0
-    from openapi_spec_validator.exceptions import OpenAPIValidationError  # type: ignore
+from openapi_spec_validator import validate_spec
+from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
 from moto.core import BaseBackend, BackendDict, BaseModel, CloudFormationModel
 from .utils import create_id, to_path
 from moto.core.utils import path_url

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,7 +1,7 @@
 coverage
 pytest
 pytest-cov
-pytest-ordering
+pytest-order
 pytest-xdist
 freezegun
 pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ all =
     PyYAML>=5.1
     cfn-lint>=0.40.0
     sshpubkeys>=3.1.0
-    openapi-spec-validator>=0.2.8
+    openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
     py-partiql-parser==0.4.1
@@ -64,7 +64,7 @@ proxy =
     PyYAML>=5.1
     cfn-lint>=0.40.0
     sshpubkeys>=3.1.0
-    openapi-spec-validator>=0.2.8
+    openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
     py-partiql-parser==0.4.1
@@ -79,7 +79,7 @@ server =
     PyYAML>=5.1
     cfn-lint>=0.40.0
     sshpubkeys>=3.1.0
-    openapi-spec-validator>=0.2.8
+    openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
     py-partiql-parser==0.4.1
@@ -94,7 +94,7 @@ apigateway =
     PyYAML>=5.1
     python-jose[cryptography]>=3.1.0,<4.0.0
     ecdsa!=0.15
-    openapi-spec-validator>=0.2.8
+    openapi-spec-validator>=0.5.0
 apigatewayv2 = PyYAML>=5.1
 applicationautoscaling =
 appsync = graphql-core
@@ -113,7 +113,7 @@ cloudformation =
     PyYAML>=5.1
     cfn-lint>=0.40.0
     sshpubkeys>=3.1.0
-    openapi-spec-validator>=0.2.8
+    openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
     py-partiql-parser==0.4.1
@@ -202,7 +202,7 @@ resourcegroupstaggingapi =
     PyYAML>=5.1
     cfn-lint>=0.40.0
     sshpubkeys>=3.1.0
-    openapi-spec-validator>=0.2.8
+    openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
     py-partiql-parser==0.4.1

--- a/tests/test_core/test_docker.py
+++ b/tests/test_core/test_docker.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 @requires_docker
-@pytest.mark.run(order=0)
+@pytest.mark.order(0)
 def test_docker_package_is_available():
     try:
         import docker  # noqa: F401   # pylint: disable=unused-import
@@ -21,7 +21,7 @@ def test_docker_package_is_available():
 
 
 @requires_docker
-@pytest.mark.run(order=0)
+@pytest.mark.order(0)
 def test_docker_is_running_and_available():
     import docker
     from docker.errors import DockerException


### PR DESCRIPTION
`openapi-spec-validator 0.5.0` was [released over a year ago](https://github.com/python-openapi/openapi-spec-validator/releases/tag/0.5.0), so it's reasonable to make that the new minimum version IMO. That way we can finally get rid of the ugly ImportError.

This PR also switches our dev-dependencies to use `pytest-order` (https://github.com/pytest-dev/pytest-order), as that a maintained fork of `pytest-ordering`.

Closes #6937 