### PR TITLE
APIGateway: Use new OpenAPISpecValidator API

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -9,7 +9,13 @@ from urllib.parse import urlparse
 import requests
 import responses
 
-from openapi_spec_validator import validate_spec
+try:
+    # Recommended as of 0.7.x
+    from openapi_spec_validator import validate  # type: ignore
+except ImportError:
+    # Only used in < 0.7.x
+    # (Also exists in 0.7.0, but throws a warning)
+    from openapi_spec_validator import validate_spec as validate  # type: ignore
 from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
 from moto.core import BaseBackend, BackendDict, BaseModel, CloudFormationModel
 from .utils import create_id, to_path
@@ -1567,7 +1573,7 @@ class APIGatewayBackend(BaseBackend):
         """
         if fail_on_warnings:
             try:
-                validate_spec(api_doc)  # type: ignore[arg-type]
+                validate(api_doc)  # type: ignore[arg-type]
             except OpenAPIValidationError as e:
                 raise InvalidOpenAPIDocumentException(e)
             except AttributeError:
@@ -1642,7 +1648,7 @@ class APIGatewayBackend(BaseBackend):
 
         if fail_on_warnings:
             try:
-                validate_spec(api_doc)  # type: ignore[arg-type]
+                validate(api_doc)  # type: ignore[arg-type]
             except OpenAPIValidationError as e:
                 raise InvalidOpenAPIDocumentException(e)
             except AttributeError:

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3413,11 +3413,10 @@ def test_delete_objects_with_empty_keyname():
     assert "Contents" not in client.list_objects(Bucket=bucket_name)
 
 
-@mock_s3
-def test_delete_objects_percent_encoded():
+@pytest.mark.aws_verified
+@s3_aws_verified
+def test_delete_objects_percent_encoded(bucket_name=None):
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
-    bucket_name = "testbucket-encoded"
-    client.create_bucket(Bucket=bucket_name)
 
     object_key_1 = "a%2Fb"
     object_key_2 = "a/%F0%9F%98%80"
@@ -3427,8 +3426,9 @@ def test_delete_objects_percent_encoded():
     )
     list_objs = client.list_objects(Bucket=bucket_name)
     assert len(list_objs["Contents"]) == 2
-    assert list_objs["Contents"][0]["Key"] == object_key_1
-    assert list_objs["Contents"][1]["Key"] == object_key_2
+    keys = [o["Key"] for o in list_objs["Contents"]]
+    assert object_key_1 in keys
+    assert object_key_2 in keys
 
     delete_objects = client.delete_objects(
         Bucket=bucket_name,
@@ -3439,8 +3439,10 @@ def test_delete_objects_percent_encoded():
             ],
         },
     )
-    assert delete_objects["Deleted"][0] == {"Key": object_key_1}
-    assert delete_objects["Deleted"][1] == {"Key": object_key_2}
+    assert len(delete_objects["Deleted"]) == 2
+    deleted_keys = [o for o in delete_objects["Deleted"]]
+    assert {"Key": object_key_1} in deleted_keys
+    assert {"Key": object_key_2} in deleted_keys
     assert "Contents" not in client.list_objects(Bucket=bucket_name)
 
 


### PR DESCRIPTION
As of 0.7.x, `openapi_spec_validator` recommends using the `validate`-method.

The old `validate-spec` method still exists, but throws a warning.

This also refactors one of the new S3 tests a bit to ensure we can run this against AWS.