### PR TITLE
docs: fix typos in markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1429,7 +1429,7 @@ Docker Digest for 3.1.10: _sha256:18c6367dbb843850a5b52bc2b74cde9fd2a03719da667a
         * AWSLamba:publish_layer_version() now supports the CompatibleArchitectures-parameter
         * DAX:create_cluster() now supports the ClusterEndpointEncryptionType-parameter
         * EC2:describe_route_tables() now supports the filter `route.gateway-id`
-        * EC2:run_instances() now validates whether the Placement-parameter has a valid availabilty zone
+        * EC2:run_instances() now validates whether the Placement-parameter has a valid availability zone
         * ECS:list_services() now supports the launchType-parameter
         * ELB:describe_instance_health() now returns the OutOfService-status when appropriate
         * Organizations:list_accounts_for_parent() now supports pagination
@@ -2072,7 +2072,7 @@ Docker Digest for 3.0.4: _sha256:320e1d2ab89729d5580dbe08d8c2153a28db4c28023c577
             * pause_cluster()
             * resume_cluster()
 
-    Miscellanous:
+    Miscellaneous:
         * ELBv2: create_listener now supports the DefaultActions.ForwardConfig parameter
         * Redshift: restore_from_cluster_snapshot() now supports the NodeType and NumberOfNodes-parameters
         * Sagemaker: list_experiments() now supports pagination

--- a/moto/dynamodb/parsing/README.md
+++ b/moto/dynamodb/parsing/README.md
@@ -20,4 +20,4 @@ validation all the values will be resolved.
 ## 4) Update Expression gets executed using the validated AST
 Finally the AST is used to execute the update expression. There should be no reason for this step to fail
 since validation has completed. Due to this we have the update expressions behaving atomically (i.e. all the
-actions of the update expresion are performed or none of them are performed).
+actions of the update expression are performed or none of them are performed).


### PR DESCRIPTION
I have fixed some typos in markdown files. Following are the fixed typos:
1. availabilty -> availability
2. Miscellanous -> Miscellaneous
3. expresion -> expression 
I kindly request the repository maintainers to review and merge it. Thanks!