### PR TITLE
MQ: Rabbits can now be configured

### DIFF
--- a/moto/mq/exceptions.py
+++ b/moto/mq/exceptions.py
@@ -52,21 +52,6 @@ class UnknownUser(MQError):
         return json.dumps(body)
 
 
-class UnsupportedEngineType(MQError):
-    def __init__(self, engine_type: str):
-        super().__init__("BadRequestException", "")
-        self.engine_type = engine_type
-
-    def get_body(
-        self, *args: Any, **kwargs: Any
-    ) -> str:  # pylint: disable=unused-argument
-        body = {
-            "errorAttribute": "engineType",
-            "message": f"Broker engine type [{self.engine_type}] does not support configuration.",
-        }
-        return json.dumps(body)
-
-
 class UnknownEngineType(MQError):
     def __init__(self, engine_type: str):
         super().__init__("BadRequestException", "")

--- a/tests/test_mq/test_mq.py
+++ b/tests/test_mq/test_mq.py
@@ -25,6 +25,11 @@ def test_create_broker_minimal():
     assert "BrokerId" in resp
     assert resp["BrokerArn"].startswith("arn:aws")
 
+    # Should create default Configuration, if not specified
+    broker = client.describe_broker(BrokerId=resp["BrokerId"])
+    assert "Current" in broker["Configurations"]
+    assert "Id" in broker["Configurations"]["Current"]
+
 
 @mock_mq
 def test_create_with_tags():
@@ -269,7 +274,6 @@ def test_describe_multiple_rabbits():
         == "https://0000.mq.us-east-2.amazonaws.com"
     )
     assert len(resp["BrokerInstances"][0]["Endpoints"]) == 1
-    assert "Configurations" not in resp
     assert resp["Logs"] == {"General": False}
     assert len(resp["SubnetIds"]) == 4
 

--- a/tests/test_mq/test_mq_configuration.py
+++ b/tests/test_mq/test_mq_configuration.py
@@ -36,22 +36,6 @@ def test_create_configuration_minimal():
 
 
 @mock_mq
-def test_create_configuration_for_rabbitmq():
-    client = boto3.client("mq", region_name="us-east-1")
-
-    with pytest.raises(ClientError) as exc:
-        client.create_configuration(
-            EngineType="RABBITMQ", EngineVersion="rabbit1", Name="myconfig"
-        )
-    err = exc.value.response["Error"]
-    assert err["Code"] == "BadRequestException"
-    assert (
-        err["Message"]
-        == "Broker engine type [RABBITMQ] does not support configuration."
-    )
-
-
-@mock_mq
 def test_create_configuration_for_unknown_engine():
     client = boto3.client("mq", region_name="us-east-1")
 


### PR DESCRIPTION
Configuring brokers with RabbitMQ wasn't possible at first, but it is now.

See the AWS blog post about this feature:
https://aws.amazon.com/about-aws/whats-new/2023/07/amazon-mq-managed-configuration-rabbitmq-brokers/

We now also create a default configuration, instead of pointing it to a random (non-existing) identifier.