### PR TITLE
Admin: Support Py 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests_decoratormode.yml
+++ b/.github/workflows/tests_decoratormode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_proxymode.yml
+++ b/.github/workflows/tests_proxymode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_servermode.yml
+++ b/.github/workflows/tests_servermode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
       run: |
         pip install build
         python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e MOTO_EC2_LOAD_DEFAULT_AMIS=false -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:${{ matrix.python-version }}-buster /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e MOTO_EC2_LOAD_DEFAULT_AMIS=false -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:${{ matrix.python-version }}-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
     - name: Get pip cache dir
       id: pip-cache

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
     # Leave a GitHub comment after all builds have passed
-    after_n_builds: 10
+    after_n_builds: 12
 coverage:
   status:
     project:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Testing
 keywords = aws ec2 s3 boto3 mock
@@ -52,7 +53,7 @@ all =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
     aws-xray-sdk!=0.96,>=0.93
     setuptools
     multipart
@@ -67,7 +68,7 @@ proxy =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
     aws-xray-sdk!=0.96,>=0.93
     setuptools
     multipart
@@ -82,7 +83,7 @@ server =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
     aws-xray-sdk!=0.96,>=0.93
     setuptools
     flask!=2.2.0,!=2.2.1
@@ -116,7 +117,7 @@ cloudformation =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
     aws-xray-sdk!=0.96,>=0.93
     setuptools
 cloudfront =
@@ -139,10 +140,10 @@ dms =
 ds = sshpubkeys>=3.1.0
 dynamodb =
     docker>=3.0.0
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
 dynamodbstreams =
     docker>=3.0.0
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
 ebs = sshpubkeys>=3.1.0
 ec2 = sshpubkeys>=3.1.0
 ec2instanceconnect =
@@ -205,15 +206,15 @@ resourcegroupstaggingapi =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
 route53 =
 route53resolver = sshpubkeys>=3.1.0
 s3 =
     PyYAML>=5.1
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
 s3crc32c =
     PyYAML>=5.1
-    py-partiql-parser==0.4.1
+    py-partiql-parser==0.4.2
     crc32c
 s3control =
 sagemaker =

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2383,13 +2383,16 @@ def test_create_instance_with_launch_template_id_produces_no_warning(
         LaunchTemplateName=str(uuid4()), LaunchTemplateData={"ImageId": EXAMPLE_AMI_ID}
     )["LaunchTemplate"]
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(record=True) as ws:
         resource.create_instances(
             MinCount=1,
             MaxCount=1,
             LaunchTemplate={launch_template_kind: template[launch_template_kind]},
         )
+    # We could have other warnings in this method, coming from botocore for instance
+    # But we should not receive a warning that the AMI could not be found
+    messages = [str(w.message) for w in ws]
+    assert all(["Could not find AMI" not in msg for msg in messages])
 
 
 @mock_ec2

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -685,9 +685,10 @@ def test_put_events():
 
     if settings.TEST_DECORATOR_MODE:
         event["Detail"] = json.dumps([{"Key": "k", "Value": "v"}])
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True) as ws:
             client.put_events(Entries=[event])
-        assert "EventDetail should be of type dict" in str(w[0].message)
+        messages = [str(w.message) for w in ws]
+        assert any(["EventDetail should be of type dict" in msg for msg in messages])
 
 
 @mock_events


### PR DESCRIPTION
Includes an upgrade to `py-partiql-parser` to a version that supports Py 3.12

From the 3.12 release notes:

> [datetime](https://docs.python.org/3/library/datetime.html#module-datetime): [datetime.datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime)’s [utcnow()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow) and [utcfromtimestamp()](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp) are deprecated and will be removed in a future version

Moto already took care of this in #6803, but botocore still uses these methods - so it throws a lot of warnings.

The test changes are necessary because we're suddenly also catching these deprecated datetime warnings, not just our own.