### PR TITLE
Update server_mode.rst with proper command for run using docker

### DIFF
--- a/docs/docs/server_mode.rst
+++ b/docs/docs/server_mode.rst
@@ -98,8 +98,8 @@ This is stored in two different repositories:
 
 .. code-block:: bash
 
-    docker run motoserver/moto:latest
-    docker run ghcr.io/getmoto/motoserver:latest
+    docker run -p 5000:5000 motoserver/moto:latest
+    docker run -p 5000:5000 ghcr.io/getmoto/motoserver:latest
 
 Example docker-compose.yaml 
  Look at `server.py <https://github.com/getmoto/moto/blob/master/moto/server.py>`_ to find more environment variables.


### PR DESCRIPTION
When running docker locally, you better open the 5000 port in order to use it properly