### PR TITLE
DynamoDB: Improve validation around KeyTypes and ExpressionAttributeValues

### DIFF
--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -10,7 +10,7 @@ from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
 def get_filter_expression(
     expr: Optional[str],
     names: Optional[Dict[str, str]],
-    values: Optional[Dict[str, str]],
+    values: Optional[Dict[str, Dict[str, str]]],
 ) -> Union["Op", "Func"]:
     """
     Parse a filter expression into an Op.
@@ -145,7 +145,7 @@ class ConditionExpressionParser:
         self,
         condition_expression: Optional[str],
         expression_attribute_names: Optional[Dict[str, str]],
-        expression_attribute_values: Optional[Dict[str, str]],
+        expression_attribute_values: Optional[Dict[str, Dict[str, str]]],
     ):
         self.condition_expression = condition_expression
         self.expression_attribute_names = expression_attribute_names
@@ -423,7 +423,7 @@ class ConditionExpressionParser:
                 children=[],
             )
 
-    def _lookup_expression_attribute_value(self, name: str) -> str:
+    def _lookup_expression_attribute_value(self, name: str) -> Dict[str, str]:
         return self.expression_attribute_values[name]  # type: ignore[index]
 
     def _lookup_expression_attribute_name(self, name: str) -> str:

--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -368,3 +368,9 @@ class TransactWriteSingleOpException(MockValidationException):
 class SerializationException(DynamodbException):
     def __init__(self, msg: str):
         super().__init__(error_type="SerializationException", message=msg)
+
+
+class UnknownKeyType(MockValidationException):
+    def __init__(self, key_type: str, position: str):
+        msg = f"1 validation error detected: Value '{key_type}' at '{position}' failed to satisfy constraint: Member must satisfy enum value set: [HASH, RANGE]"
+        super().__init__(msg)

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -317,7 +317,7 @@ class DynamoDBBackend(BaseBackend):
         projection_expressions: Optional[List[List[str]]],
         index_name: Optional[str] = None,
         expr_names: Optional[Dict[str, str]] = None,
-        expr_values: Optional[Dict[str, str]] = None,
+        expr_values: Optional[Dict[str, Dict[str, str]]] = None,
         filter_expression: Optional[str] = None,
         **filter_kwargs: Any,
     ) -> Tuple[List[Item], int, Optional[Dict[str, Any]]]:

--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Dict, Tuple, Optional
+from typing import Any, List, Dict, Tuple, Optional, Union
 from moto.dynamodb.exceptions import MockValidationException
 from moto.utilities.tokenizer import GenericTokenizer
 
@@ -19,7 +19,7 @@ def get_key(schema: List[Dict[str, str]], key_type: str) -> Optional[str]:
 
 def parse_expression(
     key_condition_expression: str,
-    expression_attribute_values: Dict[str, str],
+    expression_attribute_values: Dict[str, Dict[str, str]],
     expression_attribute_names: Dict[str, str],
     schema: List[Dict[str, str]],
 ) -> Tuple[Dict[str, Any], Optional[str], List[Dict[str, Any]]]:
@@ -35,7 +35,7 @@ def parse_expression(
     current_stage: Optional[EXPRESSION_STAGES] = None
     current_phrase = ""
     key_name = comparison = ""
-    key_values = []
+    key_values: List[Union[Dict[str, str], str]] = []
     results: List[Tuple[str, str, Any]] = []
     tokenizer = GenericTokenizer(key_condition_expression)
     for crnt_char in tokenizer:

--- a/tests/test_dynamodb/__init__.py
+++ b/tests/test_dynamodb/__init__.py
@@ -5,7 +5,7 @@ from moto import mock_dynamodb
 from uuid import uuid4
 
 
-def dynamodb_aws_verified(func):
+def dynamodb_aws_verified(create_table: bool = True):
     """
     Function that is verified to work against AWS.
     Can be run against AWS at any time by setting:
@@ -19,39 +19,47 @@ def dynamodb_aws_verified(func):
       - Delete the table
     """
 
-    @wraps(func)
-    def pagination_wrapper():
-        client = boto3.client("dynamodb", region_name="us-east-1")
-        table_name = "t" + str(uuid4())[0:6]
+    def inner(func):
+        @wraps(func)
+        def pagination_wrapper():
+            client = boto3.client("dynamodb", region_name="us-east-1")
+            table_name = "t" + str(uuid4())[0:6]
 
-        allow_aws_request = (
-            os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
-        )
+            allow_aws_request = (
+                os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
+            )
 
-        if allow_aws_request:
-            print(f"Test {func} will create DynamoDB Table {table_name}")
-            resp = create_table_and_test(table_name, client)
-        else:
-            with mock_dynamodb():
-                resp = create_table_and_test(table_name, client)
-        return resp
+            if allow_aws_request:
+                if create_table:
+                    print(f"Test {func} will create DynamoDB Table {table_name}")
+                    return create_table_and_test(table_name, client)
+                else:
+                    return func()
+            else:
+                with mock_dynamodb():
+                    if create_table:
+                        return create_table_and_test(table_name, client)
+                    else:
+                        return func()
 
-    def create_table_and_test(table_name, client):
-        client.create_table(
-            TableName=table_name,
-            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
-            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
-            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 5},
-            Tags=[{"Key": "environment", "Value": "moto_tests"}],
-        )
-        waiter = client.get_waiter("table_exists")
-        waiter.wait(TableName=table_name)
-        try:
-            resp = func(table_name)
-        finally:
-            ### CLEANUP ###
-            client.delete_table(TableName=table_name)
+        def create_table_and_test(table_name, client):
+            client.create_table(
+                TableName=table_name,
+                KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+                ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 5},
+                Tags=[{"Key": "environment", "Value": "moto_tests"}],
+            )
+            waiter = client.get_waiter("table_exists")
+            waiter.wait(TableName=table_name)
+            try:
+                resp = func(table_name)
+            finally:
+                ### CLEANUP ###
+                client.delete_table(TableName=table_name)
 
-        return resp
+            return resp
 
-    return pagination_wrapper
+        return pagination_wrapper
+
+    return inner

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -3686,7 +3686,7 @@ def test_transact_write_items_put():
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_transact_write_items_put_conditional_expressions(table_name=None):
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
 
@@ -3731,7 +3731,7 @@ def test_transact_write_items_put_conditional_expressions(table_name=None):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_transact_write_items_failure__return_item(table_name=None):
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     dynamodb.put_item(TableName=table_name, Item={"pk": {"S": "foo2"}})

--- a/tests/test_dynamodb/test_dynamodb_statements.py
+++ b/tests/test_dynamodb/test_dynamodb_statements.py
@@ -25,7 +25,7 @@ def create_items(table_name):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_execute_statement_select_star(table_name=None):
     client = boto3.client("dynamodb", "us-east-1")
     create_items(table_name)
@@ -35,7 +35,7 @@ def test_execute_statement_select_star(table_name=None):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_execute_statement_select_attr(table_name=None):
     client = boto3.client("dynamodb", "us-east-1")
     create_items(table_name)
@@ -47,7 +47,7 @@ def test_execute_statement_select_attr(table_name=None):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_execute_statement_with_quoted_table(table_name=None):
     client = boto3.client("dynamodb", "us-east-1")
     create_items(table_name)
@@ -57,7 +57,7 @@ def test_execute_statement_with_quoted_table(table_name=None):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_execute_statement_with_parameter(table_name=None):
     client = boto3.client("dynamodb", "us-east-1")
     create_items(table_name)
@@ -77,7 +77,7 @@ def test_execute_statement_with_parameter(table_name=None):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_execute_statement_with_no_results(table_name=None):
     client = boto3.client("dynamodb", "us-east-1")
     create_items(table_name)
@@ -201,7 +201,7 @@ class TestBatchExecuteStatement(TestCase):
 
 
 @pytest.mark.aws_verified
-@dynamodb_aws_verified
+@dynamodb_aws_verified()
 def test_execute_statement_with_all_clauses(table_name=None):
     dynamodb_client = boto3.client("dynamodb", "us-east-1")
 


### PR DESCRIPTION
Fixes #6973 
Fixes #6979 

IIRC, an unknown KeyType during table creation such as `{"AttributeName": "sk", "KeyType": "SORT"}` used to be ignored.
Because of that, we copied this behaviour in #5919 

But AWS now throws an error, and explicitly states that only `HASH` and `RANGE` are acceptable key-types - so we'll follow that.