### PR TITLE
Lambda: Allow Qualifier on get policy call

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2098,8 +2098,8 @@ class LambdaBackend(BaseBackend):
         fn = self.get_function(function_name)
         return fn.get_code_signing_config()
 
-    def get_policy(self, function_name: str) -> str:
-        fn = self.get_function(function_name)
+    def get_policy(self, function_name: str, qualifier: Optional[str] = None) -> str:
+        fn = self._lambdas.get_function_by_name_or_arn(function_name, qualifier)
         if not fn:
             raise UnknownFunctionException(function_name)
         return fn.policy.wire_format()  # type: ignore[union-attr]

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -227,7 +227,8 @@ class LambdaResponse(BaseResponse):
     def _get_policy(self, request: Any) -> TYPE_RESPONSE:
         path = request.path if hasattr(request, "path") else path_url(request.url)
         function_name = unquote(path.split("/")[-2])
-        out = self.backend.get_policy(function_name)
+        qualifier = self.querystring.get("Qualifier", [None])[0]
+        out = self.backend.get_policy(function_name, qualifier)
         return 200, {}, out
 
     def _del_policy(self, request: Any, querystring: Dict[str, Any]) -> TYPE_RESPONSE:


### PR DESCRIPTION
As per [AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/API_GetPolicy.html#API_GetPolicy_RequestSyntax), the get policy call also accepts a Qualifier parameter as well as an function ARN.

Notes:
- Although the ARN and qualifier is accepted, a larger change will be required to return different policies based on that qualifier which I haven't done as part of this change
- There is already a test `test_get_policy_with_qualifier` that calls this endpoint with a qualifier, although it doesn't test that the returned policy is different with and without the qualifier.