### PR TITLE
RDS: Can't delete DBCluster with active DBInstances

### DIFF
--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -83,7 +83,7 @@ class InvalidDBClusterStateFaultError(RDSClientError):
 
 
 class DBClusterToBeDeletedHasActiveMembers(RDSClientError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             "InvalidDBClusterStateFault",
             "Cluster cannot be deleted, it still contains DB instances in non-deleting state.",

--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -82,6 +82,14 @@ class InvalidDBClusterStateFaultError(RDSClientError):
         )
 
 
+class DBClusterToBeDeletedHasActiveMembers(RDSClientError):
+    def __init__(self):
+        super().__init__(
+            "InvalidDBClusterStateFault",
+            "Cluster cannot be deleted, it still contains DB instances in non-deleting state.",
+        )
+
+
 class InvalidDBInstanceStateError(RDSClientError):
     def __init__(self, database_identifier: str, istate: str):
         estate = (

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -19,6 +19,7 @@ from .exceptions import (
     DBClusterNotFoundError,
     DBClusterSnapshotAlreadyExistsError,
     DBClusterSnapshotNotFoundError,
+    DBClusterToBeDeletedHasActiveMembers,
     DBInstanceNotFoundError,
     DBSnapshotNotFoundError,
     DBSecurityGroupNotFoundError,
@@ -2339,7 +2340,8 @@ class RDSBackend(BaseBackend):
                 raise InvalidParameterValue(
                     "Can't delete Cluster with protection enabled"
                 )
-
+            if cluster.cluster_members:
+                raise DBClusterToBeDeletedHasActiveMembers()
             global_id = cluster.global_cluster_identifier or ""
             if global_id in self.global_clusters:
                 self.remove_from_global_cluster(global_id, cluster_identifier)


### PR DESCRIPTION
Error response code and message confirmed against actual AWS backend.

Fixes #6992 