### PR TITLE
EC2: Improve DescribeInstanceTypes response

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -872,7 +872,7 @@ EC2_DESCRIBE_INSTANCE_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
             </networkInfo>
             <freeTierEligible>{{ instance_type.FreeTierEligible }}</freeTierEligible>
             <hibernationSupported>{{ instance_type.HibernationSupported }}</hibernationSupported>
-            <hypervisor>{{ instance_type.Hypervisor }}</hypervisor>
+            <hypervisor>{{ instance_type.get('Hypervisor', 'motovisor') }}</hypervisor>
             <instanceStorageSupported>{{ instance_type.InstanceStorageSupported }}</instanceStorageSupported>
             <placementGroupInfo>
                 <supportedStrategies>

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -823,16 +823,94 @@ EC2_INSTANCE_STATUS = """<?xml version="1.0" encoding="UTF-8"?>
 </DescribeInstanceStatusResponse>"""
 
 EC2_DESCRIBE_INSTANCE_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
-<DescribeInstanceTypesResponse xmlns="http://api.outscale.com/wsdl/fcuext/2014-04-15/">
+<DescribeInstanceTypesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>f8b86168-d034-4e65-b48d-3b84c78e64af</requestId>
     <instanceTypeSet>
     {% for instance_type in instance_types %}
         <item>
+            <autoRecoverySupported>{{ instance_type.AutoRecoverySupported }}</autoRecoverySupported>
+            <bareMetal>{{ instance_type.BareMetal }}</bareMetal>
+            <burstablePerformanceSupported>{{ instance_type.BurstablePerformanceSupported }}</burstablePerformanceSupported>
+            <currentGeneration>{{ instance_type.CurrentGeneration }}</currentGeneration>
+            <dedicatedHostsSupported>{{ instance_type.DedicatedHostsSupported }}</dedicatedHostsSupported>
+            <ebsInfo>
+                <ebsOptimizedInfo>
+                    <baselineBandwidthInMbps>{{ instance_type.get('EbsInfo', {}).get('EbsOptimizedInfo', {}).get('BaselineBandwidthInMbps', 0) | int }}</baselineBandwidthInMbps>
+                    <baselineIops>{{  instance_type.get('EbsInfo', {}).get('EbsOptimizedInfo', {}).get('BaselineIops', 0) | int }}</baselineIops>
+                    <baselineThroughputInMBps>{{  instance_type.get('EbsInfo', {}).get('EbsOptimizedInfo', {}).get('BaselineThroughputInMBps', 0.0) | float }}</baselineThroughputInMBps>
+                    <maximumBandwidthInMbps>{{  instance_type.get('EbsInfo', {}).get('EbsOptimizedInfo', {}).get('MaximumBandwidthInMbps', 0) | int }}</maximumBandwidthInMbps>
+                    <maximumIops>{{  instance_type.get('EbsInfo', {}).get('EbsOptimizedInfo', {}).get('MaximumIops', 0) | int }}</maximumIops>
+                    <maximumThroughputInMBps>{{ instance_type.get('EbsInfo', {}).get('EbsOptimizedInfo', {}).get('MaximumThroughputInMBps', 0.0) | float }}</maximumThroughputInMBps>
+                </ebsOptimizedInfo>
+                <ebsOptimizedSupport>{{ instance_type.get('EbsInfo', {}).get('EbsOptimizedSupport', 'default') }}</ebsOptimizedSupport>
+                <encryptionSupport>{{ instance_type.get('EbsInfo', {}).get('EncryptionSupport', 'supported') }}</encryptionSupport>
+                <nvmeSupport>{{ instance_type.get('EbsInfo', {}).get('NvmeSupport', 'required') }}</nvmeSupport>
+            </ebsInfo>
+            <networkInfo>
+                <defaultNetworkCardIndex>{{ instance_type.get('NetworkInfo', {}).get('DefaultNetworkCardIndex', 0) | int }}</defaultNetworkCardIndex>
+                <efaSupported>{{ instance_type.get('NetworkInfo', {}).get('EfaSupported', False) }}</efaSupported>
+                <enaSrdSupported>{{ instance_type.get('NetworkInfo', {}).get('EnaSrdSupported', False) }}</enaSrdSupported>
+                <enaSupport>{{ instance_type.get('NetworkInfo', {}).get('EnaSupported', False) }}</enaSupport>
+                <encryptionInTransitSupported>{{ instance_type.get('NetworkInfo', {}).get('EncryptionInTransitSupported', False) }}</encryptionInTransitSupported>
+                <ipv4AddressesPerInterface>{{ instance_type.get('NetworkInfo', {}).get('Ipv4AddressesPerInterface', 0) | int }}</ipv4AddressesPerInterface>
+                <ipv6AddressesPerInterface>{{ instance_type.get('NetworkInfo', {}).get('Ipv6AddressesPerInterface', 0) | int }}</ipv6AddressesPerInterface>
+                <ipv6Supported>{{ instance_type.get('NetworkInfo', {}).get('Ipv6Supported', False) }}</ipv6Supported>
+                <maximumNetworkCards>{{ instance_type.get('NetworkInfo', {}).get('MaximumNetworkCards', 0) | int }}</maximumNetworkCards>
+                <maximumNetworkInterfaces>{{ instance_type.get('NetworkInfo', {}).get('MaximumNetworkInterfaces', 0) | int }}</maximumNetworkInterfaces>
+                <networkCards>
+                  {% for network_card in instance_type.get('NetworkInfo', {}).get('NetworkCards', []) %}
+                    <item>
+                        <baselineBandwidthInGbps>{{ network_card.get('BaselineBandwidthInGbps', 0.0) | float }}</baselineBandwidthInGbps>
+                        <maximumNetworkInterfaces>{{ network_card.get('MaximumNetworkInterfaces', 0) | int }}</maximumNetworkInterfaces>
+                        <networkCardIndex>{{ network_card.get('NetworkCardIndex', 0) | int }}</networkCardIndex>
+                        <networkPerformance>{{ network_card.get('NetworkPerformance', 'Up to 25 Schmeckles') }}</networkPerformance>
+                        <peakBandwidthInGbps>{{ network_card.get('PeakBandwidthInGbps', 0.0) | float }}</peakBandwidthInGbps>
+                    </item>
+                  {% endfor %}
+                </networkCards>
+                <networkPerformance>{{ instance_type.get('NetworkInfo', {}).get('NetworkPerformance', 'Up to 25 Schmeckles') }}</networkPerformance>
+            </networkInfo>
+            <freeTierEligible>{{ instance_type.FreeTierEligible }}</freeTierEligible>
+            <hibernationSupported>{{ instance_type.HibernationSupported }}</hibernationSupported>
+            <hypervisor>{{ instance_type.Hypervisor }}</hypervisor>
+            <instanceStorageSupported>{{ instance_type.InstanceStorageSupported }}</instanceStorageSupported>
+            <placementGroupInfo>
+                <supportedStrategies>
+                  {% for strategy in instance_type.get('PlacementGroupInfo', {}).get('SupportedStrategies', []) %}
+                    <item>{{ strategy }}</item>
+                  {% endfor %}
+                </supportedStrategies>
+            </placementGroupInfo>
+            <supportedRootDeviceTypes>
+              {% for dev_type in instance_type.get('SupportedRootDeviceTypes', []) %}
+                <item>{{ dev_type }}</item>
+              {% endfor %}
+            </supportedRootDeviceTypes>
+            <supportedUsageClasses>
+              {% for usage_class in instance_type.get('SupportedUsageClasses', []) %}
+                <item>{{ usage_class }}</item>
+              {% endfor %}
+            </supportedUsageClasses>
+            <supportedVirtualizationTypes>
+              {% for supported_vtype in instance_type.get('SupportedVirtualizationTypes', []) %}
+                <item>{{ supported_vtype }}</item>
+              {% endfor %}
+            </supportedVirtualizationTypes>
             <instanceType>{{ instance_type.InstanceType }}</instanceType>
             <vCpuInfo>
                 <defaultVCpus>{{ instance_type.get('VCpuInfo', {}).get('DefaultVCpus', 0)|int }}</defaultVCpus>
                 <defaultCores>{{ instance_type.get('VCpuInfo', {}).get('DefaultCores', 0)|int }}</defaultCores>
                 <defaultThreadsPerCore>{{ instance_type.get('VCpuInfo').get('DefaultThreadsPerCore', 0)|int }}</defaultThreadsPerCore>
+                <validCores>
+                  {% for valid_core in instance_type.get("VCpuInfo", {}).get('ValidCores', []) %}
+                    <item>{{ valid_core }}</item>
+                  {% endfor %}
+                </validCores>
+                <validThreadsPerCore>
+                  {% for threads_per_core in instance_type.get("VCpuInfo", {}).get('ValidThreadsPerCore', []) %}
+                    <item>{{ threads_per_core }}</item>
+                  {% endfor %}
+                </validThreadsPerCore>
             </vCpuInfo>
             <memoryInfo>
                 <sizeInMiB>{{ instance_type.get('MemoryInfo', {}).get('SizeInMiB', 0)|int }}</sizeInMiB>
@@ -848,6 +926,7 @@ EC2_DESCRIBE_INSTANCE_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
                     </item>
                     {% endfor %}
                 </supportedArchitectures>
+                <sustainedClockSpeedInGhz>{{ instance_type.get('ProcessorInfo', {}).get('SustainedClockSpeedInGhz', 0.0) | float }}</sustainedClockSpeedInGhz>
             </processorInfo>
             {% if instance_type.get('GpuInfo', {})|length > 0 %}
             <gpuInfo>


### PR DESCRIPTION
## Background

It was discovered that Terraform plugin was crashing with the following sample:

```tf
data "aws_ec2_instance_type" "example" {
  instance_type = "t2.micro"
}

resource "aws_instance" "example" {
  ami           = "ami-ff0fea8310f3"
  instance_type = data.aws_ec2_instance_type.example.instance_type
}
```
returning following error:
```
panic: runtime error: invalid memory address or nil pointer dereference                                                                                     
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x9aae86f]                                                                                    

goroutine 311 [running]:                                                                                                                                    
github.com/hashicorp/terraform-provider-aws/internal/service ec2.dataSourceInstanceTypeRead({0xf3ad7e0, 0xc001c92d50}, 0xdf8a960?, {0xdf8a960?, 0xc00024e4b0?})
github.com/hashicorp/terraform-provider-aws/internal/service/ec2/ec2_instance_type_data_source.go:314 +0x26f                                          
github.com/hashicorp/terraform-provider-aws/internal/provider.interceptedHandler[...].func1(0x0?, {0xdf8a960?, 0xc00024e4b0?})
```

This was caused because the full set of attributes were not being returned preventing the plugin from constructing its internal data structure: https://github.com/hashicorp/terraform-provider-aws/blob/f3855eb44a197f931331c3369e35736b8d8c6ece/internal/service/ec2/ec2_instance_type_data_source.go#L295-L404

## Changes

This PR enhances the EC2:DescribeInstanceTypes response by returning the full set of attributes.