### PR TITLE
EC2: describe_hosts() now returns the AllocationTime-attribute

### DIFF
--- a/moto/ec2/models/hosts.py
+++ b/moto/ec2/models/hosts.py
@@ -1,5 +1,6 @@
 from .core import TaggedEC2Resource
 from ..utils import generic_filter, random_dedicated_host_id
+from moto.core.utils import unix_time
 from typing import Any, Dict, List, Optional
 
 
@@ -21,6 +22,7 @@ class Host(TaggedEC2Resource):
         self.instance_family: Optional[str] = instance_family
         self.auto_placement = auto_placement or "on"
         self.ec2_backend = backend
+        self.allocation_time = unix_time()
 
     def release(self) -> None:
         self.state = "released"

--- a/moto/ec2/responses/hosts.py
+++ b/moto/ec2/responses/hosts.py
@@ -66,6 +66,7 @@ EC2_DESCRIBE_HOSTS = """<DescribeHostsResult xmlns="http://ec2.amazonaws.com/doc
     <hostSet>
         {% for host in hosts %}
             <item>
+                <allocationTime>{{ host.allocation_time }}</allocationTime>
                 <autoPlacement>{{ host.auto_placement }}</autoPlacement>
                 <availabilityZone>{{ host.zone }}</availabilityZone>
                 <availableCapacity></availableCapacity>

--- a/tests/test_ec2/test_hosts.py
+++ b/tests/test_ec2/test_hosts.py
@@ -26,6 +26,7 @@ def test_describe_hosts_with_instancefamily():
 
     host = client.describe_hosts(HostIds=host_ids)["Hosts"][0]
 
+    assert "AllocationTime" in host
     assert host["HostProperties"]["InstanceFamily"] == "c5"
 
 


### PR DESCRIPTION
Fixes #7008 