### PR TITLE
Fix EFS access point ID pattern

### DIFF
--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -54,8 +54,8 @@ class AccessPoint(BaseModel):
         root_directory: Dict[str, str],
         context: "EFSBackend",
     ):
-        self.access_point_id = mock_random.get_random_hex(8)
-        self.access_point_arn = f"arn:aws:elasticfilesystem:{region_name}:{account_id}:access-point/fsap-{self.access_point_id}"
+        self.access_point_id = f"fsap-{mock_random.get_random_hex(8)}"
+        self.access_point_arn = f"arn:aws:elasticfilesystem:{region_name}:{account_id}:access-point/{self.access_point_id}"
         self.client_token = client_token
         self.file_system_id = file_system_id
         self.name = name


### PR DESCRIPTION
## Details

https://github.com/getmoto/moto/issues/7014

EFS Access point ID string value does not match valid access point ID pattern as described in [AWS EFS documentation](https://docs.aws.amazon.com/efs/latest/ug/API_AccessPointDescription.htm).

EFS access point ID has the following regex pattern:  `fsap-[0-9a-f]{8,40}`

The previous implementation returns a 8 character hex string *without* the `fsap-` prefix. 

**Proposed change**:
- (old) ~`abcd1234`~
- (new) `fsap-abcd1234`

