### PR TITLE
Prep release 4.2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     needs: [dotnettest, javatest, test, testserver ]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'getmoto/moto' }}
     steps:
@@ -113,8 +115,6 @@ jobs:
           python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Build Docker release
         run: |
           docker build -t motoserver/moto . --tag moto:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     name: Release Moto
     permissions:
       contents: write
+      id-token: write
       packages: write
     env:
       VERSION: 0.0.0
@@ -52,8 +53,6 @@ jobs:
         docker stop moto
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
     - name: Tag version on Github
       run: |
         git tag ${{ env.VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 Moto Changelog
 ==============
 
+4.2.8
+-----
+Docker Digest for 4.2.8: <autopopulateddigest>
+
+    General:
+        * Support for Python 3.12
+        * Support for a Simple Lambda backend, that will mock functions without invoking a Docker container.
+          Use the decorator `mock_lambda_simple` for this feature.
+
+    New Methods:
+        * IdentityStore:
+            * describe_group()
+
+        * Signer:
+            * list_tags_by_resource()
+            * tag_resource()
+            * untag_resource()
+
+    Miscellaneous:
+        * DynamoDB: create_table() now throws an error when supplying an unknown KeyType
+        * DynamoDB: query() now throws an error when supplying a ExpressionAttributeValue that doesn't start with a ':'
+        * EC2: describe_hosts() now returns the AllocationTime-attribute
+        * ECS: register_task_definition() now throws an exception if the ContainerDefinition has missing keys
+        * ECR: describe_images() now returns the supplied imageDigest-values, instead of random values
+        * EFS: AccessPoints now have the correct identifier format
+        * Lambda: Various methods now support the FunctionName in the format 'name:qualifier'
+        * MQ: create_configuration() is now possible for engine-type 'RABBITMQ'
+        * RDS: create_db_cluster() now throws an error if the provided engine is not supported
+        * RDS: create_db_instance() now throws an error if the provided engine does not match the cluster engine
+        * RDS: delete_db_cluster() now throws an error if any instances are still active
+        * SageMaker: list_model_packages() and list_model_package_groups() no longer throw an error on pagination
+
 4.2.7
 -----
 Docker Digest for 4.2.7: _sha256:9149597856f5ce195ef451df1a1b96aa8db0692c4b8ed1f7952fc02952733103_

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1275,7 +1275,7 @@
 
 ## comprehend
 <details>
-<summary>13% implemented</summary>
+<summary>12% implemented</summary>
 
 - [ ] batch_detect_dominant_language
 - [ ] batch_detect_entities
@@ -1318,6 +1318,7 @@
 - [X] detect_sentiment
 - [ ] detect_syntax
 - [ ] detect_targeted_sentiment
+- [ ] detect_toxic_content
 - [ ] import_model
 - [ ] list_datasets
 - [ ] list_document_classification_jobs
@@ -2125,6 +2126,7 @@
 - [ ] describe_aws_network_performance_metric_subscriptions
 - [ ] describe_bundle_tasks
 - [ ] describe_byoip_cidrs
+- [ ] describe_capacity_block_offerings
 - [ ] describe_capacity_reservation_fleets
 - [ ] describe_capacity_reservations
 - [X] describe_carrier_gateways
@@ -2277,6 +2279,7 @@
 - [ ] disable_image_deprecation
 - [ ] disable_ipam_organization_admin_account
 - [ ] disable_serial_console_access
+- [ ] disable_snapshot_block_public_access
 - [X] disable_transit_gateway_route_table_propagation
 - [ ] disable_vgw_route_propagation
 - [X] disable_vpc_classic_link
@@ -2306,6 +2309,7 @@
 - [ ] enable_ipam_organization_admin_account
 - [ ] enable_reachability_analyzer_organization_sharing
 - [ ] enable_serial_console_access
+- [ ] enable_snapshot_block_public_access
 - [X] enable_transit_gateway_route_table_propagation
 - [ ] enable_vgw_route_propagation
 - [ ] enable_volume_io
@@ -2346,6 +2350,7 @@
 - [ ] get_reserved_instances_exchange_quote
 - [ ] get_security_groups_for_vpc
 - [ ] get_serial_console_access_status
+- [ ] get_snapshot_block_public_access_state
 - [ ] get_spot_placement_scores
 - [ ] get_subnet_cidr_reservations
 - [ ] get_transit_gateway_attachment_propagations
@@ -2438,6 +2443,7 @@
 - [ ] provision_byoip_cidr
 - [ ] provision_ipam_pool_cidr
 - [ ] provision_public_ipv4_pool_cidr
+- [ ] purchase_capacity_block
 - [ ] purchase_host_reservation
 - [ ] purchase_reserved_instances_offering
 - [ ] purchase_scheduled_instances
@@ -2656,16 +2662,18 @@
 
 ## eks
 <details>
-<summary>42% implemented</summary>
+<summary>37% implemented</summary>
 
 - [ ] associate_encryption_config
 - [ ] associate_identity_provider_config
 - [ ] create_addon
 - [X] create_cluster
+- [ ] create_eks_anywhere_subscription
 - [X] create_fargate_profile
 - [X] create_nodegroup
 - [ ] delete_addon
 - [X] delete_cluster
+- [ ] delete_eks_anywhere_subscription
 - [X] delete_fargate_profile
 - [X] delete_nodegroup
 - [ ] deregister_cluster
@@ -2673,6 +2681,7 @@
 - [ ] describe_addon_configuration
 - [ ] describe_addon_versions
 - [X] describe_cluster
+- [ ] describe_eks_anywhere_subscription
 - [X] describe_fargate_profile
 - [ ] describe_identity_provider_config
 - [X] describe_nodegroup
@@ -2680,6 +2689,7 @@
 - [ ] disassociate_identity_provider_config
 - [ ] list_addons
 - [X] list_clusters
+- [ ] list_eks_anywhere_subscriptions
 - [X] list_fargate_profiles
 - [ ] list_identity_provider_configs
 - [X] list_nodegroups
@@ -2691,6 +2701,7 @@
 - [ ] update_addon
 - [ ] update_cluster_config
 - [ ] update_cluster_version
+- [ ] update_eks_anywhere_subscription
 - [ ] update_nodegroup_config
 - [ ] update_nodegroup_version
 </details>
@@ -3824,7 +3835,7 @@
 - [X] delete_group
 - [X] delete_group_membership
 - [X] delete_user
-- [ ] describe_group
+- [X] describe_group
 - [ ] describe_group_membership
 - [X] describe_user
 - [X] get_group_id
@@ -4465,15 +4476,20 @@
 
 ## logs
 <details>
-<summary>66% implemented</summary>
+<summary>51% implemented</summary>
 
 - [ ] associate_kms_key
 - [ ] cancel_export_task
+- [ ] create_delivery
 - [X] create_export_task
 - [X] create_log_group
 - [X] create_log_stream
 - [ ] delete_account_policy
 - [ ] delete_data_protection_policy
+- [ ] delete_delivery
+- [ ] delete_delivery_destination
+- [ ] delete_delivery_destination_policy
+- [ ] delete_delivery_source
 - [X] delete_destination
 - [X] delete_log_group
 - [X] delete_log_stream
@@ -4483,6 +4499,9 @@
 - [X] delete_retention_policy
 - [X] delete_subscription_filter
 - [ ] describe_account_policies
+- [ ] describe_deliveries
+- [ ] describe_delivery_destinations
+- [ ] describe_delivery_sources
 - [X] describe_destinations
 - [ ] describe_export_tasks
 - [X] describe_log_groups
@@ -4495,6 +4514,10 @@
 - [ ] disassociate_kms_key
 - [X] filter_log_events
 - [ ] get_data_protection_policy
+- [ ] get_delivery
+- [ ] get_delivery_destination
+- [ ] get_delivery_destination_policy
+- [ ] get_delivery_source
 - [X] get_log_events
 - [ ] get_log_group_fields
 - [ ] get_log_record
@@ -4503,6 +4526,9 @@
 - [X] list_tags_log_group
 - [ ] put_account_policy
 - [ ] put_data_protection_policy
+- [ ] put_delivery_destination
+- [ ] put_delivery_destination_policy
+- [ ] put_delivery_source
 - [X] put_destination
 - [X] put_destination_policy
 - [X] put_log_events
@@ -5485,7 +5511,7 @@
 
 ## rds
 <details>
-<summary>38% implemented</summary>
+<summary>36% implemented</summary>
 
 - [ ] add_role_to_db_cluster
 - [ ] add_role_to_db_instance
@@ -5516,7 +5542,9 @@
 - [ ] create_db_subnet_group
 - [X] create_event_subscription
 - [X] create_global_cluster
+- [ ] create_integration
 - [X] create_option_group
+- [ ] create_tenant_database
 - [ ] delete_blue_green_deployment
 - [ ] delete_custom_db_engine_version
 - [X] delete_db_cluster
@@ -5534,7 +5562,9 @@
 - [ ] delete_db_subnet_group
 - [X] delete_event_subscription
 - [X] delete_global_cluster
+- [ ] delete_integration
 - [X] delete_option_group
+- [ ] delete_tenant_database
 - [ ] deregister_db_proxy_targets
 - [ ] describe_account_attributes
 - [ ] describe_blue_green_deployments
@@ -5559,6 +5589,7 @@
 - [ ] describe_db_proxy_targets
 - [ ] describe_db_security_groups
 - [ ] describe_db_snapshot_attributes
+- [ ] describe_db_snapshot_tenant_databases
 - [X] describe_db_snapshots
 - [X] describe_db_subnet_groups
 - [ ] describe_engine_default_cluster_parameters
@@ -5568,6 +5599,7 @@
 - [ ] describe_events
 - [X] describe_export_tasks
 - [X] describe_global_clusters
+- [ ] describe_integrations
 - [X] describe_option_group_options
 - [X] describe_option_groups
 - [X] describe_orderable_db_instance_options
@@ -5575,6 +5607,7 @@
 - [ ] describe_reserved_db_instances
 - [ ] describe_reserved_db_instances_offerings
 - [ ] describe_source_regions
+- [ ] describe_tenant_databases
 - [ ] describe_valid_db_instance_modifications
 - [ ] download_db_log_file_portion
 - [ ] failover_db_cluster
@@ -5599,6 +5632,7 @@
 - [ ] modify_event_subscription
 - [ ] modify_global_cluster
 - [X] modify_option_group
+- [ ] modify_tenant_database
 - [X] promote_read_replica
 - [X] promote_read_replica_db_cluster
 - [ ] purchase_reserved_db_instances_offering
@@ -5739,6 +5773,7 @@
 - [ ] disassociate_data_share_consumer
 - [ ] enable_logging
 - [X] enable_snapshot_copy
+- [ ] failover_primary_compute
 - [X] get_cluster_credentials
 - [ ] get_cluster_credentials_with_iam
 - [ ] get_reserved_node_exchange_configuration_options
@@ -7606,6 +7641,7 @@
 - kinesis-video-webrtc-storage
 - kinesisanalytics
 - kinesisanalyticsv2
+- launch-wizard
 - lex-models
 - lex-runtime
 - lexv2-models

--- a/docs/docs/faq.rst
+++ b/docs/docs/faq.rst
@@ -46,3 +46,6 @@ You can pass your own Responses-mock to Moto, to ensure that any custom (non-AWS
     override_responses_real_send(my_own_mock)
     my_own_mock.start()
     my_own_mock.add_passthru("http://some-website.com")
+
+    # Unset this behaviour at the end of your tests
+    override_responses_real_send(None)

--- a/docs/docs/services/comprehend.rst
+++ b/docs/docs/services/comprehend.rst
@@ -72,6 +72,7 @@ comprehend
 - [X] detect_sentiment
 - [ ] detect_syntax
 - [ ] detect_targeted_sentiment
+- [ ] detect_toxic_content
 - [ ] import_model
 - [ ] list_datasets
 - [ ] list_document_classification_jobs

--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -257,6 +257,7 @@ ec2
 - [ ] describe_aws_network_performance_metric_subscriptions
 - [ ] describe_bundle_tasks
 - [ ] describe_byoip_cidrs
+- [ ] describe_capacity_block_offerings
 - [ ] describe_capacity_reservation_fleets
 - [ ] describe_capacity_reservations
 - [X] describe_carrier_gateways
@@ -436,6 +437,7 @@ ec2
 - [ ] disable_image_deprecation
 - [ ] disable_ipam_organization_admin_account
 - [ ] disable_serial_console_access
+- [ ] disable_snapshot_block_public_access
 - [X] disable_transit_gateway_route_table_propagation
 - [ ] disable_vgw_route_propagation
 - [X] disable_vpc_classic_link
@@ -465,6 +467,7 @@ ec2
 - [ ] enable_ipam_organization_admin_account
 - [ ] enable_reachability_analyzer_organization_sharing
 - [ ] enable_serial_console_access
+- [ ] enable_snapshot_block_public_access
 - [X] enable_transit_gateway_route_table_propagation
 - [ ] enable_vgw_route_propagation
 - [ ] enable_volume_io
@@ -505,6 +508,7 @@ ec2
 - [ ] get_reserved_instances_exchange_quote
 - [ ] get_security_groups_for_vpc
 - [ ] get_serial_console_access_status
+- [ ] get_snapshot_block_public_access_state
 - [ ] get_spot_placement_scores
 - [ ] get_subnet_cidr_reservations
 - [ ] get_transit_gateway_attachment_propagations
@@ -601,6 +605,7 @@ ec2
 - [ ] provision_byoip_cidr
 - [ ] provision_ipam_pool_cidr
 - [ ] provision_public_ipv4_pool_cidr
+- [ ] purchase_capacity_block
 - [ ] purchase_host_reservation
 - [ ] purchase_reserved_instances_offering
 - [ ] purchase_scheduled_instances

--- a/docs/docs/services/eks.rst
+++ b/docs/docs/services/eks.rst
@@ -29,10 +29,12 @@ eks
 - [ ] associate_identity_provider_config
 - [ ] create_addon
 - [X] create_cluster
+- [ ] create_eks_anywhere_subscription
 - [X] create_fargate_profile
 - [X] create_nodegroup
 - [ ] delete_addon
 - [X] delete_cluster
+- [ ] delete_eks_anywhere_subscription
 - [X] delete_fargate_profile
 - [X] delete_nodegroup
 - [ ] deregister_cluster
@@ -40,6 +42,7 @@ eks
 - [ ] describe_addon_configuration
 - [ ] describe_addon_versions
 - [X] describe_cluster
+- [ ] describe_eks_anywhere_subscription
 - [X] describe_fargate_profile
 - [ ] describe_identity_provider_config
 - [X] describe_nodegroup
@@ -47,6 +50,7 @@ eks
 - [ ] disassociate_identity_provider_config
 - [ ] list_addons
 - [X] list_clusters
+- [ ] list_eks_anywhere_subscriptions
 - [X] list_fargate_profiles
 - [ ] list_identity_provider_configs
 - [X] list_nodegroups
@@ -70,6 +74,7 @@ eks
 - [ ] update_addon
 - [ ] update_cluster_config
 - [ ] update_cluster_version
+- [ ] update_eks_anywhere_subscription
 - [ ] update_nodegroup_config
 - [ ] update_nodegroup_version
 

--- a/docs/docs/services/identitystore.rst
+++ b/docs/docs/services/identitystore.rst
@@ -33,7 +33,7 @@ identitystore
 - [X] delete_group
 - [X] delete_group_membership
 - [X] delete_user
-- [ ] describe_group
+- [X] describe_group
 - [ ] describe_group_membership
 - [X] describe_user
 - [X] get_group_id

--- a/docs/docs/services/logs.rst
+++ b/docs/docs/services/logs.rst
@@ -27,11 +27,16 @@ logs
 
 - [ ] associate_kms_key
 - [ ] cancel_export_task
+- [ ] create_delivery
 - [X] create_export_task
 - [X] create_log_group
 - [X] create_log_stream
 - [ ] delete_account_policy
 - [ ] delete_data_protection_policy
+- [ ] delete_delivery
+- [ ] delete_delivery_destination
+- [ ] delete_delivery_destination_policy
+- [ ] delete_delivery_source
 - [X] delete_destination
 - [X] delete_log_group
 - [X] delete_log_stream
@@ -45,6 +50,9 @@ logs
 - [X] delete_retention_policy
 - [X] delete_subscription_filter
 - [ ] describe_account_policies
+- [ ] describe_deliveries
+- [ ] describe_delivery_destinations
+- [ ] describe_delivery_sources
 - [X] describe_destinations
 - [ ] describe_export_tasks
 - [X] describe_log_groups
@@ -74,6 +82,10 @@ logs
         
 
 - [ ] get_data_protection_policy
+- [ ] get_delivery
+- [ ] get_delivery_destination
+- [ ] get_delivery_destination_policy
+- [ ] get_delivery_source
 - [X] get_log_events
 - [ ] get_log_group_fields
 - [ ] get_log_record
@@ -86,6 +98,9 @@ logs
 - [X] list_tags_log_group
 - [ ] put_account_policy
 - [ ] put_data_protection_policy
+- [ ] put_delivery_destination
+- [ ] put_delivery_destination_policy
+- [ ] put_delivery_source
 - [X] put_destination
 - [X] put_destination_policy
 - [X] put_log_events

--- a/docs/docs/services/rds.rst
+++ b/docs/docs/services/rds.rst
@@ -54,7 +54,9 @@ rds
 - [ ] create_db_subnet_group
 - [X] create_event_subscription
 - [X] create_global_cluster
+- [ ] create_integration
 - [X] create_option_group
+- [ ] create_tenant_database
 - [ ] delete_blue_green_deployment
 - [ ] delete_custom_db_engine_version
 - [X] delete_db_cluster
@@ -72,7 +74,9 @@ rds
 - [ ] delete_db_subnet_group
 - [X] delete_event_subscription
 - [X] delete_global_cluster
+- [ ] delete_integration
 - [X] delete_option_group
+- [ ] delete_tenant_database
 - [ ] deregister_db_proxy_targets
 - [ ] describe_account_attributes
 - [ ] describe_blue_green_deployments
@@ -97,6 +101,7 @@ rds
 - [ ] describe_db_proxy_targets
 - [ ] describe_db_security_groups
 - [ ] describe_db_snapshot_attributes
+- [ ] describe_db_snapshot_tenant_databases
 - [X] describe_db_snapshots
 - [X] describe_db_subnet_groups
 - [ ] describe_engine_default_cluster_parameters
@@ -106,6 +111,7 @@ rds
 - [ ] describe_events
 - [X] describe_export_tasks
 - [X] describe_global_clusters
+- [ ] describe_integrations
 - [X] describe_option_group_options
 - [X] describe_option_groups
 - [X] describe_orderable_db_instance_options
@@ -117,6 +123,7 @@ rds
 - [ ] describe_reserved_db_instances
 - [ ] describe_reserved_db_instances_offerings
 - [ ] describe_source_regions
+- [ ] describe_tenant_databases
 - [ ] describe_valid_db_instance_modifications
 - [ ] download_db_log_file_portion
 - [ ] failover_db_cluster
@@ -141,6 +148,7 @@ rds
 - [ ] modify_event_subscription
 - [ ] modify_global_cluster
 - [X] modify_option_group
+- [ ] modify_tenant_database
 - [X] promote_read_replica
 - [X] promote_read_replica_db_cluster
 - [ ] purchase_reserved_db_instances_offering

--- a/docs/docs/services/redshift.rst
+++ b/docs/docs/services/redshift.rst
@@ -115,6 +115,7 @@ redshift
 - [ ] disassociate_data_share_consumer
 - [ ] enable_logging
 - [X] enable_snapshot_copy
+- [ ] failover_primary_compute
 - [X] get_cluster_credentials
 - [ ] get_cluster_credentials_with_iam
 - [ ] get_reserved_node_exchange_configuration_options

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1773,6 +1773,8 @@ class LambdaBackend(BaseBackend):
         # Note that this option will be ignored if MOTO_DOCKER_NETWORK_NAME is also set
         MOTO_DOCKER_NETWORK_MODE=host moto_server
 
+    _-_-_-_
+
     The Docker images used by Moto are taken from the following repositories:
 
     - `mlupin/docker-lambda` (for recent versions)
@@ -1784,6 +1786,8 @@ class LambdaBackend(BaseBackend):
 
         MOTO_DOCKER_LAMBDA_IMAGE=mlupin/docker-lambda
 
+    _-_-_-_
+
     Use the following environment variable if you want to configure the data directory used by the Docker containers:
 
     .. sourcecode:: bash
@@ -1791,6 +1795,15 @@ class LambdaBackend(BaseBackend):
         MOTO_LAMBDA_DATA_DIR=/tmp/data
 
     .. note:: When using the decorators, a Docker container cannot reach Moto, as the Docker-container loses all mock-context. Any boto3-invocations used within your Lambda will try to connect to AWS.
+
+    _-_-_-_
+
+    If you want to mock the Lambda-containers invocation without starting a Docker-container, use the simple decorator:
+
+    .. sourcecode:: python
+
+        @mock_lambda_simple
+
     """
 
     def __init__(self, region_name: str, account_id: str):


### PR DESCRIPTION
Also enables Trusted Publisher workflow with PyPi, so we no longer need passwords/API keys.

https://docs.pypi.org/trusted-publishers/using-a-publisher/