### PR TITLE
LakeFormation: Add Parameters for list_permissions()

### DIFF
--- a/moto/lakeformation/exceptions.py
+++ b/moto/lakeformation/exceptions.py
@@ -5,3 +5,8 @@ from moto.core.exceptions import JsonRESTError
 class EntityNotFound(JsonRESTError):
     def __init__(self) -> None:
         super().__init__("EntityNotFoundException", "Entity not found")
+
+
+class InvalidInput(JsonRESTError):
+    def __init__(self, message: str) -> None:
+        super().__init__("InvalidInputException", message)

--- a/moto/lakeformation/responses.py
+++ b/moto/lakeformation/responses.py
@@ -3,7 +3,11 @@ import json
 from typing import Any, Dict
 
 from moto.core.responses import BaseResponse
-from .models import lakeformation_backends, LakeFormationBackend
+from .models import (
+    lakeformation_backends,
+    LakeFormationBackend,
+    ListPermissionsResource,
+)
 
 
 class LakeFormationResponse(BaseResponse):
@@ -87,7 +91,21 @@ class LakeFormationResponse(BaseResponse):
 
     def list_permissions(self) -> str:
         catalog_id = self._get_param("CatalogId") or self.current_account
-        permissions = self.lakeformation_backend.list_permissions(catalog_id)
+        principal = self._get_param("Principal")
+        resource = self._get_param("Resource")
+        resource_type = self._get_param("ResourceType")
+
+        list_permission_resource = (
+            ListPermissionsResource.from_dictionary(resource)
+            if resource is not None
+            else None
+        )
+        permissions = self.lakeformation_backend.list_permissions(
+            catalog_id=catalog_id,
+            principal=principal,
+            resource=list_permission_resource,
+            resource_type=resource_type,
+        )
         return json.dumps({"PrincipalResourcePermissions": permissions})
 
     def create_lf_tag(self) -> str:

--- a/moto/lakeformation/responses.py
+++ b/moto/lakeformation/responses.py
@@ -1,6 +1,6 @@
 """Handles incoming lakeformation requests, invokes methods, returns responses."""
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from moto.core.responses import BaseResponse
 from .models import (


### PR DESCRIPTION
This implements the key behavior of filtering the results of lakeformation's list_permissions operation based on the passed parameters.

Implemented filtering by:
```
CatalogId, Principal, ResourceType, Resource
```
where:
```
ResourceType = [DATABASE, TABLE, CATALOG, DATA_LOCATION]
```
and 
```
Resource = [
    {
        "Database": {
            "CatalogId": "string", 
            "Name": "string"
        }
    },
    {
        "Table": {
            "CatalogId": "string", 
            "DatabaseName": "string"
            "Name": "string",
            "TableWildcard": {}
        }
    },
    {
        "Catalog": {}
    },
]
```

Used reference documents for behaviour:
- https://boto3.amazonaws.com/v1/documentation/api/1.26.83/reference/services/lakeformation/client/list_permissions.html
- https://docs.aws.amazon.com/cli/latest/reference/lakeformation/list-permissions.html

Note: 
I could not get all preexisting tests running on my system even though I followed the guidelines. (https://docs.getmoto.org/en/latest/docs/contributing/installation.html)
Newly implemented tests ran successfully though.
