### PR TITLE
Add subtitle support for `transcribe`

### DIFF
--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 from moto.core import BaseBackend, BackendDict, BaseModel
@@ -221,10 +222,11 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
                 "%Y-%m-%d %H:%M:%S"
             )
             if self._output_bucket_name:
+                remove_json_extension = re.compile("\\.json$")
                 transcript_file_prefix = (
                     f"https://s3.{self._region_name}.amazonaws.com/"
                     f"{self._output_bucket_name}/"
-                    f"{(self.output_key or self.transcription_job_name).replace('.json', '')}"
+                    f"{remove_json_extension.sub('', self.output_key or self.transcription_job_name)}"
                 )
                 self.output_location_type = "CUSTOMER_BUCKET"
             else:

--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -228,7 +228,7 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
                 )
                 self.output_location_type = "CUSTOMER_BUCKET"
             else:
-                url = (
+                transcript_file_prefix = (
                     f"https://s3.{self._region_name}.amazonaws.com/"
                     f"aws-transcribe-{self._region_name}-prod/"
                     f"{self._account_id}/"
@@ -238,9 +238,11 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
                 )
                 self.output_location_type = "SERVICE_BUCKET"
             self.transcript = {"TranscriptFileUri": f"{transcript_file_prefix}.json"}
-            self.subtitles["SubtitleFileUris"] = (
-                [f"{transcript_file_prefix}.{format}" for format in self.subtitles["Formats"]]
-            )
+            self.subtitles["SubtitleFileUris"] = [
+                f"{transcript_file_prefix}.{format}"
+                for format in self.subtitles["Formats"]
+            ]
+
 
 class FakeVocabulary(BaseObject, ManagedState):
     def __init__(
@@ -518,6 +520,7 @@ class TranscribeBackend(BaseBackend):
         identify_language: Optional[bool],
         identify_multiple_languages: Optional[bool],
         language_options: Optional[List[str]],
+        subtitles: Optional[Dict[str, Any]],
     ) -> Dict[str, Any]:
         if transcription_job_name in self.transcriptions:
             raise ConflictException(
@@ -549,6 +552,7 @@ class TranscribeBackend(BaseBackend):
             identify_language=identify_language,
             identify_multiple_languages=identify_multiple_languages,
             language_options=language_options,
+            subtitles=subtitles,
         )
         self.transcriptions[transcription_job_name] = transcription_job_object
 

--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -224,7 +224,7 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
                 transcript_file_prefix = (
                     f"https://s3.{self._region_name}.amazonaws.com/"
                     f"{self._output_bucket_name}/"
-                    f"{self.output_key or self.transcription_job_name}"
+                    f"{(self.output_key or self.transcription_job_name).replace('.json', '')}"
                 )
                 self.output_location_type = "CUSTOMER_BUCKET"
             else:

--- a/moto/transcribe/responses.py
+++ b/moto/transcribe/responses.py
@@ -32,6 +32,7 @@ class TranscribeResponse(BaseResponse):
             identify_language=self._get_param("IdentifyLanguage"),
             identify_multiple_languages=self._get_param("IdentifyMultipleLanguages"),
             language_options=self._get_param("LanguageOptions"),
+            subtitles=self._get_param("Subtitles"),
         )
         return json.dumps(response)
 

--- a/tests/test_transcribe/test_transcribe_boto3.py
+++ b/tests/test_transcribe/test_transcribe_boto3.py
@@ -407,7 +407,8 @@ def test_run_transcription_job_s3output_params():
         "Formats": args["Subtitles"]["Formats"],
         "SubtitleFileUris": [
             f"https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key.{format}"
-        for format in args["Subtitles"]["Formats"]],
+            for format in args["Subtitles"]["Formats"]
+        ],
     }
 
     # A new job without an "OutputKey"

--- a/tests/test_transcribe/test_transcribe_boto3.py
+++ b/tests/test_transcribe/test_transcribe_boto3.py
@@ -369,7 +369,7 @@ def test_run_transcription_job_s3output_params():
         "LanguageCode": "en-US",
         "Media": {"MediaFileUri": "s3://my-bucket/my-media-file.wav"},
         "OutputBucketName": "my-output-bucket",
-        "OutputKey": "bucket-key.json",
+        "OutputKey": "bucket.json.key.json",
         "Subtitles": {"Formats": ["vtt", "srt"]},
     }
     resp = client.start_transcription_job(**args)
@@ -401,12 +401,12 @@ def test_run_transcription_job_s3output_params():
     assert "Transcript" in transcription_job
     # Check aws hosted bucket
     assert (
-        "https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key.json"
+        "https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket.json.key.json"
     ) in transcription_job["Transcript"]["TranscriptFileUri"]
     assert transcription_job["Subtitles"] == {
         "Formats": args["Subtitles"]["Formats"],
         "SubtitleFileUris": [
-            f"https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key.{format}"
+            f"https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket.json.key.{format}"
             for format in args["Subtitles"]["Formats"]
         ],
     }

--- a/tests/test_transcribe/test_transcribe_boto3.py
+++ b/tests/test_transcribe/test_transcribe_boto3.py
@@ -209,6 +209,10 @@ def test_run_transcription_job_all_params():
             "MaxAlternatives": 6,
             "VocabularyName": vocabulary_name,
         },
+        "Subtitles": {
+            "Formats": ["srt", "vtt"],
+            "OutputStartIndex": 1,
+        },
         # Missing `ContentRedaction`, `JobExecutionSettings`,
         # `VocabularyFilterName`, `LanguageModel`
     }
@@ -268,6 +272,18 @@ def test_run_transcription_job_all_params():
             f"/{args['OutputBucketName']}"
             f"/{args['TranscriptionJobName']}.json"
         ),
+    }
+    assert transcription_job["Subtitles"] == {
+        "Formats": args["Subtitles"]["Formats"],
+        "OutputStartIndex": 1,
+        "SubtitleFileUris": [
+            (
+                f"https://s3.{region_name}.amazonaws.com"
+                f"/{args['OutputBucketName']}"
+                f"/{args['TranscriptionJobName']}.{format}"
+            )
+            for format in args["Subtitles"]["Formats"]
+        ],
     }
 
 
@@ -329,6 +345,11 @@ def test_run_transcription_job_minimal_params():
     assert (
         f"https://s3.{region_name}.amazonaws.com/aws-transcribe-{region_name}-prod/"
     ) in transcription_job["Transcript"]["TranscriptFileUri"]
+    assert transcription_job["Subtitles"] == {
+        "Formats": [],
+        "OutputStartIndex": 0,
+        "SubtitleFileUris": [],
+    }
 
     # Delete
     client.delete_transcription_job(TranscriptionJobName=job_name)
@@ -379,7 +400,7 @@ def test_run_transcription_job_s3output_params():
     assert "Transcript" in transcription_job
     # Check aws hosted bucket
     assert (
-        "https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key/MyJob.json"
+        "https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key.json"
     ) in transcription_job["Transcript"]["TranscriptFileUri"]
     # A new job without an "OutputKey"
     job_name = "MyJob2"

--- a/tests/test_transcribe/test_transcribe_boto3.py
+++ b/tests/test_transcribe/test_transcribe_boto3.py
@@ -369,7 +369,8 @@ def test_run_transcription_job_s3output_params():
         "LanguageCode": "en-US",
         "Media": {"MediaFileUri": "s3://my-bucket/my-media-file.wav"},
         "OutputBucketName": "my-output-bucket",
-        "OutputKey": "bucket-key",
+        "OutputKey": "bucket-key.json",
+        "Subtitles": {"Formats": ["vtt", "srt"]},
     }
     resp = client.start_transcription_job(**args)
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
@@ -402,6 +403,13 @@ def test_run_transcription_job_s3output_params():
     assert (
         "https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key.json"
     ) in transcription_job["Transcript"]["TranscriptFileUri"]
+    assert transcription_job["Subtitles"] == {
+        "Formats": args["Subtitles"]["Formats"],
+        "SubtitleFileUris": [
+            f"https://s3.us-east-1.amazonaws.com/my-output-bucket/bucket-key.{format}"
+        for format in args["Subtitles"]["Formats"]],
+    }
+
     # A new job without an "OutputKey"
     job_name = "MyJob2"
     args = {


### PR DESCRIPTION
Adds support for translating the `Subtitle.Formats` configuration key into appropriate outputs given `OutputBucketName` and `OutputKey` configuration. Also fixes the formatting of `Transcript.TranscriptFileUri` in the output when `OutputBucketName` and `OutputKey` are both set. When that is the case the job name is not part of the output key.