### PR TITLE
Fix CloudFormation AWS::Logs::LogGroup tagging

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -410,7 +410,9 @@ class LogGroup(CloudFormationModel):
         **kwargs: Any,
     ) -> "LogGroup":
         properties = cloudformation_json["Properties"]
-        tags = properties.get("Tags", {})
+        tags = properties.get("Tags", [])
+        tags = dict([tag.values() for tag in tags])
+
         return logs_backends[account_id][region_name].create_log_group(
             resource_name, tags, **properties
         )

--- a/tests/test_logs/test_logs_cloudformation.py
+++ b/tests/test_logs/test_logs_cloudformation.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 import boto3
 
@@ -20,14 +19,12 @@ def test_tagging():
                 "Properties": {"Tags": [{"Key": "foo", "Value": "bar"}]},
             }
         },
-        "Outputs": {"LogGroup": {"Value": {"Ref": "testGroup"}}},
     }
     template_json = json.dumps(template)
     cf_client.create_stack(
         StackName="test_stack",
         TemplateBody=template_json,
     )
-    stack_description = cf_client.describe_stacks(StackName="test_stack")["Stacks"][0]
 
     arn = logs_client.describe_log_groups()["logGroups"][0]["arn"]
     tags = logs_client.list_tags_for_resource(resourceArn=arn)["tags"]

--- a/tests/test_logs/test_logs_cloudformation.py
+++ b/tests/test_logs/test_logs_cloudformation.py
@@ -1,0 +1,34 @@
+import json
+import re
+
+import boto3
+
+from moto import mock_cloudformation, mock_logs
+
+
+@mock_logs
+@mock_cloudformation
+def test_tagging():
+    logs_client = boto3.client("logs", region_name="us-east-1")
+    cf_client = boto3.client("cloudformation", region_name="us-east-1")
+
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "testGroup": {
+                "Type": "AWS::Logs::LogGroup",
+                "Properties": {"Tags": [{"Key": "foo", "Value": "bar"}]},
+            }
+        },
+        "Outputs": {"LogGroup": {"Value": {"Ref": "testGroup"}}},
+    }
+    template_json = json.dumps(template)
+    cf_client.create_stack(
+        StackName="test_stack",
+        TemplateBody=template_json,
+    )
+    stack_description = cf_client.describe_stacks(StackName="test_stack")["Stacks"][0]
+
+    arn = logs_client.describe_log_groups()["logGroups"][0]["arn"]
+    tags = logs_client.list_tags_for_resource(resourceArn=arn)["tags"]
+    assert tags == {"foo": "bar"}


### PR DESCRIPTION
CloudFormation AWS::Logs::LogGroup expects tags as an array of Tags:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html

Whereas boto3's Logs `create_log_group()` expects tags to be a dict:

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/create_log_group.html

So we need to transform how we provide tags to avoid getting:

```
E       AttributeError: 'list' object has no attribute 'items'
```