### PR TITLE
MyPy improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,8 @@ exclude_lines =
     raise NotImplemented.
     return NotImplemented
     def __repr__
+    if TYPE_CHECKING:
+    ^\s*\.\.\.$
 
 [run]
 include = moto/*

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
     P = ParamSpec("P")
-else:
-    P = object
 
 
 T = TypeVar("T")
@@ -29,10 +27,12 @@ def lazy_load(
         ...
 
     @overload
-    def f(func: Callable[P, T]) -> Callable[P, T]:
+    def f(func: "Callable[P, T]") -> "Callable[P, T]":
         ...
 
-    def f(func: Optional[Callable[P, T]] = None) -> Union[BaseMockAWS, Callable[P, T]]:
+    def f(
+        func: "Optional[Callable[P, T]]" = None,
+    ) -> "Union[BaseMockAWS, Callable[P, T]]":
         module = importlib.import_module(module_name, "moto")
         decorator: base_decorator = getattr(module, element)
         return decorator(func)

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -2,7 +2,7 @@ import importlib
 import sys
 from contextlib import ContextDecorator
 
-from moto.core.models import BaseMockAWS, base_decorator
+from moto.core.models import BaseMockAWS, base_decorator, BaseDecorator
 from typing import Any, Callable, List, Optional, TypeVar, Union, overload
 from typing import TYPE_CHECKING
 from typing_extensions import ParamSpec
@@ -19,9 +19,9 @@ def lazy_load(
     element: str,
     boto3_name: Optional[str] = None,
     backend: Optional[str] = None,
-) -> Callable[..., BaseMockAWS]:
+) -> BaseDecorator:
     @overload
-    def f() -> BaseMockAWS:
+    def f(func: None = None) -> BaseMockAWS:
         ...
 
     @overload

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -5,12 +5,16 @@ from contextlib import ContextDecorator
 from moto.core.models import BaseMockAWS, base_decorator, BaseDecorator
 from typing import Any, Callable, List, Optional, TypeVar, Union, overload
 from typing import TYPE_CHECKING
-from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     from moto.xray import XRaySegment as xray_segment_type
+    from typing_extensions import ParamSpec
 
-P = ParamSpec("P")
+    P = ParamSpec("P")
+else:
+    P = object
+
+
 T = TypeVar("T")
 
 

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 else:
     Protocol = object
-    P = object
 
 
 DEFAULT_ACCOUNT_ID = "123456789012"
@@ -76,10 +75,10 @@ class BaseMockAWS(ContextManager["BaseMockAWS"]):
 
     def __call__(
         self,
-        func: Callable[P, T],
+        func: "Callable[P, T]",
         reset: bool = True,
         remove_data: bool = True,
-    ) -> Callable[P, T]:
+    ) -> "Callable[P, T]":
         if inspect.isclass(func):
             return self.decorate_class(func)  # type: ignore
         return self.decorate_callable(func, reset, remove_data)
@@ -129,9 +128,12 @@ class BaseMockAWS(ContextManager["BaseMockAWS"]):
             self.disable_patching()  # type: ignore[attr-defined]
 
     def decorate_callable(
-        self, func: Callable[P, T], reset: bool, remove_data: bool
-    ) -> Callable[P, T]:
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        self,
+        func: "Callable[P, T]",
+        reset: bool,
+        remove_data: bool,
+    ) -> "Callable[P, T]":
+        def wrapper(*args: "P.args", **kwargs: "P.kwargs") -> T:
             self.start(reset=reset)
             try:
                 result = func(*args, **kwargs)
@@ -527,12 +529,12 @@ class base_decorator:
         ...
 
     @overload
-    def __call__(self, func: Callable[P, T]) -> Callable[P, T]:
+    def __call__(self, func: "Callable[P, T]") -> "Callable[P, T]":
         ...
 
     def __call__(
-        self, func: Optional[Callable[P, T]] = None
-    ) -> Union[BaseMockAWS, Callable[P, T]]:
+        self, func: "Optional[Callable[P, T]]" = None
+    ) -> "Union[BaseMockAWS, Callable[P, T]]":
         if settings.test_proxy_mode():
             mocked_backend: BaseMockAWS = ProxyModeMockAWS(self.backends)
         elif settings.TEST_SERVER_MODE:
@@ -557,5 +559,5 @@ class BaseDecorator(Protocol):
         ...
 
     @overload
-    def __call__(self, func: Callable[P, T]) -> Callable[P, T]:
+    def __call__(self, func: "Callable[P, T]") -> "Callable[P, T]":
         ...

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -5,8 +5,9 @@ import os
 import re
 import unittest
 from types import FunctionType
-from typing import Any, Callable, Dict, Optional, Set, TypeVar, Union
+from typing import Any, Callable, Dict, Optional, Set, TypeVar, Union, overload
 from typing import ContextManager
+from typing_extensions import ParamSpec
 from unittest.mock import patch
 
 import boto3
@@ -27,7 +28,8 @@ from .custom_responses_mock import (
 from .model_instances import reset_model_data
 
 DEFAULT_ACCOUNT_ID = "123456789012"
-CALLABLE_RETURN = TypeVar("CALLABLE_RETURN")
+P = ParamSpec("P")
+T = TypeVar("T")
 
 
 class BaseMockAWS(ContextManager["BaseMockAWS"]):
@@ -67,10 +69,10 @@ class BaseMockAWS(ContextManager["BaseMockAWS"]):
 
     def __call__(
         self,
-        func: Callable[..., "BaseMockAWS"],
+        func: Callable[P, T],
         reset: bool = True,
         remove_data: bool = True,
-    ) -> Callable[..., "BaseMockAWS"]:
+    ) -> Callable[P, T]:
         if inspect.isclass(func):
             return self.decorate_class(func)  # type: ignore
         return self.decorate_callable(func, reset, remove_data)
@@ -120,9 +122,9 @@ class BaseMockAWS(ContextManager["BaseMockAWS"]):
             self.disable_patching()  # type: ignore[attr-defined]
 
     def decorate_callable(
-        self, func: Callable[..., "BaseMockAWS"], reset: bool, remove_data: bool
-    ) -> Callable[..., "BaseMockAWS"]:
-        def wrapper(*args: Any, **kwargs: Any) -> "BaseMockAWS":
+        self, func: Callable[P, T], reset: bool, remove_data: bool
+    ) -> Callable[P, T]:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             self.start(reset=reset)
             try:
                 result = func(*args, **kwargs)
@@ -513,13 +515,21 @@ class base_decorator:
     def __init__(self, backends: BackendDict):
         self.backends = backends
 
+    @overload
+    def __call__(self, func: None) -> BaseMockAWS:
+        ...
+
+    @overload
+    def __call__(self, func: Callable[P, T]) -> Callable[P, T]:
+        ...
+
     def __call__(
-        self, func: Optional[Callable[..., Any]] = None
-    ) -> Union[BaseMockAWS, Callable[..., BaseMockAWS]]:
+        self, func: Optional[Callable[P, T]] = None
+    ) -> Union[BaseMockAWS, Callable[P, T]]:
         if settings.test_proxy_mode():
             mocked_backend: BaseMockAWS = ProxyModeMockAWS(self.backends)
         elif settings.TEST_SERVER_MODE:
-            mocked_backend: BaseMockAWS = ServerModeMockAWS(self.backends)  # type: ignore
+            mocked_backend: BaseMockAWS = ServerModeMockAWS(self.backends)
         else:
             mocked_backend = self.mock_backend(self.backends)
 

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -6,8 +6,7 @@ import re
 import unittest
 from types import FunctionType
 from typing import Any, Callable, Dict, Optional, Set, TypeVar, Union, overload
-from typing import ContextManager
-from typing_extensions import ParamSpec, Protocol
+from typing import ContextManager, TYPE_CHECKING
 from unittest.mock import patch
 
 import boto3
@@ -27,8 +26,16 @@ from .custom_responses_mock import (
 )
 from .model_instances import reset_model_data
 
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec, Protocol
+
+    P = ParamSpec("P")
+else:
+    Protocol = object
+    P = object
+
+
 DEFAULT_ACCOUNT_ID = "123456789012"
-P = ParamSpec("P")
 T = TypeVar("T")
 
 
@@ -435,7 +442,7 @@ class ServerModeMockAWS(BaseMockAWS):
     def _get_region(self, *args: Any, **kwargs: Any) -> Optional[str]:
         if "region_name" in kwargs:
             return kwargs["region_name"]
-        if type(args) == tuple and len(args) == 2:
+        if type(args) is tuple and len(args) == 2:
             _, region = args
             return region
         return None

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -7,7 +7,7 @@ import unittest
 from types import FunctionType
 from typing import Any, Callable, Dict, Optional, Set, TypeVar, Union, overload
 from typing import ContextManager
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, Protocol
 from unittest.mock import patch
 
 import boto3
@@ -516,7 +516,7 @@ class base_decorator:
         self.backends = backends
 
     @overload
-    def __call__(self, func: None) -> BaseMockAWS:
+    def __call__(self, func: None = None) -> BaseMockAWS:
         ...
 
     @overload
@@ -529,7 +529,7 @@ class base_decorator:
         if settings.test_proxy_mode():
             mocked_backend: BaseMockAWS = ProxyModeMockAWS(self.backends)
         elif settings.TEST_SERVER_MODE:
-            mocked_backend: BaseMockAWS = ServerModeMockAWS(self.backends)
+            mocked_backend = ServerModeMockAWS(self.backends)
         else:
             mocked_backend = self.mock_backend(self.backends)
 
@@ -537,3 +537,18 @@ class base_decorator:
             return mocked_backend(func)
         else:
             return mocked_backend
+
+
+class BaseDecorator(Protocol):
+    """A protocol for base_decorator's signature.
+
+    This enables typing of callables with the same behavior as base_decorator.
+    """
+
+    @overload
+    def __call__(self, func: None = None) -> BaseMockAWS:
+        ...
+
+    @overload
+    def __call__(self, func: Callable[P, T]) -> Callable[P, T]:
+        ...

--- a/moto/identitystore/models.py
+++ b/moto/identitystore/models.py
@@ -1,5 +1,4 @@
-from typing import Dict, Tuple, List, Any, NamedTuple, Optional
-from typing_extensions import Self
+from typing import Dict, Tuple, List, Any, NamedTuple, Optional, TYPE_CHECKING
 from moto.utilities.paginator import paginate
 
 from botocore.exceptions import ParamValidationError
@@ -12,6 +11,9 @@ from .exceptions import (
     ConflictException,
 )
 import warnings
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 class Group(NamedTuple):
@@ -31,7 +33,7 @@ class Name(NamedTuple):
     HonorificSuffix: Optional[str]
 
     @classmethod
-    def from_dict(cls, name_dict: Dict[str, str]) -> Optional[Self]:
+    def from_dict(cls, name_dict: Dict[str, str]) -> "Optional[Self]":
         if not name_dict:
             return None
         return cls(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,12 @@ inflection
 lxml
 mypy
 typing-extensions<=4.5.0; python_version < '3.8'
+typing-extensions; python_version >= '3.8'
 packaging
 build
 prompt_toolkit
+
+# typing_extensions is currently used for:
+# Protocol  (3.8+)
+# ParamSpec  (3.10+)
+# Self  (3.11+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     responses>=0.13.0
     Jinja2>=2.10.1
     importlib_metadata ; python_version < '3.8'
+    typing_extensions
 package_dir =
     moto = moto
 include_package_data = True
@@ -274,7 +275,7 @@ disable = W,C,R,E
 enable = anomalous-backslash-in-string, arguments-renamed, dangerous-default-value, deprecated-module, function-redefined, import-self, redefined-builtin, redefined-outer-name, reimported, pointless-statement, super-with-arguments, unused-argument, unused-import, unused-variable, useless-else-on-loop, wildcard-import
 
 [mypy]
-files= moto, tests/test_core/test_mock_all.py, tests/test_core/test_decorator_calls.py, tests/test_core/test_responses_module.py
+files= moto, tests/test_core/test_mock_all.py, tests/test_core/test_decorator_calls.py, tests/test_core/test_responses_module.py, tests/test_core/test_mypy.py
 show_column_numbers=True
 show_error_codes = True
 disable_error_code=abstract

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     responses>=0.13.0
     Jinja2>=2.10.1
     importlib_metadata ; python_version < '3.8'
-    typing_extensions
 package_dir =
     moto = moto
 include_package_data = True

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -5,7 +5,6 @@ import unittest
 from botocore.exceptions import ClientError
 from typing import Any
 from moto import mock_ec2, mock_kinesis, mock_s3, settings
-from moto.core.models import BaseMockAWS
 from unittest import SkipTest
 
 """
@@ -48,7 +47,7 @@ def test_context_manager(aws_credentials: Any) -> None:  # type: ignore[misc]  #
 def test_decorator_start_and_stop() -> None:
     if settings.TEST_SERVER_MODE:
         raise SkipTest("Authentication always works in ServerMode")
-    mock: BaseMockAWS = mock_ec2()
+    mock = mock_ec2()
     mock.start()
     client = boto3.client("ec2", region_name="us-west-1")
     assert client.describe_addresses()["Addresses"] == []

--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -10,6 +10,12 @@ def test_without_parentheses() -> int:
     return 123
 
 
+@mock_s3()
+def test_with_parentheses() -> int:
+    assert boto3.client("s3").list_buckets()["Buckets"] == []
+    return 456
+
+
 @mock_s3
 def test_no_return() -> None:
     assert boto3.client("s3").list_buckets()["Buckets"] == []
@@ -28,6 +34,9 @@ def test_manual() -> None:
     assert boto3.client("s3").list_buckets()["Buckets"] == []
     m.stop()
 
+
+x: int = test_with_parentheses()
+assert x == 456
 
 y: int = test_without_parentheses()
 assert y == 123

--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -1,0 +1,12 @@
+import boto3
+from moto import mock_s3
+
+
+@mock_s3
+def test_without_parentheses() -> int:
+    assert boto3.client("s3").list_buckets()["Buckets"] == []
+    return 123
+
+
+y: int = test_without_parentheses()  # type: ignore
+assert y == 123

--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -1,5 +1,7 @@
 import boto3
+
 from moto import mock_s3
+from moto.core.models import BaseMockAWS
 
 
 @mock_s3
@@ -8,5 +10,24 @@ def test_without_parentheses() -> int:
     return 123
 
 
-y: int = test_without_parentheses()  # type: ignore
+@mock_s3
+def test_no_return() -> None:
+    assert boto3.client("s3").list_buckets()["Buckets"] == []
+
+
+def test_with_context_manager() -> None:
+    with mock_s3():
+        assert boto3.client("s3").list_buckets()["Buckets"] == []
+
+
+def test_manual() -> None:
+    # this has the explicit type not because it's necessary but so that mypy will
+    # complain if it's wrong
+    m: BaseMockAWS = mock_s3()
+    m.start()
+    assert boto3.client("s3").list_buckets()["Buckets"] == []
+    m.stop()
+
+
+y: int = test_without_parentheses()
 assert y == 123

--- a/tests/test_core/test_responses_module.py
+++ b/tests/test_core/test_responses_module.py
@@ -17,8 +17,8 @@ class TestResponsesModule(TestCase):
         if settings.TEST_SERVER_MODE:
             raise SkipTest("No point in testing responses-decorator in ServerMode")
 
-    @mock_s3
     @responses.activate
+    @mock_s3
     def test_moto_first(self) -> None:
         """
         Verify we can activate a user-defined `responses` on top of our Moto mocks

--- a/tests/test_core/test_responses_module.py
+++ b/tests/test_core/test_responses_module.py
@@ -17,9 +17,9 @@ class TestResponsesModule(TestCase):
         if settings.TEST_SERVER_MODE:
             raise SkipTest("No point in testing responses-decorator in ServerMode")
 
-    @responses.activate
     @mock_s3
-    def test_moto_first(self) -> None:
+    @responses.activate
+    def test_moto_first(self) -> None:  # type: ignore
         """
         Verify we can activate a user-defined `responses` on top of our Moto mocks
         """


### PR DESCRIPTION
This is my attempt to complete the work from https://github.com/getmoto/moto/pull/6421

I rebased it, and then used a Protocol to allow lazy_load to work properly. If you don't like the protocol, it also works if lazy_load has a return type of base_decorator and we just cast the inner function to that. 

I wasn't sure if maybe the name for the protocol class should be more distinct to avoid confusion.

I also added the other uses of the mock decorators listed in https://github.com/getmoto/moto/issues/4944#issuecomment-1596169486 to test_mypy.py. That was probably not really necessary, but it seemed like a reasonable thing to do.