### PR TITLE
Batch: mark job test as requiring docker

### DIFF
--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -409,6 +409,7 @@ def test_terminate_job_empty_argument_strings():
 @mock_ecs
 @mock_iam
 @mock_batch
+@requires_docker
 def test_cancel_pending_job():
     ec2_client, iam_client, _, _, batch_client = _get_clients()
     _, _, _, iam_arn = _setup(ec2_client, iam_client)


### PR DESCRIPTION
Similar to https://github.com/getmoto/moto/pull/6938, this test fails without docker:
```
___________________________ test_cancel_pending_job ____________________________

    @mock_logs
    @mock_ec2
    @mock_ecs
    @mock_iam
    @mock_batch
    def test_cancel_pending_job():
        ec2_client, iam_client, _, _, batch_client = _get_clients()
        _, _, _, iam_arn = _setup(ec2_client, iam_client)

        # We need to be able to cancel a job that has not been started yet
        # Locally, our jobs start so fast that we can't cancel them in time
        # So delay our job, by letting it depend on a slow-running job
        commands = ["sleep", "10"]
        job_def_arn, queue_arn = prepare_job(batch_client, commands, iam_arn, "deptest")

        resp = batch_client.submit_job(
            jobName="test1", jobQueue=queue_arn, jobDefinition=job_def_arn
        )
        delayed_job = resp["jobId"]

        depends_on = [{"jobId": delayed_job, "type": "SEQUENTIAL"}]
        resp = batch_client.submit_job(
            jobName="test_job_name",
            jobQueue=queue_arn,
            jobDefinition=job_def_arn,
            dependsOn=depends_on,
        )
        job_id = resp["jobId"]

        batch_client.cancel_job(jobId=job_id, reason="test_cancel")
        _wait_for_job_status(batch_client, job_id, "FAILED", seconds_to_wait=30)

        resp = batch_client.describe_jobs(jobs=[job_id])
        assert resp["jobs"][0]["jobName"] == "test_job_name"
>       assert resp["jobs"][0]["statusReason"] == "test_cancel"
E       KeyError: 'statusReason'

tests/test_batch/test_batch_jobs.py:441: KeyError
------------------------------ Captured log call -------------------------------
ERROR    moto.batch.models:models.py:908 Failed to run AWS Batch container MOTO-BATCH-e3367077-6d2c-4d97-8461-a1d1b96a1683. Error Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
ERROR    moto.batch.models:models.py:963 Terminating job MOTO-BATCH-cd131c13-9763-43e1-b2b2-ee394b0229ef due to failed dependency MOTO-BATCH-e3367077-6d2c-4d97-8461-a1d1b96a1683
```

Maybe it's better to have a github workflow that runs tests without docker?