### PR TITLE
LakeFormation: raise AlreadyExistsException when registering an existing resource

### DIFF
--- a/moto/lakeformation/exceptions.py
+++ b/moto/lakeformation/exceptions.py
@@ -10,3 +10,8 @@ class EntityNotFound(JsonRESTError):
 class InvalidInput(JsonRESTError):
     def __init__(self, message: str) -> None:
         super().__init__("InvalidInputException", message)
+
+
+class AlreadyExists(JsonRESTError):
+    def __init__(self, message: str) -> None:
+        super().__init__("AlreadyExistsException", message)

--- a/moto/lakeformation/models.py
+++ b/moto/lakeformation/models.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple, Optional
 
 from moto.core import BaseBackend, BackendDict, BaseModel
 from moto.utilities.tagging_service import TaggingService
-from .exceptions import EntityNotFound, InvalidInput
+from .exceptions import EntityNotFound, InvalidInput, AlreadyExists
 
 
 class RessourceType(Enum):
@@ -180,6 +180,10 @@ class LakeFormationBackend(BaseBackend):
         del self.resources[resource_arn]
 
     def register_resource(self, resource_arn: str, role_arn: str) -> None:
+        if resource_arn in self.resources:
+            raise AlreadyExists(
+                "An error occurred (AlreadyExistsException) when calling the RegisterResource operation: Resource is already registered"
+            )
         self.resources[resource_arn] = Resource(resource_arn, role_arn)
 
     def list_resources(self) -> List[Resource]:

--- a/tests/test_lakeformation/test_lakeformation.py
+++ b/tests/test_lakeformation/test_lakeformation.py
@@ -13,12 +13,12 @@ from moto import mock_lakeformation
 @mock_lakeformation
 def test_register_resource():
     client = boto3.client("lakeformation", region_name="us-east-2")
-    resp = client.register_resource(
-        ResourceArn="some arn",
-    )
+    resp = client.register_resource(ResourceArn="some arn", RoleArn="another arn")
 
     del resp["ResponseMetadata"]
     assert resp == {}
+    with pytest.raises(client.exceptions.AlreadyExistsException):
+        client.register_resource(ResourceArn="some arn", RoleArn="another arn")
 
 
 @mock_lakeformation


### PR DESCRIPTION
The register-resource method of lakeformation is missing the functionality to raise AlreadyExistsException when a resource is already registered.

Resource:
- https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lakeformation/client/register_resource.html,
- Testing with AWS CLI