### PR TITLE
Mypy improvements for lazy_load

### DIFF
--- a/moto/ce/models.py
+++ b/moto/ce/models.py
@@ -17,7 +17,7 @@ def first_day() -> str:
         .replace(minute=0)
         .replace(second=0)
     )
-    return iso_8601_datetime_without_milliseconds(as_date)  # type: ignore[return-value]
+    return iso_8601_datetime_without_milliseconds(as_date)
 
 
 class CostCategoryDefinition(BaseModel):

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -441,7 +441,7 @@ class FakeStack(CloudFormationModel):
 
     @property
     def creation_time_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.creation_time)  # type: ignore[return-value]
+        return iso_8601_datetime_without_milliseconds(self.creation_time)
 
     def _add_stack_event(
         self,
@@ -654,7 +654,7 @@ class FakeChangeSet(BaseModel):
 
     @property
     def creation_time_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.creation_time)  # type: ignore[return-value]
+        return iso_8601_datetime_without_milliseconds(self.creation_time)
 
     def diff(self) -> List[FakeChange]:
         changes = []

--- a/moto/core/versions.py
+++ b/moto/core/versions.py
@@ -5,7 +5,7 @@ from moto.utilities.distutils_version import LooseVersion
 try:
     from importlib.metadata import version
 except ImportError:
-    from importlib_metadata import version  # type: ignore[no-redef]
+    from importlib_metadata import version
 
 
 PYTHON_VERSION_INFO = sys.version_info

--- a/moto/dms/utils.py
+++ b/moto/dms/utils.py
@@ -46,7 +46,7 @@ def filter_tasks(tasks: Iterable[Any], filters: List[Dict[str, Any]]) -> Any:
 
         # https://github.com/python/mypy/issues/12682
         matching_tasks = filter(
-            lambda task: filter_function(task, f["Values"]), matching_tasks  # type: ignore[arg-type]
+            lambda task: filter_function(task, f["Values"]), matching_tasks
         )
 
     return matching_tasks

--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -736,7 +736,7 @@ class Table(CloudFormationModel):
 
                 results.sort(
                     key=lambda item: conv(item.attrs[index_range_key["AttributeName"]])  # type: ignore
-                    if item.attrs.get(index_range_key["AttributeName"])  # type: ignore
+                    if item.attrs.get(index_range_key["AttributeName"])
                     else None
                 )
         else:

--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -224,4 +224,4 @@ def validate_schema(
             f"Query condition missed key schema element: {index_range_key}"
         )
 
-    return hash_value, range_comparison, range_values  # type: ignore[return-value]
+    return hash_value, range_comparison, range_values

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -989,7 +989,7 @@ class SecurityGroupBackend:
         if ip_ranges:
             for cidr in ip_ranges:
                 if (
-                    isinstance(cidr, dict)  # type: ignore
+                    isinstance(cidr, dict)
                     and not any(
                         [
                             is_valid_cidr(cidr.get("CidrIp", "")),
@@ -1044,7 +1044,7 @@ class SecurityGroupBackend:
         if ip_ranges:
             for cidr in ip_ranges:
                 if (
-                    isinstance(cidr, dict)  # type: ignore
+                    isinstance(cidr, dict)
                     and not any(
                         [
                             is_valid_cidr(cidr.get("CidrIp", "")),

--- a/moto/forecast/responses.py
+++ b/moto/forecast/responses.py
@@ -73,7 +73,7 @@ class ForecastResponse(BaseResponse):
                 }
                 for dsg in self.forecast_backend.list_dataset_groups()
             ],
-            key=lambda x: x["LastModificationTime"],  # type: ignore
+            key=lambda x: x["LastModificationTime"],
             reverse=True,
         )
         response = {"DatasetGroups": list_all}

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -116,7 +116,7 @@ class MFADevice:
 
     @property
     def enabled_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.enable_date)  # type: ignore[return-value]
+        return iso_8601_datetime_without_milliseconds(self.enable_date)
 
 
 class VirtualMfaDevice:
@@ -245,7 +245,7 @@ class OpenIDConnectProvider(BaseModel):
 
     @property
     def created_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.create_date)  # type: ignore[return-value]
+        return iso_8601_datetime_without_milliseconds(self.create_date)
 
     def _validate(
         self, url: str, thumbprint_list: List[str], client_id_list: List[str]
@@ -1062,7 +1062,7 @@ class SigningCertificate(BaseModel):
 
     @property
     def uploaded_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.upload_date)  # type: ignore
+        return iso_8601_datetime_without_milliseconds(self.upload_date)
 
 
 class AccessKeyLastUsed:
@@ -1073,7 +1073,7 @@ class AccessKeyLastUsed:
 
     @property
     def timestamp(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self._timestamp)  # type: ignore
+        return iso_8601_datetime_without_milliseconds(self._timestamp)
 
 
 class AccessKey(CloudFormationModel):
@@ -1096,7 +1096,7 @@ class AccessKey(CloudFormationModel):
 
     @property
     def created_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.create_date)  # type: ignore
+        return iso_8601_datetime_without_milliseconds(self.create_date)
 
     @classmethod
     def has_cfn_attr(cls, attr: str) -> bool:
@@ -1200,7 +1200,7 @@ class SshPublicKey(BaseModel):
 
     @property
     def uploaded_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.upload_date)  # type: ignore
+        return iso_8601_datetime_without_milliseconds(self.upload_date)
 
 
 class Group(BaseModel):

--- a/moto/inspector2/urls.py
+++ b/moto/inspector2/urls.py
@@ -24,6 +24,6 @@ url_paths = {
     "{0}/organizationconfiguration/describe$": Inspector2Response.dispatch,
     "{0}/organizationconfiguration/update$": Inspector2Response.dispatch,
     "{0}/tags/(?P<resource_arn>.+)$": Inspector2Response.method_dispatch(
-        Inspector2Response.tags  # type: ignore
+        Inspector2Response.tags
     ),
 }

--- a/moto/packages/cfnresponse/cfnresponse.py
+++ b/moto/packages/cfnresponse/cfnresponse.py
@@ -50,7 +50,7 @@ def send(
     headers = {"content-type": "", "content-length": str(len(json_responseBody))}
 
     try:
-        response = http.request(  # type: ignore
+        response = http.request(
             "PUT", responseUrl, headers=headers, body=json_responseBody
         )
         print("Status code:", response.status)

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -142,7 +142,9 @@ class Cluster:
                     valid_engines=ClusterEngine.list_cluster_engines(),
                 )
             )
-        self.engine_version = kwargs.get("engine_version") or Cluster.default_engine_version(self.engine)  # type: ignore
+        self.engine_version = kwargs.get(
+            "engine_version"
+        ) or Cluster.default_engine_version(self.engine)
         self.engine_mode = kwargs.get("engine_mode") or "provisioned"
         self.iops = kwargs.get("iops")
         self.kms_key_id = kwargs.get("kms_key_id")
@@ -160,7 +162,7 @@ class Cluster:
         self.allocated_storage = kwargs.get("allocated_storage")
         if self.allocated_storage is None:
             self.allocated_storage = Cluster.default_allocated_storage(
-                engine=self.engine, storage_type=self.storage_type  # type: ignore
+                engine=self.engine, storage_type=self.storage_type
             )
         self.master_username = kwargs.get("master_username")
         self.global_cluster_identifier = kwargs.get("global_cluster_identifier")
@@ -593,7 +595,7 @@ class Database(CloudFormationModel):
         self.allocated_storage = kwargs.get("allocated_storage")
         if self.allocated_storage is None:
             self.allocated_storage = Database.default_allocated_storage(
-                engine=self.engine, storage_type=self.storage_type  # type: ignore
+                engine=self.engine, storage_type=self.storage_type
             )
         self.db_cluster_identifier: Optional[str] = kwargs.get("db_cluster_identifier")
         self.db_instance_identifier = kwargs.get("db_instance_identifier")
@@ -601,7 +603,7 @@ class Database(CloudFormationModel):
         self.db_instance_class = kwargs.get("db_instance_class")
         self.port = kwargs.get("port")
         if self.port is None:
-            self.port = Database.default_port(self.engine)  # type: ignore
+            self.port = Database.default_port(self.engine)
         self.db_instance_identifier = kwargs.get("db_instance_identifier")
         self.db_name = kwargs.get("db_name")
         self.instance_create_time = iso_8601_datetime_with_milliseconds()

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -91,13 +91,13 @@ class HealthCheck(CloudFormationModel):
 
     def set_children(self, children: Any) -> None:
         if children and isinstance(children, list):
-            self.children = children  # type: ignore
+            self.children = children
         elif children and isinstance(children, str):
             self.children = [children]  # type: ignore
 
     def set_regions(self, regions: Any) -> None:
         if regions and isinstance(regions, list):
-            self.regions = regions  # type: ignore
+            self.regions = regions
         elif regions and isinstance(regions, str):
             self.regions = [regions]  # type: ignore
 

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -238,8 +238,8 @@ class Route53(BaseResponse):
         elif method == "GET":
             querystring = parse_qs(self.parsed_url.query)
             template = Template(LIST_RRSET_RESPONSE)
-            start_type = querystring.get("type", [None])[0]  # type: ignore
-            start_name = querystring.get("name", [None])[0]  # type: ignore
+            start_type = querystring.get("type", [None])[0]
+            start_name = querystring.get("name", [None])[0]
             max_items = int(querystring.get("maxitems", ["300"])[0])
 
             if start_type and not start_name:

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -340,7 +340,7 @@ class S3Response(BaseResponse):
                 f"Method {method} has not been implemented in the S3 backend yet"
             )
 
-    def _get_querystring(self, request: Any, full_url: str) -> Dict[str, Any]:  # type: ignore[misc]
+    def _get_querystring(self, request: Any, full_url: str) -> Dict[str, Any]:
         # Flask's Request has the querystring already parsed
         # In ServerMode, we can use this, instead of manually parsing this
         if hasattr(request, "args"):
@@ -1114,7 +1114,7 @@ class S3Response(BaseResponse):
         new_key = self.backend.put_object(bucket_name, key, f)
 
         if self.querystring.get("acl"):
-            acl = get_canned_acl(self.querystring["acl"][0])  # type: ignore
+            acl = get_canned_acl(self.querystring["acl"][0])
             new_key.set_acl(acl)
 
         # Metadata
@@ -1486,7 +1486,7 @@ class S3Response(BaseResponse):
                     unquote(copy_source_parsed.path).lstrip("/").split("/", 1)
                 )
                 src_version_id = parse_qs(copy_source_parsed.query).get(
-                    "versionId", [None]  # type: ignore
+                    "versionId", [None]
                 )[0]
                 src_range = request.headers.get("x-amz-copy-source-range", "").split(
                     "bytes="
@@ -1638,7 +1638,7 @@ class S3Response(BaseResponse):
                 unquote(copy_source_parsed.path).lstrip("/").split("/", 1)
             )
             src_version_id = parse_qs(copy_source_parsed.query).get(
-                "versionId", [None]  # type: ignore
+                "versionId", [None]
             )[0]
 
             key_to_copy = self.backend.get_object(

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -3214,7 +3214,7 @@ class SageMakerModelBackend(BaseBackend):
         raise ValueError(f"Invalid model package type: {model_package_type}")
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
-    def list_model_package_groups(  # type: ignore[misc]
+    def list_model_package_groups(
         self,
         creation_time_after: Optional[int],
         creation_time_before: Optional[int],
@@ -3271,7 +3271,7 @@ class SageMakerModelBackend(BaseBackend):
         return model_package_group
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
-    def list_model_packages(  # type: ignore[misc]
+    def list_model_packages(
         self,
         creation_time_after: Optional[int],
         creation_time_before: Optional[int],

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -23,7 +23,7 @@ def load_resource(package: str, resource: str) -> Any:
 
 
 def load_resource_as_str(package: str, resource: str) -> str:
-    return load_resource_as_bytes(package, resource).decode("utf-8")  # type: ignore
+    return load_resource_as_bytes(package, resource).decode("utf-8")
 
 
 def load_resource_as_bytes(package: str, resource: str) -> bytes:
@@ -69,7 +69,7 @@ def md5_hash(data: Any = None) -> Any:
     """
     args = (data,) if data else ()
     try:
-        return hashlib.md5(*args, usedforsecurity=False)  # type: ignore
+        return hashlib.md5(*args, usedforsecurity=False)
     except TypeError:
         # The usedforsecurity-parameter is only available as of Python 3.9
         return hashlib.md5(*args)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,6 @@ build
 prompt_toolkit
 
 # typing_extensions is currently used for:
-# Protocol  (3.8+)
+# Literal, Protocol  (3.8+)
 # ParamSpec  (3.10+)
 # Self  (3.11+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -304,3 +304,6 @@ warn_unreachable=False
 strict_equality=True
 ignore_missing_imports=True
 follow_imports=silent
+
+[mypy-tests.test_core.test_mypy]
+warn_unused_ignores=True

--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -1,7 +1,8 @@
 import boto3
 
-from moto import mock_s3
+from moto import mock_s3, XRaySegment
 from moto.core.models import BaseMockAWS
+from contextlib import AbstractContextManager
 
 
 @mock_s3
@@ -40,3 +41,23 @@ assert x == 456
 
 y: int = test_without_parentheses()
 assert y == 123
+
+
+def test_xray() -> None:
+    xray: "AbstractContextManager[object]" = XRaySegment()
+    with xray:
+        assert True
+
+
+def dont_call_me() -> None:
+    # This is not a test and should never be called.
+    #
+    # warn_unused_ignores is enabed, so this will fail mypy if the typing of XRaySegment
+    # would allow this. Normally that wouldn't be a concern at all, but since lazy_load is
+    # a pretty complicated overload type, it seems worth double checking
+
+    @XRaySegment  # type: ignore[call-arg]
+    def this_is_the_wrong_use_of_XRaySegment() -> None:
+        pass
+
+    assert False


### PR DESCRIPTION
Following up on my previous MR ( https://github.com/getmoto/moto/pull/7045 ), here's what it looks like to get XRaySegment back on moto.lazy_load. It's a little bit of a funky overload, and I also enabled `warn_unused_ignores` in mypy so that I could construct a negative test for the typing on XRaySegment.

I won't mind if you decide not to take this MR, but I wanted to see if it could be done, at least.

Edit: warn_unused_ignores made mypy's approval more fragile than I realized. I walked that back to be just for test_mypy.py, and put back in some of the ignores that I had originally removed. I kept in the removal of a lot of them though, since I think they're genuinely no longer needed. 

I've made the commit history clean; one commit for removing a bunch of `type: ignore` pragmas and one for the lazy_load stuff.