### PR TITLE
SQS: Ensure all SQS responses are in JSON format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,10 @@ jobs:
     needs: lint
     uses: ./.github/workflows/tests_sdk_dotnet.yml
 
+  rubytest:
+    needs: lint
+    uses: ./.github/workflows/tests_sdk_ruby.yml
+
   test:
     needs: [lint]
     if: "!contains(github.event.pull_request.labels.*.name, 'java')"

--- a/.github/workflows/tests_sdk_dotnet.yml
+++ b/.github/workflows/tests_sdk_dotnet.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         pip install build
         python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.7-buster /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
     - uses: actions/setup-dotnet@v3
     - uses: actions/cache@v3

--- a/.github/workflows/tests_sdk_java.yml
+++ b/.github/workflows/tests_sdk_java.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         pip install build
         python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.7-buster /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/tests_sdk_ruby.yml
+++ b/.github/workflows/tests_sdk_ruby.yml
@@ -1,0 +1,36 @@
+name: Ruby SDK test
+on: [workflow_call]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: ['3.2']
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: Start MotoServer
+        run: |
+          pip install build
+          python -m build
+          docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
+          python scripts/ci_wait_for_server.py
+      - name: Install dependencies
+        run: cd other_langs/tests_ruby && bundle install
+      - name: Run tests
+        env:
+          AWS_ENDPOINT_URL: "http://localhost:5000"
+        run: |
+          mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
+          cd other_langs/tests_ruby && ruby test/*

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ moto/moto_proxy/certs/*.conf
 other_langs/tests_java/target
 other_langs/tests_dotnet/ExampleTestProject/bin
 other_langs/tests_dotnet/ExampleTestProject/obj
+other_langs/tests_ruby/Gemfile.lock

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -289,7 +289,13 @@ class SQSResponse(BaseResponse):
         queue_name = self._get_queue_name()
         self.sqs_backend.set_queue_attributes(queue_name, attribute)
 
-        return SET_QUEUE_ATTRIBUTE_RESPONSE
+        return self._empty_response(SET_QUEUE_ATTRIBUTE_RESPONSE)
+
+    def _empty_response(self, xml_response: str) -> str:
+        # 'Empty' XML response always needs some fields
+        if self.is_json():
+            return "{}"
+        return xml_response
 
     @jsonify_error
     def delete_queue(self) -> str:
@@ -298,8 +304,7 @@ class SQSResponse(BaseResponse):
 
         self.sqs_backend.delete_queue(queue_name)
 
-        template = self.response_template(DELETE_QUEUE_RESPONSE)
-        return template.render()
+        return self._empty_response(DELETE_QUEUE_RESPONSE)
 
     @jsonify_error
     def send_message(self) -> Union[str, TYPE_RESPONSE]:
@@ -506,8 +511,7 @@ class SQSResponse(BaseResponse):
     def purge_queue(self) -> str:
         queue_name = self._get_queue_name()
         self.sqs_backend.purge_queue(queue_name)
-        template = self.response_template(PURGE_QUEUE_RESPONSE)
-        return template.render()
+        return self._empty_response(PURGE_QUEUE_RESPONSE)
 
     @jsonify_error
     def receive_message(self) -> Union[str, TYPE_RESPONSE]:
@@ -684,8 +688,7 @@ class SQSResponse(BaseResponse):
 
         self.sqs_backend.add_permission(queue_name, actions, account_ids, label)
 
-        template = self.response_template(ADD_PERMISSION_RESPONSE)
-        return template.render()
+        return self._empty_response(ADD_PERMISSION_RESPONSE)
 
     @jsonify_error
     def remove_permission(self) -> str:
@@ -694,8 +697,7 @@ class SQSResponse(BaseResponse):
 
         self.sqs_backend.remove_permission(queue_name, label)
 
-        template = self.response_template(REMOVE_PERMISSION_RESPONSE)
-        return template.render()
+        return self._empty_response(REMOVE_PERMISSION_RESPONSE)
 
     @jsonify_error
     def tag_queue(self) -> str:

--- a/other_langs/tests_ruby/Gemfile
+++ b/other_langs/tests_ruby/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'aws-sdk-sqs', '1.65.0'
+gem "minitest"

--- a/other_langs/tests_ruby/test/aws_sqs_test.rb
+++ b/other_langs/tests_ruby/test/aws_sqs_test.rb
@@ -1,0 +1,40 @@
+require 'aws-sdk-sqs'
+require 'minitest/autorun'
+
+class AwsSqsTest < Minitest::Test
+  def test_all_sqs_actions
+    region = 'us-east-1'
+
+    sqs_client = Aws::SQS::Client.new(region: region)
+
+    sqs_client.list_queues
+
+    sqs_client.create_queue(queue_name: "q1")
+
+    sqs_client.list_queues
+
+    queue_url = sqs_client.get_queue_url(queue_name: "q1").queue_url
+
+    sqs_client.add_permission({queue_url: queue_url, label: "String", aws_account_ids: ["String"], actions: ["GetQueueUrl"]})
+
+    sqs_client.send_message(
+      queue_url: queue_url,
+      message_body: "message_body"
+    )
+
+    sqs_client.remove_permission({queue_url: queue_url, label: "String"})
+
+    sqs_client.set_queue_attributes({queue_url: queue_url, attributes: {"All" => "DelaySeconds"}})
+
+    sqs_client.receive_message(
+      queue_url: queue_url,
+      max_number_of_messages: 10,
+      attribute_names: ['All'],
+      message_attribute_names: ['All']
+    ).messages
+
+    sqs_client.purge_queue({queue_url: queue_url})
+
+    sqs_client.delete_queue(queue_url: queue_url)
+  end
+end


### PR DESCRIPTION
Fixes #7054 

Followup to #6331 

Validates the behaviour using the Ruby SDK, which is more strict in parsing the SQS responses.