### PR TITLE
CognitoIdentity: get_credentials_for_identity() should have Expiration as number.

### DIFF
--- a/moto/cognitoidentity/models.py
+++ b/moto/cognitoidentity/models.py
@@ -139,12 +139,11 @@ class CognitoIdentityBackend(BaseBackend):
         duration = 90
         now = utcnow()
         expiration = now + datetime.timedelta(seconds=duration)
-        expiration_str = str(iso_8601_datetime_with_milliseconds(expiration))
         return json.dumps(
             {
                 "Credentials": {
                     "AccessKeyId": "TESTACCESSKEY12345",
-                    "Expiration": expiration_str,
+                    "Expiration": expiration.timestamp(),
                     "SecretKey": "ABCSECRETKEY",
                     "SessionToken": "ABC12345",
                 },

--- a/moto/cognitoidentity/models.py
+++ b/moto/cognitoidentity/models.py
@@ -5,7 +5,7 @@ import re
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 from moto.core import BaseBackend, BackendDict, BaseModel
-from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
+from moto.core.utils import utcnow
 from .exceptions import InvalidNameException, ResourceNotFoundError
 from .utils import get_random_identity_id
 


### PR DESCRIPTION
Hi.
The type of Credentials.Expiration is a timestamp number type.

ref: https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_ResponseSyntax

It was discovered by a type conversion error in Golang's sdk v2.
ref: https://github.com/aws/aws-sdk-go-v2/blob/6afe5286d243f06aa040d3954b765b38366b88c2/service/cognitoidentity/deserializers.go#L3374-L3383

Thank you very much.