### PR TITLE
Autoscaling: describe_tags() now supports the key/value filters

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -1558,7 +1558,6 @@ class AutoScalingBackend(BaseBackend):
     def describe_tags(self, filters: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """
         Pagination is not yet implemented.
-        Only the `auto-scaling-group` and `propagate-at-launch` filters are implemented.
         """
         resources = self.autoscaling_groups.values()
         tags = list(itertools.chain(*[r.tags for r in resources]))
@@ -1572,6 +1571,10 @@ class AutoScalingBackend(BaseBackend):
                     for t in tags
                     if t.get("propagate_at_launch", "").lower() in values
                 ]
+            if f["Name"] == "key":
+                tags = [t for t in tags if t["key"] in f["Values"]]
+            if f["Name"] == "value":
+                tags = [t for t in tags if t["value"] in f["Values"]]
         return tags
 
     def enable_metrics_collection(self, group_name: str, metrics: List[str]) -> None:

--- a/tests/test_autoscaling/test_autoscaling_tags.py
+++ b/tests/test_autoscaling/test_autoscaling_tags.py
@@ -234,6 +234,39 @@ def test_describe_tags_filter_by_propgateatlaunch():
 
 
 @mock_autoscaling
+def test_describe_tags_filter_by_key_or_value():
+    subnet = setup_networking()["subnet1"]
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    create_asgs(client, subnet)
+
+    tags = client.describe_tags(Filters=[{"Name": "key", "Values": ["test_key"]}])[
+        "Tags"
+    ]
+    assert tags == [
+        {
+            "ResourceId": "test_asg",
+            "ResourceType": "auto-scaling-group",
+            "Key": "test_key",
+            "Value": "updated_test_value",
+            "PropagateAtLaunch": True,
+        }
+    ]
+
+    tags = client.describe_tags(Filters=[{"Name": "value", "Values": ["test_value2"]}])[
+        "Tags"
+    ]
+    assert tags == [
+        {
+            "ResourceId": "test_asg",
+            "ResourceType": "auto-scaling-group",
+            "Key": "test_key2",
+            "Value": "test_value2",
+            "PropagateAtLaunch": False,
+        }
+    ]
+
+
+@mock_autoscaling
 def test_create_20_tags_auto_scaling_group():
     """test to verify that the tag-members are sorted correctly, and there is no regression for
     https://github.com/getmoto/moto/issues/6033


### PR DESCRIPTION
Fixes #6787 