### PR TITLE
SSM: fix overwrite preserving non-indicated values

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -2106,6 +2106,24 @@ class SimpleSystemManagerBackend(BaseBackend):
                 self._check_for_parameter_version_limit_exception(name)
                 previous_parameter_versions.pop(0)
 
+            # Ensure all the previous values that we didn't overwrite are preserved
+            value = value if value is not None else previous_parameter.value
+            description = (
+                description
+                if description is not None
+                else previous_parameter.description
+            )
+            allowed_pattern = (
+                allowed_pattern
+                if allowed_pattern is not None
+                else previous_parameter.allowed_pattern
+            )
+            keyid = keyid if keyid is not None else previous_parameter.keyid
+            tags = tags if tags is not None else previous_parameter.tags
+            data_type = (
+                data_type if data_type is not None else previous_parameter.data_type
+            )
+
         last_modified_date = time.time()
         self._parameters[name].append(
             Parameter(

--- a/moto/ssm/responses.py
+++ b/moto/ssm/responses.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Dict, Tuple, Union
+import warnings
 
 from moto.core.responses import BaseResponse
 from .exceptions import ValidationException, ParameterAlreadyExists
@@ -270,8 +271,20 @@ class SimpleSystemManagerResponse(BaseResponse):
         allowed_pattern = self._get_param("AllowedPattern")
         keyid = self._get_param("KeyId")
         overwrite = self._get_param("Overwrite", False)
-        tags = self._get_param("Tags", [])
+        tags = self._get_param("Tags")
         data_type = self._get_param("DataType", "text")
+
+        # To be implemented arguments of put_parameter
+        tier = self._get_param("Tier")
+        if tier is not None:
+            warnings.warn(
+                "Tier configuration option is not yet implemented.  Discarding."
+            )
+        policies = self._get_param("Policies")
+        if policies is not None:
+            warnings.warn(
+                "Policies configuration option is not yet implemented.  Discarding."
+            )
 
         result = self.ssm_backend.put_parameter(
             name,

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -312,7 +312,7 @@ def test_put_parameter_unimplemented_parameters():
     """
     if settings.TEST_SERVER_MODE:
         raise SkipTest("Can't test for warning logs in server mode")
-    
+
     mock_warn = Mock()
     with patch("warnings.warn", mock_warn):
         # Ensure that the ssm parameters are still working with the Mock

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -3,13 +3,14 @@ import re
 import string
 import uuid
 from unittest.mock import patch, Mock
+from unittest import SkipTest
 
 import boto3
 import botocore.exceptions
 from botocore.exceptions import ClientError
 import pytest
 
-from moto import mock_ec2, mock_ssm
+from moto import mock_ec2, mock_ssm, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.ssm.models import PARAMETER_VERSION_LIMIT, PARAMETER_HISTORY_MAX_RESULTS
 from tests import EXAMPLE_AMI_ID
@@ -309,6 +310,9 @@ def test_put_parameter_unimplemented_parameters():
     Test to ensure coverage of unimplemented parameters.  Remove for appropriate tests
     once implemented
     """
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Can't test for warning logs in server mode")
+    
     mock_warn = Mock()
     with patch("warnings.warn", mock_warn):
         # Ensure that the ssm parameters are still working with the Mock


### PR DESCRIPTION
# Summary

This fixes a bug I stumbled across when running localstack (which runs moto server in the background) and using SSM parameters.

The Bug:  overwrite does not just change the fields supplied.  It instead, replaces all values that were not explicitily specified.  This does not happen when the same code is tested against AWS.

Changes:

1. Added a test for verifying that metadata is preserved when an overwrite occurs
2. Coalesce all Parameter values to the previous parameter if they are None type
3. update the response model to not default Tags to any empty array since that's meaningful for erasure (it is coalesced in the backend anyway)
4. Add some warnings about `Tier` and `Policies` configuration options since they seem to be new comparatively

