### PR TITLE
DynamoDB: put_item() now returns old item for ConditionalCheckFailed …

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -225,6 +225,7 @@ class DynamoDBBackend(BaseBackend):
         expression_attribute_names: Optional[Dict[str, Any]] = None,
         expression_attribute_values: Optional[Dict[str, Any]] = None,
         overwrite: bool = False,
+        return_values_on_condition_check_failure: Optional[str] = None,
     ) -> Item:
         table = self.get_table(table_name)
         return table.put_item(
@@ -234,6 +235,7 @@ class DynamoDBBackend(BaseBackend):
             expression_attribute_names,
             expression_attribute_values,
             overwrite,
+            return_values_on_condition_check_failure,
         )
 
     def get_table_keys_name(

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -456,6 +456,9 @@ class DynamoHandler(BaseResponse):
         name = self.body["TableName"]
         item = self.body["Item"]
         return_values = self.body.get("ReturnValues", "NONE")
+        return_values_on_condition_check_failure = self.body.get(
+            "ReturnValuesOnConditionCheckFailure"
+        )
 
         if return_values not in ("ALL_OLD", "NONE"):
             raise MockValidationException("Return values set to invalid value")
@@ -498,6 +501,7 @@ class DynamoHandler(BaseResponse):
             expression_attribute_names,
             expression_attribute_values,
             overwrite,
+            return_values_on_condition_check_failure,
         )
 
         item_dict = result.to_json()


### PR DESCRIPTION
…exceptions

Stood on the shoulders of https://github.com/getmoto/moto/pull/6950 to add support for  `ReturnValuesOnConditionCheckFailure` in `put_item()`.

- [x] The linter is happy
- [x] Tests are added