### PR TITLE
Techdebt: Update boto3_name to 'rds-data'

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -184,7 +184,7 @@ mock_polly = lazy_load(".polly", "mock_polly")
 mock_quicksight = lazy_load(".quicksight", "mock_quicksight")
 mock_ram = lazy_load(".ram", "mock_ram")
 mock_rds = lazy_load(".rds", "mock_rds")
-mock_rdsdata = lazy_load(".rdsdata", "mock_rdsdata")
+mock_rdsdata = lazy_load(".rdsdata", "mock_rdsdata", boto3_name="rds-data")
 mock_redshift = lazy_load(".redshift", "mock_redshift")
 mock_redshiftdata = lazy_load(
     ".redshiftdata", "mock_redshiftdata", boto3_name="redshift-data"

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -129,7 +129,7 @@ backend_url_patterns = [
     ("ram", re.compile("https?://ram\\.(.+)\\.amazonaws.com")),
     ("rds", re.compile("https?://rds\\.(.+)\\.amazonaws\\.com")),
     ("rds", re.compile("https?://rds\\.amazonaws\\.com")),
-    ("rdsdata", re.compile("https?://rds-data\\.(.+)\\.amazonaws\\.com")),
+    ("rds-data", re.compile("https?://rds-data\\.(.+)\\.amazonaws\\.com")),
     ("redshift", re.compile("https?://redshift\\.(.+)\\.amazonaws\\.com")),
     ("redshift-data", re.compile("https?://redshift-data\\.(.+)\\.amazonaws\\.com")),
     ("rekognition", re.compile("https?://rekognition\\.(.+)\\.amazonaws\\.com")),

--- a/scripts/ci_moto_server.sh
+++ b/scripts/ci_moto_server.sh
@@ -2,4 +2,4 @@
 
 set -e
 pip install $(ls /moto/dist/moto*.gz)[server,all]
-moto_server -H 0.0.0.0 > /moto/server_output.log 2>&1
+moto_server -H 0.0.0.0 | tee /moto/server_output.log 2>&1

--- a/tests/test_rdsdata/test_rdsdata.py
+++ b/tests/test_rdsdata/test_rdsdata.py
@@ -23,7 +23,9 @@ def test_execute_statement():
 @mock_rdsdata
 def test_set_query_results():
     base_url = (
-        "localhost:5000" if settings.TEST_SERVER_MODE else "motoapi.amazonaws.com"
+        settings.test_server_mode_endpoint()
+        if settings.TEST_SERVER_MODE
+        else "http://motoapi.amazonaws.com"
     )
 
     sql_result = {
@@ -37,7 +39,7 @@ def test_set_query_results():
         "region": "us-west-1",
     }
     resp = requests.post(
-        f"http://{base_url}/moto-api/static/rds-data/statement-results",
+        f"{base_url}/moto-api/static/rds-data/statement-results",
         json=sql_result,
     )
     assert resp.status_code == 201


### PR DESCRIPTION
This is consistent with redshift-data, cloudtrail-data, etc

Plus a few stray tweaks to testing that I made in the process of debugging.

I figured out what I was missing before; it was the matching change in backends_index.py. I guess it probably doesn't
matter since apparently nothing was broken by 'rdsdata' not matching the name used by boto3. But it didn't seem right to me.