### PR TITLE
route53: add CallerReference to ListHostedZones and ListHostedZonesByName

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -660,6 +660,7 @@ CREATE_HOSTED_ZONE_RESPONSE = """<CreateHostedZoneResponse xmlns="https://route5
    <HostedZone>
       <Id>/hostedzone/{{ zone.id }}</Id>
       <Name>{{ zone.name }}</Name>
+      <CallerReference>{{ zone.caller_reference }}</CallerReference>
       <ResourceRecordSetCount>{{ zone.rrsets|count }}</ResourceRecordSetCount>
       <Config>
         {% if zone.comment %}
@@ -689,6 +690,7 @@ LIST_HOSTED_ZONES_RESPONSE = """<ListHostedZonesResponse xmlns="https://route53.
       <HostedZone>
          <Id>/hostedzone/{{ zone.id }}</Id>
          <Name>{{ zone.name }}</Name>
+         <CallerReference>{{ zone.caller_reference }}</CallerReference>
          <Config>
             {% if zone.comment %}
                 <Comment>{{ zone.comment }}</Comment>
@@ -711,6 +713,7 @@ LIST_HOSTED_ZONES_BY_NAME_RESPONSE = """<ListHostedZonesByNameResponse xmlns="{{
       <HostedZone>
          <Id>/hostedzone/{{ zone.id }}</Id>
          <Name>{{ zone.name }}</Name>
+         <CallerReference>{{ zone.caller_reference }}</CallerReference>
          <Config>
             {% if zone.comment %}
                 <Comment>{{ zone.comment }}</Comment>

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -594,9 +594,13 @@ def test_list_hosted_zones_by_dns_name():
     zones = conn.list_hosted_zones_by_name()
     assert len(zones["HostedZones"]) == 4
     assert zones["HostedZones"][0]["Name"] == "test.b.com."
+    assert zones["HostedZones"][0]["CallerReference"] == str(hash("foo"))
     assert zones["HostedZones"][1]["Name"] == "my.test.net."
+    assert zones["HostedZones"][1]["CallerReference"] == str(hash("baz"))
     assert zones["HostedZones"][2]["Name"] == "test.a.org."
+    assert zones["HostedZones"][2]["CallerReference"] == str(hash("bar"))
     assert zones["HostedZones"][3]["Name"] == "test.a.org."
+    assert zones["HostedZones"][3]["CallerReference"] == str(hash("bar"))
 
 
 @mock_route53


### PR DESCRIPTION
This PR adds `CallerReference` to the return type of both [ListHostedZones](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/route53/client/list_hosted_zones.html) and [ListHostedZonedByName](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/route53/client/list_hosted_zones_by_name.html).

`test_route53.py::test_list_hosted_zones` already checks for the first operation. I improved `test_route53.py::test_list_hosted_zones_by_dns_name` for the latter.

This is a follow-up of https://github.com/getmoto/moto/pull/6911