### PR TITLE
KMS: encrypt() now validates payloads that are too large

### DIFF
--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -379,6 +379,10 @@ def encrypt(
         raise ValidationException(
             "1 validation error detected: Value at 'plaintext' failed to satisfy constraint: Member must have length greater than or equal to 1"
         )
+    if len(plaintext) > 4096:
+        raise ValidationException(
+            "1 validation error detected: Value at 'plaintext' failed to satisfy constraint: Member must have length less than or equal to 4096"
+        )
 
     iv = os.urandom(IV_LEN)
     aad = _serialize_encryption_context(encryption_context=encryption_context)

--- a/tests/test_kms/__init__.py
+++ b/tests/test_kms/__init__.py
@@ -1,1 +1,28 @@
-# This file is intentionally left blank.
+import os
+from functools import wraps
+
+from moto import mock_kms
+
+
+def kms_aws_verified(func):
+    """
+    Function that is verified to work against AWS.
+    Can be run against AWS at any time by setting:
+      MOTO_TEST_ALLOW_AWS_REQUEST=true
+
+    If this environment variable is not set, the function runs in a `mock_kms` context.
+    """
+
+    @wraps(func)
+    def pagination_wrapper():
+        allow_aws_request = (
+            os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
+        )
+
+        if allow_aws_request:
+            return func()
+        else:
+            with mock_kms():
+                return func()
+
+    return pagination_wrapper


### PR DESCRIPTION
Fixes #7100 