### PR TITLE
S3: copy() using multiparts should respect ExtraArgs

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6257,7 +6257,7 @@
 
 ## s3
 <details>
-<summary>64% implemented</summary>
+<summary>65% implemented</summary>
 
 - [X] abort_multipart_upload
 - [X] complete_multipart_upload
@@ -6356,7 +6356,7 @@
 - [ ] restore_object
 - [X] select_object_content
 - [X] upload_part
-- [ ] upload_part_copy
+- [X] upload_part_copy
 - [ ] write_get_object_response
 </details>
 

--- a/docs/docs/services/s3.rst
+++ b/docs/docs/services/s3.rst
@@ -159,6 +159,6 @@ s3
         
 
 - [X] upload_part
-- [ ] upload_part_copy
+- [X] upload_part_copy
 - [ ] write_get_object_response
 

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -24,6 +24,12 @@ user_settable_fields = {
     "expires",
     "content-disposition",
     "x-robots-tag",
+    "x-amz-checksum-algorithm",
+    "x-amz-content-sha256",
+    "x-amz-content-crc32",
+    "x-amz-content-crc32c",
+    "x-amz-content-sha1",
+    "x-amz-website-redirect-location",
 }
 ARCHIVE_STORAGE_CLASSES = [
     "GLACIER",
@@ -190,7 +196,7 @@ class _VersionedKeyStore(dict):  # type: ignore
     values = itervalues = _itervalues  # type: ignore
 
 
-def compute_checksum(body: bytes, algorithm: str) -> bytes:
+def compute_checksum(body: bytes, algorithm: str, encode_base64: bool = True) -> bytes:
     if algorithm == "SHA1":
         hashed_body = _hash(hashlib.sha1, (body,))
     elif algorithm == "CRC32C":
@@ -205,7 +211,10 @@ def compute_checksum(body: bytes, algorithm: str) -> bytes:
         hashed_body = binascii.crc32(body).to_bytes(4, "big")
     else:
         hashed_body = _hash(hashlib.sha256, (body,))
-    return base64.b64encode(hashed_body)
+    if encode_base64:
+        return base64.b64encode(hashed_body)
+    else:
+        return hashed_body
 
 
 def _hash(fn: Any, args: Any) -> bytes:


### PR DESCRIPTION
Fixes #7103 

This PR:

 - Extends the list of headers that we should keep as part of the key's metadata (the fix for the linked issue)
 - Computes the correct checksum algorithm for multipart uploads
 - Sets the `checksum_algorithm`/`checksum_value`-attributes on a copied key, if this is copied using MultipartUpload
 - Renames `copy_part` to `upload_part_copy` so that our implementation script picks it up properly

Both tests in this PR that assert the behaviour is now correct are verified against AWS.