### PR TITLE
CloudFormation: Implement Fn::GetAtt for AWS::EC2::LaunchTemplate

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -740,11 +740,9 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
         new = other_template["Resources"]
 
         resource_names_by_action = {
-            "Add": set(new) - set(old),
-            "Modify": set(
-                name for name in new if name in old and new[name] != old[name]
-            ),
-            "Remove": set(old) - set(new),
+            "Add": [name for name in new if name not in old],
+            "Modify": [name for name in new if name in old and new[name] != old[name]],
+            "Remove": [name for name in old if name not in new],
         }
 
         return resource_names_by_action

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -192,6 +192,21 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
 
         backend.delete_launch_template(name, None)
 
+    @classmethod
+    def has_cfn_attr(cls, attr: str) -> bool:
+        return attr in ["DefaultVersionNumber", "LaunchTemplateId", "LatestVersionNumber"]
+
+    def get_cfn_attribute(self, attribute_name: str) -> str:
+        from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+
+        if attribute_name == "DefaultVersionNumber":
+            return self.default_version_number
+        if attribute_name == "LaunchTemplateId":
+            return self.id
+        if attribute_name == "LatestVersionNumber":
+            return self.latest_version_number
+        raise UnformattedGetAttTemplateException()
+
 
 class LaunchTemplateBackend:
     def __init__(self) -> None:

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -204,11 +204,11 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 
         if attribute_name == "DefaultVersionNumber":
-            return self.default_version_number
+            return str(self.default_version_number)
         if attribute_name == "LaunchTemplateId":
             return self.id
         if attribute_name == "LatestVersionNumber":
-            return self.latest_version_number
+            return str(self.latest_version_number)
         raise UnformattedGetAttTemplateException()
 
 

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -194,7 +194,11 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
 
     @classmethod
     def has_cfn_attr(cls, attr: str) -> bool:
-        return attr in ["DefaultVersionNumber", "LaunchTemplateId", "LatestVersionNumber"]
+        return attr in [
+            "DefaultVersionNumber",
+            "LaunchTemplateId",
+            "LatestVersionNumber",
+        ]
 
     def get_cfn_attribute(self, attribute_name: str) -> str:
         from moto.cloudformation.exceptions import UnformattedGetAttTemplateException

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -1,0 +1,243 @@
+import json
+from uuid import uuid4
+
+import boto3
+
+from moto import mock_autoscaling, mock_cloudformation, mock_ec2
+from tests import EXAMPLE_AMI_ID, EXAMPLE_AMI_ID2
+
+
+@mock_autoscaling
+@mock_cloudformation
+@mock_ec2
+def test_asg_with_latest_launch_template_version():
+    cf_client = boto3.client("cloudformation", region_name="us-west-1")
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    autoscaling_client = boto3.client("autoscaling", region_name="us-west-1")
+
+    subnet1 = ec2.create_subnet(CidrBlock="10.0.1.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1a")
+
+    subnet2 = ec2.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1b")
+
+    autoscaling_group_name = str(uuid4())
+
+    stack_name = str(uuid4())
+
+    version_attribute = "LatestVersionNumber"
+
+    template_json = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+        "Resources": {
+            "LaunchTemplate": {
+                "Type": "AWS::EC2::LaunchTemplate",
+                "Properties": {
+                    "LaunchTemplateName": "launch-template-test",
+                    "LaunchTemplateData": {
+                        "ImageId": EXAMPLE_AMI_ID,
+                        "InstanceType": "t3.small",
+                        "UserData": ""
+                    }
+                }
+            },
+            "AutoScalingGroup": {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "Properties": {
+                    "AutoScalingGroupName": autoscaling_group_name,
+                    "VPCZoneIdentifier": [subnet1.id],
+                    "LaunchTemplate": {
+                        "LaunchTemplateId": {
+                            "Ref": "LaunchTemplate"
+                        },
+                        "Version": {
+                            "Fn::GetAtt": [
+                                "LaunchTemplate",
+                                version_attribute
+                            ]
+                        }
+                    },
+                    "MinSize": 1,
+                    "MaxSize": 1
+                }
+            }
+        }
+    })
+
+    cf_client.create_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+        OnFailure="DELETE",
+    )
+
+    template_json = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+        "Resources": {
+            "LaunchTemplate": {
+                "Type": "AWS::EC2::LaunchTemplate",
+                "Properties": {
+                    "LaunchTemplateName": "launch-template-test",
+                    "LaunchTemplateData": {
+                        "ImageId": EXAMPLE_AMI_ID2,
+                        "InstanceType": "t3.medium",
+                        "UserData": ""
+                    }
+                }
+            },
+            "AutoScalingGroup": {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "Properties": {
+                    "AutoScalingGroupName": autoscaling_group_name,
+                    "VPCZoneIdentifier": [subnet2.id],
+                    "LaunchTemplate": {
+                        "LaunchTemplateId": {
+                            "Ref": "LaunchTemplate"
+                        },
+                        "Version": {
+                            "Fn::GetAtt": [
+                                "LaunchTemplate",
+                                version_attribute
+                            ]
+                        }
+                    },
+                    "MinSize": 1,
+                    "MaxSize": 2
+                }
+            }
+        }
+    })
+
+    cf_client.update_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+    )
+
+    autoscaling_group = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[
+            autoscaling_group_name,
+        ]
+    )["AutoScalingGroups"][0]
+
+    assert autoscaling_group["LaunchTemplate"]["LaunchTemplateName"] == "launch-template-test"
+    assert autoscaling_group["LaunchTemplate"]["Version"] == "2"
+
+
+@mock_autoscaling
+@mock_cloudformation
+@mock_ec2
+def test_asg_with_default_launch_template_version():
+    cf_client = boto3.client("cloudformation", region_name="us-west-1")
+    ec2 = boto3.resource("ec2", region_name="us-west-1")
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    autoscaling_client = boto3.client("autoscaling", region_name="us-west-1")
+
+    subnet1 = ec2.create_subnet(CidrBlock="10.0.1.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1a")
+
+    subnet2 = ec2.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1b")
+
+    autoscaling_group_name = str(uuid4())
+
+    stack_name = str(uuid4())
+
+    version_attribute = "DefaultVersionNumber"
+
+    template_json = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+        "Resources": {
+            "LaunchTemplate": {
+                "Type": "AWS::EC2::LaunchTemplate",
+                "Properties": {
+                    "LaunchTemplateName": "launch-template-test",
+                    "LaunchTemplateData": {
+                        "ImageId": EXAMPLE_AMI_ID,
+                        "InstanceType": "t3.small",
+                        "UserData": ""
+                    }
+                }
+            },
+            "AutoScalingGroup": {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "Properties": {
+                    "AutoScalingGroupName": autoscaling_group_name,
+                    "VPCZoneIdentifier": [subnet1.id],
+                    "LaunchTemplate": {
+                        "LaunchTemplateId": {
+                            "Ref": "LaunchTemplate"
+                        },
+                        "Version": {
+                            "Fn::GetAtt": [
+                                "LaunchTemplate",
+                                version_attribute
+                            ]
+                        }
+                    },
+                    "MinSize": 1,
+                    "MaxSize": 1
+                }
+            }
+        }
+    })
+
+    cf_client.create_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+        OnFailure="DELETE",
+    )
+
+    template_json = json.dumps({
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+        "Resources": {
+            "LaunchTemplate": {
+                "Type": "AWS::EC2::LaunchTemplate",
+                "Properties": {
+                    "LaunchTemplateName": "launch-template-test",
+                    "LaunchTemplateData": {
+                        "ImageId": EXAMPLE_AMI_ID2,
+                        "InstanceType": "t3.medium",
+                        "UserData": ""
+                    }
+                }
+            },
+            "AutoScalingGroup": {
+                "Type": "AWS::AutoScaling::AutoScalingGroup",
+                "Properties": {
+                    "AutoScalingGroupName": autoscaling_group_name,
+                    "VPCZoneIdentifier": [subnet2.id],
+                    "LaunchTemplate": {
+                        "LaunchTemplateId": {
+                            "Ref": "LaunchTemplate"
+                        },
+                        "Version": {
+                            "Fn::GetAtt": [
+                                "LaunchTemplate",
+                                version_attribute
+                            ]
+                        }
+                    },
+                    "MinSize": 1,
+                    "MaxSize": 2
+                }
+            }
+        }
+    })
+
+    cf_client.update_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+    )
+
+    autoscaling_group = autoscaling_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[
+            autoscaling_group_name,
+        ]
+    )["AutoScalingGroups"][0]
+
+    assert autoscaling_group["LaunchTemplate"]["LaunchTemplateName"] == "launch-template-test"
+    assert autoscaling_group["LaunchTemplate"]["Version"] == "1"

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -16,9 +16,13 @@ def test_asg_with_latest_launch_template_version():
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     autoscaling_client = boto3.client("autoscaling", region_name="us-west-1")
 
-    subnet1 = ec2.create_subnet(CidrBlock="10.0.1.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1a")
+    subnet1 = ec2.create_subnet(
+        CidrBlock="10.0.1.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1a"
+    )
 
-    subnet2 = ec2.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1b")
+    subnet2 = ec2.create_subnet(
+        CidrBlock="10.0.2.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1b"
+    )
 
     autoscaling_group_name = str(uuid4())
 
@@ -26,43 +30,40 @@ def test_asg_with_latest_launch_template_version():
 
     version_attribute = "LatestVersionNumber"
 
-    template_json = json.dumps({
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
-        "Resources": {
-            "LaunchTemplate": {
-                "Type": "AWS::EC2::LaunchTemplate",
-                "Properties": {
-                    "LaunchTemplateName": "launch-template-test",
-                    "LaunchTemplateData": {
-                        "ImageId": EXAMPLE_AMI_ID,
-                        "InstanceType": "t3.small",
-                        "UserData": ""
-                    }
-                }
-            },
-            "AutoScalingGroup": {
-                "Type": "AWS::AutoScaling::AutoScalingGroup",
-                "Properties": {
-                    "AutoScalingGroupName": autoscaling_group_name,
-                    "VPCZoneIdentifier": [subnet1.id],
-                    "LaunchTemplate": {
-                        "LaunchTemplateId": {
-                            "Ref": "LaunchTemplate"
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t3.small",
+                            "UserData": "",
                         },
-                        "Version": {
-                            "Fn::GetAtt": [
-                                "LaunchTemplate",
-                                version_attribute
-                            ]
-                        }
                     },
-                    "MinSize": 1,
-                    "MaxSize": 1
-                }
-            }
+                },
+                "AutoScalingGroup": {
+                    "Type": "AWS::AutoScaling::AutoScalingGroup",
+                    "Properties": {
+                        "AutoScalingGroupName": autoscaling_group_name,
+                        "VPCZoneIdentifier": [subnet1.id],
+                        "LaunchTemplate": {
+                            "LaunchTemplateId": {"Ref": "LaunchTemplate"},
+                            "Version": {
+                                "Fn::GetAtt": ["LaunchTemplate", version_attribute]
+                            },
+                        },
+                        "MinSize": 1,
+                        "MaxSize": 1,
+                    },
+                },
+            },
         }
-    })
+    )
 
     cf_client.create_stack(
         StackName=stack_name,
@@ -71,43 +72,40 @@ def test_asg_with_latest_launch_template_version():
         OnFailure="DELETE",
     )
 
-    template_json = json.dumps({
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
-        "Resources": {
-            "LaunchTemplate": {
-                "Type": "AWS::EC2::LaunchTemplate",
-                "Properties": {
-                    "LaunchTemplateName": "launch-template-test",
-                    "LaunchTemplateData": {
-                        "ImageId": EXAMPLE_AMI_ID2,
-                        "InstanceType": "t3.medium",
-                        "UserData": ""
-                    }
-                }
-            },
-            "AutoScalingGroup": {
-                "Type": "AWS::AutoScaling::AutoScalingGroup",
-                "Properties": {
-                    "AutoScalingGroupName": autoscaling_group_name,
-                    "VPCZoneIdentifier": [subnet2.id],
-                    "LaunchTemplate": {
-                        "LaunchTemplateId": {
-                            "Ref": "LaunchTemplate"
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID2,
+                            "InstanceType": "t3.medium",
+                            "UserData": "",
                         },
-                        "Version": {
-                            "Fn::GetAtt": [
-                                "LaunchTemplate",
-                                version_attribute
-                            ]
-                        }
                     },
-                    "MinSize": 1,
-                    "MaxSize": 2
-                }
-            }
+                },
+                "AutoScalingGroup": {
+                    "Type": "AWS::AutoScaling::AutoScalingGroup",
+                    "Properties": {
+                        "AutoScalingGroupName": autoscaling_group_name,
+                        "VPCZoneIdentifier": [subnet2.id],
+                        "LaunchTemplate": {
+                            "LaunchTemplateId": {"Ref": "LaunchTemplate"},
+                            "Version": {
+                                "Fn::GetAtt": ["LaunchTemplate", version_attribute]
+                            },
+                        },
+                        "MinSize": 1,
+                        "MaxSize": 2,
+                    },
+                },
+            },
         }
-    })
+    )
 
     cf_client.update_stack(
         StackName=stack_name,
@@ -121,7 +119,10 @@ def test_asg_with_latest_launch_template_version():
         ]
     )["AutoScalingGroups"][0]
 
-    assert autoscaling_group["LaunchTemplate"]["LaunchTemplateName"] == "launch-template-test"
+    assert (
+        autoscaling_group["LaunchTemplate"]["LaunchTemplateName"]
+        == "launch-template-test"
+    )
     assert autoscaling_group["LaunchTemplate"]["Version"] == "2"
 
 
@@ -134,9 +135,13 @@ def test_asg_with_default_launch_template_version():
     vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
     autoscaling_client = boto3.client("autoscaling", region_name="us-west-1")
 
-    subnet1 = ec2.create_subnet(CidrBlock="10.0.1.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1a")
+    subnet1 = ec2.create_subnet(
+        CidrBlock="10.0.1.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1a"
+    )
 
-    subnet2 = ec2.create_subnet(CidrBlock="10.0.2.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1b")
+    subnet2 = ec2.create_subnet(
+        CidrBlock="10.0.2.0/24", VpcId=vpc.id, AvailabilityZone="us-west-1b"
+    )
 
     autoscaling_group_name = str(uuid4())
 
@@ -144,43 +149,40 @@ def test_asg_with_default_launch_template_version():
 
     version_attribute = "DefaultVersionNumber"
 
-    template_json = json.dumps({
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
-        "Resources": {
-            "LaunchTemplate": {
-                "Type": "AWS::EC2::LaunchTemplate",
-                "Properties": {
-                    "LaunchTemplateName": "launch-template-test",
-                    "LaunchTemplateData": {
-                        "ImageId": EXAMPLE_AMI_ID,
-                        "InstanceType": "t3.small",
-                        "UserData": ""
-                    }
-                }
-            },
-            "AutoScalingGroup": {
-                "Type": "AWS::AutoScaling::AutoScalingGroup",
-                "Properties": {
-                    "AutoScalingGroupName": autoscaling_group_name,
-                    "VPCZoneIdentifier": [subnet1.id],
-                    "LaunchTemplate": {
-                        "LaunchTemplateId": {
-                            "Ref": "LaunchTemplate"
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t3.small",
+                            "UserData": "",
                         },
-                        "Version": {
-                            "Fn::GetAtt": [
-                                "LaunchTemplate",
-                                version_attribute
-                            ]
-                        }
                     },
-                    "MinSize": 1,
-                    "MaxSize": 1
-                }
-            }
+                },
+                "AutoScalingGroup": {
+                    "Type": "AWS::AutoScaling::AutoScalingGroup",
+                    "Properties": {
+                        "AutoScalingGroupName": autoscaling_group_name,
+                        "VPCZoneIdentifier": [subnet1.id],
+                        "LaunchTemplate": {
+                            "LaunchTemplateId": {"Ref": "LaunchTemplate"},
+                            "Version": {
+                                "Fn::GetAtt": ["LaunchTemplate", version_attribute]
+                            },
+                        },
+                        "MinSize": 1,
+                        "MaxSize": 1,
+                    },
+                },
+            },
         }
-    })
+    )
 
     cf_client.create_stack(
         StackName=stack_name,
@@ -189,43 +191,40 @@ def test_asg_with_default_launch_template_version():
         OnFailure="DELETE",
     )
 
-    template_json = json.dumps({
-        "AWSTemplateFormatVersion": "2010-09-09",
-        "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
-        "Resources": {
-            "LaunchTemplate": {
-                "Type": "AWS::EC2::LaunchTemplate",
-                "Properties": {
-                    "LaunchTemplateName": "launch-template-test",
-                    "LaunchTemplateData": {
-                        "ImageId": EXAMPLE_AMI_ID2,
-                        "InstanceType": "t3.medium",
-                        "UserData": ""
-                    }
-                }
-            },
-            "AutoScalingGroup": {
-                "Type": "AWS::AutoScaling::AutoScalingGroup",
-                "Properties": {
-                    "AutoScalingGroupName": autoscaling_group_name,
-                    "VPCZoneIdentifier": [subnet2.id],
-                    "LaunchTemplate": {
-                        "LaunchTemplateId": {
-                            "Ref": "LaunchTemplate"
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create an ASG group with LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID2,
+                            "InstanceType": "t3.medium",
+                            "UserData": "",
                         },
-                        "Version": {
-                            "Fn::GetAtt": [
-                                "LaunchTemplate",
-                                version_attribute
-                            ]
-                        }
                     },
-                    "MinSize": 1,
-                    "MaxSize": 2
-                }
-            }
+                },
+                "AutoScalingGroup": {
+                    "Type": "AWS::AutoScaling::AutoScalingGroup",
+                    "Properties": {
+                        "AutoScalingGroupName": autoscaling_group_name,
+                        "VPCZoneIdentifier": [subnet2.id],
+                        "LaunchTemplate": {
+                            "LaunchTemplateId": {"Ref": "LaunchTemplate"},
+                            "Version": {
+                                "Fn::GetAtt": ["LaunchTemplate", version_attribute]
+                            },
+                        },
+                        "MinSize": 1,
+                        "MaxSize": 2,
+                    },
+                },
+            },
         }
-    })
+    )
 
     cf_client.update_stack(
         StackName=stack_name,
@@ -239,5 +238,8 @@ def test_asg_with_default_launch_template_version():
         ]
     )["AutoScalingGroups"][0]
 
-    assert autoscaling_group["LaunchTemplate"]["LaunchTemplateName"] == "launch-template-test"
+    assert (
+        autoscaling_group["LaunchTemplate"]["LaunchTemplateName"]
+        == "launch-template-test"
+    )
     assert autoscaling_group["LaunchTemplate"]["Version"] == "1"

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -27,6 +27,7 @@ def test_asg_with_latest_launch_template_version():
     autoscaling_group_name = str(uuid4())
 
     stack_name = str(uuid4())
+    launch_template_name = str(uuid4())[0:6]
 
     version_attribute = "LatestVersionNumber"
 
@@ -38,7 +39,7 @@ def test_asg_with_latest_launch_template_version():
                 "LaunchTemplate": {
                     "Type": "AWS::EC2::LaunchTemplate",
                     "Properties": {
-                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateName": launch_template_name,
                         "LaunchTemplateData": {
                             "ImageId": EXAMPLE_AMI_ID,
                             "InstanceType": "t3.small",
@@ -80,7 +81,7 @@ def test_asg_with_latest_launch_template_version():
                 "LaunchTemplate": {
                     "Type": "AWS::EC2::LaunchTemplate",
                     "Properties": {
-                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateName": launch_template_name,
                         "LaunchTemplateData": {
                             "ImageId": EXAMPLE_AMI_ID2,
                             "InstanceType": "t3.medium",
@@ -121,7 +122,7 @@ def test_asg_with_latest_launch_template_version():
 
     assert (
         autoscaling_group["LaunchTemplate"]["LaunchTemplateName"]
-        == "launch-template-test"
+        == launch_template_name
     )
     assert autoscaling_group["LaunchTemplate"]["Version"] == "2"
 
@@ -146,6 +147,7 @@ def test_asg_with_default_launch_template_version():
     autoscaling_group_name = str(uuid4())
 
     stack_name = str(uuid4())
+    launch_template_name = str(uuid4())[0:6]
 
     version_attribute = "DefaultVersionNumber"
 
@@ -157,7 +159,7 @@ def test_asg_with_default_launch_template_version():
                 "LaunchTemplate": {
                     "Type": "AWS::EC2::LaunchTemplate",
                     "Properties": {
-                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateName": launch_template_name,
                         "LaunchTemplateData": {
                             "ImageId": EXAMPLE_AMI_ID,
                             "InstanceType": "t3.small",
@@ -199,7 +201,7 @@ def test_asg_with_default_launch_template_version():
                 "LaunchTemplate": {
                     "Type": "AWS::EC2::LaunchTemplate",
                     "Properties": {
-                        "LaunchTemplateName": "launch-template-test",
+                        "LaunchTemplateName": launch_template_name,
                         "LaunchTemplateData": {
                             "ImageId": EXAMPLE_AMI_ID2,
                             "InstanceType": "t3.medium",
@@ -240,6 +242,6 @@ def test_asg_with_default_launch_template_version():
 
     assert (
         autoscaling_group["LaunchTemplate"]["LaunchTemplateName"]
-        == "launch-template-test"
+        == launch_template_name
     )
     assert autoscaling_group["LaunchTemplate"]["Version"] == "1"


### PR DESCRIPTION
## Purpose

* Add support for getting attributes of `AWS::EC2::LaunchTemplate` resources.
* Fix bug. Sorta. The real bug is that moto's cloudformation parsing does not honor dependencies between resources -- instead it retries resource updates that raise errors (up to 5 times). This is fine if the update raises errors, but if no error is raised, the updates may process out of order. This was discovered while writing tests for the previous bullet. In our case, we have an AutoScalingGroup that depends on a LaunchTemplate. If the updates to the AutoScalingGroup are handled first, it picks up the current/old version of the LaunchTemplate instead of the new one (because the new one is not created yet). Honoring dependency order appears hard (probably why it is not yet implemented). As a fallback, this PR makes the order of updates deterministic, so that at least if you put the resources in the right order in your template, they will be updated in that order. This is done by using lists rather than sets. The result should be the same -- since previously we were taking the `set` of a `dict`, the collection by definition has unique elements (that is, I cannot find any discernable difference between `set(some_dict)` and `list(some_dict)` except that the latter preserves order).