### PR TITLE
ECR: fix image wrong type for pushed_at

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -276,7 +276,7 @@ class Image(BaseObject):
         self.repository = repository
         self.registry_id = registry_id or account_id
         self.image_digest = digest
-        self.image_pushed_at = str(datetime.now(timezone.utc).isoformat())
+        self.image_pushed_at = int(datetime.now(timezone.utc).timestamp())
         self.last_scan: Optional[datetime] = None
 
     def _create_digest(self) -> None:


### PR DESCRIPTION
When executing ECR.DescribeImages() and there is an image to describe the Go AWS SDK fails to de-serialize the response with the following message de serialization failed, failed to decode response body, expected PushTimestamp to be a JSON Number, got string instead . 
When looking into the code https://github.com/getmoto/moto/blob/master/moto/ecr/models.py line 279 (self.image_pushed_at = str(datetime.now(timezone.utc).isoformat()) ) which obviously is a string. When looking at the AWS API documentation at https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeImages.html#API_DescribeImages_ResponseSyntax AWS expects a number (likely a timestamp) so the bug seems to not be in the GO SDK, but in Moto. 
Trying the patched version did indeed fix the problem. 