### PR TITLE
CognitoIDP: admin_initiate_auth() now correctly returns a Challenge when 2FA is enabled

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1449,6 +1449,19 @@ class CognitoIdpBackend(BaseBackend):
                     "Session": session,
                 }
 
+            if (
+                user.software_token_mfa_enabled
+                and user.preferred_mfa_setting == "SOFTWARE_TOKEN_MFA"
+            ):
+                session = str(random.uuid4())
+                self.sessions[session] = user_pool
+
+                return {
+                    "ChallengeName": "SOFTWARE_TOKEN_MFA",
+                    "ChallengeParameters": {},
+                    "Session": session,
+                }
+
             return self._log_user_in(user_pool, client, username)
         elif auth_flow in (AuthFlow.REFRESH_TOKEN, AuthFlow.REFRESH_TOKEN_AUTH):
             refresh_token: str = auth_parameters.get("REFRESH_TOKEN")  # type: ignore[assignment]


### PR DESCRIPTION
Title: 

Summary:

Issue Encountered: In Moto version 4.2.11 with Botocore version 1.32.7 on Python 3.11, an issue was identified where the admin_initiate_auth method incorrectly returned a valid token AuthenticationResult, even when Multi-Factor Authentication (MFA) was enabled for a user. This behavior was inconsistent with the expected results, as a challenge-response (specifically for Time-based One-Time Password (TOTP)) was anticipated.

Issue link: https://github.com/getmoto/moto/issues/7125