### PR TITLE
DynamoDB: execute_statement() now supports INSERT/UPDATE/DELETE queries

### DIFF
--- a/moto/dynamodb/parsing/partiql.py
+++ b/moto/dynamodb/parsing/partiql.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from py_partiql_parser import QueryMetadata
@@ -6,7 +6,10 @@ if TYPE_CHECKING:
 
 def query(
     statement: str, source_data: Dict[str, str], parameters: List[Dict[str, Any]]
-) -> List[Dict[str, Any]]:
+) -> Tuple[
+    List[Dict[str, Any]],
+    Dict[str, List[Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]]],
+]:
     from py_partiql_parser import DynamoDBStatementParser
 
     return DynamoDBStatementParser(source_data).parse(statement, parameters)

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ all =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
     aws-xray-sdk!=0.96,>=0.93
     setuptools
     multipart
@@ -71,7 +71,7 @@ proxy =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
     aws-xray-sdk!=0.96,>=0.93
     setuptools
     multipart
@@ -86,7 +86,7 @@ server =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
     aws-xray-sdk!=0.96,>=0.93
     setuptools
     flask!=2.2.0,!=2.2.1
@@ -121,7 +121,7 @@ cloudformation =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
     aws-xray-sdk!=0.96,>=0.93
     setuptools
 cloudfront =
@@ -144,10 +144,10 @@ dms =
 ds = sshpubkeys>=3.1.0
 dynamodb =
     docker>=3.0.0
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
 dynamodbstreams =
     docker>=3.0.0
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
 ebs = sshpubkeys>=3.1.0
 ec2 = sshpubkeys>=3.1.0
 ec2instanceconnect =
@@ -210,15 +210,15 @@ resourcegroupstaggingapi =
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
 route53 =
 route53resolver = sshpubkeys>=3.1.0
 s3 =
     PyYAML>=5.1
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
 s3crc32c =
     PyYAML>=5.1
-    py-partiql-parser==0.4.2
+    py-partiql-parser==0.5.0
     crc32c
 s3control =
 sagemaker =


### PR DESCRIPTION
The `py_partiql_parser` module supports updates as of >= 0.5.0. It now sends back a list of tuples in the form: `(before, after)`

This PR introduces the appropriate changes in Moto to insert data (if `before` is None), update data (if `before` and `after` are set) or delete rows (if `after` is None)