### PR TITLE
EC2: Fix invalid value for NetworkInfo.EnaSupport

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -850,7 +850,7 @@ EC2_DESCRIBE_INSTANCE_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
                 <defaultNetworkCardIndex>{{ instance_type.get('NetworkInfo', {}).get('DefaultNetworkCardIndex', 0) | int }}</defaultNetworkCardIndex>
                 <efaSupported>{{ instance_type.get('NetworkInfo', {}).get('EfaSupported', False) }}</efaSupported>
                 <enaSrdSupported>{{ instance_type.get('NetworkInfo', {}).get('EnaSrdSupported', False) }}</enaSrdSupported>
-                <enaSupport>{{ instance_type.get('NetworkInfo', {}).get('EnaSupported', False) }}</enaSupport>
+                <enaSupport>{{ instance_type.get('NetworkInfo', {}).get('EnaSupport', 'unsupported') }}</enaSupport>
                 <encryptionInTransitSupported>{{ instance_type.get('NetworkInfo', {}).get('EncryptionInTransitSupported', False) }}</encryptionInTransitSupported>
                 <ipv4AddressesPerInterface>{{ instance_type.get('NetworkInfo', {}).get('Ipv4AddressesPerInterface', 0) | int }}</ipv4AddressesPerInterface>
                 <ipv6AddressesPerInterface>{{ instance_type.get('NetworkInfo', {}).get('Ipv6AddressesPerInterface', 0) | int }}</ipv6AddressesPerInterface>

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -14,8 +14,11 @@ def test_describe_instance_types():
     assert "InstanceType" in instance_types["InstanceTypes"][0]
     assert "SizeInMiB" in instance_types["InstanceTypes"][0]["MemoryInfo"]
 
-    ena_support = set(t["NetworkInfo"]["EnaSupport"] for t in instance_types["InstanceTypes"])
+    ena_support = set(
+        t["NetworkInfo"]["EnaSupport"] for t in instance_types["InstanceTypes"]
+    )
     assert ena_support == {"required", "unsupported", "supported"}
+
 
 @mock_ec2
 def test_describe_instance_types_filter_by_type():

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -14,6 +14,8 @@ def test_describe_instance_types():
     assert "InstanceType" in instance_types["InstanceTypes"][0]
     assert "SizeInMiB" in instance_types["InstanceTypes"][0]["MemoryInfo"]
 
+    ena_support = set(t["NetworkInfo"]["EnaSupport"] for t in instance_types["InstanceTypes"])
+    assert ena_support == {"required", "unsupported", "supported"}
 
 @mock_ec2
 def test_describe_instance_types_filter_by_type():


### PR DESCRIPTION
This PR fixes an incorrect dict key and adds valid fallback value for the response field [`EnaSupport`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkInfo.html) for the `DescribeInstanceTypes` API operation.

See https://github.com/localstack/localstack/issues/9854