### PR TITLE
EC2: launch templates created by CloudFormation have a generated name if not provided

### DIFF
--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -13,6 +13,7 @@ from ..utils import (
     convert_tag_spec,
     generic_filter,
     random_launch_template_id,
+    random_launch_template_name,
     utc_date_and_time,
 )
 from .core import TaggedEC2Resource
@@ -140,6 +141,9 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
         tag_spec = convert_tag_spec(
             properties.get("TagSpecifications", {}), tag_key="Tags"
         )
+
+        if name is None:
+            name = random_launch_template_name()
 
         launch_template = backend.create_launch_template(
             name, description, data, tag_spec

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -233,6 +233,10 @@ def random_launch_template_id() -> str:
     return random_id(prefix=EC2_RESOURCE_TO_PREFIX["launch-template"], size=17)
 
 
+def random_launch_template_name() -> str:
+    return f"LaunchTemplate_{random_resource_id(size=12)}"
+
+
 def random_iam_instance_profile_association_id() -> str:
     return random_id(prefix=EC2_RESOURCE_TO_PREFIX["iam-instance-profile-association"])
 

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -245,3 +245,52 @@ def test_asg_with_default_launch_template_version():
         == launch_template_name
     )
     assert autoscaling_group["LaunchTemplate"]["Version"] == "1"
+
+
+@mock_autoscaling
+@mock_cloudformation
+@mock_ec2
+def test_two_launch_templates():
+    cf_client = boto3.client("cloudformation", region_name="us-west-1")
+    ec2_client = boto3.client("ec2", region_name="us-west-1")
+
+    stack_name = str(uuid4())
+
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create two LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate0": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t3.small",
+                            "UserData": "",
+                        },
+                    },
+                },
+                "LaunchTemplate1": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t3.medium",
+                            "UserData": "",
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    cf_client.create_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+        OnFailure="DELETE",
+    )
+
+    launch_templates = ec2_client.describe_launch_templates()
+    assert launch_templates["LaunchTemplates"][0]['LaunchTemplateName'] != launch_templates["LaunchTemplates"][1]['LaunchTemplateName']

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -293,4 +293,7 @@ def test_two_launch_templates():
     )
 
     launch_templates = ec2_client.describe_launch_templates()
-    assert launch_templates["LaunchTemplates"][0]['LaunchTemplateName'] != launch_templates["LaunchTemplates"][1]['LaunchTemplateName']
+    assert (
+        launch_templates["LaunchTemplates"][0]["LaunchTemplateName"]
+        != launch_templates["LaunchTemplates"][1]["LaunchTemplateName"]
+    )


### PR DESCRIPTION
## Purpose

Fixes a bug in the creation of launch templates via CloudFormation. If your template has more than one ***unnamed*** launch template, creation will fail with

> botocore.exceptions.ClientError: An error occurred (InvalidLaunchTemplateName.AlreadyExistsException) when calling the CreateStack operation: Launch template name already in use.

This is because moto's implementation expects that the resource have a `LaunchTemplateName` property even though [it is optional](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename).