### PR TITLE
Add cognitoidp.admin_respond_to_auth_challenge

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1180,7 +1180,7 @@
 
 ## cognito-idp
 <details>
-<summary>59% implemented</summary>
+<summary>60% implemented</summary>
 
 - [X] add_custom_attributes
 - [X] admin_add_user_to_group
@@ -1201,7 +1201,7 @@
 - [ ] admin_list_user_auth_events
 - [X] admin_remove_user_from_group
 - [X] admin_reset_user_password
-- [ ] admin_respond_to_auth_challenge
+- [X] admin_respond_to_auth_challenge
 - [X] admin_set_user_mfa_preference
 - [X] admin_set_user_password
 - [ ] admin_set_user_settings

--- a/docs/docs/services/cognito-idp.rst
+++ b/docs/docs/services/cognito-idp.rst
@@ -46,7 +46,7 @@ cognito-idp
 - [ ] admin_list_user_auth_events
 - [X] admin_remove_user_from_group
 - [X] admin_reset_user_password
-- [ ] admin_respond_to_auth_challenge
+- [X] admin_respond_to_auth_challenge
 - [X] admin_set_user_mfa_preference
 - [X] admin_set_user_password
 - [ ] admin_set_user_settings

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1485,7 +1485,6 @@ class CognitoIdpBackend(BaseBackend):
 
     def admin_respond_to_auth_challenge(
         self,
-        user_pool_id: str,
         session: str,
         client_id: str,
         challenge_name: str,
@@ -2209,7 +2208,6 @@ class RegionAgnosticBackend:
 
     def admin_respond_to_auth_challenge(
         self,
-        user_pool_id: str,
         session: str,
         client_id: str,
         challenge_name: str,
@@ -2217,7 +2215,7 @@ class RegionAgnosticBackend:
     ) -> Dict[str, Any]:
         backend = self._find_backend_for_clientid(client_id)
         return backend.admin_respond_to_auth_challenge(
-            user_pool_id, session, client_id, challenge_name, challenge_responses
+            session, client_id, challenge_name, challenge_responses
         )
 
     def respond_to_auth_challenge(

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1483,6 +1483,28 @@ class CognitoIdpBackend(BaseBackend):
             # We shouldn't get here due to enum validation of auth_flow
             return None  # type: ignore[return-value]
 
+    def admin_respond_to_auth_challenge(
+        self,
+        user_pool_id: str,
+        session: str,
+        client_id: str,
+        challenge_name: str,
+        challenge_responses: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """
+        Responds to an authentication challenge, as an administrator.
+
+        The only differences between this admin endpoint and public endpoint are not relevant and so we can safely call
+        the public endpoint to do the work:
+        - The admin endpoint requires a user pool id along with a session; the public endpoint searches across all pools
+        - ContextData is passed in; we don't use it
+
+        ref: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_AdminRespondToAuthChallenge.html
+        """
+        return self.respond_to_auth_challenge(
+            session, client_id, challenge_name, challenge_responses
+        )
+
     def respond_to_auth_challenge(
         self,
         session: str,
@@ -1490,6 +1512,11 @@ class CognitoIdpBackend(BaseBackend):
         challenge_name: str,
         challenge_responses: Dict[str, str],
     ) -> Dict[str, Any]:
+        """
+        Responds to an authentication challenge, from public client.
+
+        ref: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RespondToAuthChallenge.html
+        """
         if challenge_name == "PASSWORD_VERIFIER":
             session = challenge_responses.get("PASSWORD_CLAIM_SECRET_BLOCK")  # type: ignore[assignment]
 
@@ -2179,6 +2206,19 @@ class RegionAgnosticBackend:
     def get_user(self, access_token: str) -> CognitoIdpUser:
         backend = self._find_backend_by_access_token(access_token)
         return backend.get_user(access_token)
+
+    def admin_respond_to_auth_challenge(
+        self,
+        user_pool_id: str,
+        session: str,
+        client_id: str,
+        challenge_name: str,
+        challenge_responses: Dict[str, str],
+    ) -> Dict[str, Any]:
+        backend = self._find_backend_for_clientid(client_id)
+        return backend.admin_respond_to_auth_challenge(
+            user_pool_id, session, client_id, challenge_name, challenge_responses
+        )
 
     def respond_to_auth_challenge(
         self,

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -449,6 +449,18 @@ class CognitoIdpResponse(BaseResponse):
 
         return json.dumps(auth_result)
 
+    def admin_respond_to_auth_challenge(self) -> str:
+        user_pool_id = self._get_param("UserPoolId")
+        session = self._get_param("Session")
+        client_id = self._get_param("ClientId")
+        challenge_name = self._get_param("ChallengeName")
+        challenge_responses = self._get_param("ChallengeResponses")
+        auth_result = region_agnostic_backend.admin_respond_to_auth_challenge(
+            user_pool_id, session, client_id, challenge_name, challenge_responses
+        )
+
+        return json.dumps(auth_result)
+
     def respond_to_auth_challenge(self) -> str:
         session = self._get_param("Session")
         client_id = self._get_param("ClientId")

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -450,13 +450,12 @@ class CognitoIdpResponse(BaseResponse):
         return json.dumps(auth_result)
 
     def admin_respond_to_auth_challenge(self) -> str:
-        user_pool_id = self._get_param("UserPoolId")
         session = self._get_param("Session")
         client_id = self._get_param("ClientId")
         challenge_name = self._get_param("ChallengeName")
         challenge_responses = self._get_param("ChallengeResponses")
         auth_result = region_agnostic_backend.admin_respond_to_auth_challenge(
-            user_pool_id, session, client_id, challenge_name, challenge_responses
+            session, client_id, challenge_name, challenge_responses
         )
 
         return json.dumps(auth_result)

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -1532,7 +1532,8 @@ def test_group_in_access_token():
 
     # This sets a new password and logs the user in (creates tokens)
     new_password = "P2$Sword"
-    result = conn.respond_to_auth_challenge(
+    result = conn.admin_respond_to_auth_challenge(
+        UserPoolId=user_pool_id,
         Session=result["Session"],
         ClientId=client_id,
         ChallengeName="NEW_PASSWORD_REQUIRED",
@@ -1585,7 +1586,8 @@ def test_group_in_id_token():
 
     # This sets a new password and logs the user in (creates tokens)
     new_password = "P2$Sword"
-    result = conn.respond_to_auth_challenge(
+    result = conn.admin_respond_to_auth_challenge(
+        UserPoolId=user_pool_id,
         Session=result["Session"],
         ClientId=client_id,
         ChallengeName="NEW_PASSWORD_REQUIRED",
@@ -2749,7 +2751,8 @@ def authentication_flow(conn, auth_flow):
 
     # This sets a new password and logs the user in (creates tokens)
     new_password = "P2$Sword"
-    result = conn.respond_to_auth_challenge(
+    result = conn.admin_respond_to_auth_challenge(
+        UserPoolId=user_pool_id,
         Session=result["Session"],
         ClientId=client_id,
         ChallengeName="NEW_PASSWORD_REQUIRED",
@@ -4388,7 +4391,8 @@ def test_admin_initiate_auth_when_token_totp_enabled():
     assert result["Session"] != ""
 
     # Respond to challenge with TOTP
-    result = conn.respond_to_auth_challenge(
+    result = conn.admin_respond_to_auth_challenge(
+        UserPoolId=user_pool_id,
         ClientId=client_id,
         ChallengeName="SOFTWARE_TOKEN_MFA",
         Session=result["Session"],


### PR DESCRIPTION
Implements `cognitoidp`.`admin_respond_to_auth_challenge`. It simply calls the corresponding public endpoint `respond_to_auth_challenge` internally as there is no relevant differences between them.

Since there are no changes in logic, I didn't add any additional tests, but I did convert existing tests so a call to `admin_initiate_auth` and `initiate_auth` uses the appropriate API `admin_respond_to_auth_challenge` and `respond_to_auth_challenge` respectively.

Let me know if there's anything I missed.