### PR TITLE
ACM: describe_certificate() should return a DomainValidationOption for each SN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,10 @@ jobs:
     needs: lint
     uses: ./.github/workflows/tests_sdk_ruby.yml
 
+  terraformexamplestest:
+    needs: lint
+    uses: ./.github/workflows/tests_terraform_examples.yml
+
   test:
     needs: [lint]
     if: "!contains(github.event.pull_request.labels.*.name, 'java')"

--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -1,0 +1,33 @@
+# Small, self contained Terraform examples
+# Scripts should be placed in:
+#    other_langs/terraform/service
+
+name: Terraform Examples
+on: [workflow_call]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ["acm"]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.8"
+    - name: Start MotoServer
+      run: |
+        pip install build
+        python -m build
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
+        python scripts/ci_wait_for_server.py
+    - name: Run tests
+      run: |
+        mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
+        cd other_langs/terraform/${{ matrix.service }} && terraform init && terraform apply --auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ other_langs/tests_java/target
 other_langs/tests_dotnet/ExampleTestProject/bin
 other_langs/tests_dotnet/ExampleTestProject/obj
 other_langs/tests_ruby/Gemfile.lock
+other_langs/terraform/*/.terraform*
+other_langs/terraform/*/terraform*

--- a/other_langs/terraform/acm/acm.tf
+++ b/other_langs/terraform/acm/acm.tf
@@ -1,0 +1,42 @@
+locals {
+  domain_name = "test.co"
+}
+
+resource "aws_route53_zone" "test" {
+  name = local.domain_name
+}
+
+resource "aws_acm_certificate" "certificate" {
+  domain_name       = local.domain_name
+  validation_method = "DNS"
+
+  subject_alternative_names = ["*.${local.domain_name}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "certificate_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.test.zone_id
+}
+
+resource "aws_acm_certificate_validation" "validation" {
+  certificate_arn = aws_acm_certificate.certificate.arn
+  validation_record_fqdns = [
+    for record in aws_route53_record.certificate_validation : record.fqdn
+  ]
+}

--- a/other_langs/terraform/acm/providers.tf
+++ b/other_langs/terraform/acm/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    acm     = "http://localhost:5000"
+    route53 = "http://localhost:5000"
+  }
+
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -385,7 +385,7 @@ def test_request_certificate():
 
 
 @mock_acm
-def test_request_certificate_with_tags():
+def test_request_certificate_with_optional_arguments():
     client = boto3.client("acm", region_name="eu-central-1")
 
     token = str(uuid.uuid4())
@@ -401,6 +401,13 @@ def test_request_certificate_with_tags():
     )
     assert "CertificateArn" in resp
     arn_1 = resp["CertificateArn"]
+
+    cert = client.describe_certificate(CertificateArn=arn_1)["Certificate"]
+    assert len(cert["SubjectAlternativeNames"]) == 3
+    assert len(cert["DomainValidationOptions"]) == 3
+    assert {option["DomainName"] for option in cert["DomainValidationOptions"]} == set(
+        cert["SubjectAlternativeNames"]
+    )
 
     resp = client.list_tags_for_certificate(CertificateArn=arn_1)
     tags = {item["Key"]: item.get("Value", "__NONE__") for item in resp["Tags"]}


### PR DESCRIPTION
Fixes #7138 

Also enables a small, focused Terraform test to verify this behaviour is equivalent to how AWS behaves.