### PR TITLE
Update LaunchTemplate by physical ID rather than by name

### DIFF
--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -167,11 +167,10 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
 
         properties = cloudformation_json["Properties"]
 
-        name = properties.get("LaunchTemplateName")
         data = properties.get("LaunchTemplateData")
         description = properties.get("VersionDescription")
 
-        launch_template = backend.get_launch_template_by_name(name)
+        launch_template = backend.get_launch_template(original_resource.id)
 
         launch_template.create_version(data, description)
 

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -334,6 +334,10 @@ def test_launch_template_unnamed_update():
         OnFailure="DELETE",
     )
 
+    launch_templates = ec2_client.describe_launch_templates()["LaunchTemplates"]
+    assert len(launch_templates) == 1
+    launch_template_id = launch_templates[0]["LaunchTemplateId"]
+
     template_json = json.dumps(
         {
             "AWSTemplateFormatVersion": "2010-09-09",
@@ -358,3 +362,7 @@ def test_launch_template_unnamed_update():
         TemplateBody=template_json,
         Capabilities=["CAPABILITY_NAMED_IAM"],
     )
+
+    launch_templates = ec2_client.describe_launch_templates()["LaunchTemplates"]
+    assert len(launch_templates) == 1
+    assert launch_template_id == launch_templates[0]["LaunchTemplateId"]

--- a/tests/test_ec2/test_launch_templates_cloudformation.py
+++ b/tests/test_ec2/test_launch_templates_cloudformation.py
@@ -297,3 +297,64 @@ def test_two_launch_templates():
         launch_templates["LaunchTemplates"][0]["LaunchTemplateName"]
         != launch_templates["LaunchTemplates"][1]["LaunchTemplateName"]
     )
+
+
+@mock_autoscaling
+@mock_cloudformation
+@mock_ec2
+def test_launch_template_unnamed_update():
+    cf_client = boto3.client("cloudformation", region_name="us-west-1")
+    ec2_client = boto3.client("ec2", region_name="us-west-1")
+
+    stack_name = str(uuid4())
+
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create a LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t3.small",
+                            "UserData": "",
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    cf_client.create_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+        OnFailure="DELETE",
+    )
+
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "AWS CloudFormation Template to create a LaunchTemplate",
+            "Resources": {
+                "LaunchTemplate": {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t3.medium",
+                            "UserData": "",
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    cf_client.update_stack(
+        StackName=stack_name,
+        TemplateBody=template_json,
+        Capabilities=["CAPABILITY_NAMED_IAM"],
+    )


### PR DESCRIPTION
## Purpose

Looking up a launch template resource by its name attribute can be tricky when that name is randomly generated by cloudformation rather than one of the declared resource attributes. Instead, do the lookup using the physical resource id.