### PR TITLE
Route53: change_resource_record_sets(): Relax DELETE validation

### DIFF
--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ["acm"]
+        service: ["acm", "route53"]
 
     steps:
     - uses: actions/checkout@v4
@@ -30,4 +30,7 @@ jobs:
     - name: Run tests
       run: |
         mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
-        cd other_langs/terraform/${{ matrix.service }} && terraform init && terraform apply --auto-approve
+        cd other_langs/terraform/${{ matrix.service }}
+        terraform init
+        terraform apply --auto-approve
+        terraform apply -destroy --auto-approve

--- a/other_langs/terraform/route53/providers.tf
+++ b/other_langs/terraform/route53/providers.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    route53 = "http://localhost:5000"
+  }
+
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}

--- a/other_langs/terraform/route53/route53.tf
+++ b/other_langs/terraform/route53/route53.tf
@@ -1,0 +1,13 @@
+resource "aws_route53_zone" "test" {
+  name = "test.co"
+}
+
+resource "aws_route53_record" "svc_healtchecked_a_record" {
+  zone_id                          = aws_route53_zone.test.id
+  name                             = "svc-healthchecked.${aws_route53_zone.test.name}"
+  type                             = "A"
+  ttl                              = 60
+  set_identifier                   = "repl-0"
+  multivalue_answer_routing_policy = true
+  records                          = ["172.31.0.100", "172.31.0.101"]
+}


### PR DESCRIPTION
Fixes #7151 

The boto3 [documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53/client/change_resource_record_sets.html) states:

    To delete a resource record set, you must specify all the same values that you specified when you created it.

Which is the rule that Moto follows. But it looks like the actual behaviour is more like:

    To delete a resource record set, you must specify the same values for Name and Type (and TTL/ResourceRecords if specified)

Any other attributes such as MultiValueAnswer can be omitted, which is what Terraform does.

This feature was originally introduced in #5743 