### PR TITLE
Techdebt: Various improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: cache
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [ "3.11" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
     needs: cache
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
       run: |
         pip install --upgrade build
         python -m build
-        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e MOTO_PORT=4555 -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 4555:4555 -v /var/run/docker.sock:/var/run/docker.sock python:3.7-buster /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e MOTO_PORT=4555 -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 4555:4555 -v /var/run/docker.sock:/var/run/docker.sock python:3.11-slim /moto/scripts/ci_moto_server.sh &
         MOTO_PORT=4555 python scripts/ci_wait_for_server.py
     - name: Get pip cache dir
       id: pip-cache
@@ -100,7 +100,7 @@ jobs:
     needs: cache
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
         pip install --upgrade build
         python -m build
         docker network create -d bridge my-custom-network
-        docker run --rm -t -e TEST_SERVER_MODE=true -e MOTO_DOCKER_NETWORK_NAME=my-custom-network -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 --network my-custom-network -v /var/run/docker.sock:/var/run/docker.sock python:3.7-buster /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t -e TEST_SERVER_MODE=true -e MOTO_DOCKER_NETWORK_NAME=my-custom-network -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 --network my-custom-network -v /var/run/docker.sock:/var/run/docker.sock python:3.11-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
     - name: Get pip cache dir
       id: pip-cache
@@ -158,7 +158,7 @@ jobs:
     needs: cache
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
       run: |
         pip install --upgrade build
         python -m build
-        docker run --rm -t -e MOTO_DOCKER_NETWORK_MODE=host -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e MOTO_PORT=4555 -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 4555:4555 -v /var/run/docker.sock:/var/run/docker.sock python:3.7-buster /moto/scripts/ci_moto_server.sh &
+        docker run --rm -t -e MOTO_DOCKER_NETWORK_MODE=host -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e MOTO_PORT=4555 -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 4555:4555 -v /var/run/docker.sock:/var/run/docker.sock python:3.11-slim /moto/scripts/ci_moto_server.sh &
         MOTO_PORT=4555 python scripts/ci_wait_for_server.py
     - name: Get pip cache dir
       id: pip-cache

--- a/docs/docs/contributing/development_tips/new_state_transitions.rst
+++ b/docs/docs/contributing/development_tips/new_state_transitions.rst
@@ -45,15 +45,6 @@ An example model could look like this:
     from moto.moto_api import state_manager
 
     class Backend():
-        def __init__():
-            # This is how we register the model, and specify the default transition-behaviour
-            # Typically this is done when constructing the Backend-class
-            state_manager.register_default_transition(
-                # This name should be the same as the name used in NewModel
-                model_name="new::model",
-                # Any transition-config is possible - this is a good default option though
-                transition={"progression": "immediate"},
-            )
 
         def list_resources():
             for ec2_instance in all_resources:
@@ -76,3 +67,14 @@ An example model could look like this:
             # Make sure that each way (describe, list, get_, ) calls the advance()-method, and the resource can actually progress to the next state
             resource.advance()
             return resource
+
+Make sure that the model is registered with the StateManager. This can be done in `moto/moto_api/__init__.py`:
+
+.. sourcecode:: python
+
+    state_manager.register_default_transition(
+        # This name should be the same as the name used in NewModel
+        model_name="new::model",
+        # Any transition-config is possible - this is a good default option though
+        transition={"progression": "immediate"},
+    )

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -254,9 +254,6 @@ class MockAll(ContextDecorator):
 
 mock_all = MockAll
 
-# import logging
-# logging.getLogger('boto').setLevel(logging.CRITICAL)
-
 __title__ = "moto"
 __version__ = "4.2.13.dev"
 

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -22,7 +22,6 @@ from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends
 from moto.iam.exceptions import IAMNotFoundException
 from moto.iam.models import IAMBackend, iam_backends
 from moto.logs.models import LogsBackend, logs_backends
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.docker_utilities import DockerModel
@@ -1013,10 +1012,6 @@ class BatchBackend(BaseBackend):
         self._job_definitions: Dict[str, JobDefinition] = {}
         self._jobs: Dict[str, Job] = {}
         self._scheduling_policies: Dict[str, SchedulingPolicy] = {}
-
-        state_manager.register_default_transition(
-            "batch::job", transition={"progression": "manual", "times": 1}
-        )
 
     @property
     def iam_backend(self) -> IAMBackend:

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from moto.core import BackendDict, BaseBackend, BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.tagging_service import TaggingService
@@ -270,10 +269,6 @@ class CloudFrontBackend(BaseBackend):
         self.invalidations: Dict[str, List[Invalidation]] = dict()
         self.origin_access_controls: Dict[str, OriginAccessControl] = dict()
         self.tagger = TaggingService()
-
-        state_manager.register_default_transition(
-            "cloudfront::distribution", transition={"progression": "manual", "times": 1}
-        )
 
     def create_distribution(
         self, distribution_config: Dict[str, Any], tags: List[Dict[str, str]]

--- a/moto/dax/models.py
+++ b/moto/dax/models.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Iterable, List
 
 from moto.core import BackendDict, BaseBackend, BaseModel
 from moto.core.utils import unix_time
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.paginator import paginate
@@ -166,10 +165,6 @@ class DAXBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self._clusters: Dict[str, DaxCluster] = dict()
         self._tagger = TaggingService()
-
-        state_manager.register_default_transition(
-            model_name="dax::cluster", transition={"progression": "manual", "times": 4}
-        )
 
     @property
     def clusters(self) -> Dict[str, DaxCluster]:

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -36,6 +36,50 @@ from ..utils import (
 from .availability_zones_and_regions import RegionsAndZonesBackend
 from .core import TaggedEC2Resource
 
+# We used to load the entirety of Moto into memory, and check every module if it's supported
+# But having a fixed list is much more performant
+# Maintaining it is more difficult, but the contents of this list does not change very often
+IMPLEMENTED_ENDPOINT_SERVICES = [
+    "acm",
+    "applicationautoscaling",
+    "athena",
+    "autoscaling",
+    "lambda",
+    "cloudformation",
+    "cloudwatch",
+    "codecommit",
+    "codepipeline",
+    "config",
+    "datasync",
+    "dms",
+    "ds",
+    "dynamodb",
+    "ec2",
+    "ecr",
+    "ecs",
+    "elasticbeanstalk",
+    "elbv2",
+    "emr",
+    "events",
+    "firehose",
+    "glue",
+    "iot",
+    "kinesis",
+    "kms",
+    "logs",
+    "rds",
+    "redshift",
+    "route53resolver",
+    "s3",
+    "sagemaker",
+    "secretsmanager",
+    "sns",
+    "sqs",
+    "ssm",
+    "sts",
+    "transcribe",
+    "xray",
+]
 MAX_NUMBER_OF_ENDPOINT_SERVICES_RESULTS = 1000
 DEFAULT_VPC_ENDPOINT_SERVICES: List[Dict[str, str]] = []
 
@@ -725,7 +769,8 @@ class VPCBackend:
 
         from moto import backends  # pylint: disable=import-outside-toplevel
 
-        for _backends in backends.service_backends():
+        for implemented_service in IMPLEMENTED_ENDPOINT_SERVICES:
+            _backends = backends.get_backend(implemented_service)  # type: ignore[call-overload]
             account_backend = _backends[account_id]
             if region in account_backend:
                 service = account_backend[region].default_vpc_endpoint_service(

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -9,7 +9,6 @@ from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError
 from moto.core.utils import pascal_to_camelcase, remap_nested_keys, unix_time
 from moto.ec2 import ec2_backends
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 
@@ -961,11 +960,6 @@ class EC2ContainerServiceBackend(BaseBackend):
         self.tasks: Dict[str, Dict[str, Task]] = {}
         self.services: Dict[str, Service] = {}
         self.container_instances: Dict[str, Dict[str, ContainerInstance]] = {}
-
-        state_manager.register_default_transition(
-            model_name="ecs::task",
-            transition={"progression": "manual", "times": 1},
-        )
 
     @staticmethod
     def default_vpc_endpoint_service(service_region: str, zones: List[str]) -> List[Dict[str, Any]]:  # type: ignore[misc]

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 
 from moto.core import BackendDict, BaseBackend, BaseModel
 from moto.core.utils import unix_time, utcnow
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 
@@ -112,10 +111,6 @@ class GlueBackend(BaseBackend):
         self.registries: Dict[str, FakeRegistry] = OrderedDict()
         self.num_schemas = 0
         self.num_schema_versions = 0
-
-        state_manager.register_default_transition(
-            model_name="glue::job_run", transition={"progression": "immediate"}
-        )
 
     @staticmethod
     def default_vpc_endpoint_service(

--- a/moto/moto_api/__init__.py
+++ b/moto/moto_api/__init__.py
@@ -6,6 +6,43 @@ Use this manager to configure how AWS models transition between states. (initial
 """
 state_manager = _internal.state_manager.StateManager()
 
+"""
+Default transitions across Moto
+"""
+state_manager.register_default_transition(
+    "batch::job", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    "cloudfront::distribution", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    model_name="dax::cluster", transition={"progression": "manual", "times": 4}
+)
+state_manager.register_default_transition(
+    model_name="ecs::task", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    model_name="glue::job_run", transition={"progression": "immediate"}
+)
+state_manager.register_default_transition(
+    "s3::keyrestore", transition={"progression": "immediate"}
+)
+state_manager.register_default_transition(
+    model_name="support::case", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    "transcribe::vocabulary", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    "transcribe::medicalvocabulary", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    "transcribe::transcriptionjob", transition={"progression": "manual", "times": 1}
+)
+state_manager.register_default_transition(
+    "transcribe::medicaltranscriptionjob",
+    transition={"progression": "manual", "times": 1},
+)
 
 """"
 Recorder, used to record calls to Moto and replay them later

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -29,7 +29,6 @@ from moto.core.utils import (
     unix_time_millis,
     utcnow,
 )
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.s3.exceptions import (
@@ -1614,10 +1613,6 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         super().__init__(region_name, account_id)
         self.buckets: Dict[str, FakeBucket] = {}
         self.tagger = TaggingService()
-
-        state_manager.register_default_transition(
-            "s3::keyrestore", transition={"progression": "immediate"}
-        )
 
     def reset(self) -> None:
         # For every key and multipart, Moto opens a TemporaryFile to write the value of those keys

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -2,7 +2,6 @@ import datetime
 from typing import Any, Dict, List, Optional
 
 from moto.core import BackendDict, BaseBackend
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.utils import load_resource
@@ -66,10 +65,6 @@ class SupportBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.check_status: Dict[str, str] = {}
         self.cases: Dict[str, SupportCase] = {}
-
-        state_manager.register_default_transition(
-            model_name="support::case", transition={"progression": "manual", "times": 1}
-        )
 
     def describe_trusted_advisor_checks(self) -> List[Dict[str, Any]]:
         """

--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from moto.core import BackendDict, BaseBackend, BaseModel
-from moto.moto_api import state_manager
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 
@@ -479,22 +478,6 @@ class TranscribeBackend(BaseBackend):
         self.transcriptions: Dict[str, FakeTranscriptionJob] = {}
         self.medical_vocabularies: Dict[str, FakeMedicalVocabulary] = {}
         self.vocabularies: Dict[str, FakeVocabulary] = {}
-
-        state_manager.register_default_transition(
-            "transcribe::vocabulary", transition={"progression": "manual", "times": 1}
-        )
-        state_manager.register_default_transition(
-            "transcribe::medicalvocabulary",
-            transition={"progression": "manual", "times": 1},
-        )
-        state_manager.register_default_transition(
-            "transcribe::transcriptionjob",
-            transition={"progression": "manual", "times": 1},
-        )
-        state_manager.register_default_transition(
-            "transcribe::medicaltranscriptionjob",
-            transition={"progression": "manual", "times": 1},
-        )
 
     @staticmethod
     def default_vpc_endpoint_service(

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -22,7 +22,7 @@ def load_resource(package: str, resource: str) -> Any:
 
 
 def load_resource_as_str(package: str, resource: str) -> str:
-    return load_resource_as_bytes(package, resource).decode("utf-8")  # type: ignore
+    return load_resource_as_bytes(package, resource).decode("utf-8")
 
 
 def load_resource_as_bytes(package: str, resource: str) -> bytes:

--- a/tests/test_efs/test_server.py
+++ b/tests/test_efs/test_server.py
@@ -1,9 +1,10 @@
 import re
+from unittest import SkipTest
 
 import pytest
 
 import moto.server as server
-from moto import mock_ec2, mock_efs
+from moto import mock_ec2, mock_efs, settings
 
 FILE_SYSTEMS = "/2015-02-01/file-systems"
 MOUNT_TARGETS = "/2015-02-01/mount-targets"
@@ -20,6 +21,8 @@ def fixture_aws_credentials(monkeypatch):
 
 @pytest.fixture(scope="function", name="efs_client")
 def fixture_efs_client(aws_credentials):  # pylint: disable=unused-argument
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Using server directly - no point in testing ServerMode")
     with mock_efs():
         yield server.create_backend_app("efs").test_client()
 

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -1,6 +1,7 @@
 import csv
 import json
 from datetime import datetime
+from unittest import SkipTest
 from urllib import parse
 from uuid import uuid4
 
@@ -3580,6 +3581,8 @@ def test_role_list_config_discovered_resources():
 
 @mock_iam
 def test_role_config_dict():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Using backend directly - no point in testing ServerMode")
     from moto.iam.config import policy_config_query, role_config_query
     from moto.iam.utils import random_policy_id, random_role_id
 
@@ -4189,6 +4192,8 @@ def test_policy_list_config_discovered_resources():
 
 @mock_iam
 def test_policy_config_dict():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Using backend directly - no point in testing ServerMode")
     from moto.iam.config import policy_config_query, role_config_query
     from moto.iam.utils import random_policy_id
 


### PR DESCRIPTION
- Enable the linter for all recent Python versions
- Upgrade the Python-version for our Docker tests
- Moves the StateManager transitions to a central place, making it easier to maintain
- Cognito: The RegionAgnosticBackend had a bug where we could theoretically try to return a `backend` (or account+region) that hadn't been initialized yet. This change adds an explicit fallback
- EC2: Endpoint Services are now explicitly listed. More performant, and only a small additional maintenance overhead because the list doesn't change that often
- And finally: Skip some tests in ServerMode, because we're testing the same thing as when using the decorators