### PR TITLE
SSO Admin: list_account_assignments_for_principal

### DIFF
--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -180,6 +180,33 @@ class SSOAdminBackend(BaseBackend):
                 )
         return account_assignments
 
+    @paginate(PAGINATION_MODEL)  # type: ignore[misc]
+    def list_account_assignments_for_principal(
+        self,
+        filter_: Dict[str, Any],
+        instance_arn: str,
+        principal_id: str,
+        principal_type: str,
+    ) -> List[Dict[str, Any]]:
+        return [
+            {
+                "AccountId": account_assignment.target_id,
+                "PermissionSetArn": account_assignment.permission_set_arn,
+                "PrincipalId": account_assignment.principal_id,
+                "PrincipalType": account_assignment.principal_type,
+            }
+            for account_assignment in self.account_assignments
+            if all(
+                [
+                    filter_.get("AccountId", account_assignment.target_id)
+                    == account_assignment.target_id,
+                    principal_id == account_assignment.principal_id,
+                    principal_type == account_assignment.principal_type,
+                    instance_arn == account_assignment.instance_arn,
+                ]
+            )
+        ]
+
     def create_permission_set(
         self,
         name: str,

--- a/moto/ssoadmin/responses.py
+++ b/moto/ssoadmin/responses.py
@@ -69,6 +69,28 @@ class SSOAdminResponse(BaseResponse):
         )
         return json.dumps({"AccountAssignments": assignments})
 
+    def list_account_assignments_for_principal(self) -> str:
+        filter_ = self._get_param("Filter", {})
+        instance_arn = self._get_param("InstanceArn")
+        max_results = self._get_param("MaxResults")
+        next_token = self._get_param("NextToken")
+        principal_id = self._get_param("PrincipalId")
+        principal_type = self._get_param("PrincipalType")
+
+        (
+            assignments,
+            next_token,
+        ) = self.ssoadmin_backend.list_account_assignments_for_principal(
+            filter_=filter_,
+            instance_arn=instance_arn,
+            max_results=max_results,
+            next_token=next_token,
+            principal_id=principal_id,
+            principal_type=principal_type,
+        )
+
+        return json.dumps(dict(AccountAssignments=assignments, NextToken=next_token))
+
     def create_permission_set(self) -> str:
         name = self._get_param("Name")
         description = self._get_param("Description")

--- a/moto/ssoadmin/utils.py
+++ b/moto/ssoadmin/utils.py
@@ -6,4 +6,16 @@ PAGINATION_MODEL = {
         "result_key": "PermissionSets",
         "unique_attribute": "permission_set_arn",
     },
+    "list_account_assignments_for_principal": {
+        "input_token": "next_token",
+        "limit_key": "max_results",
+        "limit_default": 100,
+        "result_key": "PermissionSets",
+        "unique_attribute": [
+            "AccountId",
+            "PermissionSetArn",
+            "PrincipalId",
+            "PrincipalType",
+        ],
+    },
 }


### PR DESCRIPTION
Implemented `sso-admin` `list_account_assignments_for_principal` [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sso-admin/client/list_account_assignments_for_principal.html).

- [x] Feature is added
- [ ] The linter is happy
- [ ] Tests are added
- [ ] All tests pass, existing and new

Included the pagination implementation of this method and ensured proper testing.