### PR TITLE
Implements sso-admin AWS Managed Policies 

### DIFF
--- a/moto/ssoadmin/exceptions.py
+++ b/moto/ssoadmin/exceptions.py
@@ -3,9 +3,30 @@ from moto.core.exceptions import JsonRESTError
 
 
 class ResourceNotFoundException(JsonRESTError):
-    def __init__(self, message: str = "Account not found") -> None:
+    code = 400
+
+    def __init__(self, message: str = "") -> None:
         super().__init__(
             error_type="ResourceNotFoundException",
             message=message,
-            code="ResourceNotFoundException",
+        )
+
+
+class ConflictException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message: str = "") -> None:
+        super().__init__(
+            error_type="ConflictException",
+            message=message,
+        )
+
+
+class ServiceQuotaExceededException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message: str = "") -> None:
+        super().__init__(
+            error_type="ServiceQuotaExceededException",
+            message=message,
         )

--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -191,7 +191,8 @@ class SSOAdminBackend(BaseBackend):
         This pulls from moto/iam/aws_managed_policies.py
         """
         policy_name = managed_policy_arn.split("/")[-1]
-        if managed_policy := self.aws_managed_policies.get(policy_name, None):
+        managed_policy = self.aws_managed_policies.get(policy_name, None)
+        if managed_policy is not None:
             path = managed_policy.get("path", "/")
             expected_arn = f"arn:aws:iam::aws:policy{path}{policy_name}"
             if managed_policy_arn == expected_arn:

--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -399,7 +399,7 @@ class SSOAdminBackend(BaseBackend):
 
     def _detach_managed_policy(
         self, instance_arn: str, permission_set_arn: str, managed_policy_arn: str
-    ):
+    ) -> None:
         # ensure permission_set exists
         permissionset = self._find_permission_set(
             instance_arn,

--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -190,7 +190,6 @@ class SSOAdminBackend(BaseBackend):
         Checks to make sure the managed policy exists.
         This pulls from moto/iam/aws_managed_policies.py
         """
-        # arn:aws:iam::aws:policy/SecurityAudit
         policy_name = managed_policy_arn.split("/")[-1]
         if managed_policy := self.aws_managed_policies.get(policy_name, None):
             path = managed_policy.get("path", "/")

--- a/moto/ssoadmin/responses.py
+++ b/moto/ssoadmin/responses.py
@@ -195,3 +195,52 @@ class SSOAdminResponse(BaseResponse):
             permission_set_arn=permission_set_arn,
         )
         return json.dumps({})
+
+    def attach_managed_policy_to_permission_set(self) -> str:
+        instance_arn = self._get_param("InstanceArn")
+        permission_set_arn = self._get_param("PermissionSetArn")
+        managed_policy_arn = self._get_param("ManagedPolicyArn")
+        self.ssoadmin_backend.attach_managed_policy_to_permission_set(
+            instance_arn=instance_arn,
+            permission_set_arn=permission_set_arn,
+            managed_policy_arn=managed_policy_arn,
+        )
+        return json.dumps({})
+
+    def list_managed_policies_in_permission_set(self) -> str:
+        instance_arn = self._get_param("InstanceArn")
+        permission_set_arn = self._get_param("PermissionSetArn")
+        max_results = self._get_int_param("MaxResults")
+        next_token = self._get_param("NextToken")
+
+        (
+            managed_policies,
+            next_token,
+        ) = self.ssoadmin_backend.list_managed_policies_in_permission_set(
+            instance_arn=instance_arn,
+            permission_set_arn=permission_set_arn,
+            max_results=max_results,
+            next_token=next_token,
+        )
+
+        managed_policies_response = [
+            {"Arn": managed_policy.arn, "Name": managed_policy.name}
+            for managed_policy in managed_policies
+        ]
+        return json.dumps(
+            {
+                "AttachedManagedPolicies": managed_policies_response,
+                "NextToken": next_token,
+            }
+        )
+
+    def detach_managed_policy_from_permission_set(self) -> str:
+        instance_arn = self._get_param("InstanceArn")
+        permission_set_arn = self._get_param("PermissionSetArn")
+        managed_policy_arn = self._get_param("ManagedPolicyArn")
+        self.ssoadmin_backend.detach_managed_policy_from_permission_set(
+            instance_arn=instance_arn,
+            permission_set_arn=permission_set_arn,
+            managed_policy_arn=managed_policy_arn,
+        )
+        return json.dumps({})

--- a/moto/ssoadmin/utils.py
+++ b/moto/ssoadmin/utils.py
@@ -30,4 +30,11 @@ PAGINATION_MODEL = {
             "PrincipalType",
         ],
     },
+    "list_managed_policies_in_permission_set": {
+        "input_token": "next_token",
+        "limit_key": "max_results",
+        "limit_default": 100,
+        "result_key": "AttachedManagedPolicies",
+        "unique_attribute": ["arn"],
+    },
 }


### PR DESCRIPTION
Added AWS Managed policy operations for sso-admin permissionsets.

The following API calls are implemented:

- [detach_managed_policy_from_permission_set](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sso-admin/client/detach_managed_policy_from_permission_set.html)
- [attach_managed_policy_to_permission_set](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sso-admin/client/attach_managed_policy_to_permission_set.html)
- [list_managed_policies_in_permission_set](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sso-admin/client/list_managed_policies_in_permission_set.html)

Added additional exception handling.

Also references the managed policies [here](https://github.com/getmoto/moto/blob/master/moto/iam/aws_managed_policies.py) for validation of a proper AWS Managed Policy existing.
