### PR TITLE
RDS DB snapshot none handling

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1145,9 +1145,13 @@ class DatabaseSnapshot(BaseModel):
               <AvailabilityZone>{{ database.availability_zone }}</AvailabilityZone>
               <VpcId>{{ database.db_subnet_group.vpc_id }}</VpcId>
               <InstanceCreateTime>{{ snapshot.created_at }}</InstanceCreateTime>
+              {% if database.master_username %}
               <MasterUsername>{{ database.master_username }}</MasterUsername>
+              {% endif %}
               <EngineVersion>{{ database.engine_version }}</EngineVersion>
+              {% if database.license_model %}
               <LicenseModel>{{ database.license_model }}</LicenseModel>
+              {% endif %}
               <SnapshotType>{{ snapshot.snapshot_type }}</SnapshotType>
               {% if database.iops %}
               <Iops>{{ database.iops }}</Iops>
@@ -1166,10 +1170,14 @@ class DatabaseSnapshot(BaseModel):
               </TagList>
               <TdeCredentialArn></TdeCredentialArn>
               <Encrypted>{{ database.storage_encrypted }}</Encrypted>
+              {% if database.kms_key_id %}
               <KmsKeyId>{{ database.kms_key_id }}</KmsKeyId>
+              {% endif %}
               <DBSnapshotArn>{{ snapshot.snapshot_arn }}</DBSnapshotArn>
               <Timezone></Timezone>
+              {% if database.enable_iam_database_authentication %}
               <IAMDatabaseAuthenticationEnabled>{{ database.enable_iam_database_authentication|lower }}</IAMDatabaseAuthenticationEnabled>
+              {% endif %}
             </DBSnapshot>"""
         )
         return template.render(snapshot=self, database=self.database)


### PR DESCRIPTION
When trying to execute the action `CreateDBSnapshot` a deserialization error occurs. When looking at the response from Moto it became clear what the problem was:
If the value used in the template was none / nil / null it occurs in the response XML as "None" which is not valid, if a boolean value is expected. 
The proposed solution removes the values from the XML if they are none. It works with the Golang SDK. 