### PR TITLE
Feature: Allow requests to passthrough to AWS

### DIFF
--- a/docs/docs/configuration/index.rst
+++ b/docs/docs/configuration/index.rst
@@ -12,8 +12,23 @@ If you are using the decorators, some options are configurable within the decora
 
     @mock_aws(config={
         "batch": {"use_docker": True},
-        "lambda": {"use_docker": True}
+        "lambda": {"use_docker": True},
+        "core": {
+            "mock_credentials": True,
+            "passthrough": {
+                "urls": ["s3.amazonaws.com/bucket*"],
+                "services": ["dynamodb"]
+            }
+        }
     })
+
+By default, Batch and AWSLambda will spin up a Docker image to execute the provided scripts and functions.
+
+If you configure `use_docker: False` for either of these services, the scripts and functions will not be executed, and Moto will assume a successful invocation.
+
+Configure `mock_credentials: False` and `passthrough` if you want to only mock some services, but allow other requests to connect to AWS.
+
+You can either passthrough all requests to a specific service, or all URL's that match a specific pattern.
 
 
 .. toctree::

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -1,6 +1,7 @@
-from typing import TYPE_CHECKING, Callable, Dict, Optional, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, overload
 
 from moto import settings
+from moto.core.config import DefaultConfig
 from moto.core.models import MockAWS, ProxyModeMockAWS, ServerModeMockAWS
 
 if TYPE_CHECKING:
@@ -17,15 +18,13 @@ def mock_aws(func: "Callable[P, T]") -> "Callable[P, T]":
 
 
 @overload
-def mock_aws(
-    func: None = None, config: Optional[Dict[str, Dict[str, bool]]] = None
-) -> "MockAWS":
+def mock_aws(func: None = None, config: Optional[DefaultConfig] = None) -> "MockAWS":
     ...
 
 
 def mock_aws(
     func: "Optional[Callable[P, T]]" = None,
-    config: Optional[Dict[str, Dict[str, bool]]] = None,
+    config: Optional[DefaultConfig] = None,
 ) -> Union["MockAWS", "Callable[P, T]"]:
     clss = (
         ServerModeMockAWS

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -1,6 +1,6 @@
 import importlib
 import os
-from typing import TYPE_CHECKING, Iterable, Union, overload
+from typing import TYPE_CHECKING, Iterable, Optional, Union, overload
 
 import moto
 
@@ -153,6 +153,15 @@ def list_of_moto_modules() -> Iterable[str]:
         valid_folder = not backend.startswith("__")
         if is_dir and valid_folder:
             yield backend
+
+
+def get_service_from_url(url: str) -> Optional[str]:
+    from moto.backend_index import backend_url_patterns
+
+    for service, pattern in backend_url_patterns:
+        if pattern.match(url):
+            return service
+    return None
 
 
 # There's a similar Union that we could import from boto3-stubs, but it wouldn't have

--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -9,6 +9,7 @@ import moto.backend_index as backend_index
 from moto import settings
 from moto.core.base_backend import BackendDict
 from moto.core.common_types import TYPE_RESPONSE
+from moto.core.config import passthrough_service, passthrough_url
 
 
 class MockRawResponse(BytesIO):
@@ -70,8 +71,14 @@ class BotocoreStubber:
 
         clean_url = f"{x.scheme}://{host}{x.path}"
 
+        if passthrough_url(clean_url):
+            return None
+
         for service, pattern in backend_index.backend_url_patterns:
             if pattern.match(clean_url):
+
+                if passthrough_service(service):
+                    return None
 
                 import moto.backends as backends
                 from moto.core import DEFAULT_ACCOUNT_ID

--- a/moto/core/config.py
+++ b/moto/core/config.py
@@ -1,0 +1,49 @@
+import re
+from typing import List, TypedDict
+
+
+class _docker_config(TypedDict, total=False):
+    use_docker: bool
+
+
+class _passthrough_config(TypedDict, total=False):
+    services: List[str]
+    urls: List[str]
+
+
+class _core_config(TypedDict, total=False):
+    mock_credentials: bool
+    passthrough: _passthrough_config
+
+
+DefaultConfig = TypedDict(
+    "DefaultConfig",
+    {"batch": _docker_config, "core": _core_config, "lambda": _docker_config},
+    total=False,
+)
+
+default_user_config: DefaultConfig = {
+    "batch": {"use_docker": True},
+    "lambda": {"use_docker": True},
+    "core": {"mock_credentials": True, "passthrough": {"urls": [], "services": []}},
+}
+
+
+def passthrough_service(service: str) -> bool:
+    passthrough_services = (
+        default_user_config.get("core", {}).get("passthrough", {}).get("services", [])
+    )
+    return service in passthrough_services
+
+
+def passthrough_url(clean_url: str) -> bool:
+    passthrough_urls = (
+        default_user_config.get("core", {}).get("passthrough", {}).get("urls", [])
+    )
+    return any([re.match(url, clean_url) for url in passthrough_urls])
+
+
+def mock_credentials() -> bool:
+    return (
+        default_user_config.get("core", {}).get("mock_credentials", True) is not False
+    )

--- a/tests/test_core/test_backends.py
+++ b/tests/test_core/test_backends.py
@@ -1,0 +1,7 @@
+from moto.backends import get_service_from_url
+
+
+def test_get_service_from_url() -> None:
+    assert get_service_from_url("https://s3.amazonaws.com") == "s3"
+    assert get_service_from_url("https://bucket.s3.amazonaws.com") == "s3"
+    assert get_service_from_url("https://unknown.com") is None

--- a/tests/test_core/test_request_passthrough.py
+++ b/tests/test_core/test_request_passthrough.py
@@ -1,0 +1,147 @@
+import os
+from unittest import SkipTest
+from unittest.mock import patch
+
+import boto3
+import pytest
+import requests
+from botocore.exceptions import ClientError
+
+from moto import mock_aws, settings
+
+
+def test_passthrough_calls_for_entire_service() -> None:
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Can only test config when using decorators")
+    # Still mock the credentials ourselves, we don't want to reach out to AWS for real
+    with patch.dict(
+        os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
+    ):
+        list_buckets_url = "https://s3.amazonaws.com/"
+
+        # All requests to S3 are passed through
+        with mock_aws(
+            config={
+                "core": {"mock_credentials": False, "passthrough": {"services": ["s3"]}}
+            }
+        ):
+            s3 = boto3.client("s3", "us-east-1")
+            with pytest.raises(ClientError) as exc:
+                s3.list_buckets()
+            assert exc.value.response["Error"]["Code"] == "InvalidAccessKeyId"
+
+            resp = _aws_request(list_buckets_url)
+            assert resp.status_code == 403
+
+            # Calls to SQS are mocked normally
+            sqs = boto3.client("sqs", "us-east-1")
+            sqs.list_queues()
+
+        # Sanity check that the passthrough does not persist
+        with mock_aws():
+            s3 = boto3.client("s3", "us-east-1")
+            assert s3.list_buckets()["Buckets"] == []
+
+            resp = _aws_request(list_buckets_url)
+            assert resp.status_code == 200
+            assert b"<Buckets></Buckets>" in resp.content
+
+
+def test_passthrough_calls_for_specific_url() -> None:
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Can only test config when using decorators")
+    # Still mock the credentials ourselves, we don't want to reach out to AWS for real
+    with patch.dict(
+        os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
+    ):
+        list_buckets_url = "https://s3.amazonaws.com/"
+
+        # All requests to these URL's are passed through
+        with mock_aws(
+            config={
+                "core": {
+                    "mock_credentials": False,
+                    "passthrough": {"urls": ["https://realbucket.s3.amazonaws.com/"]},
+                }
+            }
+        ):
+            s3 = boto3.client("s3", "us-east-1")
+            with pytest.raises(ClientError) as exc:
+                s3.create_bucket(Bucket="realbucket")
+            assert exc.value.response["Error"]["Code"] == "InvalidAccessKeyId"
+
+            # List buckets works
+            assert _aws_request(list_buckets_url).status_code == 200
+            assert s3.list_buckets()["Buckets"] == []
+
+            # Creating different buckets works
+            s3.create_bucket(Bucket="diff")
+
+            # Manual requests are also not allowed
+            assert (
+                _aws_request("https://realbucket.s3.amazonaws.com/").status_code == 403
+            )
+
+
+def test_passthrough_calls_for_wildcard_urls() -> None:
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Can only test config when using decorators")
+    # Still mock the credentials ourselves, we don't want to reach out to AWS for real
+    with patch.dict(
+        os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
+    ):
+
+        # All requests to these URL's are passed through
+        with mock_aws(
+            config={
+                "core": {
+                    "mock_credentials": False,
+                    "passthrough": {
+                        "urls": [
+                            "https://companyname_*.s3.amazonaws.com/",
+                            "https://s3.amazonaws.com/companyname_*",
+                        ]
+                    },
+                }
+            }
+        ):
+            s3 = boto3.client("s3", "us-east-1")
+            with pytest.raises(ClientError) as exc:
+                s3.create_bucket(Bucket="companyname_prod")
+            assert exc.value.response["Error"]["Code"] == "InvalidAccessKeyId"
+
+            # Creating different buckets works
+            s3.create_bucket(Bucket="diffcompany_prod")
+
+            # Manual requests are also not allowed
+            assert (
+                _aws_request("https://s3.amazonaws.com/companyname_prod").status_code
+                == 403
+            )
+
+
+def test_passthrough__using_unsupported_service() -> None:
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Can only test config when using decorators")
+    with patch.dict(
+        os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
+    ):
+        # Requests to unsupported services still throw a NotYetImplemented
+        with mock_aws(
+            config={
+                "core": {
+                    "mock_credentials": False,
+                    "passthrough": {"services": ["s3"]},
+                }
+            }
+        ):
+            b2bi = boto3.client("b2bi", "us-east-1")
+            with pytest.raises(ClientError) as exc:
+                b2bi.list_transformers()
+            assert "Not yet implemented" in str(exc.value)
+
+
+def _aws_request(url: str) -> requests.Response:
+    creds = b"AWS4-HMAC-SHA256 Credential=a/20240107/us-east-1/s3/aws4_request, Signature=sig"
+    headers = {"Authorization": creds, "X-Amz-Content-SHA256": b"UNSIGNED-PAYLOAD"}
+    return requests.get(url, headers=headers)


### PR DESCRIPTION
User-facing changes:
 - Allow user to specify which services/urls should not be mocked
 - Add type suppport for the `config`-parameter of the `mock_aws`-decorator
 - Add documentation

Supporting changes:
 - Refactor the config-logic with some utility methods
 - Refactor the way credentials are mocked
 - Overrides the `responses.BaseResponse.match`-method to add a escape hatch for URL's that should not be intercepted by us