### PR TITLE
EC2: Add tag support for security group rules

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -4,7 +4,7 @@ import json
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import CloudFormationModel
+from moto.core import BaseModel, CloudFormationModel
 from moto.core.utils import aws_api_matches
 
 from ..exceptions import (
@@ -110,6 +110,18 @@ class SecurityRule(TaggedEC2Resource):
                 return False
 
         return True
+
+    def __deepcopy__(self, memodict: Dict[Any, Any]) -> BaseModel:
+        memodict = memodict or {}
+        cls = self.__class__
+        new = cls.__new__(cls)
+        memodict[id(self)] = new
+        for k, v in self.__dict__.items():
+            if k == "ec2_backend":
+                setattr(new, k, self.ec2_backend)
+            else:
+                setattr(new, k, copy.deepcopy(v, memodict))
+        return new
 
 
 class SecurityGroup(TaggedEC2Resource, CloudFormationModel):

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -32,7 +32,6 @@ class SecurityRule(TaggedEC2Resource):
     def __init__(
         self,
         ec2_backend: Any,
-        account_id: str,
         ip_protocol: str,
         from_port: Optional[str],
         to_port: Optional[str],
@@ -42,7 +41,6 @@ class SecurityRule(TaggedEC2Resource):
         is_egress: bool = True,
     ):
         self.ec2_backend = ec2_backend
-        self.account_id = account_id
         self.id = random_security_group_rule_id()
         self.ip_protocol = str(ip_protocol) if ip_protocol else None
         self.ip_ranges = ip_ranges or []
@@ -78,7 +76,7 @@ class SecurityRule(TaggedEC2Resource):
 
     @property
     def owner_id(self) -> str:
-        return self.account_id
+        return self.ec2_backend.account_id
 
     def __eq__(self, other: "SecurityRule") -> bool:  # type: ignore[override]
         if self.ip_protocol != other.ip_protocol:
@@ -145,7 +143,6 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
                 self.egress_rules.append(
                     SecurityRule(
                         self.ec2_backend,
-                        self.owner_id,
                         "-1",
                         None,
                         None,
@@ -157,7 +154,6 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
                 self.egress_rules.append(
                     SecurityRule(
                         self.ec2_backend,
-                        self.owner_id,
                         "-1",
                         None,
                         None,
@@ -686,7 +682,6 @@ class SecurityGroupBackend:
 
         security_rule = SecurityRule(
             self,
-            self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
             to_port,
@@ -757,7 +752,6 @@ class SecurityGroupBackend:
 
         security_rule = SecurityRule(
             self,
-            self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
             to_port,
@@ -853,7 +847,6 @@ class SecurityGroupBackend:
 
         security_rule = SecurityRule(
             self,
-            self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
             to_port,
@@ -938,7 +931,6 @@ class SecurityGroupBackend:
 
         security_rule = SecurityRule(
             self,
-            self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
             to_port,
@@ -1025,7 +1017,6 @@ class SecurityGroupBackend:
 
         security_rule = SecurityRule(
             self,
-            self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
             to_port,
@@ -1081,7 +1072,6 @@ class SecurityGroupBackend:
 
         security_rule = SecurityRule(
             self,
-            self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
             to_port,

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -28,9 +28,10 @@ from ..utils import (
 from .core import TaggedEC2Resource
 
 
-class SecurityRule:
+class SecurityRule(TaggedEC2Resource):
     def __init__(
         self,
+        ec2_backend: Any,
         account_id: str,
         ip_protocol: str,
         from_port: Optional[str],
@@ -40,6 +41,7 @@ class SecurityRule:
         prefix_list_ids: Optional[List[Dict[str, str]]] = None,
         is_egress: bool = True,
     ):
+        self.ec2_backend = ec2_backend
         self.account_id = account_id
         self.id = random_security_group_rule_id()
         self.ip_protocol = str(ip_protocol) if ip_protocol else None
@@ -142,13 +144,25 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
             if vpc:
                 self.egress_rules.append(
                     SecurityRule(
-                        self.owner_id, "-1", None, None, [{"CidrIp": "0.0.0.0/0"}], []
+                        self.ec2_backend,
+                        self.owner_id,
+                        "-1",
+                        None,
+                        None,
+                        [{"CidrIp": "0.0.0.0/0"}],
+                        [],
                     )
                 )
             if vpc and len(vpc.get_cidr_block_association_set(ipv6=True)) > 0:
                 self.egress_rules.append(
                     SecurityRule(
-                        self.owner_id, "-1", None, None, [{"CidrIpv6": "::/0"}], []
+                        self.ec2_backend,
+                        self.owner_id,
+                        "-1",
+                        None,
+                        None,
+                        [{"CidrIpv6": "::/0"}],
+                        [],
                     )
                 )
 
@@ -671,6 +685,7 @@ class SecurityGroupBackend:
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
         security_rule = SecurityRule(
+            self,
             self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
@@ -741,6 +756,7 @@ class SecurityGroupBackend:
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
         security_rule = SecurityRule(
+            self,
             self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
@@ -836,6 +852,7 @@ class SecurityGroupBackend:
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
         security_rule = SecurityRule(
+            self,
             self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
@@ -920,6 +937,7 @@ class SecurityGroupBackend:
                         ip_ranges.remove(item)
 
         security_rule = SecurityRule(
+            self,
             self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
@@ -1006,6 +1024,7 @@ class SecurityGroupBackend:
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
         security_rule = SecurityRule(
+            self,
             self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,
@@ -1061,6 +1080,7 @@ class SecurityGroupBackend:
         _source_groups = self._add_source_group(source_groups, vpc_id)
 
         security_rule = SecurityRule(
+            self,
             self.account_id,  # type: ignore[attr-defined]
             ip_protocol,
             from_port,

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -272,6 +272,14 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
                 <groupOwnerId>{{ rule.owner_id }}</groupOwnerId>
                 <isEgress>{{ 'true' if rule.is_egress else 'false' }}</isEgress>
                 <securityGroupRuleId>{{ rule.id }}</securityGroupRuleId>
+                <tagSet>
+                {% for tag in rule.get_tags() %}
+                    <item>
+                      <key>{{ tag.key }}</key>
+                      <value>{{ tag.value }}</value>
+                    </item>
+                {% endfor %}
+                </tagSet> 
             </item>
         {% endfor %}
     {% endfor %}


### PR DESCRIPTION
This PR adds tagging support for security group rules.

<https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html#working-with-security-group-rules>

See https://github.com/localstack/localstack/issues/8642