### PR TITLE
Techdebt: Hide private decorator-methods/attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Moto Changelog
 ==============
 
+5.0.0alpha2:
+------------
+
+    General:
+        * It is now possible to configure methods/services which should reach out to AWS.
+          @mock_aws(
+              config={"core": {"mock_credentials": False, "passthrough": {"urls": [], "services": []}}}
+          )
+        * All requests now return a RequestId
+
+    Miscellaneous:
+        * S3: list_objects() now returns a hashed ContinuationToken
+
 5.0.0alpha1:
 ------------
 

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -1,41 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, overload
-
-from moto import settings
-from moto.core.config import DefaultConfig
-from moto.core.models import MockAWS, ProxyModeMockAWS, ServerModeMockAWS
-
-if TYPE_CHECKING:
-    from typing_extensions import ParamSpec
-
-    P = ParamSpec("P")
-
-T = TypeVar("T")
-
-
-@overload
-def mock_aws(func: "Callable[P, T]") -> "Callable[P, T]":
-    ...
-
-
-@overload
-def mock_aws(func: None = None, config: Optional[DefaultConfig] = None) -> "MockAWS":
-    ...
-
-
-def mock_aws(
-    func: "Optional[Callable[P, T]]" = None,
-    config: Optional[DefaultConfig] = None,
-) -> Union["MockAWS", "Callable[P, T]"]:
-    clss = (
-        ServerModeMockAWS
-        if settings.TEST_SERVER_MODE
-        else (ProxyModeMockAWS if settings.test_proxy_mode() else MockAWS)
-    )
-    if func is not None:
-        return clss().__call__(func=func)
-    else:
-        return clss(config)
-
+from moto.core.decorator import mock_aws  # noqa  # pylint: disable=unused-import
 
 __title__ = "moto"
 __version__ = "4.2.14.dev"

--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -29,9 +29,6 @@ class BotocoreStubber:
     def __init__(self) -> None:
         self.enabled = False
 
-    def reset(self) -> None:
-        BackendDict.reset()
-
     def __call__(
         self, event_name: str, request: Any, **kwargs: Any
     ) -> Optional[AWSResponse]:

--- a/moto/core/decorator.py
+++ b/moto/core/decorator.py
@@ -1,0 +1,37 @@
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, Union, overload
+
+from moto import settings
+from moto.core.config import DefaultConfig
+from moto.core.models import MockAWS, ProxyModeMockAWS, ServerModeMockAWS
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+
+T = TypeVar("T")
+
+
+@overload
+def mock_aws(func: "Callable[P, T]") -> "Callable[P, T]":
+    ...
+
+
+@overload
+def mock_aws(func: None = None, config: Optional[DefaultConfig] = None) -> "MockAWS":
+    ...
+
+
+def mock_aws(
+    func: "Optional[Callable[P, T]]" = None,
+    config: Optional[DefaultConfig] = None,
+) -> Union["MockAWS", "Callable[P, T]"]:
+    clss = (
+        ServerModeMockAWS
+        if settings.TEST_SERVER_MODE
+        else (ProxyModeMockAWS if settings.test_proxy_mode() else MockAWS)
+    )
+    if func is not None:
+        return clss().__call__(func=func)
+    else:
+        return clss(config)

--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -1,6 +1,7 @@
 import boto3
 
-from moto import MockAWS, mock_aws
+from moto import mock_aws
+from moto.core.decorator import MockAWS
 
 
 @mock_aws


### PR DESCRIPTION
Prefixes all private methods/attributes with a `_`, to make it clear that users should not use them.

Only the following methods are now exposed:
 - reset()
 - start()
 - stop()

Also moves the actual decorator to `moto.core.decorator.py`, to keep the `__init__`-file clean of unnecessary imports/logic

Also removes the `botocorestubber.reset()`, as we were'nt resetting the `botocorestubber` anymore. We can now call the `BackendDict.reset`-method directly.