### PR TITLE
Admin: Update documentation generation requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-sphinx==4.2.0
-sphinx_rtd_theme==1.0.0
-readthedocs-sphinx-search==0.1.1
+sphinx
+sphinx_rtd_theme
+readthedocs-sphinx-search
 
 # Modules necessary to import individual classes and read the docstrings
 docker


### PR DESCRIPTION
There was some dependency conflict that stopped the doc builds, so our documentation was slightly outdated. This should be fixed now.