### PR TITLE
Techdebt: Verify minimum boto3-version, up minimum responses version

### DIFF
--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -13,8 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        botocore: ["--upgrade boto3 botocore", "boto3==1.11.0 botocore==1.14.0"]
         python-version: [ "3.11" ]
-        responses-version: ["0.13.0", "0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
+        responses-version: ["0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
         werkzeug-version: ["2.0.1", "2.1.1", "2.2.2"]
         openapi-spec-validator-version: ["0.5.0"]
 
@@ -38,6 +39,7 @@ jobs:
         pip install flask==${{ matrix.werkzeug-version }}
         pip install werkzeug==${{ matrix.werkzeug-version }}
         pip install openapi-spec-validator==${{ matrix.openapi-spec-validator-version }}
+        pip install ${{ matrix.botocore }}
 
     - name: Run tests
       run: |
@@ -65,6 +67,6 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-${{ matrix.responses-version }}-${{ matrix.werkzeug-version }}-${{ matrix.werkzeug-version }}-${{ matrix.openapi-spec-validator-version }}
+        name: test-${{ matrix.responses-version }}-${{ matrix.werkzeug-version }}-${{ matrix.werkzeug-version }}-${{ matrix.openapi-spec-validator-version }}-${{ matrix.botocore }}
         path: |
           serverlogs/*

--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -2,18 +2,3 @@ from moto.core.decorator import mock_aws  # noqa  # pylint: disable=unused-impor
 
 __title__ = "moto"
 __version__ = "4.2.14.dev"
-
-
-try:
-    # Need to monkey-patch botocore requests back to underlying urllib3 classes
-    from botocore.awsrequest import (  # type: ignore[attr-defined]
-        HTTPConnection,
-        HTTPConnectionPool,
-        HTTPSConnectionPool,
-        VerifiedHTTPSConnection,
-    )
-except ImportError:
-    pass
-else:
-    HTTPSConnectionPool.ConnectionCls = VerifiedHTTPSConnection
-    HTTPConnectionPool.ConnectionCls = HTTPConnection

--- a/moto/core/versions.py
+++ b/moto/core/versions.py
@@ -13,5 +13,9 @@ def is_responses_0_17_x() -> bool:
     return LooseVersion(RESPONSES_VERSION) >= LooseVersion("0.17.0")
 
 
+def is_werkzeug_2_0_x_or_older() -> bool:
+    return LooseVersion(WERKZEUG_VERSION) < LooseVersion("2.1.0")
+
+
 def is_werkzeug_2_3_x() -> bool:
     return LooseVersion(WERKZEUG_VERSION) >= LooseVersion("2.3.0")

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,13 +27,13 @@ project_urls =
 python_requires = >=3.8
 install_requires =
     boto3>=1.9.201
-    botocore>=1.13.46
+    botocore>=1.14.0
     cryptography>=3.3.1
     requests>=2.5
     xmltodict
     werkzeug>=0.5,!=2.2.0,!=2.2.1
     python-dateutil<3.0.0,>=2.1
-    responses>=0.13.0
+    responses>=0.15.0
     Jinja2>=2.10.1
 package_dir =
     moto = moto

--- a/tests/test_awslambda/test_lambda_function_urls.py
+++ b/tests/test_awslambda/test_lambda_function_urls.py
@@ -1,3 +1,5 @@
+import sys
+from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -5,15 +7,20 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from moto.utilities.distutils_version import LooseVersion
 
 from .utilities import get_role_name, get_test_zip_file1
 
 PYTHON_VERSION = "python3.11"
 
+boto3_version = sys.modules["botocore"].__version__
+
 
 @mock_aws
 @pytest.mark.parametrize("key", ["FunctionName", "FunctionArn"])
 def test_create_function_url_config(key):
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(
@@ -40,6 +47,8 @@ def test_create_function_url_config(key):
 
 @mock_aws
 def test_create_function_url_config_with_cors():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(
@@ -75,6 +84,8 @@ def test_create_function_url_config_with_cors():
 
 @mock_aws
 def test_update_function_url_config_with_cors():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(
@@ -108,6 +119,8 @@ def test_update_function_url_config_with_cors():
 @mock_aws
 @pytest.mark.parametrize("key", ["FunctionName", "FunctionArn"])
 def test_delete_function_url_config(key):
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     client = boto3.client("lambda", "us-east-2")
     function_name = str(uuid4())[0:6]
     fxn = client.create_function(

--- a/tests/test_awslambda/test_lambda_layers.py
+++ b/tests/test_awslambda/test_lambda_layers.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from unittest import SkipTest, mock
 from uuid import uuid4
 
@@ -9,11 +10,14 @@ from freezegun import freeze_time
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.utilities.distutils_version import LooseVersion
 
 from .utilities import get_role_name, get_test_zip_file1
 
 PYTHON_VERSION = "python3.11"
 _lambda_region = "us-west-2"
+
+boto3_version = sys.modules["botocore"].__version__
 
 
 @mock_aws
@@ -50,6 +54,8 @@ def test_publish_layer_with_unknown_s3_file():
 @mock_aws
 @freeze_time("2015-01-01 00:00:00")
 def test_get_lambda_layers():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(
@@ -152,6 +158,8 @@ def test_get_lambda_layers():
 
 @mock_aws
 def test_get_layer_version():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", _lambda_region)
     s3_conn.create_bucket(

--- a/tests/test_awslambda/test_lambda_policy.py
+++ b/tests/test_awslambda/test_lambda_policy.py
@@ -1,4 +1,6 @@
 import json
+import sys
+from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -7,11 +9,14 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.utilities.distutils_version import LooseVersion
 
 from .utilities import get_role_name, get_test_zip_file1, get_test_zip_file2
 
 PYTHON_VERSION = "python3.11"
 _lambda_region = "us-west-2"
+
+boto3_version = sys.modules["botocore"].__version__
 
 
 @pytest.mark.parametrize("key", ["FunctionName", "FunctionArn"])
@@ -51,6 +56,8 @@ def test_add_function_permission(key):
 
 @mock_aws
 def test_add_permission_with_principalorgid():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameters only available in newer versions")
     conn = boto3.client("lambda", _lambda_region)
     zip_content = get_test_zip_file1()
     function_name = str(uuid4())[0:6]

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -1,5 +1,7 @@
 import json
+import sys
 from typing import Any, Dict, Optional
+from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -9,6 +11,9 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.core import set_initial_no_auth_action_count
+from moto.utilities.distutils_version import LooseVersion
+
+boto3_version = sys.modules["botocore"].__version__
 
 
 @mock_aws
@@ -191,6 +196,8 @@ def test_invalid_client_token_id() -> None:
 @set_initial_no_auth_action_count(0)
 @mock_aws
 def test_auth_failure() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     client = boto3.client(
         "ec2",
         region_name="us-east-1",
@@ -230,6 +237,8 @@ def test_signature_does_not_match() -> None:
 @set_initial_no_auth_action_count(2)
 @mock_aws
 def test_auth_failure_with_valid_access_key_id() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     access_key = create_user_with_access_key()
     client = boto3.client(
         "ec2",
@@ -250,6 +259,8 @@ def test_auth_failure_with_valid_access_key_id() -> None:
 @set_initial_no_auth_action_count(2)
 @mock_aws
 def test_access_denied_with_no_policy() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     user_name = "test-user"
     access_key = create_user_with_access_key(user_name)
     client = boto3.client(
@@ -271,6 +282,8 @@ def test_access_denied_with_no_policy() -> None:
 @set_initial_no_auth_action_count(3)
 @mock_aws
 def test_access_denied_with_not_allowing_policy() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     user_name = "test-user"
     inline_policy_document = {
         "Version": "2012-10-17",
@@ -339,6 +352,8 @@ def test_access_denied_explicitly_on_specific_resource() -> None:
 @set_initial_no_auth_action_count(3)
 @mock_aws
 def test_access_denied_for_run_instances() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     # https://github.com/getmoto/moto/issues/2774
     # The run-instances method was broken between botocore versions 1.15.8 and 1.15.12
     # This was due to the inclusion of '"idempotencyToken":true' in the response, somehow altering the signature and breaking the authentication
@@ -372,6 +387,8 @@ def test_access_denied_for_run_instances() -> None:
 @set_initial_no_auth_action_count(3)
 @mock_aws
 def test_access_denied_with_denying_policy() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     user_name = "test-user"
     inline_policy_document = {
         "Version": "2012-10-17",
@@ -533,6 +550,8 @@ def test_s3_access_denied_with_denying_inline_group_policy() -> None:
 @set_initial_no_auth_action_count(10)
 @mock_aws
 def test_access_denied_with_many_irrelevant_policies() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     user_name = "test-user"
     inline_policy_document = {
         "Version": "2012-10-17",

--- a/tests/test_core/test_importorder.py
+++ b/tests/test_core/test_importorder.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, List
 from unittest import SkipTest
 
@@ -5,6 +6,9 @@ import boto3
 import pytest
 
 from moto import mock_aws, settings
+from moto.utilities.distutils_version import LooseVersion
+
+boto3_version = sys.modules["botocore"].__version__
 
 
 @pytest.fixture(scope="function", name="aws_credentials")
@@ -70,6 +74,8 @@ def test_mock_works_with_resource_created_outside(
 
 
 def test_patch_can_be_called_on_a_mocked_client() -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     # start S3 after the mock, ensuring that the client contains our event-handler
     m = mock_aws()
     m.start()
@@ -118,6 +124,8 @@ class ImportantBusinessLogic:
 def test_mock_works_when_replacing_client(
     aws_credentials: Any,  # pylint: disable=unused-argument
 ) -> None:
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Error handling is different in newer versions")
     logic = ImportantBusinessLogic()
 
     m = mock_aws()

--- a/tests/test_core/test_request_passthrough.py
+++ b/tests/test_core/test_request_passthrough.py
@@ -8,11 +8,16 @@ import requests
 from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
+from moto.core.versions import is_werkzeug_2_0_x_or_older
 
 
 def test_passthrough_calls_for_entire_service() -> None:
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("Can only test config when using decorators")
+    if is_werkzeug_2_0_x_or_older():
+        raise SkipTest(
+            "Bug in old werkzeug versions where headers with byte-values throw errors"
+        )
     # Still mock the credentials ourselves, we don't want to reach out to AWS for real
     with patch.dict(
         os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
@@ -50,6 +55,10 @@ def test_passthrough_calls_for_entire_service() -> None:
 def test_passthrough_calls_for_specific_url() -> None:
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("Can only test config when using decorators")
+    if is_werkzeug_2_0_x_or_older():
+        raise SkipTest(
+            "Bug in old werkzeug versions where headers with byte-values throw errors"
+        )
     # Still mock the credentials ourselves, we don't want to reach out to AWS for real
     with patch.dict(
         os.environ, {"AWS_ACCESS_KEY_ID": "a", "AWS_SECRET_ACCESS_KEY": "b"}
@@ -135,9 +144,9 @@ def test_passthrough__using_unsupported_service() -> None:
                 }
             }
         ):
-            b2bi = boto3.client("b2bi", "us-east-1")
+            workdocs = boto3.client("workdocs", "us-east-1")
             with pytest.raises(ClientError) as exc:
-                b2bi.list_transformers()
+                workdocs.describe_users()
             assert "Not yet implemented" in str(exc.value)
 
 

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -1,4 +1,6 @@
 import json
+import sys
+from unittest import SkipTest
 
 import boto3
 import pytest
@@ -7,6 +9,9 @@ from botocore.exceptions import ClientError
 import moto.iotdata.models
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.utilities.distutils_version import LooseVersion
+
+boto3_version = sys.modules["botocore"].__version__
 
 
 @mock_aws
@@ -94,6 +99,8 @@ def test_update():
 
 @mock_aws
 def test_create_named_shadows():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("Parameter only available in newer versions")
     iot_client = boto3.client("iot", region_name="ap-northeast-1")
     client = boto3.client("iot-data", region_name="ap-northeast-1")
     thing_name = "my-thing"


### PR DESCRIPTION
Officially verify that tests against an outdated version of boto3 still pass

Remove some old patching that should no longer be necessary for recent boto3 versions

Also skips a bunch of tests (~20) when running the old botocore version, because of parameters that are only available in newer versions