### PR TITLE
Techdebt: Remove old/deprecated code

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -10,7 +10,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509 import OID_COMMON_NAME, DNSName, NameOID
 
 from moto import settings
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 
 from .exceptions import (

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -9,7 +9,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509 import Certificate, NameOID, load_pem_x509_certificate
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/amp/models.py
+++ b/moto/amp/models.py
@@ -2,7 +2,8 @@
 
 from typing import Any, Callable, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -19,7 +19,8 @@ except ImportError:
 from openapi_spec_validator.validation.exceptions import OpenAPIValidationError
 
 from moto.apigateway.exceptions import MethodNotFoundException
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import path_url
 from moto.moto_api._internal import mock_random as random
 

--- a/moto/apigatewaymanagementapi/models.py
+++ b/moto/apigatewaymanagementapi/models.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import Any, Dict
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import unix_time
 
 

--- a/moto/apigatewayv2/models.py
+++ b/moto/apigatewayv2/models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import yaml
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/appconfig/models.py
+++ b/moto/appconfig/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 

--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -3,7 +3,8 @@ from collections import OrderedDict
 from enum import Enum, unique
 from typing import Dict, List, Optional, Tuple, Union
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.ecs import ecs_backends
 from moto.moto_api._internal import mock_random
 

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -3,7 +3,8 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -2,7 +2,8 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate
 

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -2,7 +2,8 @@ import itertools
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2 import ec2_backends
 from moto.ec2.exceptions import InvalidInstanceIdError
@@ -805,7 +806,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
             if self.launch_config
             else None
         )
-        reservation = self.autoscaling_backend.ec2_backend.add_instances(
+        reservation = self.autoscaling_backend.ec2_backend.run_instances(
             self.image_id,
             count_needed,
             self.user_data,

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -23,7 +23,8 @@ import requests.exceptions
 
 from moto import settings
 from moto.awslambda.policy import Policy
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.core.utils import iso_8601_datetime_with_nanoseconds, unix_time_millis, utcnow
 from moto.dynamodb import dynamodb_backends
@@ -149,7 +150,7 @@ class _DockerDataVolumeContext:
             try:
                 with zip2tar(self._lambda_func.code_bytes) as stream:
                     container.put_archive(settings.LAMBDA_DATA_DIR, stream)
-                if settings.test_proxy_mode():
+                if settings.is_test_proxy_mode():
                     ca_cert = load_resource_as_bytes(__name__, "../moto_proxy/ca.crt")
                     with file2tar(ca_cert, "ca.crt") as cert_stream:
                         container.put_archive(settings.LAMBDA_DATA_DIR, cert_stream)
@@ -968,7 +969,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             env_vars["MOTO_PORT"] = moto_port
             env_vars["MOTO_HTTP_ENDPOINT"] = f'{env_vars["MOTO_HOST"]}:{moto_port}'
 
-            if settings.test_proxy_mode():
+            if settings.is_test_proxy_mode():
                 env_vars["HTTPS_PROXY"] = env_vars["MOTO_HTTP_ENDPOINT"]
                 env_vars["AWS_CA_BUNDLE"] = "/var/task/ca.crt"
 

--- a/moto/awslambda_simple/models.py
+++ b/moto/awslambda_simple/models.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional, Union
 
-from ..awslambda.models import LambdaBackend
-from ..core import BackendDict
+from moto.awslambda.models import LambdaBackend
+from moto.core.base_backend import BackendDict
 
 
 class LambdaSimpleBackend(LambdaBackend):

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from moto.cognitoidp.models import CognitoIdpBackend
     from moto.comprehend.models import ComprehendBackend
     from moto.config.models import ConfigBackend
-    from moto.core import SERVICE_BACKEND, BackendDict
+    from moto.core.base_backend import SERVICE_BACKEND, BackendDict
     from moto.databrew.models import DataBrewBackend
     from moto.datapipeline.models import DataPipelineBackend
     from moto.datasync.models import DataSyncBackend

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import dateutil.parser
 
 from moto import settings
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time_millis
 from moto.ec2.exceptions import InvalidSubnetIdError
 from moto.ec2.models import EC2Backend, ec2_backends
@@ -1270,7 +1271,7 @@ class BatchBackend(BaseBackend):
             subnet_cycle = cycle(compute_resources["subnets"])
 
             for instance_type in needed_instance_types:
-                reservation = self.ec2_backend.add_instances(
+                reservation = self.ec2_backend.run_instances(
                     image_id="ami-03cf127a",  # Todo import AMIs
                     count=1,
                     user_data=None,

--- a/moto/batch_simple/models.py
+++ b/moto/batch_simple/models.py
@@ -3,13 +3,9 @@ from os import getenv
 from time import sleep
 from typing import Any, Dict, List, Optional, Tuple
 
-from ..batch.models import (
-    BatchBackend,
-    ClientException,
-    Job,
-    batch_backends,
-)
-from ..core import BackendDict
+from moto.batch.exceptions import ClientException
+from moto.batch.models import BatchBackend, Job, batch_backends
+from moto.core.base_backend import BackendDict
 
 
 class BatchSimpleBackend(BatchBackend):

--- a/moto/budgets/models.py
+++ b/moto/budgets/models.py
@@ -3,7 +3,8 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict, Iterable, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 
 from .exceptions import BudgetMissingLimit, DuplicateRecordException, NotFoundException

--- a/moto/ce/models.py
+++ b/moto/ce/models.py
@@ -3,7 +3,8 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/cloudformation/custom_model.py
+++ b/moto/cloudformation/custom_model.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from moto import settings
 from moto.awslambda import lambda_backends
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.moto_api._internal import mock_random
 
 

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -7,7 +7,8 @@ import yaml
 from yaml.parser import ParserError  # pylint:disable=c-extension-no-member
 from yaml.scanner import ScannerError  # pylint:disable=c-extension-no-member
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import (
     iso_8601_datetime_with_milliseconds,
     iso_8601_datetime_without_milliseconds,

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -35,7 +35,7 @@ from moto.cloudformation.custom_model import CustomModel
 from moto.cloudwatch import models as cw_models  # noqa  # pylint: disable=all
 
 # End ugly list of imports
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.datapipeline import models as data_models  # noqa  # pylint: disable=all
 from moto.dynamodb import models as ddb_models  # noqa  # pylint: disable=all
 from moto.ec2 import models as ec2_models

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -1,7 +1,8 @@
 import string
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -3,7 +3,8 @@ import time
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds, utcnow
 from moto.utilities.tagging_service import TaggingService
 

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Iterable, List, Optional, SupportsFloat, Tuple
 from dateutil import parser
 from dateutil.tz import tzutc
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudWatchMetricProvider
+from moto.core.base_backend import BaseBackend
+from moto.core.common_models import BackendDict, BaseModel, CloudWatchMetricProvider
 from moto.core.utils import (
     iso_8601_datetime_with_nanoseconds,
     iso_8601_datetime_without_milliseconds,

--- a/moto/codebuild/models.py
+++ b/moto/codebuild/models.py
@@ -4,7 +4,8 @@ from typing import Any, Dict, List, Optional
 
 from dateutil import parser
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random
 

--- a/moto/codecommit/models.py
+++ b/moto/codecommit/models.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random
 

--- a/moto/codepipeline/models.py
+++ b/moto/codepipeline/models.py
@@ -8,7 +8,8 @@ from moto.codepipeline.exceptions import (
     ResourceNotFoundException,
     TooManyTagsException,
 )
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.iam.exceptions import IAMNotFoundException
 from moto.iam.models import IAMBackend, iam_backends

--- a/moto/cognitoidentity/models.py
+++ b/moto/cognitoidentity/models.py
@@ -4,7 +4,8 @@ import re
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 
 from .exceptions import InvalidNameException, ResourceNotFoundError

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from jose import jws
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.paginator import paginate

--- a/moto/comprehend/models.py
+++ b/moto/comprehend/models.py
@@ -2,7 +2,8 @@
 
 from typing import Any, Dict, Iterable, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.utilities.tagging_service import TaggingService
 
 from .exceptions import (

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -48,8 +48,8 @@ from moto.config.exceptions import (
     TooManyTags,
     ValidationException,
 )
-from moto.core import BackendDict, BaseBackend, BaseModel
-from moto.core.common_models import ConfigQueryModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, ConfigQueryModel
 from moto.core.responses import AWSServiceSpec
 from moto.core.utils import utcnow
 from moto.iam.config import policy_config_query, role_config_query

--- a/moto/core/__init__.py
+++ b/moto/core/__init__.py
@@ -1,7 +1,4 @@
 from .models import DEFAULT_ACCOUNT_ID  # noqa
-from .base_backend import BaseBackend, BackendDict, SERVICE_BACKEND  # noqa
-from .common_models import BaseModel  # noqa
-from .common_models import CloudFormationModel, CloudWatchMetricProvider  # noqa
 from .models import patch_client, patch_resource  # noqa
 from .responses import ActionAuthenticatorMixin
 

--- a/moto/core/decorator.py
+++ b/moto/core/decorator.py
@@ -29,7 +29,7 @@ def mock_aws(
     clss = (
         ServerModeMockAWS
         if settings.TEST_SERVER_MODE
-        else (ProxyModeMockAWS if settings.test_proxy_mode() else MockAWS)
+        else (ProxyModeMockAWS if settings.is_test_proxy_mode() else MockAWS)
     )
     if func is not None:
         return clss().__call__(func=func)

--- a/moto/databrew/models.py
+++ b/moto/databrew/models.py
@@ -5,7 +5,8 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import camelcase_to_pascal, underscores_to_camelcase
 from moto.utilities.paginator import paginate
 

--- a/moto/datapipeline/models.py
+++ b/moto/datapipeline/models.py
@@ -2,7 +2,8 @@ import datetime
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import utcnow
 
 from .utils import get_random_pipeline_id, remove_capitalization_of_dict_keys

--- a/moto/datasync/models.py
+++ b/moto/datasync/models.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import InvalidRequestException
 

--- a/moto/dax/models.py
+++ b/moto/dax/models.py
@@ -1,7 +1,8 @@
 """DAXBackend class with methods for supported APIs."""
 from typing import Any, Dict, Iterable, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState

--- a/moto/dms/models.py
+++ b/moto/dms/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 
 from .exceptions import (

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -2,7 +2,8 @@
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.ds.exceptions import (
     ClientException,
     DirectoryLimitExceededException,

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -3,7 +3,7 @@ import re
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.exceptions import JsonRESTError
 from moto.core.utils import unix_time
 from moto.dynamodb.comparisons import get_expected, get_filter_expression

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Union
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from botocore.utils import merge_dicts
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.dynamodb.exceptions import (
     EmptyKeyAttributeException,
     IncorrectDataType,

--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -2,7 +2,7 @@ import copy
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
 
-from moto.core import BaseModel, CloudFormationModel
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time, unix_time_millis, utcnow
 from moto.dynamodb.comparisons import get_expected, get_filter_expression
 from moto.dynamodb.exceptions import (

--- a/moto/dynamodb_v20111205/models.py
+++ b/moto/dynamodb_v20111205/models.py
@@ -2,7 +2,8 @@ import json
 from collections import OrderedDict, defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 
 from .comparisons import get_comparison_func

--- a/moto/dynamodbstreams/models.py
+++ b/moto/dynamodbstreams/models.py
@@ -3,7 +3,8 @@ import json
 import os
 from typing import Any, Dict, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.dynamodb.models import DynamoDBBackend, dynamodb_backends
 from moto.dynamodb.models.table import StreamShard, Table
 from moto.dynamodb.models.utilities import DynamoJsonEncoder

--- a/moto/ebs/models.py
+++ b/moto/ebs/models.py
@@ -2,7 +2,8 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.ec2.models import EC2Backend, ec2_backends
 from moto.ec2.models.elastic_block_store import Snapshot

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 from ..exceptions import (
     EC2ClientError,

--- a/moto/ec2/models/core.py
+++ b/moto/ec2/models/core.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 
 from ..exceptions import FilterNotImplementedError
 

--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Iterable, List, Optional, Set
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.packages.boto.ec2.blockdevicemapping import BlockDeviceType
 
 from ..exceptions import (

--- a/moto/ec2/models/elastic_ip_addresses.py
+++ b/moto/ec2/models/elastic_ip_addresses.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import (
     FilterNotImplementedError,

--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import InvalidNetworkAttachmentIdError, InvalidNetworkInterfaceIdError
 from .core import TaggedEC2Resource

--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -158,7 +158,7 @@ class Fleet(TaggedEC2Resource):
     def create_on_demand_requests(self, weight_to_add: float) -> None:
         weight_map, added_weight = self.get_launch_spec_counts(weight_to_add)
         for launch_spec, count in weight_map.items():
-            reservation = self.ec2_backend.add_instances(
+            reservation = self.ec2_backend.run_instances(
                 image_id=launch_spec.image_id,
                 count=count,
                 instance_type=launch_spec.instance_type,

--- a/moto/ec2/models/flow_logs.py
+++ b/moto/ec2/models/flow_logs.py
@@ -1,7 +1,7 @@
 import itertools
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import (
     FlowLogAlreadyExists,

--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.ec2.models.instances import Instance
 from moto.iam.models import InstanceProfile
 

--- a/moto/ec2/models/internet_gateways.py
+++ b/moto/ec2/models/internet_gateways.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import (
     DependencyViolationError,

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import (
     InvalidLaunchTemplateNameAlreadyExistsError,

--- a/moto/ec2/models/nat_gateways.py
+++ b/moto/ec2/models/nat_gateways.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 
 from ..utils import random_nat_gateway_id, random_private_ip

--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -1,7 +1,7 @@
 import ipaddress
 from typing import Any, Dict, List, Optional, Set
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.ec2.models.carrier_gateways import CarrierGateway
 from moto.ec2.models.elastic_network_interfaces import NetworkInterface
 from moto.ec2.models.instances import Instance

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -4,7 +4,7 @@ import json
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.core.utils import aws_api_matches
 
 from ..exceptions import (

--- a/moto/ec2/models/spot_requests.py
+++ b/moto/ec2/models/spot_requests.py
@@ -125,7 +125,7 @@ class SpotInstanceRequest(TaggedEC2Resource):
             return super().get_filter_value(filter_name, "DescribeSpotInstanceRequests")
 
     def launch_instance(self) -> "Instance":
-        reservation = self.ec2_backend.add_instances(
+        reservation = self.ec2_backend.run_instances(
             image_id=self.launch_specification.image_id,
             count=1,
             user_data=self.user_data,

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -3,7 +3,7 @@ import itertools
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 if TYPE_CHECKING:
     from moto.ec2.models.instances import Instance

--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.utilities.utils import filter_resources, merge_multiple_dicts
 

--- a/moto/ec2/models/vpc_peering_connections.py
+++ b/moto/ec2/models/vpc_peering_connections.py
@@ -2,7 +2,7 @@ import weakref
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import (
     InvalidVPCPeeringConnectionIdError,

--- a/moto/ec2/models/vpc_service_configuration.py
+++ b/moto/ec2/models/vpc_service_configuration.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 from moto.moto_api._internal import mock_random
 
 from ..exceptions import UnknownVpcEndpointService

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from operator import itemgetter
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import (
     CidrLimitExceeded,

--- a/moto/ec2/models/vpn_gateway.py
+++ b/moto/ec2/models/vpn_gateway.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import CloudFormationModel
+from moto.core.common_models import CloudFormationModel
 
 from ..exceptions import InvalidVpnGatewayAttachmentError, InvalidVpnGatewayIdError
 from ..utils import generic_filter, random_vpn_gateway_id

--- a/moto/ec2/models/windows.py
+++ b/moto/ec2/models/windows.py
@@ -1,4 +1,4 @@
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random as random
 
 

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -103,7 +103,7 @@ class InstanceResponse(EC2BaseResponse):
         iam_instance_profile_name = kwargs.get("iam_instance_profile_name")
         iam_instance_profile_arn = kwargs.get("iam_instance_profile_arn")
         if iam_instance_profile_arn or iam_instance_profile_name:
-            # Validate the profile exists, before we error_on_dryrun and add_instances
+            # Validate the profile exists, before we error_on_dryrun and run_instances
             filter_iam_instance_profiles(
                 self.current_account,
                 iam_instance_profile_arn=iam_instance_profile_arn,
@@ -112,7 +112,7 @@ class InstanceResponse(EC2BaseResponse):
 
         self.error_on_dryrun()
 
-        new_reservation = self.ec2_backend.add_instances(
+        new_reservation = self.ec2_backend.run_instances(
             image_id, min_count, user_data, security_group_names, **kwargs
         )
         if iam_instance_profile_name:

--- a/moto/ec2instanceconnect/models.py
+++ b/moto/ec2instanceconnect/models.py
@@ -1,6 +1,6 @@
 import json
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 
 class Ec2InstanceConnectBackend(BaseBackend):

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from botocore.exceptions import ParamValidationError
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds, utcnow
 from moto.ecr.exceptions import (
     ImageAlreadyExistsException,

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -5,7 +5,8 @@ from os import getenv
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from moto import settings
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError
 from moto.core.utils import pascal_to_camelcase, remap_nested_keys, unix_time
 from moto.ec2 import ec2_backends

--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -9,7 +9,8 @@ import time
 from copy import deepcopy
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import camelcase_to_underscores, underscores_to_camelcase
 from moto.ec2 import ec2_backends
 from moto.ec2.exceptions import InvalidSubnetIdError

--- a/moto/eks/models.py
+++ b/moto/eks/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.moto_api._internal import mock_random as random
 

--- a/moto/elasticache/models.py
+++ b/moto/elasticache/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 
 from ..moto_api._internal import mock_random

--- a/moto/elasticbeanstalk/models.py
+++ b/moto/elasticbeanstalk/models.py
@@ -1,7 +1,8 @@
 import weakref
 from typing import Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import (
     ApplicationNotFound,

--- a/moto/elastictranscoder/models.py
+++ b/moto/elastictranscoder/models.py
@@ -1,7 +1,8 @@
 import string
 from typing import Any, Dict, List, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random as random
 
 

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -2,7 +2,8 @@ import datetime
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.ec2.exceptions import InvalidInstanceIdError
 from moto.ec2.models import ec2_backends
 from moto.moto_api._internal import mock_random

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Iterable, List, Optional
 from botocore.exceptions import ParamValidationError
 from jinja2 import Template
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.ec2.models import ec2_backends

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -1,10 +1,10 @@
-import warnings
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from dateutil.parser import parse as dtparse
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.emr.exceptions import (
     InvalidRequestException,
     ResourceNotFoundException,
@@ -436,7 +436,7 @@ class ElasticMapReduceBackend(BaseBackend):
             result_groups.append(group)
         return result_groups
 
-    def add_instances(
+    def run_instances(
         self,
         cluster_id: str,
         instances: Dict[str, Any],
@@ -444,7 +444,7 @@ class ElasticMapReduceBackend(BaseBackend):
     ) -> None:
         cluster = self.clusters[cluster_id]
         instances["is_instance_type_default"] = not instances.get("instance_type")
-        response = self.ec2_backend.add_instances(
+        response = self.ec2_backend.run_instances(
             EXAMPLE_AMI_ID, instances["instance_count"], "", [], **instances
         )
         for instance in response.instances:
@@ -648,13 +648,6 @@ class ElasticMapReduceBackend(BaseBackend):
         try:
             subnet = self.ec2_backend.get_subnet(ec2_subnet_id)
         except InvalidSubnetIdError:
-            warnings.warn(
-                f"Could not find Subnet with id: {ec2_subnet_id}\n"
-                "In the near future, this will raise an error.\n"
-                "Use ec2.describe_subnets() to find a suitable id "
-                "for your test.",
-                PendingDeprecationWarning,
-            )
             return default_return_value
 
         manager = EmrSecurityGroupManager(self.ec2_backend, subnet.vpc_id)

--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -402,7 +402,7 @@ class ElasticMapReduceResponse(BaseResponse):
                 cluster.id, instance_groups
             )
             for i in range(0, len(instance_group_result)):
-                self.backend.add_instances(
+                self.backend.run_instances(
                     cluster.id, instance_groups[i], instance_group_result[i]
                 )
 

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -3,7 +3,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 
 from ..config.exceptions import ValidationException

--- a/moto/emrserverless/models.py
+++ b/moto/emrserverless/models.py
@@ -4,7 +4,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.emrcontainers.utils import get_partition, paginated_list
 

--- a/moto/es/models.py
+++ b/moto/es/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 from .exceptions import DomainNotFound

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -13,7 +13,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 
 from moto import settings
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError
 from moto.core.utils import (
     iso_8601_datetime_without_milliseconds,

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -22,7 +22,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.firehose.exceptions import (
     ConcurrentModificationException,

--- a/moto/forecast/models.py
+++ b/moto/forecast/models.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 
 from .exceptions import (

--- a/moto/glacier/models.py
+++ b/moto/glacier/models.py
@@ -2,7 +2,8 @@ import datetime
 import hashlib
 from typing import Any, Dict, List, Optional, Union
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.exceptions import JsonRESTError
 from moto.utilities.utils import md5_hash
 

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -5,7 +5,8 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState

--- a/moto/greengrass/models.py
+++ b/moto/greengrass/models.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.moto_api._internal import mock_random
 

--- a/moto/guardduty/models.py
+++ b/moto/guardduty/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 from .exceptions import DetectorNotFoundException, FilterNotFoundException

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -12,13 +12,9 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from jinja2 import Template
 
-from moto.core import (
-    DEFAULT_ACCOUNT_ID,
-    BackendDict,
-    BaseBackend,
-    BaseModel,
-    CloudFormationModel,
-)
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.core.utils import (
     iso_8601_datetime_with_milliseconds,

--- a/moto/identitystore/models.py
+++ b/moto/identitystore/models.py
@@ -1,9 +1,9 @@
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Tuple
 
 from botocore.exceptions import ParamValidationError
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BaseBackend
+from moto.core.models import BackendDict
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate
 
@@ -134,6 +134,9 @@ class IdentityStoreBackend(BaseBackend):
     def get_group_id(
         self, identity_store_id: str, alternate_identifier: Dict[str, Any]
     ) -> Tuple[str, str]:
+        """
+        The ExternalId alternate identifier is not yet implemented
+        """
         identity_store = self.__get_identity_store(identity_store_id)
         if "UniqueAttribute" in alternate_identifier:
             if (
@@ -147,8 +150,6 @@ class IdentityStoreBackend(BaseBackend):
                         == alternate_identifier["UniqueAttribute"]["AttributeValue"]
                     ):
                         return g.GroupId, identity_store_id
-        elif "ExternalId" in alternate_identifier:
-            warnings.warn("ExternalId has not been implemented.")
 
         raise ResourceNotFoundException(
             message="GROUP not found.", resource_type="GROUP"

--- a/moto/inspector2/models.py
+++ b/moto/inspector2/models.py
@@ -1,7 +1,8 @@
 import json
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/instance_metadata/models.py
+++ b/moto/instance_metadata/models.py
@@ -1,4 +1,4 @@
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 
 class InstanceMetadataBackend(BaseBackend):

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -11,7 +11,8 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.paginator import paginate

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -4,7 +4,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import jsondiff
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import merge_dicts
 from moto.iot.models import IoTBackend, iot_backends
 

--- a/moto/ivs/models.py
+++ b/moto/ivs/models.py
@@ -1,7 +1,7 @@
 """IVSBackend class with methods for supported APIs."""
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.ivs.exceptions import ResourceNotFoundException
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -9,7 +9,8 @@ from gzip import GzipFile
 from operator import attrgetter
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.paginator import paginate

--- a/moto/kinesisvideo/models.py
+++ b/moto/kinesisvideo/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random as random
 

--- a/moto/kinesisvideoarchivedmedia/models.py
+++ b/moto/kinesisvideoarchivedmedia/models.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.kinesisvideo.models import KinesisVideoBackend, kinesisvideo_backends
 from moto.sts.utils import random_session_token
 

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -5,7 +5,8 @@ from copy import copy
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
@@ -650,6 +651,7 @@ class KmsBackend(BaseBackend):
         Verify message using public key from generated private key.
 
         - grant_tokens are not implemented
+        - The MessageType-parameter DIGEST is not yet implemented
         """
         key = self.describe_key(key_id)
 

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -2,7 +2,6 @@ import base64
 import json
 import os
 import re
-import warnings
 from typing import Any, Dict
 
 from moto.core.responses import BaseResponse
@@ -621,19 +620,12 @@ class KmsResponse(BaseResponse):
         return json.dumps({"Plaintext": response_entropy})
 
     def sign(self) -> str:
-        """https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html"""
         key_id = self._get_param("KeyId")
         message = self._get_param("Message")
         message_type = self._get_param("MessageType")
-        grant_tokens = self._get_param("GrantTokens")
         signing_algorithm = self._get_param("SigningAlgorithm")
 
         self._validate_key_id(key_id)
-
-        if grant_tokens:
-            warnings.warn(
-                "The GrantTokens-parameter is not yet implemented for client.sign()"
-            )
 
         if isinstance(message, str):
             message = message.encode("utf-8")
@@ -669,19 +661,8 @@ class KmsResponse(BaseResponse):
         message_type = self._get_param("MessageType")
         signature = self._get_param("Signature")
         signing_algorithm = self._get_param("SigningAlgorithm")
-        grant_tokens = self._get_param("GrantTokens")
 
         self._validate_key_id(key_id)
-
-        if grant_tokens:
-            warnings.warn(
-                "The GrantTokens-parameter is not yet implemented for client.verify()"
-            )
-
-        if message_type == "DIGEST":
-            warnings.warn(
-                "The MessageType-parameter DIGEST is not yet implemented for client.verify()"
-            )
 
         if not message_type:
             message_type = "RAW"

--- a/moto/lakeformation/models.py
+++ b/moto/lakeformation/models.py
@@ -2,7 +2,8 @@ from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.utilities.tagging_service import TaggingService
 
 from .exceptions import AlreadyExists, EntityNotFound, InvalidInput

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -2,7 +2,8 @@ from datetime import datetime, timedelta
 from gzip import compress as gzip_compress
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time_millis, utcnow
 from moto.logs.exceptions import (
     InvalidParameterException,

--- a/moto/managedblockchain/models.py
+++ b/moto/managedblockchain/models.py
@@ -2,7 +2,8 @@ import datetime
 import re
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 
 from .exceptions import (

--- a/moto/mediaconnect/models.py
+++ b/moto/mediaconnect/models.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.mediaconnect.exceptions import NotFoundException
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/medialive/models.py
+++ b/moto/medialive/models.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 

--- a/moto/mediapackage/models.py
+++ b/moto/mediapackage/models.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import ClientError
 

--- a/moto/mediastore/models.py
+++ b/moto/mediastore/models.py
@@ -2,7 +2,8 @@ from collections import OrderedDict
 from datetime import date
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import (
     ContainerNotFoundException,

--- a/moto/mediastoredata/models.py
+++ b/moto/mediastoredata/models.py
@@ -2,7 +2,8 @@ import hashlib
 from collections import OrderedDict
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import ClientError
 

--- a/moto/meteringmarketplace/models.py
+++ b/moto/meteringmarketplace/models.py
@@ -1,7 +1,8 @@
 import collections
 from typing import Any, Deque, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 

--- a/moto/moto_api/_internal/models.py
+++ b/moto/moto_api/_internal/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import DEFAULT_ACCOUNT_ID, BackendDict, BaseBackend
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.model_instances import reset_model_data
 
 

--- a/moto/moto_proxy/proxy3.py
+++ b/moto/moto_proxy/proxy3.py
@@ -11,7 +11,8 @@ from botocore.awsrequest import AWSPreparedRequest
 
 from moto.backend_index import backend_url_patterns
 from moto.backends import get_backend
-from moto.core import DEFAULT_ACCOUNT_ID, BackendDict
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.core.base_backend import BackendDict
 from moto.core.exceptions import RESTError
 
 from . import debug, error, info, with_color

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -17,7 +17,8 @@ except ImportError:
 
 import moto.backend_index as backend_index
 import moto.backends as backends
-from moto.core import DEFAULT_ACCOUNT_ID, BackendDict
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.core.base_backend import BackendDict
 from moto.core.utils import convert_to_flask_response
 
 from .utilities import AWSTestHelper, RegexConverter
@@ -56,24 +57,16 @@ class DomainDispatcherApplication:
     value. We'll match the host header value with the url_bases of each backend.
     """
 
-    def __init__(
-        self,
-        create_app: Callable[[backends.SERVICE_NAMES], Flask],
-        service: Optional[str] = None,
-    ):
+    def __init__(self, create_app: Callable[[backends.SERVICE_NAMES], Flask]):
         self.create_app = create_app
         self.lock = Lock()
         self.app_instances: Dict[str, Flask] = {}
-        self.service = service
         self.backend_url_patterns = backend_index.backend_url_patterns
 
     def get_backend_for_host(self, host: str) -> Any:
 
         if host == "moto_api":
             return host
-
-        if self.service:
-            return self.service
 
         if host in backends.list_of_moto_modules():
             return host

--- a/moto/mq/models.py
+++ b/moto/mq/models.py
@@ -3,7 +3,8 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import xmltodict
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/neptune/models.py
+++ b/moto/neptune/models.py
@@ -4,7 +4,8 @@ from typing import Any, Dict, List, Optional
 
 from jinja2 import Template
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.utils import load_resource

--- a/moto/opensearch/models.py
+++ b/moto/opensearch/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.utilities.tagging_service import TaggingService
 
 from .data import compatible_versions

--- a/moto/opsworks/models.py
+++ b/moto/opsworks/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.ec2 import ec2_backends
 from moto.moto_api._internal import mock_random as random
@@ -89,7 +90,7 @@ class OpsworkInstance(BaseModel):
         attributes
         """
         if self.instance is None:
-            reservation = self.ec2_backend.add_instances(
+            reservation = self.ec2_backend.run_instances(
                 image_id=self.ami_id,
                 count=1,
                 user_data="",

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -2,7 +2,8 @@ import json
 import re
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.exceptions import RESTError
 from moto.core.utils import unix_time, utcnow
 from moto.organizations import utils

--- a/moto/panorama/models.py
+++ b/moto/panorama/models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from dateutil.tz import tzutc
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.panorama.utils import deep_convert_datetime_to_isoformat, hash_device_name
 from moto.utilities.paginator import paginate

--- a/moto/personalize/models.py
+++ b/moto/personalize/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 
 from .exceptions import ResourceNotFoundException

--- a/moto/pinpoint/models.py
+++ b/moto/pinpoint/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/polly/models.py
+++ b/moto/polly/models.py
@@ -2,7 +2,8 @@ import datetime
 from typing import Any, Dict, List, Optional
 from xml.etree import ElementTree as ET
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .resources import VOICE_DATA
 from .utils import make_arn_for_lexicon

--- a/moto/quicksight/models.py
+++ b/moto/quicksight/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random as random
 
 from .exceptions import ResourceNotFoundException

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -2,7 +2,8 @@ import re
 import string
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random as random
 from moto.organizations.models import OrganizationsBackend, organizations_backends

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -8,7 +8,8 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Un
 
 from jinja2 import Template
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.ec2.models import ec2_backends
 from moto.moto_api._internal import mock_random as random

--- a/moto/rdsdata/models.py
+++ b/moto/rdsdata/models.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 
 class QueryResults:

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from dateutil.tz import tzutc
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.ec2 import ec2_backends
 from moto.ec2.models.security_groups import SecurityGroup as EC2SecurityGroup

--- a/moto/redshiftdata/models.py
+++ b/moto/redshiftdata/models.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.moto_api._internal import mock_random as random
 from moto.redshiftdata.exceptions import ResourceNotFoundException, ValidationException

--- a/moto/rekognition/models.py
+++ b/moto/rekognition/models.py
@@ -3,7 +3,7 @@
 import string
 from typing import Any, Dict, List, Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
 
 

--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -2,7 +2,8 @@ import json
 import re
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import BadRequestException
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from moto.acm.models import AWSCertificateManagerBackend, acm_backends
 from moto.awslambda.models import LambdaBackend, lambda_backends
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.exceptions import RESTError
 from moto.ec2 import ec2_backends
 from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends

--- a/moto/robomaker/models.py
+++ b/moto/robomaker/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 
 

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from jinja2 import Template
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.moto_api._internal import mock_random as random
 from moto.route53.exceptions import (
     DnsNameInvalidForZone,

--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -5,7 +5,8 @@ from datetime import datetime, timezone
 from ipaddress import IPv4Address, ip_address, ip_network
 from typing import Any, Dict, List, Optional, Set
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.ec2 import ec2_backends
 from moto.ec2.exceptions import InvalidSecurityGroupNotFoundError, InvalidSubnetIdError
 from moto.moto_api._internal import mock_random

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -15,9 +15,8 @@ from importlib import reload
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from moto.cloudwatch.models import MetricDatum
-from moto.core import (
-    BackendDict,
-    BaseBackend,
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import (
     BaseModel,
     CloudFormationModel,
     CloudWatchMetricProvider,

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -2,7 +2,8 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 from moto.s3.exceptions import (
     InvalidPublicAccessBlockConfiguration,

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 from dateutil.tz import tzutc
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.sagemaker import validators
 from moto.utilities.paginator import paginate
 

--- a/moto/sagemakerruntime/models.py
+++ b/moto/sagemakerruntime/models.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Tuple
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 
 class SageMakerRuntimeBackend(BaseBackend):

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -1,7 +1,8 @@
 """EventBridgeSchedulerBackend class with methods for supported APIs."""
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.utilities.tagging_service import TaggingService
 

--- a/moto/sdb/models.py
+++ b/moto/sdb/models.py
@@ -4,7 +4,8 @@ from collections import defaultdict
 from threading import Lock
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 
 from .exceptions import InvalidDomainName, UnknownDomainName
 

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -3,7 +3,8 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcfromtimestamp, utcnow
 from moto.moto_api._internal import mock_random
 

--- a/moto/server.py
+++ b/moto/server.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import signal
 import sys
-import warnings
 from typing import Any, List, Optional
 
 from werkzeug.serving import run_simple
@@ -25,13 +24,6 @@ def main(argv: Optional[List[str]] = None) -> None:
     argv = argv or sys.argv[1:]
     parser = argparse.ArgumentParser()
 
-    # Keep this for backwards compat
-    parser.add_argument(
-        "service",
-        type=str,
-        nargs="?",  # http://stackoverflow.com/a/4480202/731592
-        default=os.environ.get("MOTO_SERVICE"),
-    )
     parser.add_argument(
         "-H", "--host", type=str, help="Which host to bind", default="127.0.0.1"
     )
@@ -74,13 +66,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     except Exception:
         pass  # ignore "ValueError: signal only works in main thread"
 
-    if args.service:
-        warnings.warn(
-            f"The service-argument ({args.service}) is considered deprecated, and will be deprecated in a future release. Please let us know if you have any questions: https://github.com/getmoto/moto/issues"
-        )
-
     # Wrap the main application
-    main_app = DomainDispatcherApplication(create_backend_app, service=args.service)
+    main_app = DomainDispatcherApplication(create_backend_app)
     main_app.debug = True  # type: ignore
 
     ssl_context: Any = None

--- a/moto/servicediscovery/models.py
+++ b/moto/servicediscovery/models.py
@@ -1,7 +1,8 @@
 import string
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/servicequotas/models.py
+++ b/moto/servicequotas/models.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 from .exceptions import NoSuchResource
 from .resources.default_quotas.vpc import VPC_DEFAULT_QUOTAS

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -7,7 +7,8 @@ from email.mime.multipart import MIMEMultipart
 from email.utils import formataddr, getaddresses, parseaddr
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.sns.models import sns_backends
 

--- a/moto/sesv2/models.py
+++ b/moto/sesv2/models.py
@@ -2,7 +2,8 @@
 
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 
 from ..ses.models import Message, RawMessage, ses_backends

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -5,12 +5,12 @@ from functools import lru_cache
 from typing import List, Optional
 
 
-def test_proxy_mode() -> bool:
+def is_test_proxy_mode() -> bool:
     return os.environ.get("TEST_PROXY_MODE", "0").lower() == "true"
 
 
 TEST_SERVER_MODE = os.environ.get("TEST_SERVER_MODE", "0").lower() == "true"
-TEST_DECORATOR_MODE = not TEST_SERVER_MODE and not test_proxy_mode()
+TEST_DECORATOR_MODE = not TEST_SERVER_MODE and not is_test_proxy_mode()
 
 INITIAL_NO_AUTH_ACTION_COUNT = float(
     os.environ.get("INITIAL_NO_AUTH_ACTION_COUNT", float("inf"))

--- a/moto/signer/models.py
+++ b/moto/signer/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import requests
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import (
     camelcase_to_underscores,
     iso_8601_datetime_with_milliseconds,

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import ParseResult
 from xml.sax.saxutils import escape
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.core.utils import (
     camelcase_to_underscores,

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -9,7 +9,8 @@ from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Tuple
 
 import yaml
 
-from moto.core import BackendDict, BaseBackend, BaseModel, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import RESTError
 from moto.core.utils import utcnow
 from moto.ec2 import ec2_backends

--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -1,7 +1,8 @@
 import json
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.iam.aws_managed_policies import aws_managed_policies_data
 from moto.moto_api._internal import mock_random as random

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -6,7 +6,8 @@ from typing import Any, Dict, Iterable, List, Optional, Pattern
 from dateutil.tz import tzlocal
 
 from moto import settings
-from moto.core import BackendDict, BaseBackend, CloudFormationModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate

--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import xmltodict
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.iam.models import AccessKey, iam_backends
 from moto.sts.utils import (

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.utils import load_resource

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -1,7 +1,7 @@
 from time import sleep
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend
+from moto.core.base_backend import BackendDict, BaseBackend
 
 from ..exceptions import (
     SWFDomainAlreadyExistsFault,

--- a/moto/swf/models/activity_task.py
+++ b/moto/swf/models/activity_task.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 

--- a/moto/swf/models/decision_task.py
+++ b/moto/swf/models/decision_task.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 

--- a/moto/swf/models/domain.py
+++ b/moto/swf/models/domain.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 
 from ..exceptions import (
     SWFUnknownResourceFault,

--- a/moto/swf/models/generic_type.py
+++ b/moto/swf/models/generic_type.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, TypeVar
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.core.utils import camelcase_to_underscores
 
 

--- a/moto/swf/models/history_event.py
+++ b/moto/swf/models/history_event.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Optional
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.core.utils import underscores_to_camelcase, unix_time
 
 from ..utils import decapitalize

--- a/moto/swf/models/timeout.py
+++ b/moto/swf/models/timeout.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 
 

--- a/moto/swf/models/timer.py
+++ b/moto/swf/models/timer.py
@@ -1,6 +1,6 @@
 from threading import Timer as ThreadingTimer
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 
 
 class Timer(BaseModel):

--- a/moto/swf/models/workflow_execution.py
+++ b/moto/swf/models/workflow_execution.py
@@ -2,7 +2,7 @@ from threading import Lock
 from threading import Timer as ThreadingTimer
 from typing import Any, Dict, Iterable, List, Optional
 
-from moto.core import BaseModel
+from moto.core.common_models import BaseModel
 from moto.core.utils import camelcase_to_underscores, unix_time
 from moto.moto_api._internal import mock_random
 

--- a/moto/textract/models.py
+++ b/moto/textract/models.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from typing import Any, Dict, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 from .exceptions import InvalidJobIdException, InvalidParameterException

--- a/moto/timestreamwrite/models.py
+++ b/moto/timestreamwrite/models.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable, List
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
 from moto.utilities.tagging_service import TaggingService
 

--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -2,7 +2,8 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -2,7 +2,8 @@ import re
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService

--- a/moto/xray/models.py
+++ b/moto/xray/models.py
@@ -4,7 +4,8 @@ import json
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
 
-from moto.core import BackendDict, BaseBackend, BaseModel
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
 from moto.core.exceptions import AWSError
 
 from .exceptions import BadSegmentException

--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -345,7 +345,7 @@ def test_invoke_function_large_response():
 
 @mock_aws
 def test_invoke_lambda_with_proxy():
-    if not settings.test_proxy_mode():
+    if not settings.is_test_proxy_mode():
         raise SkipTest("We only want to test this in ProxyMode")
 
     conn = boto3.resource("ec2", _lambda_region)

--- a/tests/test_core/test_backenddict.py
+++ b/tests/test_core/test_backenddict.py
@@ -6,8 +6,8 @@ from typing import Any, List, Optional
 import pytest
 
 from moto.autoscaling.models import AutoScalingBackend
-from moto.core import DEFAULT_ACCOUNT_ID, BackendDict, BaseBackend
-from moto.core.base_backend import AccountSpecificBackend
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.core.base_backend import AccountSpecificBackend, BackendDict, BaseBackend
 from moto.ec2.models import EC2Backend
 from moto.elbv2.models import ELBv2Backend
 

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -1,11 +1,11 @@
 from unittest.mock import Mock, patch
 
-from moto.server import DomainDispatcherApplication, create_backend_app, main
+from moto.server import main
 
 
 def test_wrong_arguments() -> None:
     try:
-        main(["name", "test1", "test2", "test3"])
+        main(["test1", "test2", "test3"])
         assert False, (
             "main() when called with the incorrect number of args"
             " should raise a system exit"
@@ -16,7 +16,7 @@ def test_wrong_arguments() -> None:
 
 @patch("moto.server.run_simple")
 def test_right_arguments(run_simple: Mock) -> None:  # type: ignore[misc]
-    main(["s3"])
+    main(["-r"])
     func_call = run_simple.call_args[0]
     assert func_call[0] == "127.0.0.1"
     assert func_call[1] == 5000
@@ -24,24 +24,7 @@ def test_right_arguments(run_simple: Mock) -> None:  # type: ignore[misc]
 
 @patch("moto.server.run_simple")
 def test_port_argument(run_simple: Mock) -> None:  # type: ignore[misc]
-    main(["s3", "--port", "8080"])
+    main(["--port", "8080"])
     func_call = run_simple.call_args[0]
     assert func_call[0] == "127.0.0.1"
     assert func_call[1] == 8080
-
-
-def test_domain_dispatched() -> None:
-    dispatcher = DomainDispatcherApplication(create_backend_app)
-    backend_app = dispatcher.get_application(
-        {"HTTP_HOST": "email.us-east1.amazonaws.com"}
-    )
-    keys = list(backend_app.view_functions.keys())
-    assert keys[0] == "EmailResponse.dispatch"
-
-
-def test_domain_dispatched_with_service() -> None:
-    # If we pass a particular service, always return that.
-    dispatcher = DomainDispatcherApplication(create_backend_app, service="s3")
-    backend_app = dispatcher.get_application({"HTTP_HOST": "s3.us-east1.amazonaws.com"})
-    keys = set(backend_app.view_functions.keys())
-    assert "moto.s3.responses.key_response" in keys

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2189,18 +2189,6 @@ def test_describe_instance_attribute():
 
 
 @mock_aws
-def test_warn_on_invalid_ami():
-    if settings.TEST_SERVER_MODE:
-        raise SkipTest("Can't capture warnings in server mode.")
-    ec2 = boto3.resource("ec2", "us-east-1")
-    with pytest.warns(
-        PendingDeprecationWarning,
-        match=r"Could not find AMI with image-id:invalid-ami.+",
-    ):
-        ec2.create_instances(ImageId="invalid-ami", MinCount=1, MaxCount=1)
-
-
-@mock_aws
 @mock.patch(
     "moto.ec2.models.instances.settings.ENABLE_AMI_VALIDATION",
     new_callable=mock.PropertyMock(return_value=True),

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -461,7 +461,7 @@ def test_bucket_name_with_special_chars(name):
 )
 @mock_aws
 def test_key_with_special_characters(key):
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         raise SkipTest("Keys starting with a / don't work well in ProxyMode")
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
@@ -778,7 +778,7 @@ def test_streaming_upload_from_file_to_presigned_url():
     )
     with open(__file__, "rb") as fhandle:
         get_kwargs = {"data": fhandle}
-        if settings.test_proxy_mode():
+        if settings.is_test_proxy_mode():
             add_proxy_details(get_kwargs)
         response = requests.get(presigned_url, **get_kwargs)
     assert response.status_code == 200
@@ -800,7 +800,7 @@ def test_upload_from_file_to_presigned_url():
     files = {"upload_file": open("text.txt", "rb")}
 
     put_kwargs = {"files": files}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(put_kwargs)
     requests.put(presigned_url, **put_kwargs)
     resp = s3_client.get_object(Bucket="mybucket", Key="file_upload")
@@ -2638,7 +2638,7 @@ def test_root_dir_with_empty_name_works():
 @mock_aws
 def test_leading_slashes_not_removed(bucket_name):
     """Make sure that leading slashes are not removed internally."""
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         raise SkipTest("Doesn't quite work right with the Proxy")
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket=bucket_name)
@@ -2827,7 +2827,7 @@ def test_creating_presigned_post():
         "files": {"file": fdata},
         "allow_redirects": False,
     }
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     resp = requests.post(data["url"], **kwargs)
     assert resp.status_code == 303
@@ -2859,7 +2859,7 @@ def test_presigned_put_url_with_approved_headers():
 
     # Verify S3 throws an error when the header is not provided
     kwargs = {"data": content}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     response = requests.put(url, **kwargs)
     assert response.status_code == 403
@@ -2871,7 +2871,7 @@ def test_presigned_put_url_with_approved_headers():
 
     # Verify S3 throws an error when the header has the wrong value
     kwargs = {"data": content, "headers": {"Content-Type": "application/unknown"}}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     response = requests.put(url, **kwargs)
     assert response.status_code == 403
@@ -2883,7 +2883,7 @@ def test_presigned_put_url_with_approved_headers():
 
     # Verify S3 uploads correctly when providing the meta data
     kwargs = {"data": content, "headers": {"Content-Type": expected_contenttype}}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     response = requests.put(url, **kwargs)
     assert response.status_code == 200
@@ -2916,7 +2916,7 @@ def test_presigned_put_url_with_custom_headers():
 
     # Verify S3 uploads correctly when providing the meta data
     kwargs = {"data": content}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     response = requests.put(url, **kwargs)
     assert response.status_code == 200

--- a/tests/test_s3/test_s3_acl.py
+++ b/tests/test_s3/test_s3_acl.py
@@ -119,7 +119,7 @@ def test_s3_object_in_public_bucket_using_multiple_presigned_urls():
         "get_object", params, ExpiresIn=900
     )
     kwargs = {}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     for i in range(1, 10):
         response = requests.get(presigned_url, **kwargs)
@@ -269,7 +269,7 @@ def test_object_acl_with_presigned_post():
 
     with open(object_name, "rb") as fhandle:
         kwargs = {"files": {"file": (object_name, fhandle)}}
-        if settings.test_proxy_mode():
+        if settings.is_test_proxy_mode():
             add_proxy_details(kwargs)
         requests.post(response["url"], data=response["fields"], **kwargs)
 

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -15,7 +15,7 @@ from moto.s3.responses import DEFAULT_REGION_NAME
 from moto.settings import (
     S3_UPLOAD_PART_MIN_SIZE,
     get_s3_default_key_buffer_size,
-    test_proxy_mode,
+    is_test_proxy_mode,
 )
 from tests import DEFAULT_ACCOUNT_ID
 
@@ -986,7 +986,7 @@ def test_generate_presigned_url_on_multipart_upload_without_acl():
         "head_object", Params={"Bucket": bucket_name, "Key": object_key}
     )
     kwargs = {}
-    if test_proxy_mode():
+    if is_test_proxy_mode():
         add_proxy_details(kwargs)
     res = requests.get(url, **kwargs)
     assert res.status_code == 200

--- a/tests/test_s3/test_s3_tagging.py
+++ b/tests/test_s3/test_s3_tagging.py
@@ -476,7 +476,7 @@ def test_generate_url_for_tagged_object():
         "get_object", Params={"Bucket": "my-bucket", "Key": "test.txt"}
     )
     kwargs = {}
-    if settings.test_proxy_mode():
+    if settings.is_test_proxy_mode():
         add_proxy_details(kwargs)
     response = requests.get(url, **kwargs)
     assert response.content == b"abc"


### PR DESCRIPTION
Remove warning when describing an unknown EC2 image. The warning has been there for ages, and I've never heard of someone needing this validation, so I'm just removing it for now. If necessary, we can make the exception opt-in (allow it by default, but throw the correct exception of the user explicitly configures it) (The warning was introduced in https://github.com/getmoto/moto/pull/1331, for context.)

Remove `moto_server service` argument - we can just run `moto_server` for all services, no need to run a separate server per service anymore

Remove warnings from KMS/Events - info about what params are implemented should just be part of the documentation

Rename EC2 `add_instances` to `run_instances` to make it more obvious which action we're talking about

Removes imports from `moto.core`, as they shouldn't necessarily be exposed to end-users