### PR TITLE
Fix more test failures on platforms with 32-bit time_t

### DIFF
--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -92,7 +92,10 @@ def test_list_certificates():
     issued_arn = _import_cert(client)
     pending_arn = client.request_certificate(DomainName="google.com")["CertificateArn"]
 
-    certs = client.list_certificates()["CertificateSummaryList"]
+    try:
+        certs = client.list_certificates()["CertificateSummaryList"]
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
     assert issued_arn in [c["CertificateArn"] for c in certs]
     assert pending_arn in [c["CertificateArn"] for c in certs]
     for cert in certs:

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -515,7 +515,10 @@ def test_list_pipelines_created_after(sagemaker_client):
     _ = create_sagemaker_pipelines(sagemaker_client, pipelines)
 
     created_after_str = "2099-12-31 23:59:59"
-    response = sagemaker_client.list_pipelines(CreatedAfter=created_after_str)
+    try:
+        response = sagemaker_client.list_pipelines(CreatedAfter=created_after_str)
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
     assert not response["PipelineSummaries"]
 
     created_after_datetime = datetime.strptime(created_after_str, "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Fix two more test failures that are caused by platform `time_t` not being able to represent dates beyond 2038.  This is the same approach as used in #4954.