### PR TITLE
MotoServer: skip using HTTP_HOST header when determining request origin

### DIFF
--- a/tests/test_dynamodb_v20111205/test_servermode.py
+++ b/tests/test_dynamodb_v20111205/test_servermode.py
@@ -18,7 +18,7 @@ def test_table_list():
         raise SkipTest("Only run test with external server")
     headers = {
         "X-Amz-Target": "DynamoDB_20111205.ListTables",
-        "Host": "dynamodb.us-east-1.amazonaws.com",
+        "AUTHORIZATION": "AWS4-HMAC-SHA256 Credential=ACCESS_KEY/20220226/us-east-1/dynamodb/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=sig",
     }
     requests.post(settings.test_server_mode_endpoint() + "/moto-api/reset")
     res = requests.get(settings.test_server_mode_endpoint(), headers=headers)


### PR DESCRIPTION
This was useful when running multiple MotoServer's, one for each service, but now that we use a single MotoServer to service all requests, this is no longer necessary.

With this change, MotoServer determines the intended target for an incoming request based on:
 - authorization header
 - path
 - action header
 - action-value in the body

In the following order:

 - Check if path points to an internal API (such as `/moto-api/reset`)
 - Check if path points to the EC2 metadata (`/latest/meta-data`)
 - If the request is authorized
   - Get service/region from authorization header
 - Else:
   - Check if the unsigned request comes from CognitoIDP (based on request body)
   - Check if the unsigned request comes from STS (based on request body)
    - Check if the request body contains a specific SDK version (used for SDB)
    - Check if the request is coming from Moto itself based on the path (special case for CloudFormation)

This PR also delays reading of the request-body so that this is only done when necessary, instead of for every request