### PR TITLE
ACM: DomainValidationOptions should be the same for validated certificates

### DIFF
--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -33,4 +33,9 @@ jobs:
         cd other_langs/terraform/${{ matrix.service }}
         terraform init
         terraform apply --auto-approve
+        echo "Verify nothing changes when ACM certificates are validated"
+        sleep 30
+        terraform plan -detailed-exitcode
+        sleep 30
+        terraform plan -detailed-exitcode
         terraform apply -destroy --auto-approve

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -343,24 +343,22 @@ class CertBundle(BaseModel):
         domain_names = set(sans + [self.common_name])
         validation_options = []
 
-        if self.status == "PENDING_VALIDATION":
-            for san in domain_names:
-                resource_record = {
-                    "Name": f"_d930b28be6c5927595552b219965053e.{san}.",
-                    "Type": "CNAME",
-                    "Value": "_c9edd76ee4a0e2a74388032f3861cc50.ykybfrwcxw.acm-validations.aws.",
+        for san in domain_names:
+            resource_record = {
+                "Name": f"_d930b28be6c5927595552b219965053e.{san}.",
+                "Type": "CNAME",
+                "Value": "_c9edd76ee4a0e2a74388032f3861cc50.ykybfrwcxw.acm-validations.aws.",
+            }
+            validation_options.append(
+                {
+                    "DomainName": san,
+                    "ValidationDomain": san,
+                    "ValidationStatus": self.status,
+                    "ValidationMethod": "DNS",
+                    "ResourceRecord": resource_record,
                 }
-                validation_options.append(
-                    {
-                        "DomainName": san,
-                        "ValidationDomain": san,
-                        "ValidationStatus": self.status,
-                        "ValidationMethod": "DNS",
-                        "ResourceRecord": resource_record,
-                    }
-                )
-        else:
-            validation_options = [{"DomainName": name} for name in domain_names]
+            )
+
         result["Certificate"]["DomainValidationOptions"] = validation_options
 
         if self.type == "IMPORTED":

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -208,6 +208,7 @@ class RecordSet(CloudFormationModel):
         self.alias_target = kwargs.get("AliasTarget", [])
         self.failover = kwargs.get("Failover", [])
         self.geo_location = kwargs.get("GeoLocation", [])
+        self.multi_value = kwargs.get("MultiValueAnswer")
 
     @staticmethod
     def cloudformation_name_type() -> str:

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -562,6 +562,9 @@ LIST_RRSET_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
            {% if record.failover %}
                <Failover>{{ record.failover }}</Failover>
            {% endif %}
+           {% if record.multi_value %}
+               <MultiValueAnswer>{{ record.multi_value }}</MultiValueAnswer>
+           {% endif %}
            {% if record.geo_location %}
            <GeoLocation>
            {% for geo_key in ['ContinentCode','CountryCode','SubdivisionCode'] %}

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from time import sleep
 from unittest import SkipTest, mock
 
 import boto3
@@ -177,7 +178,6 @@ def test_describe_certificate():
     assert len(resp["Certificate"]["DomainValidationOptions"]) == 1
     validation_option = resp["Certificate"]["DomainValidationOptions"][0]
     assert validation_option["DomainName"] == SERVER_COMMON_NAME
-    assert "ValidationDomain" not in validation_option
 
 
 @mock_acm
@@ -385,7 +385,10 @@ def test_request_certificate():
 
 
 @mock_acm
+@mock.patch("moto.settings.ACM_VALIDATION_WAIT", 1)
 def test_request_certificate_with_optional_arguments():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Can only change setting in DecoratorMode")
     client = boto3.client("acm", region_name="eu-central-1")
 
     token = str(uuid.uuid4())
@@ -403,11 +406,20 @@ def test_request_certificate_with_optional_arguments():
     arn_1 = resp["CertificateArn"]
 
     cert = client.describe_certificate(CertificateArn=arn_1)["Certificate"]
+    assert cert["Status"] == "PENDING_VALIDATION"
     assert len(cert["SubjectAlternativeNames"]) == 3
-    assert len(cert["DomainValidationOptions"]) == 3
-    assert {option["DomainName"] for option in cert["DomainValidationOptions"]} == set(
+    validation_options = cert["DomainValidationOptions"].copy()
+    assert len(validation_options) == 3
+    assert {option["DomainName"] for option in validation_options} == set(
         cert["SubjectAlternativeNames"]
     )
+
+    # Verify SAN's are still the same, even after the Certificate is validated
+    sleep(2)
+    for opt in validation_options:
+        opt["ValidationStatus"] = "ISSUED"
+    cert = client.describe_certificate(CertificateArn=arn_1)["Certificate"]
+    assert cert["DomainValidationOptions"] == validation_options
 
     resp = client.list_tags_for_certificate(CertificateArn=arn_1)
     tags = {item["Key"]: item.get("Value", "__NONE__") for item in resp["Tags"]}

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -809,6 +809,7 @@ def test_change_resource_record_sets_crud_valid_with_special_xml_chars(
     assert cname_record_detail["ResourceRecords"] == [
         {"Value": "SomeInitialValue&NewValue"}
     ]
+    assert cname_record_detail.get("MultiValueAnswer") == multi_value_answer
 
     # Delete record.
     delete_payload = {


### PR DESCRIPTION
Followup to #7144 

Fixes #7228 

This PR also ensures that `route53.list_resource_record_sets()` now returns the `MultiValueAnswer`-attribute, to ensure TF behaves the same for subsequent requests