### PR TITLE
Refactoring: Adding typing for event message structure

### DIFF
--- a/moto/events/notifications.py
+++ b/moto/events/notifications.py
@@ -1,16 +1,18 @@
 import json
-from typing import Any, Dict
+from typing import Any
 
-_EVENT_S3_OBJECT_CREATED: Dict[str, Any] = {
+from .utils import EventMessageType
+
+_EVENT_S3_OBJECT_CREATED: EventMessageType = {
     "version": "0",
     "id": "17793124-05d4-b198-2fde-7ededc63b103",
     "detail-type": "Object Created",
     "source": "aws.s3",
     "account": "123456789012",
     "time": "2021-11-12T00:00:00Z",
-    "region": None,
+    "region": "us-west-2",
     "resources": [],
-    "detail": None,
+    "detail": {},
 }
 
 

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -1,3 +1,25 @@
+from typing import TYPE_CHECKING, Any, Dict, List, TypedDict, Union
+
+if TYPE_CHECKING:
+    from typing_extentions import Required
+
+
+# NOTE: Typing is based on the following document https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
+EventMessageType = TypedDict(
+    "EventMessageType",
+    {
+        "version": str,
+        "id": str,
+        "detail-type": Required[Union[str, List[str]]],
+        "source": Required[Union[str, List[str]]],
+        "account": str,
+        "time": str,
+        "region": str,
+        "resources": List[str],
+        "detail": "Required[Dict[str, Any]]",
+    },
+)
+
 PAGINATION_MODEL = {
     "list_rules": {
         "input_token": "next_token",

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING, List, TypedDict, Union
+from typing import TYPE_CHECKING, List, TypedDict
 
 if TYPE_CHECKING:
-    from typing_extentions import Any, Dict, Required
+    from typing_extentions import Any, Dict, Required, Union
 
 
 # NOTE: Typing is based on the following document https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
@@ -10,8 +10,8 @@ EventMessageType = TypedDict(
     {
         "version": str,
         "id": str,
-        "detail-type": Required[Union[str, List[str]]],
-        "source": Required[Union[str, List[str]]],
+        "detail-type": "Required[Union[str, List[str]]]",
+        "source": "Required[Union[str, List[str]]]",
         "account": str,
         "time": str,
         "region": str,

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -1,7 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, List, TypedDict, Union
+from typing import TYPE_CHECKING, List, TypedDict, Union
 
 if TYPE_CHECKING:
-    from typing_extentions import Required
+    from typing_extentions import Any, Dict, Required
 
 
 # NOTE: Typing is based on the following document https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html


### PR DESCRIPTION
Adding typing for the event message structure.
(supported only in moto v5. Check https://github.com/getmoto/moto/pull/7230)

Document: https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html