### PR TITLE
RDS instance restore to point in time - fix failing to copy DB subnet…

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1818,7 +1818,13 @@ class RDSBackend(BaseBackend):
         db_instance = self.describe_db_instances(
             db_instance_identifier=source_db_identifier
         )[0]
-        new_instance_props = copy.deepcopy(db_instance.__dict__)
+
+        # remove the db subnet group as it cannot be copied
+        # and is not used in the restored instance
+        source_dict = db_instance.__dict__
+        del source_dict["db_subnet_group"]
+
+        new_instance_props = copy.deepcopy(source_dict)
         if not db_instance.option_group_supplied:
             # If the option group is not supplied originally, the 'option_group_name' will receive a default value
             # Force this reconstruction, and prevent any validation on the default value


### PR DESCRIPTION
When restoring a RDS instance, where the source instance has a DB subnet group, Moto throws a 500 error. This is due to it not being able to deep copy DB subnet group. 
The attribute can be removed as the DB Subnet group (name) is part of the RestoreRDSInstanceToPointInTime endpoint. 