### PR TITLE
SageMaker: correct describe_model_package_group does not exist msg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ lint:
 
 format:
 	black moto/ tests/
+	ruff --fix moto/ tests/
 
 test-only:
 	rm -f .coverage

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -3330,8 +3330,14 @@ class SageMakerModelBackend(BaseBackend):
     ) -> ModelPackageGroup:
         model_package_group = self.model_package_groups.get(model_package_group_name)
         if model_package_group is None:
+            model_package_group_arn = arn_formatter(
+                region_name=self.region_name,
+                account_id=self.account_id,
+                _type="model-package-group",
+                _id=f"{model_package_group_name}",
+            )
             raise ValidationError(
-                f"Model package group {model_package_group_name} not found"
+                f"ModelPackageGroup {model_package_group_arn} does not exist."
             )
         return model_package_group
 


### PR DESCRIPTION
## Description

The message that boto3 raises when a `ValidationException` happens (the model package group does not exist) is actually:

```shell
❯ aws sagemaker describe-model-package-group --model-package-group-name hello

An error occurred (ValidationException) when calling the DescribeModelPackageGroup operation: ModelPackageGroup arn:aws:sagemaker:us-east-1:12345678910:model-package-group/hello does not exist.
```