### PR TITLE
Support Route53 create_hosted_zone raising ClientError ConflictingDomainExists

### DIFF
--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -12,6 +12,19 @@ class Route53ClientError(RESTError):
         super().__init__(*args, **kwargs)
 
 
+class ConflictingDomainExists(Route53ClientError):
+    """Domain already exists."""
+
+    code = 400
+
+    def __init__(self, domain_name: str, delegation_set_id: str) -> None:
+        message = (
+            f"Cannot create hosted zone with DelegationSetId DelegationSetId:{delegation_set_id} as the DNSName"
+            f"{domain_name} conflicts with existing ones sharing the delegation set"
+        )
+        super().__init__("ConflictingDomainExists", message)
+
+
 class InvalidInput(Route53ClientError):
     """Malformed ARN for the CloudWatch log group."""
 

--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions raised by the Route53 service."""
-from typing import Any
+from typing import Any, Optional
 
 from moto.core.exceptions import RESTError
 
@@ -17,7 +17,7 @@ class ConflictingDomainExists(Route53ClientError):
 
     code = 400
 
-    def __init__(self, domain_name: str, delegation_set_id: str) -> None:
+    def __init__(self, domain_name: str, delegation_set_id: Optional[str]) -> None:
         message = (
             f"Cannot create hosted zone with DelegationSetId DelegationSetId:{delegation_set_id} as the DNSName"
             f"{domain_name} conflicts with existing ones sharing the delegation set"

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -534,7 +534,7 @@ class Route53Backend(BaseBackend):
         self.delegation_sets: Dict[str, DelegationSet] = dict()
 
     def _has_prev_conflicting_domain(
-        self, name: str, delegation_set_id: str | None
+        self, name: str, delegation_set_id: Optional[str]
     ) -> bool:
         """Check if a conflicting domain exists in the backend"""
         if not delegation_set_id:


### PR DESCRIPTION
Project does not support Route53 create_hosted_zone raising ConflictingDomainExists if one attempts to create a hosted zone with the same name on the same delegation set.  According to the docs, this should raise a ClientError named ConflictingDomainExists.

Simple Reproduction

```
@mock_route53
def test():
    conn = boto3.client('route53')
    conn.create_hosted_zone(Name='test.com', CallerReference='1', DelegationSetId='1')
    conn.create_hosted_zone(Name='test.com', CallerReference='2', DelegationSetId='1')
```

[Reference](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Route53/Types/ConflictingDomainExists.html)

Introduced test covers:
- Two create_hosted_zone requests on the same delegation set == should raise exception
- Two create_hosted_zone reqs with unnamed delegation set ids == should not raise
- Two create_hosted_zone reqs with different, named delegation set ids == should not raise

I read & followed the contribution guide, `make format` and tests pass but lmk if I missed anything!