### PR TITLE
SNS: allow SetSubscriptionAttributes to unset FilterPolicy

### DIFF
--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -405,6 +405,16 @@ def test_set_subscription_attributes():
 
     assert attrs["Attributes"]["FilterPolicyScope"] == filter_policy_scope
 
+    # test unsetting a filter policy
+    conn.set_subscription_attributes(
+        SubscriptionArn=subscription_arn,
+        AttributeName="FilterPolicy",
+        AttributeValue="",
+    )
+
+    attrs = conn.get_subscription_attributes(SubscriptionArn=subscription_arn)
+    assert "FilterPolicy" not in attrs["Attributes"]
+
     # not existing subscription
     with pytest.raises(ClientError):
         conn.set_subscription_attributes(
@@ -413,7 +423,7 @@ def test_set_subscription_attributes():
             AttributeValue="true",
         )
     with pytest.raises(ClientError):
-        attrs = conn.get_subscription_attributes(SubscriptionArn="invalid")
+        conn.get_subscription_attributes(SubscriptionArn="invalid")
 
     # invalid attr name
     with pytest.raises(ClientError):

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -393,6 +393,7 @@ def test_set_subscription_attributes():
     assert attrs["Attributes"]["RawMessageDelivery"] == "true"
     assert attrs["Attributes"]["DeliveryPolicy"] == delivery_policy
     assert attrs["Attributes"]["FilterPolicy"] == filter_policy
+    assert attrs["Attributes"]["FilterPolicyScope"] == "MessageAttributes"
 
     filter_policy_scope = "MessageBody"
     conn.set_subscription_attributes(
@@ -414,6 +415,7 @@ def test_set_subscription_attributes():
 
     attrs = conn.get_subscription_attributes(SubscriptionArn=subscription_arn)
     assert "FilterPolicy" not in attrs["Attributes"]
+    assert "FilterPolicyScope" not in attrs["Attributes"]
 
     # not existing subscription
     with pytest.raises(ClientError):


### PR DESCRIPTION
We've had a report that a user could not "unset" a FilterPolicy by setting it to an empty string like they could in AWS.
This was due to always trying to decode the FilterPolicy as JSON, raising a `JSONDecodeError`. 

I've introduce a conditional check for the value, and manually set the filter policy and the matcher to None to not have a filter in place anymore. 

I've also sneaked a little change to what is returned from `GetSubscriptionAttributes`: SNS does not return the FilterPolicy if it is not set (None or empty string), and will not return the FilterPolicyScope either in that case. Also, if a FilterPolicy is set without manually setting a FilterPolicyScope, it will return the default filter policy scope as well in the fields. This was validated against AWS. 