### PR TITLE
CloudFront - Remove InvalidOriginServer validation, as it's not correct

### DIFF
--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ["acm", "route53"]
+        service: ["acm", "cloudfront", "route53"]
 
     steps:
     - uses: actions/checkout@v4

--- a/moto/cloudfront/exceptions.py
+++ b/moto/cloudfront/exceptions.py
@@ -33,14 +33,6 @@ class OriginDoesNotExist(CloudFrontException):
         )
 
 
-class InvalidOriginServer(CloudFrontException):
-    def __init__(self) -> None:
-        super().__init__(
-            "InvalidOrigin",
-            message="The specified origin server does not exist or is not valid.",
-        )
-
-
 class DomainNameNotAnS3Bucket(CloudFrontException):
     def __init__(self) -> None:
         super().__init__(

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -12,7 +12,6 @@ from .exceptions import (
     DistributionAlreadyExists,
     DomainNameNotAnS3Bucket,
     InvalidIfMatchVersion,
-    InvalidOriginServer,
     NoSuchDistribution,
     NoSuchOriginAccessControl,
     OriginDoesNotExist,
@@ -120,9 +119,6 @@ class Origin:
         self.origin_shield = origin.get("OriginShield")
         self.connection_attempts = origin.get("ConnectionAttempts") or 3
         self.connection_timeout = origin.get("ConnectionTimeout") or 10
-
-        if "S3OriginConfig" not in origin and "CustomOriginConfig" not in origin:
-            raise InvalidOriginServer
 
         if "S3OriginConfig" in origin:
             # Very rough validation

--- a/other_langs/terraform/cloudfront/cloudfront.tf
+++ b/other_langs/terraform/cloudfront/cloudfront.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "test-bucket"
+}
+
+module "cloudfront" {
+  source  = "terraform-aws-modules/cloudfront/aws"
+  version = "3.2.1"
+
+  default_cache_behavior = {
+    target_origin_id       = "s3-bucket"
+    viewer_protocol_policy = "allow-all"
+  }
+
+  origin = {
+    s3-bucket = {
+      domain_name = aws_s3_bucket.bucket.bucket_domain_name
+    }
+  }
+}

--- a/other_langs/terraform/cloudfront/providers.tf
+++ b/other_langs/terraform/cloudfront/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # version = "5.18.1" # with this line uncommented, the destroy works
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    s3         = "http://localhost:5000"
+    cloudfront = "http://localhost:5000"
+  }
+
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}

--- a/tests/test_cloudfront/test_cloudfront_distributions.py
+++ b/tests/test_cloudfront/test_cloudfront_distributions.py
@@ -369,36 +369,6 @@ def test_get_distribution_config_with_mismatched_originid():
 
 
 @mock_aws
-def test_create_origin_without_origin_config():
-    client = boto3.client("cloudfront", region_name="us-west-1")
-
-    with pytest.raises(ClientError) as exc:
-        client.create_distribution(
-            DistributionConfig={
-                "CallerReference": "ref",
-                "Origins": {
-                    "Quantity": 1,
-                    "Items": [{"Id": "origin1", "DomainName": "https://getmoto.org"}],
-                },
-                "DefaultCacheBehavior": {
-                    "TargetOriginId": "origin1",
-                    "ViewerProtocolPolicy": "allow-all",
-                },
-                "Comment": "an optional comment that's not actually optional",
-                "Enabled": False,
-            }
-        )
-
-    metadata = exc.value.response["ResponseMetadata"]
-    assert metadata["HTTPStatusCode"] == 400
-    err = exc.value.response["Error"]
-    assert err["Code"] == "InvalidOrigin"
-    assert (
-        err["Message"] == "The specified origin server does not exist or is not valid."
-    )
-
-
-@mock_aws
 def test_create_distribution_with_invalid_s3_bucket():
     client = boto3.client("cloudfront", region_name="us-west-1")
 


### PR DESCRIPTION
Fixes #7245 

TF updates the Distribution to disable it and remove it's OriginConfigs, before proceeding with the deletion. So it is possible to have an Origin configured without an `S3OriginConfig` or `CustomOriginConfig` specified.

The test that is removed here, `test_create_origin_without_origin_config`, does succeed against AWS, indicating that there is something wrong about that particular combination of input parameters. But I don't know what it is exactly. IMO it's better to be too liberal in what we accept, then too conservative and throw errors where we shouldn't.

Validation was originally introduced in #4640 