### PR TITLE
Admin: Add missing dependency for APIGatewayV2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,9 @@ apigateway =
     python-jose[cryptography]>=3.1.0,<4.0.0
     ecdsa!=0.15
     openapi-spec-validator>=0.5.0
-apigatewayv2 = PyYAML>=5.1
+apigatewayv2 = 
+    PyYAML>=5.1
+    openapi-spec-validator>=0.5.0
 applicationautoscaling =
 appsync = graphql-core
 athena =


### PR DESCRIPTION
Not sure how - I think this broke somewhere with the v5 merge. I verified that all dependencies were correct on the v5 branch itself, but after it was merged into master it suddenly broke (as in - APIGatewayV2 no longer had the correct dependencies)