### PR TITLE
Mark `mock_aws` for explicit reexport

### DIFF
--- a/moto/__init__.py
+++ b/moto/__init__.py
@@ -1,4 +1,4 @@
-from moto.core.decorator import mock_aws  # noqa  # pylint: disable=unused-import
+from moto.core.decorator import mock_aws as mock_aws
 
 __title__ = "moto"
 __version__ = "5.0.1.dev"


### PR DESCRIPTION
This is required for mypy to recognize this as exported with [`--no-implicit-reexport`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport) (implied by `--strict`).