### PR TITLE
Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Now see how you could test it with Moto:
 
 ```python
 import boto3
-from moto import mock_s3
+from moto import mock_aws
 from mymodule import MyModel
 
 
-@mock_s3
+@mock_aws
 def test_my_model_save():
     conn = boto3.resource("s3", region_name="us-east-1")
     # We need to create the bucket since this is all in Moto's 'virtual' AWS account


### PR DESCRIPTION
Update README to use new decorator `mock_aws` instead of the old `mock_s3`.
This change was introduced in the newest version - 5.0.0