### PR TITLE
Feature: Allow user to specify to not reset boto3-Sessions

### DIFF
--- a/docs/docs/configuration/index.rst
+++ b/docs/docs/configuration/index.rst
@@ -18,18 +18,36 @@ If you are using the decorators, some options are configurable within the decora
             "passthrough": {
                 "urls": ["s3.amazonaws.com/bucket*"],
                 "services": ["dynamodb"]
-            }
+            },
+            "reset_boto3_session": True,
         }
     })
+
+
+Dockerless Services
+--------------------
 
 By default, Batch and AWSLambda will spin up a Docker image to execute the provided scripts and functions.
 
 If you configure `use_docker: False` for either of these services, the scripts and functions will not be executed, and Moto will assume a successful invocation.
 
+Passthrough Requests
+--------------------
+
 Configure `mock_credentials: False` and `passthrough` if you want to only mock some services, but allow other requests to connect to AWS.
 
 You can either passthrough all requests to a specific service, or all URL's that match a specific pattern.
 
+Reset Boto Session
+------------------
+
+When creating boto3-client for the first time, `boto3` will create a default session that caches all kinds of things - including credentials. Subsequent boto3-clients will reuse that `Session`.
+
+If the first test in your test suite is mocked, the default `Session` created in that test will have fake credentials, as supplied by Moto. But if the next test is not mocked and should reach out to AWS, it would do so with the mocked credentials from our cached `Session`.
+
+That is why Moto resets the `boto3-Session`, to make sure that it is recreated with the correct credentials (either fake or mocked) everytime. It does come at a cost though, as instantiating a new boto3-Session is an expensive operation.
+
+If all of your tests use Moto, and you never want to reach out to AWS, you can choose to _not_ reset the `boto3-session`. New boto3-clients that are created will reuse the `boto3-Session` (with fake credentials), making Moto much more performant.
 
 .. toctree::
   :maxdepth: 1

--- a/moto/core/config.py
+++ b/moto/core/config.py
@@ -14,6 +14,7 @@ class _passthrough_config(TypedDict, total=False):
 class _core_config(TypedDict, total=False):
     mock_credentials: bool
     passthrough: _passthrough_config
+    reset_boto3_session: bool
 
 
 class _iam_config(TypedDict, total=False):
@@ -34,7 +35,11 @@ DefaultConfig = TypedDict(
 default_user_config: DefaultConfig = {
     "batch": {"use_docker": True},
     "lambda": {"use_docker": True},
-    "core": {"mock_credentials": True, "passthrough": {"urls": [], "services": []}},
+    "core": {
+        "mock_credentials": True,
+        "passthrough": {"urls": [], "services": []},
+        "reset_boto3_session": True,
+    },
     "iam": {"load_aws_managed_policies": False},
 }
 

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -84,7 +84,8 @@ class MockAWS(ContextManager["MockAWS"]):
             if mock_credentials():
                 self._mock_env_variables()
             if not self.__class__._mocks_active:
-                self._default_session_mock.start()
+                if default_user_config.get("core", {}).get("reset_boto3_session", True):
+                    self._default_session_mock.start()
                 self.__class__._mocks_active = True
 
             self.__class__._nested_count += 1
@@ -104,7 +105,10 @@ class MockAWS(ContextManager["MockAWS"]):
 
             if self.__class__._nested_count == 0:
                 if self.__class__._mocks_active:
-                    self._default_session_mock.stop()
+                    if default_user_config.get("core", {}).get(
+                        "reset_boto3_session", True
+                    ):
+                        self._default_session_mock.stop()
                     self._user_config_mock.stop()
                     self.__class__._mocks_active = False
                 self._disable_patching(remove_data)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from moto.core.config import default_user_config
+
 # Disable extra logging for tests
 logging.getLogger("boto").setLevel(logging.CRITICAL)
 logging.getLogger("boto3").setLevel(logging.CRITICAL)
@@ -17,3 +19,6 @@ DEFAULT_ACCOUNT_ID = "123456789012"
 
 # For the majority of tests we don't need the default AMI's
 os.environ["MOTO_EC2_LOAD_DEFAULT_AMIS"] = "false"
+
+# Don't reset boto3 Session, as it's unnecessarily slow
+default_user_config["core"]["reset_boto3_session"] = False


### PR DESCRIPTION
When creating boto3-client for the first time, `boto3` will create a default session that caches all kinds of things - including credentials. Subsequent boto3-clients will reuse that `Session`.

If the first test in your test suite is mocked, the default `Session` created in that test will have fake credentials, as supplied by Moto. But if the next test is not mocked and should reach out to AWS, it would do so with the mocked credentials from our cached `Session`.

That is why Moto resets the `boto3-Session`, to make sure that it is recreated with the correct credentials (either fake or real) everytime. (This was introduced in #2578) It does come at a cost though, as instantiating a new boto3-Session is an expensive operation.

If all of your tests use Moto, and you never want to reach out to AWS, you can choose to _not_ reset the `boto3-session`. New boto3-clients that are created will reuse the `boto3-Session` (with fake credentials), making Moto much more performant.

`@mock_aws(config={"core": {"reset_boto3_session": False}})`

All of our tests are mocked, so it's safe to disable this for every test - but we really don't want to set this value for every single test individually. That's why, as part of this PR, we just override the default config to always set this value to false (in `tests/__init__.py`). 

Test runtime drops from ~30 mins to <15 mins with this change.