### PR TITLE
S3: Allow in place copies when bucket versioning is enabled

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -108,7 +108,7 @@ class FakeKey(BaseModel, ManagedState):
         storage: Optional[str] = "STANDARD",
         etag: Optional[str] = None,
         is_versioned: bool = False,
-        version_id: str = "null",
+        version_id: Optional[str] = None,
         max_buffer_size: Optional[int] = None,
         multipart: Optional["FakeMultipart"] = None,
         bucket_name: Optional[str] = None,
@@ -170,7 +170,7 @@ class FakeKey(BaseModel, ManagedState):
 
     @property
     def version_id(self) -> str:
-        return self._version_id
+        return self._version_id or "null"
 
     @property
     def value(self) -> bytes:
@@ -2674,7 +2674,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
                     mdirective == "REPLACE",
                     website_redirect_location,
                     bucket.encryption,  # S3 will allow copy in place if the bucket has encryption configured
-                    src_key.version_id != "null" and bucket.is_versioned,
+                    src_key._version_id and bucket.is_versioned,
                 )
             ):
                 raise CopyObjectMustChangeSomething

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2674,6 +2674,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
                     mdirective == "REPLACE",
                     website_redirect_location,
                     bucket.encryption,  # S3 will allow copy in place if the bucket has encryption configured
+                    bucket.is_versioned,
                 )
             ):
                 raise CopyObjectMustChangeSomething

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2674,7 +2674,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
                     mdirective == "REPLACE",
                     website_redirect_location,
                     bucket.encryption,  # S3 will allow copy in place if the bucket has encryption configured
-                    bucket.is_versioned,
+                    src_key.version_id != "null" and bucket.is_versioned,
                 )
             ):
                 raise CopyObjectMustChangeSomething

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -810,7 +810,7 @@ def test_copy_object_in_place_with_versioning():
 
     response = client.copy_object(
         Bucket=bucket_name,
-        CopySource={"Bucket": bucket_name, "Key": key},
+        CopySource={"Bucket": bucket_name, "Key": key, "VersionId": version_id},
         Key=key,
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -791,6 +791,12 @@ def test_copy_object_in_place_with_versioning():
     client.create_bucket(Bucket=bucket_name)
     key = "source-key"
 
+    response = client.put_object(
+        Body=b"",
+        Bucket=bucket_name,
+        Key=key,
+    )
+
     response = client.put_bucket_versioning(
         Bucket=bucket_name,
         VersioningConfiguration={
@@ -815,11 +821,18 @@ def test_copy_object_in_place_with_versioning():
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
+    response = client.copy_object(
+        Bucket=bucket_name,
+        CopySource={"Bucket": bucket_name, "Key": key, "VersionId": "null"},
+        Key=key,
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
     response = client.list_object_versions(
         Bucket=bucket_name,
         Prefix=key,
     )
-    assert len(response["Versions"]) == 2
+    assert len(response["Versions"]) == 4
 
 
 @mock_aws

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -784,6 +784,45 @@ def test_copy_object_in_place_with_bucket_encryption():
 
 
 @mock_aws
+def test_copy_object_in_place_with_versioning():
+    # If a bucket has versioning enabled, it will allow copy in place
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "testbucket"
+    client.create_bucket(Bucket=bucket_name)
+    key = "source-key"
+
+    response = client.put_bucket_versioning(
+        Bucket=bucket_name,
+        VersioningConfiguration={
+            "MFADelete": "Disabled",
+            "Status": "Enabled",
+        },
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    response = client.put_object(
+        Body=b"",
+        Bucket=bucket_name,
+        Key=key,
+    )
+    version_id = response["ResponseMetadata"]["HTTPHeaders"]["x-amz-version-id"]
+    assert version_id and version_id != "null"
+
+    response = client.copy_object(
+        Bucket=bucket_name,
+        CopySource={"Bucket": bucket_name, "Key": key},
+        Key=key,
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    response = client.list_object_versions(
+        Bucket=bucket_name,
+        Prefix=key,
+    )
+    assert len(response["Versions"]) == 2
+
+
+@mock_aws
 @pytest.mark.parametrize(
     "algorithm",
     ["CRC32", "SHA1", "SHA256"],


### PR DESCRIPTION
AWS allows self-copies for keys when the bucket has versioning enabled.

Fixes #7300

Related earlier work: #6303