### PR TITLE
EC2: modify_image_attributes() now supports all LaunchPermissions

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2523,7 +2523,7 @@
 - [X] modify_hosts
 - [ ] modify_id_format
 - [ ] modify_identity_id_format
-- [ ] modify_image_attribute
+- [X] modify_image_attribute
 - [X] modify_instance_attribute
 - [ ] modify_instance_capacity_reservation_attributes
 - [ ] modify_instance_credit_specification

--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -545,7 +545,7 @@ ec2
 - [X] modify_hosts
 - [ ] modify_id_format
 - [ ] modify_identity_id_format
-- [ ] modify_image_attribute
+- [X] modify_image_attribute
 - [X] modify_instance_attribute
 - [ ] modify_instance_capacity_reservation_attributes
 - [ ] modify_instance_credit_specification


### PR DESCRIPTION
Fixes #7318 

`modify_image_attributes()` now supports the `LaunchPermission`, `OrganizationArns` and `OrganizationalUnitArns` attributes

Internally, the launch_permissions are now stored as a dict, more closely resembling the actual data.