### PR TITLE
feat: use AWS Lambda entry point if ImageConfig.EntryPoint is set

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1001,6 +1001,10 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                             "host.docker.internal": "host-gateway"
                         }
 
+                    # Change entry point if requested
+                    if self.image_config.entry_point:
+                        run_kwargs["entrypoint"] = self.image_config.entry_point
+
                     # The requested image can be found in one of a few repos:
                     # - User-provided repo
                     # - mlupin/docker-lambda (the repo with up-to-date AWSLambda images

--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -377,3 +377,39 @@ def test_invoke_lambda_with_proxy():
 
     expected_payload = {"id": vol.id, "state": vol.state, "size": vol.size}
     assert json.loads(payload) == expected_payload
+
+
+@mock_aws
+def test_invoke_lambda_with_entrypoint():
+    conn = boto3.client("lambda", _lambda_region)
+    function_name = str(uuid4())[0:6]
+    conn.create_function(
+        FunctionName=function_name,
+        Runtime=PYTHON_VERSION,
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": get_test_zip_file1()},
+        ImageConfig={
+            "EntryPoint": [
+                "/var/rapid/init",
+                "--bootstrap",
+                "/var/runtime/bootstrap",
+                "--enable-msg-logs",
+            ],
+        },
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    in_data = {"hello": "world"}
+    result = conn.invoke(
+        FunctionName=function_name,
+        InvocationType="RequestResponse",
+        Payload=json.dumps(in_data),
+    )
+    assert result["StatusCode"] == 200
+    payload = result["Payload"].read().decode("utf-8")
+
+    assert json.loads(payload) == in_data


### PR DESCRIPTION
With the proposed change it is possible to use `public.ecr.aws/lambda/python:3.12` image in a hacky way as
```
@mock.patch.dict(
    os.environ,
    {
        "MOTO_DOCKER_LAMBDA_IMAGE": "public.ecr.aws/lambda/python",
    },
)
def test_send_message():
    ...

    func = lambda_.create_function(
        FunctionName=function_name,

        Runtime=f"{sys.version_info.major}.{sys.version_info.minor}",
        ImageConfig={
            "EntryPoint": [
                "/var/lang/bin/python3",
                "-c",
                f"import sys, json; from {handler_package} import {handler_callback} as cb; cb(json.loads(sys.argv[2]), None)",
            ],
        },
   )
...
```