### PR TITLE
Bug: Fixing ValueError when using Range with get_object

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1170,7 +1170,7 @@ class S3Response(BaseResponse):
         length = len(response_content)
         last = length - 1
 
-        _, rspec = request.headers.get("range").split("=")
+        rspec = request.headers.get("range")
         if "," in rspec:
             return 200, response_headers, response_content
 


### PR DESCRIPTION
When using `get_object` with `Range` set I get the following error:

```
    def _handle_range_header(
        self, request: Any, response_headers: Dict[str, Any], response_content: Any
    ) -> TYPE_RESPONSE:
        length = len(response_content)
        last = length - 1
    
        print(request.headers.get("range"))
>       _, rspec = request.headers.get("range").split("=")
E       ValueError: not enough values to unpack (expected 2, got 1)

venv/lib/python3.10/site-packages/moto/s3/responses.py:1174: ValueError
```

I've printed the value of `request.headers.get("range")` and can confirm it doesn't contain any `=` signs in it, just the ranges. 

This fixes the `ValueError` thrown when using `Range` with `get_object`.