### PR TITLE
Techdebt: Remove warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: pip cache
         id: pip-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -55,7 +55,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -22,7 +22,7 @@ jobs:
           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
       - name: pip cache
         id: pip-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -62,7 +62,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -82,8 +82,6 @@ jobs:
       if: always()
       run: |
         mkdir serverlogs1
-        pwd
-        ls -la
         cp server_output.log serverlogs1/server_output.log
         docker stop motoserver
     - name: Archive Logs
@@ -122,7 +120,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -141,8 +139,6 @@ jobs:
       if: always()
       run: |
         mkdir serverlogs2
-        pwd
-        ls -la
         cp server_output.log serverlogs2/server_output.log
     - name: Archive logs
       if: always()
@@ -179,7 +175,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -200,10 +196,7 @@ jobs:
       if: always()
       run: |
         mkdir serverlogs3
-        pwd
-        ls -la
         cp server_output.log serverlogs3/server_output.log
-        ls -la serverlogs3
     - name: Archive Logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -18,6 +18,7 @@ jobs:
         responses-version: ["0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
         werkzeug-version: ["2.0.1", "2.1.1", "2.2.2"]
         openapi-spec-validator-version: ["0.5.0"]
+        cryptography-version: ["39.0.0"]
 
     steps:
     - name: Checkout repository
@@ -40,6 +41,7 @@ jobs:
         pip install werkzeug==${{ matrix.werkzeug-version }}
         pip install openapi-spec-validator==${{ matrix.openapi-spec-validator-version }}
         pip install ${{ matrix.botocore }}
+        pip install cryptography==${{ matrix.cryptography-version }}
 
     - name: Run tests
       run: |
@@ -59,8 +61,6 @@ jobs:
       if: always()
       run: |
         mkdir serverlogs
-        pwd
-        ls -la
         cp server_output.log serverlogs/server_output.log
         docker stop motoserver
     - name: Archive TF logs

--- a/.github/workflows/tests_decoratormode.yml
+++ b/.github/workflows/tests_decoratormode.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}

--- a/.github/workflows/tests_proxymode.yml
+++ b/.github/workflows/tests_proxymode.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -45,8 +45,6 @@ jobs:
     - name: "Stop MotoProxy"
       if: always()
       run: |
-        pwd
-        ls -la
         kill $(lsof -t -i:5005)
     - name: Archive Proxy logs
       if: always()

--- a/.github/workflows/tests_real_aws.yml
+++ b/.github/workflows/tests_real_aws.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-3.11-${{ hashFiles('**/setup.cfg') }}

--- a/.github/workflows/tests_sdk_dotnet.yml
+++ b/.github/workflows/tests_sdk_dotnet.yml
@@ -20,7 +20,7 @@ jobs:
         docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
     - uses: actions/setup-dotnet@v4
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
         # Look to see if there is a cache hit for the corresponding requirements file

--- a/.github/workflows/tests_servermode.yml
+++ b/.github/workflows/tests_servermode.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: pip-${{ matrix.python-version }}-${{ hashFiles('**/setup.cfg') }}
@@ -60,8 +60,6 @@ jobs:
       if: always()
       run: |
         mkdir serverlogs
-        pwd
-        ls -la
         cp server_output.log serverlogs/server_output.log
         docker stop motoserver
     - name: Archive TF logs

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -149,13 +149,19 @@ class CertificateAuthority(BaseModel):
     def not_valid_after(self) -> Optional[float]:
         if self.certificate is None:
             return None
-        return unix_time(self.certificate.not_valid_after)
+        try:
+            return unix_time(self.certificate.not_valid_after_utc.replace(tzinfo=None))
+        except AttributeError:
+            return unix_time(self.certificate.not_valid_after)
 
     @property
     def not_valid_before(self) -> Optional[float]:
         if self.certificate is None:
             return None
-        return unix_time(self.certificate.not_valid_before)
+        try:
+            return unix_time(self.certificate.not_valid_before_utc.replace(tzinfo=None))
+        except AttributeError:
+            return unix_time(self.certificate.not_valid_before)
 
     def import_certificate_authority_certificate(
         self, certificate: bytes, certificate_chain: Optional[bytes]

--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -10,6 +10,7 @@ from botocore.exceptions import ClientError
 from moto import mock_aws, settings
 
 from ..markers import requires_docker
+from .test_lambda import LooseVersion, boto3_version
 from .utilities import (
     get_lambda_using_environment_port,
     get_lambda_using_network_mode,
@@ -383,6 +384,8 @@ def test_invoke_lambda_with_proxy():
 @mock_aws
 @requires_docker
 def test_invoke_lambda_with_entrypoint():
+    if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
+        raise SkipTest("ImageConfig parameter not available in older versions")
     conn = boto3.client("lambda", _lambda_region)
     function_name = str(uuid4())[0:6]
     conn.create_function(

--- a/tests/test_core/test_mypy.py
+++ b/tests/test_core/test_mypy.py
@@ -5,13 +5,13 @@ from moto.core.decorator import MockAWS
 
 
 @mock_aws
-def test_without_parentheses() -> int:
+def method_without_parentheses() -> int:
     assert boto3.client("s3").list_buckets()["Buckets"] == []
     return 123
 
 
 @mock_aws()
-def test_with_parentheses() -> int:
+def method_with_parentheses() -> int:
     assert boto3.client("s3").list_buckets()["Buckets"] == []
     return 456
 
@@ -35,8 +35,8 @@ def test_manual() -> None:
     m.stop()
 
 
-x: int = test_with_parentheses()
+x: int = method_with_parentheses()
 assert x == 456
 
-y: int = test_without_parentheses()
+y: int = method_without_parentheses()
 assert y == 123

--- a/tests/test_ec2/test_route_tables.py
+++ b/tests/test_ec2/test_route_tables.py
@@ -1058,7 +1058,7 @@ def test_create_route_with_vpc_endpoint():
         VpcEndpointId=vpce_id,
         RouteTableId=route_table.id,
     )
-    rt = ec2_client.describe_route_tables()
+    rt = ec2_client.describe_route_tables(RouteTableIds=[route_table.id])
     new_route = rt["RouteTables"][-1]["Routes"][1]
 
     # Verify


### PR DESCRIPTION
Cryptography >= 40.0.0 introduces a new property, `not_valid_before_utc`, that will replace the old `not_valid_before`-property. This PR supports both properties (and therefore all versions of cryptography).

This PR also:
 - updates some CI dependencies
 - tests these changes with an older version of `cryptography`
 - improves an EC2 test to reduce the chances that it finds a resources created by other tests.
 - fixes some `pytest` warnings since tests (methods that start with `test_`) should not return anything