### PR TITLE
Add numbers as `Decimal` objects

### DIFF
--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -100,8 +100,12 @@ class DynamoType(object):
         if self.type != other.type:
             raise TypeError("Different types of operandi is not allowed.")
         if self.is_number():
-            self_value = decimal.Decimal(self.value) if "." in self.value else int(self.value)
-            other_value = decimal.Decimal(other.value) if "." in other.value else int(other.value)
+            self_value = (
+                decimal.Decimal(self.value) if "." in self.value else int(self.value)
+            )
+            other_value = (
+                decimal.Decimal(other.value) if "." in other.value else int(other.value)
+            )
             return DynamoType({DDBType.NUMBER: f"{self_value + other_value}"})
         else:
             raise IncorrectDataType()

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -100,8 +100,8 @@ class DynamoType(object):
         if self.type != other.type:
             raise TypeError("Different types of operandi is not allowed.")
         if self.is_number():
-            self_value = float(self.value) if "." in self.value else int(self.value)
-            other_value = float(other.value) if "." in other.value else int(other.value)
+            self_value = decimal.Decimal(self.value) if "." in self.value else int(self.value)
+            other_value = decimal.Decimal(other.value) if "." in other.value else int(other.value)
             return DynamoType({DDBType.NUMBER: f"{self_value + other_value}"})
         else:
             raise IncorrectDataType()


### PR DESCRIPTION
Fixes https://github.com/getmoto/moto/issues/7349

TODO:

- [ ] I've only updated the `DynamoType.__add__` method, but there are other places where floating-point arithmetic is performed that should probably be updated as well, e.g. `DynamoType.__sub__`.
- [ ] Add test cases for these changes?
- [ ] Fix failing tests

On my machine, `make test` fails with:

```
moto/dynamodb/models/dynamo_type.py:109:48: error: Unsupported left operand type for + ("object")  [operator]
Found 1 error in 1 file (checked 900 source files)
make: *** [Makefile:30: lint] Error 1
```