### PR TITLE
Doc: Adding `upload_file, upload_fileobj` method to the document

### DIFF
--- a/docs/docs/services/s3.rst
+++ b/docs/docs/services/s3.rst
@@ -147,6 +147,8 @@ s3
          - FieldDelimiters are ignored
         
 
+- [X] upload_file
+- [X] upload_fileobj
 - [X] upload_part
 - [X] upload_part_copy
 - [ ] write_get_object_response


### PR DESCRIPTION
`upload_file, upload_fileobj` method is added to the documentation of moto.

closes #7364 

#### `upload_file` is already supported:

https://github.com/getmoto/moto/blob/7c87bddeae2e222f29def0aa73735baac1d32eb6/tests/test_s3/test_s3.py#L814-L829


#### `upload_fileobj` is already supported:

https://github.com/getmoto/moto/blob/7c87bddeae2e222f29def0aa73735baac1d32eb6/tests/test_s3/test_s3.py#L3214-L3232
