### PR TITLE
DynamoDB: transact_write_items() should raise ValidationException when putting and deleting the same item

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -579,7 +579,11 @@ class DynamoDBBackend(BaseBackend):
                     item = item["Put"]
                     attrs = item["Item"]
                     table_name = item["TableName"]
-                    check_unicity(table_name, item)
+                    table = self.get_table(table_name)
+                    key = {table.hash_key_attr: attrs[table.hash_key_attr]}
+                    if table.range_key_attr is not None:
+                        key[table.range_key_attr] = attrs[table.range_key_attr]
+                    check_unicity(table_name, key)
                     condition_expression = item.get("ConditionExpression", None)
                     expression_attribute_names = item.get(
                         "ExpressionAttributeNames", None


### PR DESCRIPTION
DynamoDB: transact_write_items() should raise ValidationException when putting and deleting the same item.

### How to reproduce

Given

`main.py`

```python
import boto3


def main():
    client = boto3.client("dynamodb", region_name="us-east-1")

    client.transact_write_items(
        TransactItems=[
            {
                "Put": {
                    "TableName": "test-table",
                    "Item": {
                        "pk": {"S": "test-pk"},
                        "sk": {"S": "test-sk"},
                        "field": {"S": "test-field"}
                    }
                }
            },
            {
                "Delete": {
                    "TableName": "test-table",
                    "Key": {
                        "pk": {"S": "test-pk"},
                        "sk": {"S": "test-sk"},
                    }
                }
            }
        ]
    )


if __name__ == "__main__":
    main()
```

and `test_main.py`

```python
import boto3
from moto import mock_aws


@mock_aws
def test_main():
    client = boto3.client("dynamodb", region_name="us-east-1")

    client.create_table(
        TableName="test-table",
        KeySchema=[
            {"AttributeName": "pk", "KeyType": "HASH"},
            {"AttributeName": "sk", "KeyType": "RANGE"},
        ],
        AttributeDefinitions=[
            {"AttributeName": "pk", "AttributeType": "S"},
            {"AttributeName": "sk", "AttributeType": "S"}
        ],
        BillingMode="PAY_PER_REQUEST",
    )

    from main import main

    main()
```

Running `main.py` will raise a `ValidationError` when connecting to an actual DynamoDB

```console
Traceback (most recent call last):
  File "/Users/khanh.le/moto-test/moto-test/main.py", line 33, in <module>
    main()
  File "/Users/khanh.le/moto-test/moto-test/main.py", line 7, in main
    client.transact_write_items(
  File "/Users/khanh.le/moto-test/moto-test/.venv/lib/python3.12/site-packages/botocore/client.py", line 553, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/khanh.le/moto-test/moto-test/.venv/lib/python3.12/site-packages/botocore/client.py", line 1009, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the TransactWriteItems operation: Transaction request cannot include multiple operations on one item
```

But running `test_main.py` will not (PASSED)

```
boto3==1.34.46
botocore==1.34.46
moto==5.0.2
```

### Checklist

- [x] Feature is added
- [x] The linter is happy
- [x] Tests are added
- [x] All tests pass, existing and new