### PR TITLE
DynamoDB: fix: support top level lists for Dynamo Item to_json

### DIFF
--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -324,6 +324,12 @@ class Item(BaseModel):
                     for key, value in attribute.value.items()
                 }
                 attributes[attribute_key] = {attribute.type: attr_value}
+            elif isinstance(attribute.value, list):
+                attr_value = [
+                    value.to_regular_json() if isinstance(value, DynamoType) else value
+                    for value in attribute.value
+                ]
+                attributes[attribute_key] = {attribute.type: attr_value}
             else:
                 attributes[attribute_key] = {attribute.type: attribute.value}
 

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -316,20 +316,20 @@ class Item(BaseModel):
         return sum(bytesize(key) + value.size() for key, value in self.attrs.items())
 
     def to_json(self) -> Dict[str, Any]:
-        attributes = {}
+        attributes: Dict[str, Any] = {}
         for attribute_key, attribute in self.attrs.items():
             if isinstance(attribute.value, dict):
-                attr_value = {
+                attr_dict_value = {
                     key: value.to_regular_json()
                     for key, value in attribute.value.items()
                 }
-                attributes[attribute_key] = {attribute.type: attr_value}
+                attributes[attribute_key] = {attribute.type: attr_dict_value}
             elif isinstance(attribute.value, list):
-                attr_value = [
+                attr_list_value = [
                     value.to_regular_json() if isinstance(value, DynamoType) else value
                     for value in attribute.value
                 ]
-                attributes[attribute_key] = {attribute.type: attr_value}
+                attributes[attribute_key] = {attribute.type: attr_list_value}
             else:
                 attributes[attribute_key] = {attribute.type: attribute.value}
 

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -964,12 +964,14 @@ class DynamoHandler(BaseResponse):
                 if len(changed) != len(original):
                     return changed
                 else:
-                    return [
+                    any_element_has_changed = any(
                         self._build_updated_new_attributes(
                             original[index], changed[index]
                         )
+                        != original[index]
                         for index in range(len(changed))
-                    ]
+                    )
+                    return changed if any_element_has_changed else original
             else:
                 return changed
 

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -965,10 +965,7 @@ class DynamoHandler(BaseResponse):
                     return changed
                 else:
                     any_element_has_changed = any(
-                        self._build_updated_new_attributes(
-                            original[index], changed[index]
-                        )
-                        != original[index]
+                        changed[index] != original[index]
                         for index in range(len(changed))
                     )
                     return changed if any_element_has_changed else original


### PR DESCRIPTION
The tests in this example (prior to the fix) reproduce an issue where the exception `TypeError: Object of type DynamoType is not JSON serializable` is raised when `Dynamo.Item.to_json` is passed a top level list.

I have chosen to test this via a condition expression with `ReturnValuesOnConditionCheckFailure="ALL_OLD"` as this is a very close reproduction to the issue I faced.
Some additional tests for top level string sets and lists in dictionaries were added to ensure different paths through the new and existing code are handled correctly.

Also fixes issue with `UPDATED_NEW` handling for lists:
- Before this change: when `update` is called to change one value in a list, `_build_updated_new_attributes` attempts to return the list with the value at the position of the changed element as an empty dictionary (which leads to a deserialization error)
- With this change: when `update` is called to change one value in a list, `_build_updated_new_attributes` returns the whole changed list if any element in the original list differs from the changed list - otherwise the whole original list is returned.