### PR TITLE
RDS: Allow copying snapshots of deleted DB instances

### DIFF
--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1039,8 +1039,9 @@ def test_create_db_snapshots_with_tags():
     ]
 
 
+@pytest.mark.parametrize("delete_db_instance", [True, False])
 @mock_aws
-def test_copy_db_snapshots():
+def test_copy_db_snapshots(delete_db_instance: bool):
     conn = boto3.client("rds", region_name=DEFAULT_REGION)
 
     conn.create_db_instance(
@@ -1058,6 +1059,10 @@ def test_copy_db_snapshots():
     conn.create_db_snapshot(
         DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier="snapshot-1"
     ).get("DBSnapshot")
+
+    if delete_db_instance:
+        # Delete the original instance, but the copy snapshot operation should still succeed.
+        conn.delete_db_instance(DBInstanceIdentifier="db-primary-1")
 
     target_snapshot = conn.copy_db_snapshot(
         SourceDBSnapshotIdentifier="snapshot-1", TargetDBSnapshotIdentifier="snapshot-2"


### PR DESCRIPTION
Fix a regression introduced in #6444, in which copying a snapshot of an already deleted DB instance results in raising a `DBInstanceNotFoundError`.
The expected behavior is that copying a snapshot is supported regardless whether its source database exists or not.

Change `create_db_snapshot` to accept a `Database` object (instead of an identifier), and use this flow in the `copy_db_snapshot` implementation. This works because the actual `Database` object is not deleted (as it is referred to by the snapshot), but rather it is already removed from the `databases` dictionary.