### PR TITLE
EC2: Fix vpn gateway tags and type

### DIFF
--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ["acm", "awslambda", "cloudfront", "elb", "route53", "sqs"]
+        service: ["acm", "awslambda", "cloudfront", "elb", "ec2", "route53", "sqs"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ["acm", "awslambda", "cloudfront", "elb", "ec2", "route53", "sqs"]
+        service: ["acm", "awslambda", "cloudfront", "elb", "route53", "sqs"]
 
     steps:
     - uses: actions/checkout@v4

--- a/moto/ec2/responses/virtual_private_gateways.py
+++ b/moto/ec2/responses/virtual_private_gateways.py
@@ -13,7 +13,7 @@ class VirtualPrivateGateways(EC2BaseResponse):
         gateway_type = self._get_param("Type")
         amazon_side_asn = self._get_param("AmazonSideAsn")
         availability_zone = self._get_param("AvailabilityZone")
-        tags = self._parse_tag_specification().get("virtual-private-gateway", {})
+        tags = self._parse_tag_specification().get("vpn-gateway", {})
         vpn_gateway = self.ec2_backend.create_vpn_gateway(
             gateway_type=gateway_type,
             amazon_side_asn=amazon_side_asn,
@@ -78,7 +78,7 @@ DESCRIBE_VPN_GATEWAYS_RESPONSE = """
         <amazonSideAsn>{{ vpn_gateway.amazon_side_asn }}</amazonSideAsn>
         {% endif %}
         <state>{{ vpn_gateway.state }}</state>
-        <type>{{ vpn_gateway.id }}</type>
+        <type>{{ vpn_gateway.type }}</type>
         <availabilityZone>{{ vpn_gateway.availability_zone }}</availabilityZone>
         <attachments>
           {% for attachment in vpn_gateway.attachments.values() %}
@@ -88,7 +88,6 @@ DESCRIBE_VPN_GATEWAYS_RESPONSE = """
             </item>
           {% endfor %}
         </attachments>
-        <tagSet/>
         <tagSet>
           {% for tag in vpn_gateway.get_tags() %}
             <item>

--- a/other_langs/terraform/ec2/provider.tf
+++ b/other_langs/terraform/ec2/provider.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ec2   = "http://localhost:5000"
+  }
+
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}

--- a/other_langs/terraform/ec2/vpc.tf
+++ b/other_langs/terraform/ec2/vpc.tf
@@ -1,0 +1,18 @@
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  enable_vpn_gateway = true
+
+  tags = {
+    Terraform = "true"
+    Environment = "dev"
+  }
+}


### PR DESCRIPTION
# Motivation
It was discovered that Terraform was crashing with the following sample:
```
module "vpc" {
  source = "terraform-aws-modules/vpc/aws"

  name = "my-vpc"
  cidr = "10.0.0.0/16"

  azs             = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]

  enable_nat_gateway = true
  enable_vpn_gateway = true

  tags = {
    Terraform = "true"
    Environment = "dev"
  }
}
```
With the following stack trace:
```
Stack trace from the terraform-provider-aws plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10353a858]

goroutine 293 [running]:
github.com/hashicorp/terraform-provider-aws/internal/tags.(*TagData).ValueString(0x0)
        /Users/lakkeger/Documents/Workspace/go/terraform-provider-aws/internal/tags/key_value_tags.go:671 +0x18
github.com/hashicorp/terraform-provider-aws/internal/tags.KeyValueTags.ResolveDuplicates(0x14001d4d3e0, {0x1129d2800, 0x14003242a80}, 0x0, 0x0, {0x123493a18, 0x1400320e700})
        /Users/lakkeger/Documents/Workspace/go/terraform-provider-aws/internal/tags/key_value_tags.go:780 +0x194
github.com/hashicorp/terraform-provider-aws/internal/provider.tagsResourceInterceptor.run({0x140010591e0, 0x112876af8, 0x112876af0}, {0x1129d2800, 0x14003242a80}, {0x1129e03a0, 0x1400320e700}, {0x112816000, 0x14000044a50}, 0x2, ...)
        /Users/lakkeger/Documents/Workspace/go/terraform-provider-aws/internal/provider/intercept.go:353 +0x13bc
github.com/hashicorp/terraform-provider-aws/internal/provider.interceptedHandler[...].func1(0x1400320e700, {0x112816000, 0x14000044a50})
        /Users/lakkeger/Documents/Workspace/go/terraform-provider-aws/internal/provider/intercept.go:120 +0x3b4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x14000f2d5e0, {0x1129d2800, 0x14002f2bbf0}, 0x1400320e700, {0x112816000, 0x14000044a50})
        /Users/lakkeger/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/resource.go:773 +0x11c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14000f2d5e0, {0x1129d2800, 0x14002f2bbf0}, 0x1400321e340, 0x1400320e580, {0x112816000, 0x14000044a50})
        /Users/lakkeger/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/resource.go:909 +0xab8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x14003037d40, {0x1129d2800, 0x14002f2bbf0}, 0x14002f6a370)
        /Users/lakkeger/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/grpc_provider.go:1072 +0x1544
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.(*muxServer).ApplyResourceChange(0x140019939d0, {0x1129d2800, 0x14002f2ba70}, 0x14002f6a370)
        /Users/lakkeger/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.12.0/tf5muxserver/mux_server_ApplyResourceChange.go:36 +0x29c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x140006ea640, {0x1129d2800, 0x14002f2b5c0}, 0x14003210000)
        /Users/lakkeger/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.19.1/tfprotov5/tf5server/server.go:859 +0x584
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x11257b080, 0x140006ea640}, {0x1129d2800, 0x14002f2aab0}, 0x1400320e000, 0x0)
        /Users/lakkeger/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.19.1/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:467 +0x28c
google.golang.org/grpc.(*Server).processUnaryRPC(0x1400006c000, {0x1129d2800, 0x14002f2aa20}, {0x1129e18a0, 0x1400268eea0}, 0x14002f2fd40, 0x14002f5ac30, 0x118675538, 0x0)
        /Users/lakkeger/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:1343 +0x1310
google.golang.org/grpc.(*Server).handleStream(0x1400006c000, {0x1129e18a0, 0x1400268eea0}, 0x14002f2fd40)
        /Users/lakkeger/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:1737 +0x934
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        /Users/lakkeger/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:986 +0xf4
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 56
        /Users/lakkeger/go/pkg/mod/google.golang.org/grpc@v1.59.0/server.go:997 +0x1fc

Error: The terraform-provider-aws plugin crashed!
```
This was caused as the describe vpn gateway command returned some odd responses (see the Tags and Type values):
```
awslocal ec2 describe-vpn-gateways --vpn-gateway-ids
{
    "VpnGateways": [
        {
            "AvailabilityZone": "None",
            "State": "available",
            "Type": "vgw-30fa436d",
            "VpcAttachments": [
                {
                    "State": "attached",
                    "VpcId": "vpc-5d90ff0c"
                }
            ],
            "VpnGatewayId": "vgw-30fa436d",
            "Tags": [
                {},
                {}
            ]
        }
    ]
}
```
# Changes
- fixes the tag parsing at vpn gateway creation
- adds the right type property to the describe vpn gateway response template
- removes the orphan close tag for tagSet and by that fixing the tag parsing for the describe response