### PR TITLE
CloudFormation: Allow deletion of deeply nested structures

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -743,7 +743,7 @@ class Role(CloudFormationModel):
 
         for role in backend.roles.values():
             if role.name == resource_name:
-                for arn in role.policies.keys():
+                for arn in list(role.policies.keys()):
                     role.delete_policy(arn)
         backend.delete_role(resource_name)
 


### PR DESCRIPTION
Scenario: Resource A depends on resource B

When CloudFormation tries to delete both resources, it will do so in an unspecified order.
If CF tries to delete resource B first, it will fail because A depends on it
CloudFormation continues with the deletion of resource A (and any other unrelated resources)

Because B is not yet deleted, CF will iterate over the remaining resources. Nothing depends on resource B anymore, so it will be deleted successfully.

This was already implemented, but with the caveat that we would only iterate over the list of remaining resources up to 5 times.

With this change, we will iterate as long as we are deleting some resources per iteration, i.e.: there is some progression. This has two benefits:
 - Deletion of resources with a chain of 5 or more dependencies should now be successful (as we just keep retrying until everything is gone)
 - If the deletion of a resource will never work, for whatever reason, we don't need to retry 5 times. Moto now immediately realizes that we haven't been able to delete any resources, and stop processing.

Related: #7381 