### PR TITLE
S3: Add EventBridge Notification for DeleteObject

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2599,11 +2599,17 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket = self.get_bucket(bucket_name)
 
         response_meta = {}
-        delete_key = self.get_object(bucket_name, key_name)
+        delete_key = bucket.keys.get(key_name)
 
         try:
             if not bucket.is_versioned:
                 bucket.keys.pop(key_name)
+                notifications.send_event(
+                    self.account_id,
+                    notifications.S3NotificationEvent.OBJECT_REMOVED_DELETE_EVENT,
+                    bucket,
+                    delete_key,
+                )
             else:
                 if version_id is None:
                     delete_marker = self._set_delete_marker(bucket_name, key_name)
@@ -2646,12 +2652,13 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
                     if not bucket.keys.getlist(key_name):
                         bucket.keys.pop(key_name)
-            notify_event_name = (
-                notifications.S3NotificationEvent.OBJECT_REMOVED_DELETE_EVENT
-            )
-            notifications.send_event(
-                self.account_id, notify_event_name, bucket, delete_key
-            )
+                        notifications.send_event(
+                            self.account_id,
+                            notifications.S3NotificationEvent.OBJECT_REMOVED_DELETE_EVENT,
+                            bucket,
+                            delete_key,
+                        )
+
             return True, response_meta
         except KeyError:
             return False, None

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2645,6 +2645,12 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
                     if not bucket.keys.getlist(key_name):
                         bucket.keys.pop(key_name)
+            notify_event_name = (
+                notifications.S3NotificationEvent.OBJECT_REMOVED_DELETE_EVENT
+            )
+            notifications.send_event(
+                self.account_id, notify_event_name, bucket, key=key_name
+            )
             return True, response_meta
         except KeyError:
             return False, None

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2599,7 +2599,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket = self.get_bucket(bucket_name)
 
         response_meta = {}
-        key = self.get_object(bucket_name, key_name)
+        delete_key = self.get_object(bucket_name, key_name)
 
         try:
             if not bucket.is_versioned:
@@ -2649,7 +2649,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             notify_event_name = (
                 notifications.S3NotificationEvent.OBJECT_REMOVED_DELETE_EVENT
             )
-            notifications.send_event(self.account_id, notify_event_name, bucket, key)
+            notifications.send_event(
+                self.account_id, notify_event_name, bucket, delete_key
+            )
             return True, response_meta
         except KeyError:
             return False, None

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2599,6 +2599,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket = self.get_bucket(bucket_name)
 
         response_meta = {}
+        key = self.get_object(bucket_name, key_name)
 
         try:
             if not bucket.is_versioned:
@@ -2648,9 +2649,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             notify_event_name = (
                 notifications.S3NotificationEvent.OBJECT_REMOVED_DELETE_EVENT
             )
-            notifications.send_event(
-                self.account_id, notify_event_name, bucket, key=key_name
-            )
+            notifications.send_event(self.account_id, notify_event_name, bucket, key)
             return True, response_meta
         except KeyError:
             return False, None

--- a/tests/test_s3/test_s3_eventbridge_integration.py
+++ b/tests/test_s3/test_s3_eventbridge_integration.py
@@ -164,4 +164,4 @@ def test_delete_object_notification():
     assert event_message["account"] == ACCOUNT_ID
     assert event_message["region"] == REGION_NAME
     assert event_message["detail"]["bucket"]["name"] == bucket_name
-    assert event_message["detail"]["reason"] == "ObjectDeleted"
+    assert event_message["detail"]["reason"] == "ObjectRemoved"

--- a/tests/test_s3/test_s3_eventbridge_integration.py
+++ b/tests/test_s3/test_s3_eventbridge_integration.py
@@ -142,3 +142,26 @@ def test_copy_object_notification():
     assert event_message["detail"]["bucket"]["name"] == bucket_name
     assert event_message["detail"]["object"]["key"] == object_key
     assert event_message["detail"]["reason"] == "ObjectCreated"
+
+
+@mock_aws
+def test_delete_object_notification():
+    resource_names = _seteup_bucket_notification_eventbridge()
+    bucket_name = resource_names["bucket_name"]
+    s3_client = boto3.client("s3", region_name=REGION_NAME)
+
+    # Put Object
+    s3_client.put_object(Bucket=bucket_name, Key="keyname", Body="bodyofnewobject")
+
+    # Delete Object
+    s3_client.delete_object(Bucket=bucket_name, Key="keyname")
+
+    events = _get_send_events()
+    assert len(events) == 2
+    event_message = json.loads(events[1]["message"])
+    assert event_message["detail-type"] == "Object Deleted"
+    assert event_message["source"] == "aws.s3"
+    assert event_message["account"] == ACCOUNT_ID
+    assert event_message["region"] == REGION_NAME
+    assert event_message["detail"]["bucket"]["name"] == bucket_name
+    assert event_message["detail"]["reason"] == "ObjectDeleted"


### PR DESCRIPTION
PR for DeleteObject in #7363 
 - send EventBridge notification when Object is Deleted(for buckets that are versioned and not versioned)
 - added a test case for sending eventbridge notification