### PR TITLE
Fix EC2 security group ingress/egress deletion for non-existing SGs

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -803,6 +803,8 @@ class SecurityGroupBackend:
         vpc_id: Optional[str] = None,
     ) -> None:
         group: SecurityGroup = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)  # type: ignore[assignment]
+        if group is None:
+            raise InvalidSecurityGroupNotFoundError(group_name_or_id)
 
         if security_rule_ids:
             group.ingress_rules = [
@@ -972,6 +974,8 @@ class SecurityGroupBackend:
         vpc_id: Optional[str] = None,
     ) -> None:
         group: SecurityGroup = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)  # type: ignore[assignment]
+        if group is None:
+            raise InvalidSecurityGroupNotFoundError(group_name_or_id)
 
         if security_rule_ids:
             group.egress_rules = [


### PR DESCRIPTION
When trying to delete a security group ingress/egress we've been running into some unexpected issues, since it doesn't return a proper 4xx error, but instead fails with a 500 internal server exception due to an attribute access on None:


```
2024-03-06T14:06:40.0969862Z            ^^^^^^^^^^^^^^^^^^
2024-03-06T14:06:40.0973388Z   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/core/responses.py", line 575, in call_action
2024-03-06T14:06:40.0974737Z     response = method()
2024-03-06T14:06:40.0975219Z                ^^^^^^^^
2024-03-06T14:06:40.0976704Z   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ec2/responses/security_groups.py", line 220, in revoke_security_group_ingress
2024-03-06T14:06:40.0978219Z     self.ec2_backend.revoke_security_group_ingress(*args)
2024-03-06T14:06:40.0979850Z   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/ec2/models/security_groups.py", line 759, in revoke_security_group_ingress
2024-03-06T14:06:40.0981473Z     rule for rule in group.ingress_rules if rule.id not in security_rule_ids
2024-03-06T14:06:40.0984656Z                      ^^^^^^^^^^^^^^^^^^^
2024-03-06T14:06:40.0985602Z AttributeError: 'NoneType' object has no attribute 'ingress_rules'
```

The PR adds a check for this on both revoking ingress and egress rules


## TODO
- [ ] write a test