### PR TITLE
S3: Sending notification to EventBridge `OBJECT_CREATED_COMPLETE_MULTIPART_UPLOAD_EVENT`

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2429,6 +2429,13 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         value, etag, checksum = multipart.complete(body)
         if value is not None:
             del bucket.multiparts[multipart_id]
+
+        notifications.send_event(
+            self.account_id,
+            notifications.S3NotificationEvent.OBJECT_CREATED_COMPLETE_MULTIPART_UPLOAD_EVENT,
+            bucket,
+            bucket.keys.get(multipart.key_name),
+        )
         return multipart, value, etag, checksum
 
     def get_all_multiparts(self, bucket_name: str) -> Dict[str, FakeMultipart]:

--- a/tests/test_s3/test_s3_eventbridge_integration.py
+++ b/tests/test_s3/test_s3_eventbridge_integration.py
@@ -188,7 +188,7 @@ def test_complete_multipart_upload_notification():
     )
 
     events = _get_send_events()
-    assert len(events) == 2()  # [PutObject event, CompleteMultipartUpload event]
+    assert len(events) == 2  # [PutObject event, CompleteMultipartUpload event]
     event_message = json.loads(events[-1]["message"])
     assert event_message["detail-type"] == "Object Created"
     assert event_message["source"] == "aws.s3"


### PR DESCRIPTION
- Sending a notification to EventBridge when multipart upload is completed.
- Unittest is added.


related #7363
