### PR TITLE
Docs: refer to client, not client2, in sample

### DIFF
--- a/docs/docs/multi_account.rst
+++ b/docs/docs/multi_account.rst
@@ -26,11 +26,11 @@ Here is an example of what this looks like in practice:
     os.environ["MOTO_ACCOUNT_ID"] = "111111111111"
     client.create_bucket(Bucket="bucket-in-account-2")
 
-    assert [b["Name"] for b in client2.list_buckets()["Buckets"]] == ["bucket-in-account-2"]
+    assert [b["Name"] for b in client.list_buckets()["Buckets"]] == ["bucket-in-account-2"]
 
     # Now revert to the default account, by removing the environment variable
     del os.environ["MOTO_ACCOUNT_ID"]
-    assert [b["Name"] for b in client2.list_buckets()["Buckets"]] == ["bucket-default-account"]
+    assert [b["Name"] for b in client.list_buckets()["Buckets"]] == ["bucket-default-account"]
 
 
 


### PR DESCRIPTION
Later examples have a `client1` and a `client2`. This one only has `client`.