### PR TITLE
Fix requests mock for custom S3 endpoints

### DIFF
--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -44,7 +44,7 @@ class BotocoreStubber:
     def process_request(self, request: Any) -> Optional[TYPE_RESPONSE]:
         # Handle non-standard AWS endpoint hostnames from ISO regions or custom
         # S3 endpoints.
-        parsed_url = get_equivalent_url_in_aws_domain(request.url)
+        parsed_url, _ = get_equivalent_url_in_aws_domain(request.url)
         # Remove the querystring from the URL, as we'll never match on that
         clean_url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
 

--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -1,15 +1,14 @@
 import re
 from io import BytesIO
 from typing import Any, Optional, Union
-from urllib.parse import urlparse
 
 from botocore.awsrequest import AWSResponse
 
 import moto.backend_index as backend_index
-from moto import settings
 from moto.core.base_backend import BackendDict
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.config import passthrough_service, passthrough_url
+from moto.core.utils import get_equivalent_url_in_aws_domain
 
 
 class MockRawResponse(BytesIO):
@@ -43,30 +42,11 @@ class BotocoreStubber:
             return response
 
     def process_request(self, request: Any) -> Optional[TYPE_RESPONSE]:
+        # Handle non-standard AWS endpoint hostnames from ISO regions or custom
+        # S3 endpoints.
+        parsed_url = get_equivalent_url_in_aws_domain(request.url)
         # Remove the querystring from the URL, as we'll never match on that
-        x = urlparse(request.url)
-        host = x.netloc
-
-        # https://github.com/getmoto/moto/pull/6412
-        # Support ISO regions
-        iso_region_domains = [
-            "amazonaws.com.cn",
-            "c2s.ic.gov",
-            "sc2s.sgov.gov",
-            "cloud.adc-e.uk",
-            "csp.hci.ic.gov",
-        ]
-        for domain in iso_region_domains:
-            if host.endswith(domain):
-                host = host.replace(domain, "amazonaws.com")
-
-        # https://github.com/getmoto/moto/issues/2993
-        # Support S3-compatible tools (Ceph, Digital Ocean, etc)
-        for custom_endpoint in settings.get_s3_custom_endpoints():
-            if host == custom_endpoint or host == custom_endpoint.split("://")[-1]:
-                host = "s3.amazonaws.com"
-
-        clean_url = f"{x.scheme}://{host}{x.path}"
+        clean_url = f"{parsed_url.scheme}://{parsed_url.netloc}{parsed_url.path}"
 
         if passthrough_url(clean_url):
             return None

--- a/moto/core/responses_custom_registry.py
+++ b/moto/core/responses_custom_registry.py
@@ -45,11 +45,15 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
         match_failed_reasons = []
 
         # Handle non-standard AWS endpoint hostnames from ISO regions or custom S3 endpoints.
-        url_with_standard_aws_domain = urlunparse(
-            get_equivalent_url_in_aws_domain(request.url)
-        )
-        request_with_standard_aws_domain = request.copy()
-        request_with_standard_aws_domain.prepare_url(url_with_standard_aws_domain, {})
+        parsed_url, url_was_modified = get_equivalent_url_in_aws_domain(request.url)
+        if url_was_modified:
+            url_with_standard_aws_domain = urlunparse(parsed_url)
+            request_with_standard_aws_domain = request.copy()
+            request_with_standard_aws_domain.prepare_url(
+                url_with_standard_aws_domain, {}
+            )
+        else:
+            request_with_standard_aws_domain = request
 
         for response in all_possibles:
             match_result, reason = response.matches(request_with_standard_aws_domain)

--- a/moto/core/responses_custom_registry.py
+++ b/moto/core/responses_custom_registry.py
@@ -1,10 +1,12 @@
 # This will only exist in responses >= 0.17
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlunparse
 
 import responses
 
 from .custom_responses_mock import CallbackResponse, not_implemented_callback
+from .utils import get_equivalent_url_in_aws_domain
 
 
 class CustomRegistry(responses.registries.FirstMatchRegistry):
@@ -41,8 +43,16 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
         )
         found = []
         match_failed_reasons = []
+
+        # Handle non-standard AWS endpoint hostnames from ISO regions or custom S3 endpoints.
+        url_with_standard_aws_domain = urlunparse(
+            get_equivalent_url_in_aws_domain(request.url)
+        )
+        request_with_standard_aws_domain = request.copy()
+        request_with_standard_aws_domain.prepare_url(url_with_standard_aws_domain, {})
+
         for response in all_possibles:
-            match_result, reason = response.matches(request)
+            match_result, reason = response.matches(request_with_standard_aws_domain)
             if match_result:
                 found.append(response)
             else:

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -3,10 +3,11 @@ import inspect
 import re
 from gzip import decompress
 from typing import Any, Callable, Dict, List, Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from botocore.exceptions import ClientError
 
+from ..settings import get_s3_custom_endpoints
 from .common_types import TYPE_RESPONSE
 from .versions import PYTHON_311
 
@@ -398,3 +399,40 @@ def get_partition_from_region(region_name: str) -> str:
     if region_name.startswith("cn-"):
         return "aws-cn"
     return "aws"
+
+
+def get_equivalent_url_in_aws_domain(url: str) -> ParseResult:
+    """Parses a URL and converts non-standard AWS endpoint hostnames (from ISO
+    regions or custom S3 endpoints) to the equivalent standard AWS domain.
+    """
+
+    parsed = urlparse(url)
+    host = parsed.netloc
+
+    # https://github.com/getmoto/moto/pull/6412
+    # Support ISO regions
+    iso_region_domains = [
+        "amazonaws.com.cn",
+        "c2s.ic.gov",
+        "sc2s.sgov.gov",
+        "cloud.adc-e.uk",
+        "csp.hci.ic.gov",
+    ]
+    for domain in iso_region_domains:
+        if host.endswith(domain):
+            host = host.replace(domain, "amazonaws.com")
+
+    # https://github.com/getmoto/moto/issues/2993
+    # Support S3-compatible tools (Ceph, Digital Ocean, etc)
+    for custom_endpoint in get_s3_custom_endpoints():
+        if host == custom_endpoint or host == custom_endpoint.split("://")[-1]:
+            host = "s3.amazonaws.com"
+
+    return ParseResult(
+        scheme=parsed.scheme,
+        netloc=host,
+        path=parsed.path,
+        params=parsed.params,
+        query=parsed.query,
+        fragment=parsed.fragment,
+    )

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -401,7 +401,7 @@ def get_partition_from_region(region_name: str) -> str:
     return "aws"
 
 
-def get_equivalent_url_in_aws_domain(url: str) -> tuple[ParseResult, bool]:
+def get_equivalent_url_in_aws_domain(url: str) -> Tuple[ParseResult, bool]:
     """Parses a URL and converts non-standard AWS endpoint hostnames (from ISO
     regions or custom S3 endpoints) to the equivalent standard AWS domain.
 


### PR DESCRIPTION
Prior to the commit that introduced mock_aws (a7f3b367b), it was possible to use the requests mock to access S3 presigned URLs that had a custom endpoint.

This commit restores that behavior by applying the hostname-remapping logic from BotocoreStubber to CustomRegistry.