### PR TITLE
S3: Add Notifications for Restore-actions

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6509,7 +6509,7 @@
 
 ## s3
 <details>
-<summary>67% implemented</summary>
+<summary>68% implemented</summary>
 
 - [X] abort_multipart_upload
 - [X] complete_multipart_upload
@@ -6605,7 +6605,7 @@
 - [X] put_object_retention
 - [X] put_object_tagging
 - [X] put_public_access_block
-- [ ] restore_object
+- [X] restore_object
 - [X] select_object_content
 - [X] upload_file
 - [X] upload_fileobj

--- a/docs/docs/services/s3.rst
+++ b/docs/docs/services/s3.rst
@@ -138,7 +138,7 @@ s3
 - [X] put_object_retention
 - [X] put_object_tagging
 - [X] put_public_access_block
-- [ ] restore_object
+- [X] restore_object
 - [X] select_object_content
   
         Highly experimental. Please raise an issue if you find any inconsistencies/bugs.

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -42,6 +42,7 @@ from moto.s3.exceptions import (
     InvalidBucketName,
     InvalidNotificationDestination,
     InvalidNotificationEvent,
+    InvalidObjectState,
     InvalidPart,
     InvalidPublicAccessBlockConfiguration,
     InvalidRequest,
@@ -197,6 +198,25 @@ class FakeKey(BaseModel, ManagedState):
         self._value_buffer.write(new_value)
         self.contentsize = len(new_value)
 
+    @property
+    def status(self) -> Optional[str]:
+        previous = self._status
+        new_status = super().status
+        if previous != "RESTORED" and new_status == "RESTORED":
+            s3_backend = s3_backends[self.account_id]["global"]
+            bucket = s3_backend.get_bucket(self.bucket_name)  # type: ignore
+            notifications.send_event(
+                self.account_id,
+                notifications.S3NotificationEvent.OBJECT_RESTORE_COMPLETED_EVENT,
+                bucket,
+                key=self,
+            )
+        return new_status
+
+    @status.setter
+    def status(self, value: str) -> None:
+        self._status = value
+
     def set_metadata(self, metadata: Any, replace: bool = False) -> None:
         if replace:
             self._metadata = {}  # type: ignore
@@ -215,6 +235,14 @@ class FakeKey(BaseModel, ManagedState):
 
     def restore(self, days: int) -> None:
         self._expiry = utcnow() + datetime.timedelta(days)
+        s3_backend = s3_backends[self.account_id]["global"]
+        bucket = s3_backend.get_bucket(self.bucket_name)  # type: ignore
+        notifications.send_event(
+            self.account_id,
+            notifications.S3NotificationEvent.OBJECT_RESTORE_POST_EVENT,
+            bucket,
+            key=self,
+        )
 
     @property
     def etag(self) -> str:
@@ -2853,6 +2881,16 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             )
             for x in query_result
         ]
+
+    def restore_object(self, bucket_name: str, key_name: str, days: str) -> bool:
+        key = self.get_object(bucket_name, key_name)
+        if not key:
+            raise MissingKey
+        if key.storage_class not in ARCHIVE_STORAGE_CLASSES:
+            raise InvalidObjectState(storage_class=key.storage_class)
+        had_expiry_date = key.expiry_date is not None
+        key.restore(int(days))
+        return had_expiry_date
 
     def upload_file(self) -> None:
         # Listed for the implementation coverage

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2274,14 +2274,11 @@ class S3Response(BaseResponse):
         elif "restore" in query:
             es = minidom.parseString(body).getElementsByTagName("Days")
             days = es[0].childNodes[0].wholeText
-            key = self.backend.get_object(bucket_name, key_name)  # type: ignore
-            if key.storage_class not in ARCHIVE_STORAGE_CLASSES:  # type: ignore
-                raise InvalidObjectState(storage_class=key.storage_class)  # type: ignore
-            r = 202
-            if key.expiry_date is not None:  # type: ignore
-                r = 200
-            key.restore(int(days))  # type: ignore
-            return r, {}, ""
+            previously_restored = self.backend.restore_object(
+                bucket_name, key_name, days
+            )
+            status_code = 200 if previously_restored else 202
+            return status_code, {}, ""
         elif "select" in query:
             request = xmltodict.parse(body)["SelectObjectContentRequest"]
             select_query = request["Expression"]

--- a/tests/test_s3/test_s3_storageclass.py
+++ b/tests/test_s3/test_s3_storageclass.py
@@ -203,9 +203,10 @@ def test_s3_copy_object_for_glacier_storage_class_restored():
     )
 
     s3_client.create_bucket(Bucket="Bucket2")
-    s3_client.restore_object(
+    resp = s3_client.restore_object(
         Bucket="Bucket", Key="First_Object", RestoreRequest={"Days": 123}
     )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 202
 
     s3_client.copy_object(
         CopySource={"Bucket": "Bucket", "Key": "First_Object"},
@@ -241,9 +242,10 @@ def test_s3_copy_object_for_deep_archive_storage_class_restored():
     assert err["StorageClass"] == "DEEP_ARCHIVE"
 
     s3_client.create_bucket(Bucket="Bucket2")
-    s3_client.restore_object(
+    resp = s3_client.restore_object(
         Bucket="Bucket", Key="First_Object", RestoreRequest={"Days": 123}
     )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 202
     s3_client.get_object(Bucket="Bucket", Key="First_Object")
 
     s3_client.copy_object(


### PR DESCRIPTION
See @7363

@tsugumi-sys The `restore_object`-function was implemented in S3, it was just hidden in `responses.py`.
This PR:
 - extracts the logic into the models-class
 - Adds a notification when a Restore-action is initiated and completed

Any feedback/improvements that you can see?