### PR TITLE
S3: `Days` must not be provided for select request when restoring object

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -584,3 +584,13 @@ class HeadOnDeleteMarker(Exception):
 
     def __init__(self, marker: "FakeDeleteMarker"):
         self.marker = marker
+
+
+class DaysMustNotProvidedForSelectRequest(S3ClientError):
+    code = 400
+
+    def __init__(self) -> None:
+        super().__init__(
+            "DaysMustNotProvidedForSelectRequest",
+            "`Days` must not be provided for select requests",
+        )

--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -594,3 +594,13 @@ class DaysMustNotProvidedForSelectRequest(S3ClientError):
             "DaysMustNotProvidedForSelectRequest",
             "`Days` must not be provided for select requests",
         )
+
+
+class DaysMustProvidedExceptForSelectRequest(S3ClientError):
+    code = 400
+
+    def __init__(self) -> None:
+        super().__init__(
+            "DaysMustProvidedExceptForSelectRequest",
+            "`Days` must be provided except for select requests",
+        )

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -38,6 +38,7 @@ from moto.s3.exceptions import (
     CopyObjectMustChangeSomething,
     CrossLocationLoggingProhibitted,
     DaysMustNotProvidedForSelectRequest,
+    DaysMustProvidedExceptForSelectRequest,
     EntityTooSmall,
     HeadOnDeleteMarker,
     InvalidBucketName,
@@ -2884,11 +2885,14 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         ]
 
     def restore_object(
-        self, bucket_name: str, key_name: str, days: Optional[str], type: Optional[str]
+        self, bucket_name: str, key_name: str, days: Optional[int], type: Optional[str]
     ) -> bool:
         key = self.get_object(bucket_name, key_name)
         if not key:
             raise MissingKey
+
+        if days is None and type is None:
+            raise DaysMustProvidedExceptForSelectRequest()
 
         if days and type:
             raise DaysMustNotProvidedForSelectRequest()
@@ -2896,7 +2900,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         if key.storage_class not in ARCHIVE_STORAGE_CLASSES:
             raise InvalidObjectState(storage_class=key.storage_class)
         had_expiry_date = key.expiry_date is not None
-        key.restore(int(days))
+        if days:
+            key.restore(days)
         return had_expiry_date
 
     def upload_file(self) -> None:

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -37,6 +37,7 @@ from moto.s3.exceptions import (
     BucketNeedsToBeNew,
     CopyObjectMustChangeSomething,
     CrossLocationLoggingProhibitted,
+    DaysMustNotProvidedForSelectRequest,
     EntityTooSmall,
     HeadOnDeleteMarker,
     InvalidBucketName,
@@ -2882,10 +2883,16 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             for x in query_result
         ]
 
-    def restore_object(self, bucket_name: str, key_name: str, days: str) -> bool:
+    def restore_object(
+        self, bucket_name: str, key_name: str, days: Optional[str], type: Optional[str]
+    ) -> bool:
         key = self.get_object(bucket_name, key_name)
         if not key:
             raise MissingKey
+
+        if days and type:
+            raise DaysMustNotProvidedForSelectRequest()
+
         if key.storage_class not in ARCHIVE_STORAGE_CLASSES:
             raise InvalidObjectState(storage_class=key.storage_class)
         had_expiry_date = key.expiry_date is not None

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -2885,23 +2885,23 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         ]
 
     def restore_object(
-        self, bucket_name: str, key_name: str, days: Optional[int], type: Optional[str]
+        self, bucket_name: str, key_name: str, days: Optional[str], type_: Optional[str]
     ) -> bool:
         key = self.get_object(bucket_name, key_name)
         if not key:
             raise MissingKey
 
-        if days is None and type is None:
+        if days is None and type_ is None:
             raise DaysMustProvidedExceptForSelectRequest()
 
-        if days and type:
+        if days and type_:
             raise DaysMustNotProvidedForSelectRequest()
 
         if key.storage_class not in ARCHIVE_STORAGE_CLASSES:
             raise InvalidObjectState(storage_class=key.storage_class)
         had_expiry_date = key.expiry_date is not None
         if days:
-            key.restore(days)
+            key.restore(int(days))
         return had_expiry_date
 
     def upload_file(self) -> None:

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2272,10 +2272,19 @@ class S3Response(BaseResponse):
             )
 
         elif "restore" in query:
-            es = minidom.parseString(body).getElementsByTagName("Days")
-            days = es[0].childNodes[0].wholeText
+            params = minidom.parseString(body)
+            _days = params.getElementsByTagName("Days")
+            days = None
+            if any(_days):
+                days = _days[0].childNodes[0].wholeText
+
+            _type = params.getElementsByTagName("Type")
+            type = None
+            if any(_type):
+                type = _type[0].childNodes[0].wholeText
+
             previously_restored = self.backend.restore_object(
-                bucket_name, key_name, days
+                bucket_name, key_name, days, type
             )
             status_code = 200 if previously_restored else 202
             return status_code, {}, ""

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2272,19 +2272,12 @@ class S3Response(BaseResponse):
             )
 
         elif "restore" in query:
-            params = minidom.parseString(body)
-            _days = params.getElementsByTagName("Days")
-            days = None
-            if any(_days):
-                days = _days[0].childNodes[0].wholeText
-
-            _type = params.getElementsByTagName("Type")
-            type = None
-            if any(_type):
-                type = _type[0].childNodes[0].wholeText
-
+            params = xmltodict.parse(body)["RestoreRequest"]
             previously_restored = self.backend.restore_object(
-                bucket_name, key_name, days, type
+                bucket_name,
+                key_name,
+                params.get("Days", None),
+                params.get("Type", None),
             )
             status_code = 200 if previously_restored else 202
             return status_code, {}, ""

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -638,7 +638,14 @@ def test_restore_object_invalid_request_params():
 
     key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
 
-    # Days must not be provided for select requests
+    # `Days` must be provided except for select requests
+    with pytest.raises(ClientError) as exc:
+        key.restore_object(RestoreRequest={})
+    err = exc.value.response["Error"]
+    assert err["Code"] == "DaysMustProvidedExceptForSelectRequest"
+    assert err["Message"] == "`Days` must be provided except for select requests"
+
+    # `Days` must not be provided for select requests
     with pytest.raises(ClientError) as exc:
         key.restore_object(RestoreRequest={"Days": 1, "Type": "SELECT"})
     err = exc.value.response["Error"]

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -628,6 +628,25 @@ def test_cannot_restore_standard_class_object():
 
 
 @mock_aws
+def test_restore_object_invalid_request_params():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Can't set transition directly in ServerMode")
+
+    s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
+    bucket = s3_resource.Bucket("foobar")
+    bucket.create()
+
+    key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
+
+    # Days must not be provided for select requests
+    with pytest.raises(ClientError) as exc:
+        key.restore_object(RestoreRequest={"Days": 1, "Type": "SELECT"})
+    err = exc.value.response["Error"]
+    assert err["Code"] == "DaysMustNotProvidedForSelectRequest"
+    assert err["Message"] == "`Days` must not be provided for select requests"
+
+
+@mock_aws
 def test_get_versioning_status():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     bucket = s3_resource.Bucket("foobar")


### PR DESCRIPTION
- Raise error when both `Days` and `Type` parameters exist in restore object request.

![image](https://github.com/getmoto/moto/assets/61897166/2f364864-297f-4c30-bdea-dd07fc3162b0)
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/restore_object.html

related: https://github.com/getmoto/moto/issues/7467