### PR TITLE
Admin: Fix ruff warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 
 format:
 	black moto/ tests/
-	ruff --fix moto/ tests/
+	ruff check --fix moto/ tests/
 
 test-only:
 	rm -f .coverage


### PR DESCRIPTION
If you run `make format`, ruff shows the following warning.

![image](https://github.com/getmoto/moto/assets/61897166/53bd5920-04d2-413e-a3ba-8b8363227488)

I changed the ruff command to solve this warning.
