### PR TITLE
Sets autoscalinggroup CreatedTime during creation.

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -1,5 +1,6 @@
 import itertools
 from collections import OrderedDict
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -439,6 +440,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         mixed_instance_policy: Optional[Dict[str, Any]],
         capacity_rebalance: bool,
         new_instances_protected_from_scale_in: bool = False,
+        created_time: datetime = datetime.now(),
     ):
         self.autoscaling_backend = autoscaling_backend
         self.ec2_backend = ec2_backend
@@ -483,6 +485,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
 
         self.metrics: List[str] = []
         self.warm_pool: Optional[FakeWarmPool] = None
+        self.created_time = created_time
 
     @property
     def tags(self) -> List[Dict[str, str]]:

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -833,7 +833,7 @@ DESCRIBE_AUTOSCALING_GROUPS_TEMPLATE = """<DescribeAutoScalingGroupsResponse xml
         </SuspendedProcesses>
         <AutoScalingGroupName>{{ group.name }}</AutoScalingGroupName>
         <HealthCheckType>{{ group.health_check_type }}</HealthCheckType>
-        <CreatedTime>2013-05-06T17:47:15.107Z</CreatedTime>
+        <CreatedTime>{{ group.created_time }}</CreatedTime>
         {% if group.launch_config_name %}
         <LaunchConfigurationName>{{ group.launch_config_name }}</LaunchConfigurationName>
         {% elif group.mixed_instance_policy %}

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1347,6 +1347,7 @@ def test_sets_created_time():
     )
 
     asgs = conn.describe_auto_scaling_groups()["AutoScalingGroups"]
-    old_created_time = "2013-05-06T17:47:15.107Z"
     assert len(asgs) == 1
-    assert asgs[0]["CreatedTime"] != datetime.fromisoformat(old_created_time)
+    assert asgs[0]["CreatedTime"] != datetime.strptime(
+        "2013-05-06T17:47:15.107Z", "%Y-%m-%dT%H:%M:%S.%f%z"
+    )

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from uuid import uuid4
 
 import boto3
@@ -1325,3 +1326,27 @@ def test_create_template_with_block_device():
     # Our Ebs-volume
     assert volumes[1]["VolumeType"] == "gp3"
     assert volumes[1]["Size"] == 20
+
+
+@mock_aws
+def test_sets_created_time():
+    mocked_networking = setup_networking()
+    conn = boto3.client("autoscaling", region_name="us-east-1")
+    conn.create_launch_configuration(
+        LaunchConfigurationName="TestLC",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
+    )
+
+    conn.create_auto_scaling_group(
+        AutoScalingGroupName="TestGroup1",
+        MinSize=1,
+        MaxSize=2,
+        LaunchConfigurationName="TestLC",
+        VPCZoneIdentifier=mocked_networking["subnet1"],
+    )
+
+    asgs = conn.describe_auto_scaling_groups()["AutoScalingGroups"]
+    old_created_time = "2013-05-06T17:47:15.107Z"
+    assert len(asgs) == 1
+    assert asgs[0]["CreatedTime"] != datetime.fromisoformat(old_created_time)


### PR DESCRIPTION
Use the current time instead of hard coded '2013-05-06T17:47:15.107Z' when creating an autoscaling group.
Updated template to return the correct created time.
Added unit test.