### PR TITLE
Server: check ready state with `threading.Event`

### DIFF
--- a/moto/moto_server/threaded_moto_server.py
+++ b/moto/moto_server/threaded_moto_server.py
@@ -18,10 +18,6 @@ class ThreadedMotoServer:
         self._server_ready_event = Event()
         self._verbose = verbose
 
-    @property
-    def _server_ready(self) -> bool:
-        return self._server_ready_event.is_set()
-
     def _server_entry(self) -> None:
         app = DomainDispatcherApplication(create_backend_app)
 

--- a/moto/moto_server/threaded_moto_server.py
+++ b/moto/moto_server/threaded_moto_server.py
@@ -1,5 +1,4 @@
-import time
-from threading import Thread
+from threading import Event, Thread
 from typing import Optional
 
 from werkzeug.serving import BaseWSGIServer, make_server
@@ -11,20 +10,23 @@ class ThreadedMotoServer:
     def __init__(
         self, ip_address: str = "0.0.0.0", port: int = 5000, verbose: bool = True
     ):
-
         self._port = port
 
         self._thread: Optional[Thread] = None
         self._ip_address = ip_address
         self._server: Optional[BaseWSGIServer] = None
-        self._server_ready = False
+        self._server_ready_event = Event()
         self._verbose = verbose
+
+    @property
+    def _server_ready(self) -> bool:
+        return self._server_ready_event.is_set()
 
     def _server_entry(self) -> None:
         app = DomainDispatcherApplication(create_backend_app)
 
         self._server = make_server(self._ip_address, self._port, app, True)
-        self._server_ready = True
+        self._server_ready_event.set()
         self._server.serve_forever()
 
     def start(self) -> None:
@@ -34,11 +36,10 @@ class ThreadedMotoServer:
             )
         self._thread = Thread(target=self._server_entry, daemon=True)
         self._thread.start()
-        while not self._server_ready:
-            time.sleep(0.1)
+        self._server_ready_event.wait()
 
     def stop(self) -> None:
-        self._server_ready = False
+        self._server_ready_event.clear()
         if self._server:
             self._server.shutdown()
 


### PR DESCRIPTION
This PR aims to replace the busy waiting of the `ThreadedMotoServer` startup with the more clear `threading.Event` object. This change will also reduce the `ThreadedMotoServer.start` method execution time, as the Werkzeug server startup time is usually less than 0.1 seconds.