### PR TITLE
Add StreamSummaries to the respose of kinesis.list_streams

### DIFF
--- a/moto/kinesis/responses.py
+++ b/moto/kinesis/responses.py
@@ -56,7 +56,10 @@ class KinesisResponse(BaseResponse):
             {
                 "HasMoreStreams": has_more_streams,
                 "StreamNames": streams_resp,
-                "StreamSummaries": [stream.to_json_summary() for stream in streams],
+                "StreamSummaries": [
+                    stream.to_json_summary()["StreamDescriptionSummary"]
+                    for stream in streams
+                ],
             }
         )
 

--- a/moto/kinesis/responses.py
+++ b/moto/kinesis/responses.py
@@ -53,7 +53,11 @@ class KinesisResponse(BaseResponse):
             has_more_streams = True
 
         return json.dumps(
-            {"HasMoreStreams": has_more_streams, "StreamNames": streams_resp}
+            {
+                "HasMoreStreams": has_more_streams,
+                "StreamNames": streams_resp,
+                "StreamSummaries": [stream.to_json_summary() for stream in streams],
+            }
         )
 
     def delete_stream(self) -> str:

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -149,12 +149,12 @@ def test_list_streams_stream_discription():
     for i, stream in enumerate(resp["StreamSummaries"]):
         stream_name = f"stream{i}"
         assert stream["StreamName"] == stream_name
-        assert stream["OpenShardCount"] == i + 1
         assert (
             stream["StreamARN"]
             == f"arn:aws:kinesis:us-west-2:{ACCOUNT_ID}:stream/{stream_name}"
         )
         assert stream["StreamStatus"] == "ACTIVE"
+        assert stream.get("StreamCreationTimestamp")
 
 
 @mock_aws

--- a/tests/test_kinesis/test_kinesis.py
+++ b/tests/test_kinesis/test_kinesis.py
@@ -138,6 +138,26 @@ def test_describe_stream_summary():
 
 
 @mock_aws
+def test_list_streams_stream_discription():
+    conn = boto3.client("kinesis", region_name="us-west-2")
+
+    for i in range(3):
+        conn.create_stream(StreamName=f"stream{i}", ShardCount=i+1)
+
+    resp = conn.list_streams()
+    assert len(resp["StreamSummaries"]) == 3
+    for i, stream in enumerate(resp["StreamSummaries"]):
+        stream_name = f"stream{i}"
+        assert stream["StreamName"] == stream_name
+        assert stream["OpenShardCount"] == i + 1
+        assert (
+            stream["StreamARN"]
+            == f"arn:aws:kinesis:us-west-2:{ACCOUNT_ID}:stream/{stream_name}"
+        )
+        assert stream["StreamStatus"] == "ACTIVE"
+
+
+@mock_aws
 def test_basic_shard_iterator():
     client = boto3.client("kinesis", region_name="us-west-1")
 

--- a/tests/test_kinesis/test_server.py
+++ b/tests/test_kinesis/test_server.py
@@ -12,4 +12,8 @@ def test_list_streams():
     res = test_client.get("/?Action=ListStreams")
 
     json_data = json.loads(res.data.decode("utf-8"))
-    assert json_data == {"HasMoreStreams": False, "StreamNames": []}
+    assert json_data == {
+        "HasMoreStreams": False,
+        "StreamNames": [],
+        "StreamSummaries": []
+    }


### PR DESCRIPTION
The default [boto3 response](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kinesis/client/list_streams.html) includes the StreamSummaries key.  This is added in this PR.
Closes #7476 