### PR TITLE
add validations and tag filter to describe-security-group-rules operation

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -198,10 +198,10 @@ class InvalidSecurityGroupNotFoundError(EC2ClientError):
 
 
 class InvalidGroupIdMalformedError(EC2ClientError):
-    def __init__(self, group_id: Any):
+    def __init__(self, group_id: str):
         super().__init__(
             "InvalidGroupId.Malformed",
-            f"The security group ID 'foobar' is malformed",
+            f"The security group ID '{group_id}' is malformed",
         )
 
 
@@ -444,12 +444,14 @@ class InvalidParameterValueError(EC2ClientError):
             f"Value {parameter_value} is invalid for parameter.",
         )
 
+
 class InvalidParameterValueFilterError(EC2ClientError):
     def __init__(self, parameter_value: str):
         super().__init__(
             "InvalidParameterValue",
             f"The filter '{parameter_value}' is invalid",
         )
+
 
 class InvalidParameterValueErrorPeeringAttachment(EC2ClientError):
     def __init__(self, operation: str, transit_gateway_attachment_id: str):

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -197,6 +197,14 @@ class InvalidSecurityGroupNotFoundError(EC2ClientError):
         )
 
 
+class InvalidGroupIdMalformedError(EC2ClientError):
+    def __init__(self, group_id: Any):
+        super().__init__(
+            "InvalidGroupId.Malformed",
+            f"The security group ID 'foobar' is malformed",
+        )
+
+
 class InvalidPermissionNotFoundError(EC2ClientError):
     def __init__(self) -> None:
         super().__init__(
@@ -436,6 +444,12 @@ class InvalidParameterValueError(EC2ClientError):
             f"Value {parameter_value} is invalid for parameter.",
         )
 
+class InvalidParameterValueFilterError(EC2ClientError):
+    def __init__(self, parameter_value: str):
+        super().__init__(
+            "InvalidParameterValue",
+            f"The filter '{parameter_value}' is invalid",
+        )
 
 class InvalidParameterValueErrorPeeringAttachment(EC2ClientError):
     def __init__(self, operation: str, transit_gateway_attachment_id: str):

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -10,14 +10,15 @@ from moto.core.utils import aws_api_matches
 
 from ..exceptions import (
     InvalidCIDRSubnetError,
+    InvalidGroupIdMalformedError,
+    InvalidParameterValueFilterError,
     InvalidPermissionDuplicateError,
     InvalidPermissionNotFoundError,
     InvalidSecurityGroupDuplicateError,
     InvalidSecurityGroupNotFoundError,
     MissingParameterError,
     MotoNotImplementedError,
-    RulesPerSecurityGroupLimitExceededError, InvalidGroupIdMalformedError, InvalidParameterValueError,
-    InvalidParameterValueFilterError,
+    RulesPerSecurityGroupLimitExceededError,
 )
 from ..utils import (
     is_tag_filter,
@@ -578,12 +579,14 @@ class SecurityGroupBackend:
 
         # filters validation
         group_id_regex = r"sg-[a-f0-9]{8,17}"
-        for filter in filters:
-            if filter not in ["security-group-rule-id", "group-id", "tag"]:
-                raise InvalidParameterValueFilterError(filter)
+        for filter_name in filters:
+            if filter_name not in ["security-group-rule-id", "group-id", "tag"]:
+                raise InvalidParameterValueFilterError(filter_name)
 
-            if filter == "group-id" and not re.match(group_id_regex, filters[filter][0]):
-                raise InvalidGroupIdMalformedError(filters[filter][0])
+            if filter_name == "group-id" and not re.match(
+                group_id_regex, filters[filter_name][0]
+            ):
+                raise InvalidGroupIdMalformedError(filters[filter_name][0])
 
         matches = self.describe_security_groups(group_ids=group_ids, filters=filters)
         rules = {}

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Dict, List, Tuple
 
 from ._base_response import EC2BaseResponse

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any, Dict, List, Tuple
 
 from ._base_response import EC2BaseResponse

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -1896,8 +1896,7 @@ def test_security_group_rules_filter():
     group_name = "test"
 
     response = ec2.create_security_group(
-        Description="Inventing a security group",
-        GroupName=group_name
+        Description="Inventing a security group", GroupName=group_name
     )
     group_id = response["GroupId"]
 
@@ -1908,58 +1907,36 @@ def test_security_group_rules_filter():
                 "IpProtocol": "tcp",
                 "FromPort": 1234,
                 "ToPort": 1234,
-                "IpRanges": [
-                    {
-                        "CidrIp": "12.34.56.78/32",
-                        "Description": "fakeip"
-                    }
-                ]
+                "IpRanges": [{"CidrIp": "12.34.56.78/32", "Description": "fakeip"}],
             }
-        ]
+        ],
     )
 
     response = ec2.describe_security_group_rules(
-        Filters=[
-            {
-                "Name": "group-id",
-                "Values": [group_id]
-            }
-        ]
+        Filters=[{"Name": "group-id", "Values": [group_id]}]
     )
 
     assert len(response["SecurityGroupRules"]) == 2
 
     response = ec2.describe_security_group_rules(
-            Filters=[
-                {
-                    "Name": "group-id",
-                    "Values": ["sg-12345678"]
-                }
-            ]
-        )
+        Filters=[{"Name": "group-id", "Values": ["sg-12345678"]}]
+    )
 
     assert len(response["SecurityGroupRules"]) == 0
 
     with pytest.raises(ClientError) as ex:
         ec2.describe_security_group_rules(
-            Filters=[
-                {
-                    "Name": "group-id",
-                    "Values": ["foobar"]
-                }
-            ]
+            Filters=[{"Name": "group-id", "Values": ["foobar"]}]
         )
     assert ex.value.response["Error"]["Code"] == "InvalidGroupId.Malformed"
-    assert ex.value.response["Error"]["Message"] == "The security group ID 'foobar' is malformed"
+    assert (
+        ex.value.response["Error"]["Message"]
+        == "The security group ID 'foobar' is malformed"
+    )
 
     with pytest.raises(ClientError) as ex:
         ec2.describe_security_group_rules(
-            Filters=[
-                {
-                    "Name": "group-name",
-                    "Values": [group_name]
-                }
-            ]
+            Filters=[{"Name": "group-name", "Values": [group_name]}]
         )
     assert ex.value.response["Error"]["Code"] == "InvalidParameterValue"
     assert ex.value.response["Error"]["Message"] == "The filter 'group-name' is invalid"


### PR DESCRIPTION
This pull request includes additional validations for the filters in the ec2 describe-security-group-rules operation. This resolves the issue identified in localstack/localstack#10315.