### PR TITLE
updated default value for share status in route53resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,6 @@ test-only:
 
 test: lint test-only
 
-terraformtests:
-	@echo "Make sure that the MotoServer is already running on port 4566 (moto_server -p 4566)"
-	@echo "USAGE: make terraformtests SERVICE_NAME=acm TEST_NAMES=TestAccACMCertificate"
-	@echo ""
-	cd tests/terraformtests && bin/run_go_test $(SERVICE_NAME) "$(TEST_NAMES)"
-
 test_server:
 	@TEST_SERVER_MODE=true pytest -sv --cov=moto --cov-report xml ./tests/
 

--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -122,7 +122,7 @@ class ResolverRule(BaseModel):  # pylint: disable=too-many-instance-attributes
             f"[Trace id: 1-{mock_random.get_random_hex(8)}-{mock_random.get_random_hex(24)}] "
             f"Successfully created Resolver Rule"
         )
-        self.share_status = "SHARED_WITH_ME"
+        self.share_status = "NOT_SHARED"
         self.creation_time = datetime.now(timezone.utc).isoformat()
         self.modification_time = datetime.now(timezone.utc).isoformat()
 

--- a/tests/test_route53resolver/test_route53resolver_rule.py
+++ b/tests/test_route53resolver/test_route53resolver_rule.py
@@ -160,7 +160,7 @@ def test_route53resolver_create_resolver_rule():  # pylint: disable=too-many-loc
     assert rule["TargetIps"][0]["Port"] == target_ips[0]["Port"]
     assert rule["ResolverEndpointId"] == endpoint_id
     assert rule["OwnerId"] == ACCOUNT_ID
-    assert rule["ShareStatus"] == "SHARED_WITH_ME"
+    assert rule["ShareStatus"] == "NOT_SHARED"
 
     time_format = "%Y-%m-%dT%H:%M:%S.%f+00:00"
     now = datetime.now(timezone.utc).replace(tzinfo=None)


### PR DESCRIPTION
# Changes
- Updated default value for `shared_status` in route53resolver
- Removed unused code from `Makefile` which was used for terraform tests
- Updated the test cases