### PR TITLE
Fix: ruff check error in `test_resourcegroupstaggingapi.py

### DIFF
--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -745,11 +745,13 @@ def test_get_resources_sqs():
     assert len(resp["ResourceTagMappingList"]) == 1
     assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
 
+
 def create_directory():
     ec2_client = boto3.client("ec2", region_name="eu-central-1")
     ds_client = boto3.client("ds", region_name="eu-central-1")
     directory_id = create_test_directory(ds_client, ec2_client)
     return directory_id
+
 
 @mock_aws
 def test_get_resources_workspaces():
@@ -758,26 +760,25 @@ def test_get_resources_workspaces():
     # Create two tagged Workspaces
     directory_id = create_directory()
     workspaces.register_workspace_directory(
-        DirectoryId=directory_id,
-        EnableWorkDocs=False
+        DirectoryId=directory_id, EnableWorkDocs=False
     )
     workspaces.create_workspaces(
         Workspaces=[
             {
-                'DirectoryId': directory_id,
-                'UserName': 'Administrator',
-                'BundleId': 'wsb-bh8rsxt14',
-                'Tags': [
-                        {"Key": "Test", "Value": "1"},
-                    ],
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
+                "Tags": [
+                    {"Key": "Test", "Value": "1"},
+                ],
             },
             {
-                'DirectoryId': directory_id,
-                'UserName': 'Administrator',
-                'BundleId': 'wsb-bh8rsxt14',
-                'Tags': [
-                        {"Key": "Test", "Value": "2"},
-                    ],
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
+                "Tags": [
+                    {"Key": "Test", "Value": "2"},
+                ],
             },
         ]
     )
@@ -795,6 +796,7 @@ def test_get_resources_workspaces():
     )
     assert len(resp["ResourceTagMappingList"]) == 1
     assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
+
 
 @mock_aws
 def test_get_resources_workspace_directories():
@@ -826,6 +828,7 @@ def test_get_resources_workspace_directories():
     assert len(resp["ResourceTagMappingList"]) == 1
     assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
 
+
 @mock_aws
 def test_get_resources_workspace_images():
     workspaces = boto3.client("workspaces", region_name="eu-central-1")
@@ -833,26 +836,25 @@ def test_get_resources_workspace_images():
     # Create two tagged Workspace Images
     directory_id = create_directory()
     workspaces.register_workspace_directory(
-        DirectoryId=directory_id,
-        EnableWorkDocs=False
+        DirectoryId=directory_id, EnableWorkDocs=False
     )
     resp = workspaces.create_workspaces(
         Workspaces=[
             {
-                'DirectoryId': directory_id,
-                'UserName': 'Administrator',
-                'BundleId': 'wsb-bh8rsxt14',
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
             },
         ]
     )
     workspace_id = resp["PendingRequests"][0]["WorkspaceId"]
     for i in range(1, 3):
         i_str = str(i)
-        image = workspaces.create_workspace_image(
-            Name=f'test-image-{i_str}',
-            Description='Test workspace image',
+        _ = workspaces.create_workspace_image(
+            Name=f"test-image-{i_str}",
+            Description="Test workspace image",
             WorkspaceId=workspace_id,
-            Tags=[{"Key": "Test", "Value": i_str}]
+            Tags=[{"Key": "Test", "Value": i_str}],
         )
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
 
@@ -868,6 +870,7 @@ def test_get_resources_workspace_images():
     assert len(resp["ResourceTagMappingList"]) == 1
     assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
 
+
 @mock_aws
 def test_get_resources_sns():
     sns = boto3.client("sns", region_name="us-east-1")
@@ -881,6 +884,7 @@ def test_get_resources_sns():
     assert {"Key": "Shape", "Value": "Square"} in resp["ResourceTagMappingList"][0][
         "Tags"
     ]
+
 
 @mock_aws
 def test_get_resources_ssm():
@@ -899,16 +903,16 @@ def test_get_resources_ssm():
         Name="TestDocument",
         DocumentType="Command",
         DocumentFormat="JSON",
-        Tags=[{"Key": 'testing', "Value": "testingValue"}],
+        Tags=[{"Key": "testing", "Value": "testingValue"}],
     )
 
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
     resp = rtapi.get_resources(ResourceTypeFilters=["ssm"])
 
     assert len(resp["ResourceTagMappingList"]) == 1
-    assert {"Key": 'testing', "Value": "testingValue"} in resp["ResourceTagMappingList"][0][
-        "Tags"
-    ]
+    assert {"Key": "testing", "Value": "testingValue"} in resp[
+        "ResourceTagMappingList"
+    ][0]["Tags"]
 
 
 @mock_aws


### PR DESCRIPTION
- Fix the following error by ruff: 
- black format is applied.
```
tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py:851:9: F841 Local variable `image` is assigned to but never used.
```
