### PR TITLE
fixed secretsmanager list api to support filtering correctly

### DIFF
--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import List
 
 from moto.core.base_backend import BackendDict, BaseBackend
 

--- a/moto/secretsmanager/list_secrets/filters.py
+++ b/moto/secretsmanager/list_secrets/filters.py
@@ -33,8 +33,8 @@ def filter_all(secret: "FakeSecret", values: List[str]) -> bool:
 def _matcher(patterns: List[str], strings: List[str]) -> bool:
     for pattern in [p for p in patterns if p.startswith("!")]:
         for string in strings:
-            if _match_pattern(pattern[1:], string):
-                return False
+            if not _match_pattern(pattern[1:], string):
+                return True
 
     for pattern in [p for p in patterns if not p.startswith("!")]:
         for string in strings:
@@ -45,6 +45,6 @@ def _matcher(patterns: List[str], strings: List[str]) -> bool:
 
 def _match_pattern(pattern: str, value: str) -> bool:
     for word in pattern.split(" "):
-        if word not in value:
+        if not value.startswith(word):
             return False
     return True

--- a/tests/test_secretsmanager/test_list_secrets.py
+++ b/tests/test_secretsmanager/test_list_secrets.py
@@ -271,9 +271,7 @@ def test_with_filter_with_negation():
     for secret_name in ["foo", "bar", "baz"]:
         assert secret_name in secret_names
 
-    secrets = conn.list_secrets(
-        Filters=[{"Key": "description", "Values": ["!o"]}]
-    )
+    secrets = conn.list_secrets(Filters=[{"Key": "description", "Values": ["!o"]}])
     secret_names = list(map(lambda s: s["Name"], secrets["SecretList"]))
     for secret_name in ["qux", "none"]:
         assert secret_name in secret_names

--- a/tests/test_secretsmanager/test_list_secrets.py
+++ b/tests/test_secretsmanager/test_list_secrets.py
@@ -268,7 +268,15 @@ def test_with_filter_with_negation():
     )
 
     secret_names = list(map(lambda s: s["Name"], secrets["SecretList"]))
-    assert secret_names == ["baz"]
+    for secret_name in ["foo", "bar", "baz"]:
+        assert secret_name in secret_names
+
+    secrets = conn.list_secrets(
+        Filters=[{"Key": "description", "Values": ["!o"]}]
+    )
+    secret_names = list(map(lambda s: s["Name"], secrets["SecretList"]))
+    for secret_name in ["qux", "none"]:
+        assert secret_name in secret_names
 
 
 @mock_aws


### PR DESCRIPTION
# Motivation
This PR addresses the issue in the list operation of Secrets Manager where filters were incorrectly applied to the entire key rather than just the prefix.

# Issue
Previously, filters were matched against the entire key, which is incorrect. The correct behavior is to match filters against the prefix only.

- Reference: [AWS Boto3 Secrets Manager list_secrets documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/list_secrets.html#list-secrets)
- This issue was initially reported in [LocalStack issue #4820](https://github.com/localstack/localstack/issues/4820).
- AWS validated test case implemented [here](https://github.com/localstack/localstack/pull/10520).
- More details on the list api: https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_search-secret.html