### PR TITLE
SNS: delete_endpoint() is now an idempotent operation, just like AWS

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -715,7 +715,7 @@ class SNSBackend(BaseBackend):
         try:
             del self.platform_endpoints[arn]
         except KeyError:
-            raise SNSNotFoundError(f"Endpoint with arn {arn} not found")
+            pass  # idempotent operation
 
     def get_subscription_attributes(self, arn: str) -> Dict[str, Any]:
         subscription = self.subscriptions.get(arn)

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -266,6 +266,13 @@ def test_get_list_endpoints_by_platform_application(api_key=None):
         assert len(endpoint_list) == 1
         assert endpoint_list[0]["Attributes"]["CustomUserData"] == "some data"
         assert endpoint_list[0]["EndpointArn"] == endpoint_arn
+
+        resp = conn.delete_endpoint(EndpointArn=endpoint_arn)
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        # Idempotent operation
+        resp = conn.delete_endpoint(EndpointArn=endpoint_arn)
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
     finally:
         if application_arn is not None:
             conn.delete_platform_application(PlatformApplicationArn=application_arn)


### PR DESCRIPTION
Fixes #7517 