### PR TITLE
Simplify time check in logs.create_export_task

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1264,7 +1264,7 @@ class LogsBackend(BaseBackend):
             value=b"Permission Check Successful",
         )
 
-        if fromTime <= unix_time_millis(datetime.now()) <= to:
+        if fromTime <= to:
             for stream_name in self.groups[logGroupName].streams.keys():
                 logs, _, _ = self.filter_log_events(
                     log_group_name=logGroupName,


### PR DESCRIPTION
In our codebase, we had some errors where created export tasks weren't "running", after some tracking down it was because the "now" time in our tests wasn't between the `to`/`from` times, so the case that marked them as done was getting skipped.

I can see that this check that "now" is in the middle was added in #7058, but I couldn't find any context as to why. My understanding is the "real" API would kick off an export task even if both `from` and `to` were in the past, so this PR proposes simplifying that check.