### PR TITLE
fix tag operations in secretsmanager

### DIFF
--- a/moto/secretsmanager/list_secrets/filters.py
+++ b/moto/secretsmanager/list_secrets/filters.py
@@ -13,19 +13,23 @@ def description_filter(secret: "FakeSecret", descriptions: List[str]) -> bool:
 
 
 def tag_key(secret: "FakeSecret", tag_keys: List[str]) -> bool:
+    if not secret.tags:
+        return False
     return _matcher(tag_keys, [tag["Key"] for tag in secret.tags])
 
 
 def tag_value(secret: "FakeSecret", tag_values: List[str]) -> bool:
+    if not secret.tags:
+        return False
     return _matcher(tag_values, [tag["Value"] for tag in secret.tags])
 
 
 def filter_all(secret: "FakeSecret", values: List[str]) -> bool:
-    attributes = (
-        [secret.name, secret.description]
-        + [tag["Key"] for tag in secret.tags]
-        + [tag["Value"] for tag in secret.tags]
-    )
+    attributes = [secret.name, secret.description]
+    if secret.tags:
+        attributes += [tag["Key"] for tag in secret.tags] + [
+            tag["Value"] for tag in secret.tags
+        ]
 
     return _matcher(values, attributes)  # type: ignore
 

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1622,6 +1622,10 @@ def test_tag_resource(pass_arn):
     conn = boto3.client("secretsmanager", region_name="us-west-2")
     created_secret = conn.create_secret(Name="test-secret", SecretString="foosecret")
     secret_id = created_secret["ARN"] if pass_arn else "test-secret"
+
+    response = conn.describe_secret(SecretId=secret_id)
+    assert "Tags" not in response
+
     conn.tag_resource(
         SecretId=secret_id, Tags=[{"Key": "FirstTag", "Value": "SomeValue"}]
     )
@@ -1677,6 +1681,14 @@ def test_untag_resource(pass_arn):
         "Secrets Manager can't find the specified secret."
         == cm.value.response["Error"]["Message"]
     )
+
+    conn.tag_resource(
+        SecretId=secret_id, Tags=[{"Key": "FirstTag", "Value": "SomeValue"}]
+    )
+    conn.untag_resource(SecretId=secret_id, TagKeys=["FirstTag", "SecondTag"])
+    response = conn.describe_secret(SecretId=secret_id)
+    assert "Tags" in response
+    assert response["Tags"] == []
 
 
 @mock_aws


### PR DESCRIPTION
# Description
This PR resolves the problem outlined in https://github.com/localstack/localstack/issues/10477.

# Breaking Scenarios

### Scenario 1
  - Secret creation without tags.
  - Addition of tags to the secret.
  - Removal of all tags from the secret.
  - Describing the secret reveals a `Tags` key with an empty list `[]`. *(Previously, this functionality was defective in moto.)*


### Scenario 2
  - Secret creation without tags.
  - Addition of tags to the secret.
  - Complete tag removal using `untag_resource` by specifying all tags.
  - On describing the secret, it should not contain of any tags. *(Previously, this was not correctly implemented in moto.)*

# Fixes
- Changing the default value of tags to `None` to identify weather the tags ever added.
- Addition of `NoneType` handling in filtering functions
- Updated logic for `untag_resource` to remove multiple tags at once.

# Testing
- Updated existing test cases to cover the scenario fixed 