### PR TITLE
DynamoDB: query/scan secondary index fixes

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -730,7 +730,7 @@ class DynamoHandler(BaseResponse):
         index_name = self.body.get("IndexName")
         exclusive_start_key = self.body.get("ExclusiveStartKey")
         limit = self.body.get("Limit")
-        scan_index_forward = self.body.get("ScanIndexForward")
+        scan_index_forward = self.body.get("ScanIndexForward", True)
         consistent_read = self.body.get("ConsistentRead", False)
 
         items, scanned_count, last_evaluated_key = self.dynamodb_backend.query(


### PR DESCRIPTION
Recent logic added in 194088 to accommodate a missing start key brain-damaged pagination because determination of previously-encountered items was not implemented correctly for all use cases.

* Make sure comparisons are performed in the sense of `ScanIndexForward` (previously, this was assumed to be `True` -- the default -- and returned incorrect results when reverse sorting was requested)
* When querying/scanning a secondary index, make comparisons using the index attribute(s) instead of the primary table attribute(s)

This commit now passes my project's internal test suite, and also passes all existing moto DynamoDB unit tests. I expect to add a commit with a unit test that exercises a query with reverse sorting on a GSI with different key attributes, which describes my application's unit test that failed prior to this fix.