### PR TITLE
fix(cognito-idp): avoid KeyError on unexisting refresh token

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1964,7 +1964,7 @@ class CognitoIdpBackend(BaseBackend):
             if not refresh_token:
                 raise ResourceNotFoundError(refresh_token)
 
-            res = user_pool.refresh_tokens[refresh_token]
+            res = user_pool.refresh_tokens.get(refresh_token)
             if res is None:
                 raise NotAuthorizedError("Refresh Token has been revoked")
 


### PR DESCRIPTION
If an unexisting refresh token was passed to the `initiate_auth` with the `REFRESH_TOKEN_AUTH` flow, firstly the operation fails because of `KeyError` and after a few retrials, Moto returns a 500 status code response.

The fix was to use the `.get()` method to get a dictionary member or `None` if such doesn't exist instead of direct dictionary access with `[]`.