### PR TITLE
ResourceGroupsTaggingAPI: Fix Workspaces access in unsupported region

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -126,6 +126,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Workspaces service has limited region availability
         if self.region_name in workspaces_backends[self.account_id].regions:
             return workspaces_backends[self.account_id][self.region_name]
+        return None
 
     def _get_resources_generator(
         self,
@@ -539,7 +540,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # Workspaces
-        if self.workspaces_backend and (not resource_type_filters or "workspaces" in resource_type_filters):
+        if self.workspaces_backend and (
+            not resource_type_filters or "workspaces" in resource_type_filters
+        ):
             for ws in self.workspaces_backend.workspaces.values():
                 tags = format_tag_keys(ws.tags, ["Key", "Value"])
                 if not tags or not tag_filter(
@@ -553,7 +556,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # Workspace Directories
-        if self.workspaces_backend and (not resource_type_filters or "workspaces-directory" in resource_type_filters):
+        if self.workspaces_backend and (
+            not resource_type_filters or "workspaces-directory" in resource_type_filters
+        ):
             for wd in self.workspaces_backend.workspace_directories.values():
                 tags = format_tag_keys(wd.tags, ["Key", "Value"])
                 if not tags or not tag_filter(
@@ -567,7 +572,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # Workspace Images
-        if self.workspaces_backend and (not resource_type_filters or "workspaces-image" in resource_type_filters):
+        if self.workspaces_backend and (
+            not resource_type_filters or "workspaces-image" in resource_type_filters
+        ):
             for wi in self.workspaces_backend.workspace_images.values():
                 tags = format_tag_keys(wi.tags, ["Key", "Value"])
                 if not tags or not tag_filter(
@@ -934,7 +941,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 )
             elif arn.startswith("arn:aws:workspaces:"):
                 resource_id = arn.split("/")[-1]
-                self.workspaces_backend.create_tags(
+                self.workspaces_backend.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
                 )
             elif arn.startswith("arn:aws:logs:"):

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -122,8 +122,10 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return dynamodb_backends[self.account_id][self.region_name]
 
     @property
-    def workspaces_backend(self) -> WorkSpacesBackend:
-        return workspaces_backends[self.account_id][self.region_name]
+    def workspaces_backend(self) -> Optional[WorkSpacesBackend]:
+        # Workspaces service has limited region availability
+        if self.region_name in workspaces_backends[self.account_id].regions:
+            return workspaces_backends[self.account_id][self.region_name]
 
     def _get_resources_generator(
         self,
@@ -537,7 +539,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # Workspaces
-        if not resource_type_filters or "workspaces" in resource_type_filters:
+        if self.workspaces_backend and (not resource_type_filters or "workspaces" in resource_type_filters):
             for ws in self.workspaces_backend.workspaces.values():
                 tags = format_tag_keys(ws.tags, ["Key", "Value"])
                 if not tags or not tag_filter(
@@ -551,7 +553,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # Workspace Directories
-        if not resource_type_filters or "workspaces-directory" in resource_type_filters:
+        if self.workspaces_backend and (not resource_type_filters or "workspaces-directory" in resource_type_filters):
             for wd in self.workspaces_backend.workspace_directories.values():
                 tags = format_tag_keys(wd.tags, ["Key", "Value"])
                 if not tags or not tag_filter(
@@ -565,7 +567,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # Workspace Images
-        if not resource_type_filters or "workspaces-image" in resource_type_filters:
+        if self.workspaces_backend and (not resource_type_filters or "workspaces-image" in resource_type_filters):
             for wi in self.workspaces_backend.workspace_images.values():
                 tags = format_tag_keys(wi.tags, ["Key", "Value"])
                 if not tags or not tag_filter(

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_glue.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstagging_glue.py
@@ -8,7 +8,7 @@ from moto.core import DEFAULT_ACCOUNT_ID
 
 @mock_aws
 def test_glue_jobs():
-    glue = boto3.client("glue", region_name="us-west-2")
+    glue = boto3.client("glue", region_name="us-west-1")
     tag_key = str(uuid4())[0:6]
     tag_val = str(uuid4())[0:6]
     job_name = glue.create_job(
@@ -17,9 +17,9 @@ def test_glue_jobs():
         Command={"Name": "test_command"},
         Tags={tag_key: tag_val},
     )["Name"]
-    job_arn = f"arn:aws:glue:us-west-2:{DEFAULT_ACCOUNT_ID}:job/{job_name}"
+    job_arn = f"arn:aws:glue:us-west-1:{DEFAULT_ACCOUNT_ID}:job/{job_name}"
 
-    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-1")
     resources = rtapi.get_resources(ResourceTypeFilters=["glue"])[
         "ResourceTagMappingList"
     ]


### PR DESCRIPTION
This PR fixes a bug in ResourceGroupsTaggingAPI GetResources operation when called in us-east-2.

Internally the operation enumerates through the backends on various services. Backends also check whether a given service is available in a region. In this case, if a request to ResourceGroupsTaggingAPI GetResources is made to us-east-2 (or any region where Workspaces is not supported), an unhandled exception is thrown.

The issue is fixed by checking whether a service exists in a given region before attempting backend retrieval.

```py
$ ipy
Python 3.11.0rc1 (main, Aug 12 2022, 10:02:14) [GCC 11.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import boto3
   ...: import os
   ...: from moto import mock_aws

In [2]: mock = mock_aws()

In [3]: mock.start()

In [4]: client = boto3.client('resourcegroupstaggingapi', region_name='us-east-2')

In [5]: client.get_resources()
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)

(truncated)

File ~/repo/moto-ext/moto/resourcegroupstaggingapi/responses.py:23, in ResourceGroupsTaggingAPIResponse.get_resources(self)
     20 tags_per_page = self._get_int_param("TagsPerPage", 100)
     21 resource_type_filters = self._get_param("ResourceTypeFilters", [])
---> 23 pagination_token, resource_tag_mapping_list = self.backend.get_resources(
     24     pagination_token=pagination_token,
     25     tag_filters=tag_filters,
     26     resources_per_page=resources_per_page,
     27     tags_per_page=tags_per_page,
     28     resource_type_filters=resource_type_filters,
     29 )
     31 # Format tag response
     32 response = {"ResourceTagMappingList": resource_tag_mapping_list}

File ~/repo/moto-ext/moto/resourcegroupstaggingapi/models.py:795, in ResourceGroupsTaggingAPIBackend.get_resources(self, pagination_token, resources_per_page, tags_per_page, tag_filters, resource_type_filters)
    792 try:
    793     while True:
    794         # Generator format: [{'ResourceARN': str, 'Tags': [{'Key': str, 'Value': str]}, ...]
--> 795         next_item = next(generator)
    796         resource_tags = len(next_item["Tags"])
    798         if current_resources >= resources_per_page:

File ~/repo/moto-ext/moto/resourcegroupstaggingapi/models.py:541, in ResourceGroupsTaggingAPIBackend._get_resources_generator(self, tag_filters, resource_type_filters)
    539 # Workspaces
    540 if not resource_type_filters or "workspaces" in resource_type_filters:
--> 541     for ws in self.workspaces_backend.workspaces.values():
    542         tags = format_tag_keys(ws.tags, ["Key", "Value"])
    543         if not tags or not tag_filter(
    544             tags
    545         ):  # Skip if no tags, or invalid filter

File ~/repo/moto-ext/moto/resourcegroupstaggingapi/models.py:126, in ResourceGroupsTaggingAPIBackend.workspaces_backend(self)
    124 @property
    125 def workspaces_backend(self) -> WorkSpacesBackend:
--> 126     return workspaces_backends[self.account_id][self.region_name]

File ~/repo/moto-ext/moto/core/base_backend.py:291, in AccountSpecificBackend.__getitem__(self, region_name)
    287     if region_name not in self.regions and allow_unknown_region():
    288         super().__setitem__(
    289             region_name, self.backend(region_name, account_id=self.account_id)
    290         )
--> 291 return super().__getitem__(region_name)

KeyError: 'us-east-2'
```

Related: https://github.com/getmoto/moto/pull/7493