### PR TITLE
SecretsManager: Add some error messages for BatchGetSecretValue

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -496,11 +496,13 @@ class SecretsManagerBackend(BaseBackend):
                 # TODO perhaps there should be a check if the secret id is valid identifier
                 # and add an error to the list if not
                 try:
-                    # TODO investigate the behaviour when the secret doesn't exist or has been deleted,
-                    # might need to add an error to the list
                     secret_list.append(self.get_secret_value(secret_id, "", ""))
-                except (SecretNotFoundException, InvalidRequestException):
-                    pass
+                except (SecretNotFoundException, InvalidRequestException) as e:
+                    errors.append({
+                        "SecretId": secret_id,
+                        "ErrorCode": e.error_type,
+                        "Message": e.message
+                    })
 
         if filters:
             for secret in self.secrets.values():

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -210,6 +210,38 @@ def test_batch_get_secret_value_for_secret_id_list_without_matches():
         SecretIdList=["test-secret-b", "test-secret-c"]
     )
     assert len(secrets_batch["SecretValues"]) == 0
+    assert len(secrets_batch["Errors"]) == 2
+    assert secrets_batch["Errors"][0]["SecretId"] == "test-secret-b"
+    assert secrets_batch["Errors"][0]["ErrorCode"] == "ResourceNotFoundException"
+    assert secrets_batch["Errors"][0]["Message"] == "Secrets Manager can't find the specified secret."
+    assert secrets_batch["Errors"][1]["SecretId"] == "test-secret-c"
+    assert secrets_batch["Errors"][1]["ErrorCode"] == "ResourceNotFoundException"
+    assert secrets_batch["Errors"][1]["Message"] == "Secrets Manager can't find the specified secret."
+
+@mock_aws
+def test_batch_get_secret_value_for_secret_id_list_with_deleted_secret():
+    conn = boto3.client("secretsmanager", region_name="us-west-2")
+
+    conn.create_secret(Name="test-secret1", SecretString="foosecret1")
+    conn.create_secret(Name="test-secret2", SecretString="foosecret2")
+    conn.delete_secret(SecretId="test-secret1")
+
+    secrets_batch = conn.batch_get_secret_value(
+        SecretIdList=["test-secret1", "test-secret2"]
+    )
+
+    # test-secret1 has been marked as deleted and should be in the errors list
+    assert len(secrets_batch["Errors"]) == 1
+    assert secrets_batch["Errors"][0]["SecretId"] == "test-secret1"
+    assert secrets_batch["Errors"][0]["ErrorCode"] == "InvalidRequestException"
+    assert "currently marked deleted" in secrets_batch["Errors"][0]["Message"]
+
+    # test-secret2 is valid
+    assert len(secrets_batch["SecretValues"]) == 1
+    assert secrets_batch["SecretValues"][0]["SecretString"] == "foosecret2"
+    assert secrets_batch["SecretValues"][0]["Name"] == "test-secret2"
+
+
 
 
 @mock_aws
@@ -250,8 +282,6 @@ def test_batch_get_secret_value_with_both_secret_id_list_and_filters():
 
 @mock_aws
 def test_batch_get_secret_value_with_max_results_and_no_filters():
-    conn = boto3.client("secretsmanager", region_name="us-west-2")
-
     conn = boto3.client("secretsmanager", region_name="us-west-2")
     with pytest.raises(ClientError) as exc:
         conn.batch_get_secret_value(MaxResults=10, SecretIdList=["foo", "bar"])

--- a/tests/test_secretsmanager/test_server.py
+++ b/tests/test_secretsmanager/test_server.py
@@ -964,6 +964,13 @@ def test_batch_get_secret_value_for_secret_id_list_with_no_matches():
 
     json_data = json.loads(batch_get_secret_values.data.decode("utf-8"))
     assert len(json_data["SecretValues"]) == 0
+    assert len(json_data["Errors"]) == 2
+    assert json_data["Errors"][0]["SecretId"] == "db/username"
+    assert json_data["Errors"][0]["ErrorCode"] == "ResourceNotFoundException"
+    assert json_data["Errors"][0]["Message"] == "Secrets Manager can't find the specified secret."
+    assert json_data["Errors"][1]["SecretId"] == "db/password"
+    assert json_data["Errors"][1]["ErrorCode"] == "ResourceNotFoundException"
+    assert json_data["Errors"][1]["Message"] == "Secrets Manager can't find the specified secret."
 
 
 @mock_aws


### PR DESCRIPTION
For the `batch_get_secret_value` call, adds error reporting for secrets that aren't found or those that are marked as deleted. These will be included in the format returned from the AWS call:

```
{
  'SecretValues': [],
  'Errors': [
    {
      'SecretId': 'secret-id-arn',
      'ErrorCode': 'ResourceNotFoundException',
      'Message': "Secrets Manager can't find the specified secret."
    }
  ],
  'ResponseMetadata': ...
}
```