### PR TITLE
ec2: improve describe_instances() filters

### DIFF
--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -145,6 +145,10 @@ class Ami(TaggedEC2Resource):
             return self.owner_id
         elif filter_name == "owner-alias":
             return self.owner_alias
+        elif filter_name == "product-code":
+            return self.product_codes
+        elif filter_name == "product-code.type":
+            return "marketplace"  # devpay is not (yet?) supported
         else:
             return super().get_filter_value(filter_name, "DescribeImages")
 

--- a/moto/ec2/responses/amis.py
+++ b/moto/ec2/responses/amis.py
@@ -61,7 +61,7 @@ class AmisResponse(EC2BaseResponse):
 
         # only valid attributes as per
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_image_attribute.html
-        valid_atrributes_list = {
+        valid_attributes_list = {
             "description": "description",
             "kernel": "kernel_id",
             "ramdisk": "ramdisk",
@@ -75,7 +75,7 @@ class AmisResponse(EC2BaseResponse):
             "lastLaunchedTime": "lld",
             "imdsSupport": "imds",
         }
-        if attribute_name not in valid_atrributes_list:
+        if attribute_name not in valid_attributes_list:
             raise InvalidRequest
         elif attribute_name == "blockDeviceMapping":
             # replicate real aws behaviour and throw and error
@@ -86,11 +86,11 @@ class AmisResponse(EC2BaseResponse):
         launch_permissions = None
         if attribute_name == "launchPermission":
             launch_permissions = self.ec2_backend.describe_image_attribute(
-                ami_id, valid_atrributes_list[attribute_name]
+                ami_id, valid_attributes_list[attribute_name]
             )
         else:
             attribute_value = self.ec2_backend.describe_image_attribute(
-                ami_id, valid_atrributes_list[attribute_name]
+                ami_id, valid_attributes_list[attribute_name]
             )
 
         template = self.response_template(DESCRIBE_IMAGE_ATTRIBUTES_RESPONSE)

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -431,6 +431,7 @@ filter_dict_attribute_mapping = {
     "subnet-id": "subnet_id",
     "dns-name": "public_dns",
     "key-name": "key_name",
+    "product-code": "product_codes",
 }
 
 

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -483,6 +483,14 @@ def test_ami_filters():
     )["Images"]
     assert imageA.id in [ami["ImageId"] for ami in amis_by_nonpublic]
 
+    amis_by_product_code = ec2.describe_images(
+        Filters=[
+            {"Name": "product-code", "Values": ["code123"]},
+            {"Name": "product-code.type", "Values": ["marketplace"]},
+        ]
+    )["Images"]
+    assert "ami-0b301ce3ce3475r4f" in [ami["ImageId"] for ami in amis_by_product_code]
+
 
 @mock_aws
 def test_ami_filtering_via_tag():


### PR DESCRIPTION
Extend `Filters=` support in `ec2.describe_instances()` so that it now supports `product-code` and `product-code.type` filters, with the following restriction:

* All codes registered in `amis.json` in an image's `product_codes` property are treated as "marketplace" codes, i.e. it is not possible to specify an image with "devpay" codes.

The latent formatting support clearly intended these to be used as marketplace codes, and that's the use case I require, so this scratches my itch as-is.