### PR TITLE
Athena: Check for None on config before iterating to avoid execute_query error

### DIFF
--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -96,7 +96,7 @@ class Execution(BaseModel):
         self.start_time = time.time()
         self.status = "SUCCEEDED"
 
-        if "OutputLocation" in self.config:
+        if self.config is not None and "OutputLocation" in self.config:
             if not self.config["OutputLocation"].endswith("/"):
                 self.config["OutputLocation"] += "/"
             self.config["OutputLocation"] += f"{self.id}.csv"

--- a/tests/test_athena/test_athena.py
+++ b/tests/test_athena/test_athena.py
@@ -108,6 +108,19 @@ def test_start_query_execution():
 
 
 @mock_aws
+def test_start_query_execution_without_result_configuration():
+    client = boto3.client("athena", region_name="us-east-1")
+
+    create_basic_workgroup(client=client, name="athena_workgroup")
+    response = client.start_query_execution(
+        QueryString="query1",
+        QueryExecutionContext={"Database": "string"},
+        WorkGroup="athena_workgroup",
+    )
+    assert "QueryExecutionId" in response
+
+
+@mock_aws
 def test_start_query_validate_workgroup():
     client = boto3.client("athena", region_name="us-east-1")
 


### PR DESCRIPTION
Resolves: https://github.com/getmoto/moto/issues/7602

Add a None type check before iterating. Check is to a recent addition to the Athena Execution model. This allows for None configs, as is supported by Athena for configurations overridden by Workspace configs.