### PR TITLE
add validation to describe_security_group_rules filter

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -499,6 +499,14 @@ class InvalidInternetGatewayIdError(EC2ClientError):
         )
 
 
+class InvalidGroupIdMalformedError(EC2ClientError):
+    def __init__(self, group_id: str):
+        super().__init__(
+            "InvalidGroupId.Malformed",
+            f"The security group ID '{group_id}' is malformed",
+        )
+
+
 class GatewayNotAttachedError(EC2ClientError):
     def __init__(self, internet_gateway_id: str, vpc_id: str):
         super().__init__(

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -9,13 +9,14 @@ from moto.core.utils import aws_api_matches
 
 from ..exceptions import (
     InvalidCIDRSubnetError,
+    InvalidGroupIdMalformedError,
     InvalidPermissionDuplicateError,
     InvalidPermissionNotFoundError,
     InvalidSecurityGroupDuplicateError,
     InvalidSecurityGroupNotFoundError,
     MissingParameterError,
     MotoNotImplementedError,
-    RulesPerSecurityGroupLimitExceededError, InvalidGroupIdMalformedError,
+    RulesPerSecurityGroupLimitExceededError,
 )
 from ..utils import (
     is_tag_filter,

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -15,12 +15,13 @@ from ..exceptions import (
     InvalidSecurityGroupNotFoundError,
     MissingParameterError,
     MotoNotImplementedError,
-    RulesPerSecurityGroupLimitExceededError,
+    RulesPerSecurityGroupLimitExceededError, InvalidGroupIdMalformedError,
 )
 from ..utils import (
     is_tag_filter,
     is_valid_cidr,
     is_valid_ipv6_cidr,
+    is_valid_security_group_id,
     random_security_group_id,
     random_security_group_rule_id,
     tag_filter_matches,
@@ -607,6 +608,10 @@ class SecurityGroupBackend:
             return results
 
         if filters and "group-id" in filters:
+            for group_id in filters["group-id"]:
+                if not is_valid_security_group_id(group_id):
+                    raise InvalidGroupIdMalformedError(group_id)
+
             matches = self.describe_security_groups(
                 group_ids=group_ids, filters=filters
             )

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -638,6 +638,12 @@ def is_valid_ipv6_cidr(cird: str) -> bool:
     return cidr_pattern_re.match(cird) is not None
 
 
+def is_valid_security_group_id(sg_id:str) -> bool:
+    security_group_id_pattern = r"^sg-[a-f0-9]{8,17}$"
+    compiled_re = re.compile(security_group_id_pattern)
+    return compiled_re.match(sg_id) is not None
+
+
 def generate_instance_identity_document(instance: Any) -> Dict[str, Any]:
     """
     http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -638,7 +638,7 @@ def is_valid_ipv6_cidr(cird: str) -> bool:
     return cidr_pattern_re.match(cird) is not None
 
 
-def is_valid_security_group_id(sg_id:str) -> bool:
+def is_valid_security_group_id(sg_id: str) -> bool:
     security_group_id_pattern = r"^sg-[a-f0-9]{8,17}$"
     compiled_re = re.compile(security_group_id_pattern)
     return compiled_re.match(sg_id) is not None

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -1944,48 +1944,37 @@ def test_revoke_security_group_ingress():
 
 @mock_aws()
 def test_invalid_security_group_id_in_rules_search():
-    ec2 = boto3.client('ec2')
+    ec2 = boto3.client("ec2")
 
-    vpc = ec2.create_vpc(CidrBlock='10.0.0.0/16')
-    vpc_id = vpc['Vpc']['VpcId']
-    group_name = 'test-group'
+    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+    vpc_id = vpc["Vpc"]["VpcId"]
+    group_name = "test-group"
 
     response = ec2.create_security_group(
-        Description='Inventing a security group',
-        GroupName=group_name,
-        VpcId=vpc_id
+        Description="Inventing a security group", GroupName=group_name, VpcId=vpc_id
     )
-    group_id = response['GroupId']
+    group_id = response["GroupId"]
 
     ec2.authorize_security_group_ingress(
         GroupId=group_id,
         IpPermissions=[
             {
-                'FromPort': 1234,
-                'IpProtocol': 'tcp',
-                'IpRanges': [
-                    {
-                        'CidrIp': '12.34.56.78/32',
-                        'Description': 'fakeip'
-                    }
-                ],
-                'ToPort': 1234
+                "FromPort": 1234,
+                "IpProtocol": "tcp",
+                "IpRanges": [{"CidrIp": "12.34.56.78/32", "Description": "fakeip"}],
+                "ToPort": 1234,
             }
-        ]
+        ],
     )
 
     try:
         response = ec2.describe_security_group_rules(
-            Filters=[
-                {
-                    'Name': 'group-id',
-                    'Values': ['foobar']
-                }
-            ],
-            DryRun=False
+            Filters=[{"Name": "group-id", "Values": ["foobar"]}], DryRun=False
         )
-        assert len(response['SecurityGroupRules']) == 0, "Expected an empty list for a non-existent group"
+        assert (
+            len(response["SecurityGroupRules"]) == 0
+        ), "Expected an empty list for a non-existent group"
     except ClientError as e:
-        error = e.response['Error']
-        assert 'InvalidGroupId.Malformed' == error["Code"]
-        assert "The security group ID 'foobar' is malformed" in error['Message']
+        error = e.response["Error"]
+        assert "InvalidGroupId.Malformed" == error["Code"]
+        assert "The security group ID 'foobar' is malformed" in error["Message"]

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -1940,3 +1940,52 @@ def test_revoke_security_group_ingress():
 
     ingress_rules = [r for r in response["SecurityGroupRules"] if not r["IsEgress"]]
     assert len(ingress_rules) == 1
+
+
+@mock_aws()
+def test_invalid_security_group_id_in_rules_search():
+    ec2 = boto3.client('ec2')
+
+    vpc = ec2.create_vpc(CidrBlock='10.0.0.0/16')
+    vpc_id = vpc['Vpc']['VpcId']
+    group_name = 'test-group'
+
+    response = ec2.create_security_group(
+        Description='Inventing a security group',
+        GroupName=group_name,
+        VpcId=vpc_id
+    )
+    group_id = response['GroupId']
+
+    ec2.authorize_security_group_ingress(
+        GroupId=group_id,
+        IpPermissions=[
+            {
+                'FromPort': 1234,
+                'IpProtocol': 'tcp',
+                'IpRanges': [
+                    {
+                        'CidrIp': '12.34.56.78/32',
+                        'Description': 'fakeip'
+                    }
+                ],
+                'ToPort': 1234
+            }
+        ]
+    )
+
+    try:
+        response = ec2.describe_security_group_rules(
+            Filters=[
+                {
+                    'Name': 'group-id',
+                    'Values': ['foobar']
+                }
+            ],
+            DryRun=False
+        )
+        assert len(response['SecurityGroupRules']) == 0, "Expected an empty list for a non-existent group"
+    except ClientError as e:
+        error = e.response['Error']
+        assert 'InvalidGroupId.Malformed' == error["Code"]
+        assert "The security group ID 'foobar' is malformed" in error['Message']


### PR DESCRIPTION
This pull request includes an additional validation for the filters in the ec2 describe-security-group-rules operation. This resolves the issue identified in https://github.com/localstack/localstack/issues/10315.