### PR TITLE
Refactor: Remove the Elasticache default cluster configuration

### DIFF
--- a/moto/elasticache/models.py
+++ b/moto/elasticache/models.py
@@ -152,44 +152,7 @@ class ElastiCacheBackend(BaseBackend):
             no_password_required=True,
         )
 
-        # Define the cache_clusters dictionary to detect duplicates
-        self.cache_clusters = dict()
-        self.cache_clusters["default"] = CacheCluster(
-            account_id=self.account_id,
-            region_name=self.region_name,
-            cache_cluster_id="default",
-            replication_group_id=None,
-            az_mode=None,
-            preferred_availability_zone=None,
-            num_cache_nodes=1,
-            cache_node_type=None,
-            engine="redis",
-            engine_version=None,
-            cache_parameter_group_name=None,
-            cache_subnet_group_name=None,
-            transit_encryption_enabled=True,
-            network_type=None,
-            ip_discovery=None,
-            snapshot_name=None,
-            preferred_maintenance_window=None,
-            port=6379,
-            notification_topic_arn=None,
-            auto_minor_version_upgrade=True,
-            snapshot_retention_limit=0,
-            snapshot_window=None,
-            auth_token=None,
-            outpost_mode=None,
-            preferred_outpost_arn=None,
-            preferred_availability_zones=[],
-            cache_security_group_names=[],
-            security_group_ids=[],
-            tags=[],
-            snapshot_arns=[],
-            preferred_outpost_arns=[],
-            log_delivery_configurations=[],
-            cache_node_ids_to_remove=[],
-            cache_node_ids_to_reboot=[],
-        )
+        self.cache_clusters: Dict[str, Any] = dict()
 
     def create_user(
         self,

--- a/tests/test_elasticache/test_elasticache.py
+++ b/tests/test_elasticache/test_elasticache.py
@@ -305,8 +305,6 @@ def test_describe_all_cache_clusters():
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     cache_clusters = resp["CacheClusters"]
-    # account for the default cluster created moto/elasticache/models.py line 148
-    del cache_clusters[0]
 
     for i, cache_cluster in enumerate(cache_clusters):
         if cache_cluster["CacheClusterId"] == f"test-cache-cluster-{i}":


### PR DESCRIPTION
# Purpose

Due to an oversight, a default cache cluster is being created during the initialization phase of the Elasticache model. The default cluster is being created under the `cache_cluster` dictionary.

# Changes

- Removed the default `cache_cluster` creation step
- Update the `test_describe_all_cache_clusters` Elasticache test to exclude the action to delete the default `cache_cluster`

#7591 