### PR TITLE
EC2: Fix unhandled error for nonexistent security groups

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -812,6 +812,9 @@ class SecurityGroupBackend:
             group_name_or_id, vpc_id
         )  # type: ignore[assignment]
 
+        if group is None:
+            raise InvalidSecurityGroupNotFoundError(group_name_or_id)
+
         if security_rule_ids:
             group.ingress_rules = [
                 rule for rule in group.ingress_rules if rule.id not in security_rule_ids
@@ -982,6 +985,9 @@ class SecurityGroupBackend:
         group: SecurityGroup = self.get_security_group_by_name_or_id(
             group_name_or_id, vpc_id
         )  # type: ignore[assignment]
+
+        if group is None:
+            raise InvalidSecurityGroupNotFoundError(group_name_or_id)
 
         if security_rule_ids:
             group.egress_rules = [

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -304,6 +304,13 @@ def test_authorize_ip_range_and_revoke():
         {"CidrIp": "123.123.123.123/32"}
     ]
 
+    # Bad group must produce error
+    with pytest.raises(ClientError) as ex:
+        client.revoke_security_group_egress(GroupId="badcompany")
+    assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert "RequestId" in ex.value.response["ResponseMetadata"]
+    assert ex.value.response["Error"]["Code"] == "InvalidGroup.NotFound"
+
     # Wrong Cidr should throw error
     with pytest.raises(ClientError) as ex:
         wrong_permissions = copy.deepcopy(egress_permissions)
@@ -376,6 +383,13 @@ def test_authorize_other_group_and_revoke():
         wrong_permissions = copy.deepcopy(permissions)
         wrong_permissions[0]["UserIdGroupPairs"][0]["GroupId"] = "unknown"
         security_group.revoke_ingress(IpPermissions=wrong_permissions)
+    assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert "RequestId" in ex.value.response["ResponseMetadata"]
+    assert ex.value.response["Error"]["Code"] == "InvalidGroup.NotFound"
+
+    # Bad group must produce error
+    with pytest.raises(ClientError) as ex:
+        client.revoke_security_group_ingress(GroupId="badcompany")
     assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
     assert "RequestId" in ex.value.response["ResponseMetadata"]
     assert ex.value.response["Error"]["Code"] == "InvalidGroup.NotFound"


### PR DESCRIPTION
This PR fixes an unhandled case where a non-existent security group when passed to `RevokeSecurityGroupIngress` and `RevokeSecurityGroupEgress` would raise an `AttributeError`.

```
  File "/home/viren/repo/moto-ext/moto/core/responses.py", line 270, in dispatch
    return cls()._dispatch(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/viren/repo/moto-ext/moto/core/responses.py", line 478, in _dispatch
    return self.call_action()
           ^^^^^^^^^^^^^^^^^^
  File "/home/viren/repo/moto-ext/moto/core/responses.py", line 575, in call_action
    response = method()
               ^^^^^^^^
  File "/home/viren/repo/moto-ext/moto/ec2/responses/security_groups.py", line 236, in revoke_security_group_ingress
    self.ec2_backend.revoke_security_group_ingress(**args)
  File "/home/viren/repo/moto-ext/moto/ec2/models/security_groups.py", line 824, in revoke_security_group_ingress
    group.group_id,
    ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group_id'
```

The expected behaviour is as follows (tested against AWS)

```
$ aws ec2 revoke-security-group-ingress --group-name fasdf

An error occurred (InvalidGroup.NotFound) when calling the RevokeSecurityGroupIngress operation: The security group 'fasdf' does not exist in default VPC 'vpc-026b0bxxxxxx'
```

Supersedes https://github.com/getmoto/moto/pull/7428