### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -255,11 +255,11 @@ Here is an example:
 
     @pytest.fixture
     def create_bucket1(aws):
-        boto3.client("s3").create_bucket(Bucket="b1")
+        boto3.client("s3").create_bucket(Bucket="bb1")
 
     @pytest.fixture
     def create_bucket2(aws):
-        boto3.client("s3").create_bucket(Bucket="b2")
+        boto3.client("s3").create_bucket(Bucket="bb2")
 
     def test_s3_directly(aws):
         s3.create_bucket(Bucket="somebucket")


### PR DESCRIPTION
Bucket="b1" throws an error.

Bucket names must be at least 3 characters long.

Bucket="bb1" works.

The code example does not work. This fixes it by making the Bucket names longer.