### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/docs/getting_started.rst
+++ b/docs/docs/getting_started.rst
@@ -268,7 +268,7 @@ Here is an example:
         assert len(result["Buckets"]) == 1
 
     def test_bucket_creation(create_bucket1, create_bucket2):
-        buckets = boto3.client("s3").list_buckets()["Buckets"]
+        result = boto3.client("s3").list_buckets()
         assert len(result["Buckets"]) == 2
 
 


### PR DESCRIPTION
The code example is wrong:

    buckets = boto3.client("s3").list_buckets()["Buckets"]
    assert len(result["Buckets"]) == 2

Should be:

    result = boto3.client("s3").list_buckets()
    assert len(result["Buckets"]) == 2

The second line expects to assert against result, and the "Buckets" key should also be accessed in the second line.