### PR TITLE
SES: GetSendStatistics() now uses a datetime format that the Java SDK understands

### DIFF
--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -548,7 +548,7 @@ GET_SEND_STATISTICS = """<GetSendStatisticsResponse xmlns="http://ses.amazonaws.
                 <Rejects>{{ statistics["Rejects"] }}</Rejects>
                 <Bounces>{{ statistics["Bounces"] }}</Bounces>
                 <Complaints>{{ statistics["Complaints"] }}</Complaints>
-                <Timestamp>{{ statistics["Timestamp"].isoformat() }}</Timestamp>
+                <Timestamp>{{ statistics["Timestamp"].strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}</Timestamp>
             </member>
         {% endfor %}
       </SendDataPoints>

--- a/other_langs/tests_java/pom.xml
+++ b/other_langs/tests_java/pom.xml
@@ -13,8 +13,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.9</maven.compiler.source>
+    <maven.compiler.target>1.9</maven.compiler.target>
   </properties>
 
   <dependencyManagement>
@@ -112,5 +112,15 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>9</source>
+          <target>9</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/other_langs/tests_java/src/test/java/moto/tests/SESTest.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/SESTest.java
@@ -6,13 +6,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import software.amazon.awssdk.services.dynamodb.model.Get;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.ses.model.Body;
 import software.amazon.awssdk.services.ses.model.Content;
 import software.amazon.awssdk.services.ses.model.Destination;
 import software.amazon.awssdk.services.ses.model.Message;
 import software.amazon.awssdk.services.ses.model.SendEmailRequest;
-import software.amazon.awssdk.services.ses.model.SendEmailResponse;
+import software.amazon.awssdk.services.ses.model.VerifyEmailAddressRequest;
+import software.amazon.awssdk.services.ses.model.GetSendStatisticsResponse;
 import software.amazon.awssdk.services.ses.model.SesException;
 
 public class SESTest {
@@ -41,5 +43,36 @@ public class SESTest {
         } catch (SesException e) {
             assertEquals(e.awsErrorDetails().errorMessage(), "Email address not verified noreply@thedomain.com");
         }
+    }
+
+    @Test
+    public void testGetSendStatistics() {
+        SesClient sesClient = DependencyFactory.sesClient();
+
+        VerifyEmailAddressRequest verifyEmailAddressRequest = VerifyEmailAddressRequest.builder().emailAddress("noreply@thedomain.com").build();
+        sesClient.verifyEmailAddress(verifyEmailAddressRequest);
+
+        Message message = Message
+                .builder()
+                .subject(Content.builder().charset("UTF-8").data("subject").build())
+                .body(Body.builder().text(Content.builder().charset("UTF-8").data("body").build()).build())
+                .build();
+
+        SendEmailRequest request = SendEmailRequest
+                .builder()
+                .source("noreply@thedomain.com")
+                .destination(Destination.builder().toAddresses(List.of("one@one.com")).build())
+                .message(message)
+                .build();
+
+        GetSendStatisticsResponse statisticsBefore = sesClient.getSendStatistics();
+        Long prev = statisticsBefore.sendDataPoints().get(0).deliveryAttempts().longValue();
+
+        sesClient.sendEmail(request);
+
+        GetSendStatisticsResponse statisticsAfter = sesClient.getSendStatistics();
+        Long after = statisticsAfter.sendDataPoints().get(0).deliveryAttempts().longValue();
+
+        assertTrue("Delivery attempts should increase", after > prev);
     }
 }

--- a/tests/test_ses/test_server.py
+++ b/tests/test_ses/test_server.py
@@ -22,4 +22,4 @@ def test_ses_get_send_statistics():
     # Timestamps must be in ISO 8601 format
     groups = re.search("<Timestamp>(.*)</Timestamp>", res.data.decode("utf-8"))
     timestamp = groups.groups()[0]
-    datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f")
+    datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")


### PR DESCRIPTION
Fixes #7640 