### PR TITLE
IAM: add instance profile tagging

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -4069,7 +4069,7 @@
 - [ ] set_security_token_service_preferences
 - [ ] simulate_custom_policy
 - [ ] simulate_principal_policy
-- [ ] tag_instance_profile
+- [X] tag_instance_profile
 - [ ] tag_mfa_device
 - [X] tag_open_id_connect_provider
 - [X] tag_policy
@@ -4077,7 +4077,7 @@
 - [ ] tag_saml_provider
 - [ ] tag_server_certificate
 - [X] tag_user
-- [ ] untag_instance_profile
+- [X] untag_instance_profile
 - [ ] untag_mfa_device
 - [X] untag_open_id_connect_provider
 - [X] untag_policy

--- a/docs/docs/services/iam.rst
+++ b/docs/docs/services/iam.rst
@@ -164,7 +164,7 @@ iam
 - [ ] set_security_token_service_preferences
 - [ ] simulate_custom_policy
 - [ ] simulate_principal_policy
-- [ ] tag_instance_profile
+- [X] tag_instance_profile
 - [ ] tag_mfa_device
 - [X] tag_open_id_connect_provider
 - [X] tag_policy
@@ -172,7 +172,7 @@ iam
 - [ ] tag_saml_provider
 - [ ] tag_server_certificate
 - [X] tag_user
-- [ ] untag_instance_profile
+- [X] untag_instance_profile
 - [ ] untag_mfa_device
 - [X] untag_open_id_connect_provider
 - [X] untag_policy

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -3320,6 +3320,22 @@ class IAMBackend(BaseBackend):
         """
         return True
 
+    def tag_instance_profile(
+        self, instance_profile_name: str, tags: List[Dict[str, str]] = []
+    ) -> None:
+        profile = self.get_instance_profile(profile_name=instance_profile_name)
+
+        for value in tags:
+            profile.tags[value["Key"]] = value["Value"]
+
+    def untag_instance_profile(
+        self, instance_profile_name: str, tagKeys: List[str] = []
+    ) -> None:
+        profile = self.get_instance_profile(profile_name=instance_profile_name)
+
+        for value in tagKeys:
+            del profile.tags[value]
+
 
 iam_backends = BackendDict(
     IAMBackend, "iam", use_boto3_regions=False, additional_regions=["global"]

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1128,6 +1128,28 @@ class IamResponse(BaseResponse):
         )
         return template.render()
 
+    def tag_instance_profile(self) -> str:
+        instance_profile_name = self._get_param("InstanceProfileName")
+        tags = self._get_multi_param("Tags.member")
+
+        self.backend.tag_instance_profile(
+            instance_profile_name=instance_profile_name,
+            tags=tags,
+        )
+        template = self.response_template(TAG_INSTANCE_PROFILE_TEMPLATE)
+        return template.render()
+
+    def untag_instance_profile(self) -> str:
+        instance_profile_name = self._get_param("InstanceProfileName")
+        tags = self._get_multi_param("TagKeys.member")
+
+        self.backend.untag_instance_profile(
+            instance_profile_name=instance_profile_name,
+            tagKeys=tags,
+        )
+        template = self.response_template(UNTAG_INSTANCE_PROFILE_TEMPLATE)
+        return template.render()
+
 
 LIST_ENTITIES_FOR_POLICY_TEMPLATE = """<ListEntitiesForPolicyResponse>
  <ListEntitiesForPolicyResult>
@@ -2774,3 +2796,17 @@ UNTAG_USER_TEMPLATE = """<UntagUserResponse xmlns="https://iam.amazonaws.com/doc
     <RequestId>EXAMPLE8-90ab-cdef-fedc-ba987EXAMPLE</RequestId>
   </ResponseMetadata>
 </UntagUserResponse>"""
+
+TAG_INSTANCE_PROFILE_TEMPLATE = """<TagInstanceProfileResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ResponseMetadata>
+    <RequestId>EXAMPLE8-90ab-cdef-fedc-ba987EXAMPLE</RequestId>
+  </ResponseMetadata>
+</TagInstanceProfileResponse>
+"""
+
+UNTAG_INSTANCE_PROFILE_TEMPLATE = """<UntagInstanceProfileResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ResponseMetadata>
+    <RequestId>EXAMPLE8-90ab-cdef-fedc-ba987EXAMPLE</RequestId>
+  </ResponseMetadata>
+</UntagInstanceProfileResponse>
+"""

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -4803,3 +4803,39 @@ def test_delete_service_linked_role():
     err = ex.value.response["Error"]
     assert err["Code"] == "NoSuchEntity"
     assert "not found" in err["Message"]
+
+
+@mock_aws
+def test_tag_instance_profile():
+    client = boto3.client("iam", region_name="eu-central-1")
+
+    name = "test-ip"
+    tags = [{"Key": "MyKey", "Value": "myValue"}]
+
+    client.create_instance_profile(InstanceProfileName=name)
+    client.tag_instance_profile(InstanceProfileName=name, Tags=tags)
+    ip = client.get_instance_profile(InstanceProfileName=name)
+
+    assert ip["InstanceProfile"]["Tags"] == tags
+
+    # add another tag
+    addTags = [{"Key": "MyKey2", "Value": "myValue2"}]
+    client.tag_instance_profile(InstanceProfileName=name, Tags=addTags)
+    ip = client.get_instance_profile(InstanceProfileName=name)
+
+    assert ip["InstanceProfile"]["Tags"] == tags + addTags
+
+
+@mock_aws
+def test_untag_instance_profile():
+    client = boto3.client("iam", region_name="eu-central-1")
+
+    name = "test-ip"
+    tags = [{"Key": "MyKey", "Value": "myValue"}]
+    unTags = ["MyKey"]
+
+    client.create_instance_profile(InstanceProfileName=name, Tags=tags)
+    client.untag_instance_profile(InstanceProfileName=name, TagKeys=unTags)
+    ip = client.get_instance_profile(InstanceProfileName=name)
+
+    assert ip["InstanceProfile"]["Tags"] == []


### PR DESCRIPTION
IAM instance profile missed an implementation to add & remove tags (besides creation). This PR adds the functionality.  