### PR TITLE
Update Data Brew Recipe Latest Working Version Create Date

### DIFF
--- a/moto/databrew/models.py
+++ b/moto/databrew/models.py
@@ -477,6 +477,9 @@ class FakeRecipe(BaseModel):
         del self.versions[self.latest_working.version]
         self.versions[self.latest_published.version] = self.latest_published
         self.latest_working.version = self.latest_published.version + 0.1
+
+        if self.latest_published.published_date:
+            self.latest_working.created_time = self.latest_published.published_date
         self.versions[self.latest_working.version] = self.latest_working
 
     def update(

--- a/tests/test_databrew/test_databrew_recipes.py
+++ b/tests/test_databrew/test_databrew_recipes.py
@@ -374,6 +374,12 @@ def test_publish_recipe(recipe_name):
     assert recipe["PublishedDate"] > dt_before_publish
     first_published_date = recipe["PublishedDate"]
 
+    # Latest Working should have created date == publish date
+    working_response = client.describe_recipe(
+        Name=recipe_name, RecipeVersion="LATEST_WORKING"
+    )
+    assert working_response["CreateDate"] == first_published_date
+
     # Publish the recipe a 2nd time
     publish_response = client.publish_recipe(Name=recipe_name, Description="2nd desc")
     assert publish_response["Name"] == recipe_name
@@ -382,6 +388,12 @@ def test_publish_recipe(recipe_name):
     assert recipe["Description"] == "2nd desc"
     assert recipe["RecipeVersion"] == "2.0"
     assert recipe["PublishedDate"] >= first_published_date
+
+    # Check working Created Date
+    working_response = client.describe_recipe(
+        Name=recipe_name, RecipeVersion="LATEST_WORKING"
+    )
+    assert recipe["PublishedDate"] == working_response["CreateDate"]
 
 
 @mock_aws


### PR DESCRIPTION
Corrects an issue where the Create Date of the Latest Working version remains the same as the published version. This should be the Publish Date as observed through interactions with AWS API Interactions for Publish Recipe.

Steps:

* Added field setting in moto/databrew/models.py
* Updated Publish Recipe Tests to compare publish date and latest working create date

Issues Addressed:

* [Issue 7666](https://github.com/getmoto/moto/issues/7666)