### PR TITLE
RouteTables: Filter by route.nat-gateway-id

### DIFF
--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -116,6 +116,12 @@ class RouteTable(TaggedEC2Resource, CloudFormationModel):
                 for route in self.routes.values()
                 if route.vpc_pcx is not None
             ]
+        elif filter_name == "route.nat-gateway-id":
+            return [
+                route.nat_gateway.id
+                for route in self.routes.values()
+                if route.nat_gateway is not None
+            ]
         else:
             return super().get_filter_value(filter_name, "DescribeRouteTables")
 


### PR DESCRIPTION
## Background
In my work, we do DescribeRouteTables and filter by `route.nat-gateway-id`. However, it is currently not implemented yet and returns the following error:
```
moto.ec2.exceptions.FilterNotImplementedError: The filter 'route.nat-gateway-id' for DescribeRouteTables has not been implemented in Moto yet. Feel free to open an issue at https://github.com/getmoto/moto/issues
```

## Changes
- Implement filter by `route.nat-gateway-id`
- Add test