### PR TITLE
WAFv2: Add support for IP sets and logging configuration

### DIFF
--- a/moto/wafv2/exceptions.py
+++ b/moto/wafv2/exceptions.py
@@ -19,3 +19,11 @@ class WAFNonexistentItemException(WAFv2ClientError):
             "WAFNonexistentItemException",
             "AWS WAF couldn’t perform the operation because your resource doesn’t exist.",
         )
+
+
+class WAFOptimisticLockException(WAFv2ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "WAFOptimisticLockException",
+            "AWS WAF couldn’t save your changes because someone changed the resource after you started to edit it. Reapply your changes.",
+        )

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -132,9 +132,9 @@ class FakeLoggingConfiguration:
         self,
         arn,
         log_destination_configs: list[str],
-        redacted_fields: Optional[dict[str, any]],
+        redacted_fields: Optional[Dict[str, any]],
         managed_gy_firewall_manager: Optional[bool],
-        logging_filter: Optional[dict],
+        logging_filter: Optional[Dict],
     ):
         self.arn = arn
         self.log_destination_configs = log_destination_configs
@@ -142,7 +142,7 @@ class FakeLoggingConfiguration:
         self.managed_by_firewall_manager = managed_gy_firewall_manager or False
         self.logging_filter = logging_filter
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "ResourceArn": self.arn,
             "LogDestinationConfigs": self.log_destination_configs,
@@ -383,9 +383,9 @@ class WAFV2Backend(BaseBackend):
         self,
         arn: str,
         log_destination_configs: list[str],
-        redacted_fields: list[dict[str, any]],
+        redacted_fields: list[Dict[str, any]],
         managed_gy_firewall_manager: bool,
-        logging_filter: dict,
+        logging_filter: Dict[str, any],
     ) -> FakeLoggingConfiguration:
         logging_configuration = FakeLoggingConfiguration(
             arn,

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -130,11 +130,11 @@ class FakeIPSet(BaseModel):
 class FakeLoggingConfiguration:
     def __init__(
         self,
-        arn,
+        arn: str,
         log_destination_configs: List[str],
         redacted_fields: Optional[Dict[str, Any]],
         managed_gy_firewall_manager: Optional[bool],
-        logging_filter: Optional[Dict],
+        logging_filter: Optional[Dict[str, Any]]
     ):
         self.arn = arn
         self.log_destination_configs = log_destination_configs
@@ -291,7 +291,7 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         description: str,
         ip_address_version: str,
-        addresses: List[Dict[str, Any]],
+        addresses: List[str],
         tags: List[Dict[str, str]],
     ) -> FakeIPSet:
         ip_set_id = str(mock_random.uuid4())
@@ -316,7 +316,7 @@ class WAFV2Backend(BaseBackend):
         self.tag_resource(arn, tags)
         return new_ip_set
 
-    def delete_ip_set(self, name: str, scope: str, _id: str, lock_token: str):
+    def delete_ip_set(self, name: str, scope: str, _id: str, lock_token: str) -> None:
         arn = make_arn_for_ip_set(
             name=name,
             account_id=self.account_id,
@@ -383,7 +383,7 @@ class WAFV2Backend(BaseBackend):
         self,
         arn: str,
         log_destination_configs: List[str],
-        redacted_fields: List[Dict[str, Any]],
+        redacted_fields: Optional[Dict[str, Any]],
         managed_gy_firewall_manager: bool,
         logging_filter: Dict[str, Any],
     ) -> FakeLoggingConfiguration:

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -126,8 +126,16 @@ class FakeIPSet(BaseModel):
             "LockToken": self.lock_token,
         }
 
+
 class FakeLoggingConfiguration:
-    def __init__(self, arn, log_destination_configs: list[str], redacted_fields: Optional[dict[str,any]], managed_gy_firewall_manager: Optional[bool], logging_filter: Optional[dict]):
+    def __init__(
+        self,
+        arn,
+        log_destination_configs: list[str],
+        redacted_fields: Optional[dict[str, any]],
+        managed_gy_firewall_manager: Optional[bool],
+        logging_filter: Optional[dict],
+    ):
         self.arn = arn
         self.log_destination_configs = log_destination_configs
         self.redacted_fields = redacted_fields
@@ -140,7 +148,7 @@ class FakeLoggingConfiguration:
             "LogDestinationConfigs": self.log_destination_configs,
             "RedactedFields": self.redacted_fields,
             "ManagedByFirewallManager": self.managed_by_firewall_manager,
-            "LoggingFilter": self.logging_filter
+            "LoggingFilter": self.logging_filter,
         }
 
 
@@ -371,8 +379,21 @@ class WAFV2Backend(BaseBackend):
 
         return ip_set
 
-    def put_logging_configuration(self, arn: str, log_destination_configs: list[str], redacted_fields: list[dict[str,any]], managed_gy_firewall_manager: bool, logging_filter: dict) -> FakeLoggingConfiguration:
-        logging_configuration = FakeLoggingConfiguration(arn, log_destination_configs, redacted_fields, managed_gy_firewall_manager, logging_filter)
+    def put_logging_configuration(
+        self,
+        arn: str,
+        log_destination_configs: list[str],
+        redacted_fields: list[dict[str, any]],
+        managed_gy_firewall_manager: bool,
+        logging_filter: dict,
+    ) -> FakeLoggingConfiguration:
+        logging_configuration = FakeLoggingConfiguration(
+            arn,
+            log_destination_configs,
+            redacted_fields,
+            managed_gy_firewall_manager,
+            logging_filter,
+        )
         self.logging_configurations[arn] = logging_configuration
         return logging_configuration
 
@@ -390,11 +411,13 @@ class WAFV2Backend(BaseBackend):
         if scope == "CLOUDFRONT":
             scope = "global"
         else:
-            scope  = self.region_name
+            scope = self.region_name
 
-
-        return [logging_configuration for arn, logging_configuration in self.logging_configurations.items() if f":{scope}:" in arn]
-
+        return [
+            logging_configuration
+            for arn, logging_configuration in self.logging_configurations.items()
+            if f":{scope}:" in arn
+        ]
 
 
 wafv2_backends = BackendDict(

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -134,7 +134,7 @@ class FakeLoggingConfiguration:
         log_destination_configs: List[str],
         redacted_fields: Optional[Dict[str, Any]],
         managed_gy_firewall_manager: Optional[bool],
-        logging_filter: Optional[Dict[str, Any]]
+        logging_filter: Optional[Dict[str, Any]],
     ):
         self.arn = arn
         self.log_destination_configs = log_destination_configs

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -8,8 +8,12 @@ from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 
-from .exceptions import WAFNonexistentItemException, WAFV2DuplicateItemException, WAFOptimisticLockException
-from .utils import make_arn_for_wacl, make_arn_for_ip_set
+from .exceptions import (
+    WAFNonexistentItemException,
+    WAFOptimisticLockException,
+    WAFV2DuplicateItemException,
+)
+from .utils import make_arn_for_ip_set, make_arn_for_wacl
 
 if TYPE_CHECKING:
     from moto.apigateway.models import Stage
@@ -85,14 +89,14 @@ class FakeIPSet(BaseModel):
     """
 
     def __init__(
-            self,
-            arn: str,
-            ip_set_id: str,
-            ip_address_version: str,
-            addresses: list[str],
-            name: str,
-            description: str,
-            scope: str,
+        self,
+        arn: str,
+        ip_set_id: str,
+        ip_address_version: str,
+        addresses: list[str],
+        name: str,
+        description: str,
+        scope: str,
     ):
         self.name = name
         self.ip_set_id = ip_set_id
@@ -104,11 +108,7 @@ class FakeIPSet(BaseModel):
 
         self.lock_token = str(mock_random.uuid4())[0:6]
 
-    def update(
-            self,
-            description: Optional[str],
-            addresses: list[str]
-    ) -> None:
+    def update(self, description: Optional[str], addresses: list[str]) -> None:
         if description is not None:
             self.description = description
         self.addresses = addresses
@@ -123,7 +123,7 @@ class FakeIPSet(BaseModel):
             "Description": self.description,
             "IPAddressVersion": self.ip_address_version,
             "Addresses": self.addresses,
-            "LockToken": self.lock_token
+            "LockToken": self.lock_token,
         }
 
 
@@ -260,21 +260,21 @@ class WAFV2Backend(BaseBackend):
         return acl.lock_token
 
     def create_ip_set(
-            self,
-            name: str,
-            scope: str,
-            description: str,
-            ip_address_version: str,
-            addresses: List[Dict[str, Any]],
-            tags: List[Dict[str, str]],
+        self,
+        name: str,
+        scope: str,
+        description: str,
+        ip_address_version: str,
+        addresses: List[Dict[str, Any]],
+        tags: List[Dict[str, str]],
     ) -> FakeIPSet:
         ip_set_id = str(mock_random.uuid4())
         arn = make_arn_for_ip_set(
-                name=name,
-                account_id=self.account_id,
-                region_name=self.region_name,
-                _id = ip_set_id,
-                scope=scope,
+            name=name,
+            account_id=self.account_id,
+            region_name=self.region_name,
+            _id=ip_set_id,
+            scope=scope,
         )
 
         new_ip_set = FakeIPSet(
@@ -308,7 +308,9 @@ class WAFV2Backend(BaseBackend):
         self.ip_sets.pop(arn)
 
     def list_ip_sets(self, scope: str) -> list[FakeIPSet]:
-        ip_sets = [ip_set for arn, ip_set in self.ip_sets.items() if ip_set.scope == scope]
+        ip_sets = [
+            ip_set for arn, ip_set in self.ip_sets.items() if ip_set.scope == scope
+        ]
         return ip_sets
 
     def get_ip_set(self, name: str, scope: str, _id: str) -> FakeIPSet:
@@ -324,7 +326,15 @@ class WAFV2Backend(BaseBackend):
 
         return self.ip_sets[arn]
 
-    def update_ip_set(self, name: str, scope: str, _id: str, description: Optional[str], addresses: list[str], lock_token: str) -> FakeIPSet:
+    def update_ip_set(
+        self,
+        name: str,
+        scope: str,
+        _id: str,
+        description: Optional[str],
+        addresses: list[str],
+        lock_token: str,
+    ) -> FakeIPSet:
         arn = make_arn_for_ip_set(
             name=name,
             account_id=self.account_id,

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -93,7 +93,7 @@ class FakeIPSet(BaseModel):
         arn: str,
         ip_set_id: str,
         ip_address_version: str,
-        addresses: list[str],
+        addresses: List[str],
         name: str,
         description: str,
         scope: str,
@@ -108,7 +108,7 @@ class FakeIPSet(BaseModel):
 
         self.lock_token = str(mock_random.uuid4())[0:6]
 
-    def update(self, description: Optional[str], addresses: list[str]) -> None:
+    def update(self, description: Optional[str], addresses: List[str]) -> None:
         if description is not None:
             self.description = description
         self.addresses = addresses
@@ -131,8 +131,8 @@ class FakeLoggingConfiguration:
     def __init__(
         self,
         arn,
-        log_destination_configs: list[str],
-        redacted_fields: Optional[Dict[str, any]],
+        log_destination_configs: List[str],
+        redacted_fields: Optional[Dict[str, Any]],
         managed_gy_firewall_manager: Optional[bool],
         logging_filter: Optional[Dict],
     ):
@@ -333,7 +333,7 @@ class WAFV2Backend(BaseBackend):
 
         self.ip_sets.pop(arn)
 
-    def list_ip_sets(self, scope: str) -> list[FakeIPSet]:
+    def list_ip_sets(self, scope: str) -> List[FakeIPSet]:
         ip_sets = [
             ip_set for arn, ip_set in self.ip_sets.items() if ip_set.scope == scope
         ]
@@ -358,7 +358,7 @@ class WAFV2Backend(BaseBackend):
         scope: str,
         _id: str,
         description: Optional[str],
-        addresses: list[str],
+        addresses: List[str],
         lock_token: str,
     ) -> FakeIPSet:
         arn = make_arn_for_ip_set(
@@ -382,10 +382,10 @@ class WAFV2Backend(BaseBackend):
     def put_logging_configuration(
         self,
         arn: str,
-        log_destination_configs: list[str],
-        redacted_fields: list[Dict[str, any]],
+        log_destination_configs: List[str],
+        redacted_fields: List[Dict[str, Any]],
         managed_gy_firewall_manager: bool,
-        logging_filter: Dict[str, any],
+        logging_filter: Dict[str, Any],
     ) -> FakeLoggingConfiguration:
         logging_configuration = FakeLoggingConfiguration(
             arn,
@@ -407,7 +407,7 @@ class WAFV2Backend(BaseBackend):
             raise WAFNonexistentItemException()
         return logging_configuration
 
-    def list_logging_configurations(self, scope: str) -> list[FakeLoggingConfiguration]:
+    def list_logging_configurations(self, scope: str) -> List[FakeLoggingConfiguration]:
         if scope == "CLOUDFRONT":
             scope = "global"
         else:

--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -250,7 +250,9 @@ class WAFV2Response(BaseResponse):
         body = json.loads(self.body)
         logging_configuration_parameter = body["LoggingConfiguration"]
         resource_arn = logging_configuration_parameter["ResourceArn"]
-        log_destination_configs = logging_configuration_parameter["LogDestinationConfigs"]
+        log_destination_configs = logging_configuration_parameter[
+            "LogDestinationConfigs"
+        ]
         redacted_fields = logging_configuration_parameter.get("RedactedFields")
         managed_by_firewall_manager = logging_configuration_parameter.get(
             "ManagedByFirewallManager"
@@ -263,13 +265,39 @@ class WAFV2Response(BaseResponse):
             managed_by_firewall_manager,
             logging_filter,
         )
-        return 200, {}, json.dumps({ "LoggingConfiguration":{k: v for k, v in logging_configuration.to_dict().items() if v is not None}})
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "LoggingConfiguration": {
+                        k: v
+                        for k, v in logging_configuration.to_dict().items()
+                        if v is not None
+                    }
+                }
+            ),
+        )
 
     def get_logging_configuration(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)
         resource_arn = body["ResourceArn"]
-        logging_configuration = self.wafv2_backend.get_logging_configuration(resource_arn)
-        return 200, {}, json.dumps({ "LoggingConfiguration":{k: v for k, v in logging_configuration.to_dict().items() if v is not None}})
+        logging_configuration = self.wafv2_backend.get_logging_configuration(
+            resource_arn
+        )
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "LoggingConfiguration": {
+                        k: v
+                        for k, v in logging_configuration.to_dict().items()
+                        if v is not None
+                    }
+                }
+            ),
+        )
 
     def list_logging_configurations(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)
@@ -277,7 +305,8 @@ class WAFV2Response(BaseResponse):
         log_configs = self.wafv2_backend.list_logging_configurations(scope)
 
         formatted = [
-            {k: v for k, v in config.to_dict().items() if v is not None} for config in log_configs
+            {k: v for k, v in config.to_dict().items() if v is not None}
+            for config in log_configs
         ]
         return 500, {}, json.dumps({"LoggingConfigurations": formatted})
 
@@ -286,6 +315,7 @@ class WAFV2Response(BaseResponse):
         resource_arn = body["ResourceArn"]
         self.wafv2_backend.delete_logging_configuration(resource_arn)
         return 200, {}, "{}"
+
 
 # notes about region and scope
 # --scope = CLOUDFRONT is ALWAYS us-east-1 (but we use "global" instead to differentiate between REGIONAL us-east-1)

--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -246,6 +246,46 @@ class WAFV2Response(BaseResponse):
 
         return 200, {}, json.dumps({"NextLockToken": updated_ip_set.lock_token})
 
+    def put_logging_configuration(self) -> TYPE_RESPONSE:
+        body = json.loads(self.body)
+        logging_configuration_parameter = body["LoggingConfiguration"]
+        resource_arn = logging_configuration_parameter["ResourceArn"]
+        log_destination_configs = logging_configuration_parameter["LogDestinationConfigs"]
+        redacted_fields = logging_configuration_parameter.get("RedactedFields")
+        managed_by_firewall_manager = logging_configuration_parameter.get(
+            "ManagedByFirewallManager"
+        )
+        logging_filter = logging_configuration_parameter.get("LoggingFilter")
+        logging_configuration = self.wafv2_backend.put_logging_configuration(
+            resource_arn,
+            log_destination_configs,
+            redacted_fields,
+            managed_by_firewall_manager,
+            logging_filter,
+        )
+        return 200, {}, json.dumps({ "LoggingConfiguration":{k: v for k, v in logging_configuration.to_dict().items() if v is not None}})
+
+    def get_logging_configuration(self) -> TYPE_RESPONSE:
+        body = json.loads(self.body)
+        resource_arn = body["ResourceArn"]
+        logging_configuration = self.wafv2_backend.get_logging_configuration(resource_arn)
+        return 200, {}, json.dumps({ "LoggingConfiguration":{k: v for k, v in logging_configuration.to_dict().items() if v is not None}})
+
+    def list_logging_configurations(self) -> TYPE_RESPONSE:
+        body = json.loads(self.body)
+        scope = body.get("Scope")
+        log_configs = self.wafv2_backend.list_logging_configurations(scope)
+
+        formatted = [
+            {k: v for k, v in config.to_dict().items() if v is not None} for config in log_configs
+        ]
+        return 500, {}, json.dumps({"LoggingConfigurations": formatted})
+
+    def delete_logging_configuration(self) -> TYPE_RESPONSE:
+        body = json.loads(self.body)
+        resource_arn = body["ResourceArn"]
+        self.wafv2_backend.delete_logging_configuration(resource_arn)
+        return 200, {}, "{}"
 
 # notes about region and scope
 # --scope = CLOUDFRONT is ALWAYS us-east-1 (but we use "global" instead to differentiate between REGIONAL us-east-1)

--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -3,8 +3,8 @@ import json
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
 
-from .models import GLOBAL_REGION, WAFV2Backend, wafv2_backends
 from ..moto_api._internal import mock_random
+from .models import GLOBAL_REGION, WAFV2Backend, wafv2_backends
 
 
 class WAFV2Response(BaseResponse):
@@ -158,10 +158,21 @@ class WAFV2Response(BaseResponse):
         ip_set = self.wafv2_backend.create_ip_set(
             name, scope, description, ip_address_version, addresses, tags
         )
-        return 200, {}, json.dumps({"Summary":{
-            "Name": ip_set.name,
-            "Id": ip_set.ip_set_id, "Description": ip_set.description, "LockToken": ip_set.lock_token , "ARN": ip_set.arn
-        }})
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "Summary": {
+                        "Name": ip_set.name,
+                        "Id": ip_set.ip_set_id,
+                        "Description": ip_set.description,
+                        "LockToken": ip_set.lock_token,
+                        "ARN": ip_set.arn,
+                    }
+                }
+            ),
+        )
 
     def delete_ip_set(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)
@@ -174,9 +185,7 @@ class WAFV2Response(BaseResponse):
         _id = body.get("Id")
         lock_token = body.get("LockToken")
 
-        self.wafv2_backend.delete_ip_set(
-            name, scope, _id, lock_token
-        )
+        self.wafv2_backend.delete_ip_set(name, scope, _id, lock_token)
 
         return 200, {}, "{}"
 
@@ -188,18 +197,22 @@ class WAFV2Response(BaseResponse):
 
         formatted_ip_sets = [
             {
-                'Name': ip_set.name,
-                'Id': ip_set.ip_set_id,
-                'Description': ip_set.description,
-                'LockToken': ip_set.lock_token,
-                'ARN': ip_set.arn
-            } for ip_set in ip_sets
+                "Name": ip_set.name,
+                "Id": ip_set.ip_set_id,
+                "Description": ip_set.description,
+                "LockToken": ip_set.lock_token,
+                "ARN": ip_set.arn,
+            }
+            for ip_set in ip_sets
         ]
 
-        return 200, {}, json.dumps({
-            "NextMarker": str(mock_random.uuid4()),
-            "IPSets": formatted_ip_sets
-        })
+        return (
+            200,
+            {},
+            json.dumps(
+                {"NextMarker": str(mock_random.uuid4()), "IPSets": formatted_ip_sets}
+            ),
+        )
 
     def get_ip_set(self) -> TYPE_RESPONSE:
         scope = self._get_param("Scope")
@@ -207,17 +220,12 @@ class WAFV2Response(BaseResponse):
             self.region = GLOBAL_REGION
 
         ip_set = self.wafv2_backend.get_ip_set(
-            name=self._get_param("Name"),
-            scope=scope,
-            _id=self._get_param("Id")
+            name=self._get_param("Name"), scope=scope, _id=self._get_param("Id")
         )
 
         dict_ip = ip_set.to_dict()
         lock_token = dict_ip.pop("LockToken")
-        return 200, {}, json.dumps({
-           "IPSet": dict_ip,
-           "LockToken": lock_token
-        })
+        return 200, {}, json.dumps({"IPSet": dict_ip, "LockToken": lock_token})
 
     def update_ip_set(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)
@@ -236,9 +244,7 @@ class WAFV2Response(BaseResponse):
             name, scope, _id, description, addresses, lock_token
         )
 
-        return 200, {}, json.dumps({
-            "NextLockToken": updated_ip_set.lock_token
-        })
+        return 200, {}, json.dumps({"NextLockToken": updated_ip_set.lock_token})
 
 
 # notes about region and scope

--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -308,7 +308,7 @@ class WAFV2Response(BaseResponse):
             {k: v for k, v in config.to_dict().items() if v is not None}
             for config in log_configs
         ]
-        return 500, {}, json.dumps({"LoggingConfigurations": formatted})
+        return 200, {}, json.dumps({"LoggingConfigurations": formatted})
 
     def delete_logging_configuration(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -6,13 +6,13 @@ def make_arn_for_wacl(
 
 
 def make_arn_for_ip_set(
-        name: str, account_id: str, region_name: str, _id: str, scope: str
+    name: str, account_id: str, region_name: str, _id: str, scope: str
 ) -> str:
     return make_arn(name, account_id, region_name, _id, scope, "ipset")
 
 
 def make_arn(
-        name: str, account_id: str, region_name: str, _id: str, scope: str, resource: str
+    name: str, account_id: str, region_name: str, _id: str, scope: str, resource: str
 ) -> str:
     if scope == "REGIONAL":
         scope = "regional"

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -10,6 +10,10 @@ def make_arn_for_ip_set(
 ) -> str:
     return make_arn(name, account_id, region_name, _id, scope, "ipset")
 
+def make_arn_for_logging_configuration(
+        name: str, account_id: str, region_name: str, _id: str, scope: str
+) -> str:
+    return make_arn(name, account_id, region_name, _id, scope, "logingconfiguration")
 
 def make_arn(
     name: str, account_id: str, region_name: str, _id: str, scope: str, resource: str

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -2,9 +2,21 @@ def make_arn_for_wacl(
     name: str, account_id: str, region_name: str, wacl_id: str, scope: str
 ) -> str:
     """https://docs.aws.amazon.com/waf/latest/developerguide/how-aws-waf-works.html - explains --scope (cloudfront vs regional)"""
+    return make_arn(name, account_id, region_name, wacl_id, scope, "webacl")
 
+
+def make_arn_for_ip_set(
+        name: str, account_id: str, region_name: str, _id: str, scope: str
+) -> str:
+    return make_arn(name, account_id, region_name, _id, scope, "ipset")
+
+
+def make_arn(
+        name: str, account_id: str, region_name: str, _id: str, scope: str, resource: str
+) -> str:
     if scope == "REGIONAL":
         scope = "regional"
     elif scope == "CLOUDFRONT":
         scope = "global"
-    return f"arn:aws:wafv2:{region_name}:{account_id}:{scope}/webacl/{name}/{wacl_id}"
+
+    return f"arn:aws:wafv2:{region_name}:{account_id}:{scope}/{resource}/{name}/{_id}"

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -10,10 +10,12 @@ def make_arn_for_ip_set(
 ) -> str:
     return make_arn(name, account_id, region_name, _id, scope, "ipset")
 
+
 def make_arn_for_logging_configuration(
-        name: str, account_id: str, region_name: str, _id: str, scope: str
+    name: str, account_id: str, region_name: str, _id: str, scope: str
 ) -> str:
     return make_arn(name, account_id, region_name, _id, scope, "logingconfiguration")
+
 
 def make_arn(
     name: str, account_id: str, region_name: str, _id: str, scope: str, resource: str

--- a/tests/test_wafv2/test_wafv2.py
+++ b/tests/test_wafv2/test_wafv2.py
@@ -198,25 +198,18 @@ def test_update_web_acl():
         "MetricName": "updated",
     }
 
+
 @mock_aws
 def test_ip_set_crud():
     client = boto3.client("wafv2", region_name="us-east-1")
 
     create_response = client.create_ip_set(
-        Name='test-ip-set',
-        Scope='CLOUDFRONT',
-        Description='Test IP set',
-        IPAddressVersion='IPV4',
-        Addresses=[
-            '192.168.0.1/32',
-            '10.0.0.0/8'
-        ],
-        Tags=[
-            {
-                'Key': 'Environment',
-                'Value': 'Test'
-            }
-        ]
+        Name="test-ip-set",
+        Scope="CLOUDFRONT",
+        Description="Test IP set",
+        IPAddressVersion="IPV4",
+        Addresses=["192.168.0.1/32", "10.0.0.0/8"],
+        Tags=[{"Key": "Environment", "Value": "Test"}],
     )
 
     assert "Summary" in create_response
@@ -225,13 +218,11 @@ def test_ip_set_crud():
     assert summary["Id"]
     assert summary["LockToken"]
     assert summary["ARN"]
-    assert summary["Name"] == 'test-ip-set'
+    assert summary["Name"] == "test-ip-set"
     assert "Test IP set" in summary["Description"]
 
     get_response = client.get_ip_set(
-        Name=summary["Name"],
-        Scope="CLOUDFRONT",
-        Id=summary["Id"]
+        Name=summary["Name"], Scope="CLOUDFRONT", Id=summary["Id"]
     )
     assert "IPSet" in get_response
     assert "LockToken" in get_response
@@ -242,59 +233,59 @@ def test_ip_set_crud():
     with pytest.raises(ClientError) as e:
         client.update_ip_set(
             Name="test-ip-set",
-            Scope='CLOUDFRONT',
+            Scope="CLOUDFRONT",
             Id=summary["Id"],
-            Addresses=[
-                '10.0.0.0/8'
-            ],
-            LockToken="aaaaaaaaaaaaaaaaaa"  # invalid lock token
+            Addresses=["10.0.0.0/8"],
+            LockToken="aaaaaaaaaaaaaaaaaa",  # invalid lock token
         )
     e.value.response["Error"]["Code"] == "WAFOptimisticLockException"
-    e.value.response["Error"]["Message"]== "AWS WAF couldn’t save your changes because someone changed the resource after you started to edit it. Reapply your changes."
+    e.value.response["Error"][
+        "Message"
+    ] == "AWS WAF couldn’t save your changes because someone changed the resource after you started to edit it. Reapply your changes."
 
     update_response = client.update_ip_set(
         Name="test-ip-set",
-        Scope='CLOUDFRONT',
+        Scope="CLOUDFRONT",
         Id=summary["Id"],
-        Description='Updated test IP set',
-        Addresses=[
-            '192.168.1.0/24',
-            '10.0.0.0/8'
-        ],
-        LockToken=get_response["LockToken"]
+        Description="Updated test IP set",
+        Addresses=["192.168.1.0/24", "10.0.0.0/8"],
+        LockToken=get_response["LockToken"],
     )
 
     assert "NextLockToken" in update_response
 
     updated_get_response = client.get_ip_set(
-        Name=summary["Name"],
-        Scope="CLOUDFRONT",
-        Id=summary["Id"]
+        Name=summary["Name"], Scope="CLOUDFRONT", Id=summary["Id"]
     )
 
     updated_ip_set = updated_get_response["IPSet"]
     assert updated_ip_set["Description"] == "Updated test IP set"
     assert updated_get_response["LockToken"] == update_response["NextLockToken"]
-    assert all(addr in ['192.168.1.0/24', '10.0.0.0/8'] for addr in updated_ip_set["Addresses"])
+    assert all(
+        addr in ["192.168.1.0/24", "10.0.0.0/8"] for addr in updated_ip_set["Addresses"]
+    )
 
     list_response = client.list_ip_sets(Scope="CLOUDFRONT")
     assert len(list_response["IPSets"]) == 1
 
-    assert all([key in list_response["IPSets"][0] for key in ["ARN", "Description", "Id", "LockToken", "Name"]])
+    assert all(
+        [
+            key in list_response["IPSets"][0]
+            for key in ["ARN", "Description", "Id", "LockToken", "Name"]
+        ]
+    )
     assert "NextMarker" in list_response
 
     client.delete_ip_set(
         Name=summary["Name"],
         Scope="CLOUDFRONT",
         Id=summary["Id"],
-        LockToken=updated_get_response["LockToken"]
+        LockToken=updated_get_response["LockToken"],
     )
 
     with pytest.raises(ClientError) as e:
-        client.get_ip_set(
-            Name=summary["Name"],
-            Scope="CLOUDFRONT",
-            Id=summary["Id"]
-        )
+        client.get_ip_set(Name=summary["Name"], Scope="CLOUDFRONT", Id=summary["Id"])
     e.value.response["Error"]["Code"] == "WAFNonexistentItemException"
-    e.value.response["Error"]["Message"]== "AWS WAF couldn’t perform the operation because your resource doesn’t exist."
+    e.value.response["Error"][
+        "Message"
+    ] == "AWS WAF couldn’t perform the operation because your resource doesn’t exist."

--- a/tests/test_wafv2/test_wafv2.py
+++ b/tests/test_wafv2/test_wafv2.py
@@ -310,16 +310,14 @@ def test_logging_configuration_crud():
     # Create log groups
     logs_client = boto3.client("logs", region_name="us-east-1")
     logs_client.create_log_group(logGroupName="aws-waf-logs-test")
-    log_group = logs_client.describe_log_groups(
-        logGroupNamePrefix="aws-waf-logs-test"
-    )["logGroups"][0]
+    log_group = logs_client.describe_log_groups(logGroupNamePrefix="aws-waf-logs-test")[
+        "logGroups"
+    ][0]
 
     create_response = wafv2_client.put_logging_configuration(
         LoggingConfiguration={
             "ResourceArn": web_acl_arn,
-            "LogDestinationConfigs": [
-                log_group["arn"]
-            ],
+            "LogDestinationConfigs": [log_group["arn"]],
         }
     )
 


### PR DESCRIPTION
This pull request introduces support for IP Sets and Logging configurations resources within the WAFv2 service. It includes the implementation of new operations:

- create_ip_set
- delete_ip_set
- list_ip_sets
- get_ip_set
- update_ip_set
- put_logging_configuration
- get_logging_configuration
- list_logging_configurations
- delete_logging_configuration


Additionally, two CRUD tests have been added for these resources. These tests have been successfully executed against AWS without any complications.

Partially addresses localstack/localstack#10558
