### PR TITLE
Partitions: Backends of all global services are now partitioned

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -1021,7 +1021,7 @@ class BatchBackend(BaseBackend):
         :return: IAM Backend
         :rtype: moto.iam.models.IAMBackend
         """
-        return iam_backends[self.account_id]["global"]
+        return iam_backends[self.account_id][self.partition]
 
     @property
     def ec2_backend(self) -> EC2Backend:

--- a/moto/budgets/models.py
+++ b/moto/budgets/models.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterable, List
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time
+from moto.utilities.utils import PARTITION_NAMES
 
 from .exceptions import BudgetMissingLimit, DuplicateRecordException, NotFoundException
 
@@ -144,5 +145,8 @@ class BudgetsBackend(BaseBackend):
 
 
 budgets_backends = BackendDict(
-    BudgetsBackend, "budgets", use_boto3_regions=False, additional_regions=["global"]
+    BudgetsBackend,
+    "budgets",
+    use_boto3_regions=False,
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/budgets/responses.py
+++ b/moto/budgets/responses.py
@@ -11,7 +11,7 @@ class BudgetsResponse(BaseResponse):
 
     @property
     def backend(self) -> BudgetsBackend:
-        return budgets_backends[self.current_account]["global"]
+        return budgets_backends[self.current_account][self.partition]
 
     def create_budget(self) -> str:
         account_id = self._get_param("AccountId")

--- a/moto/ce/models.py
+++ b/moto/ce/models.py
@@ -8,6 +8,7 @@ from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
+from moto.utilities.utils import PARTITION_NAMES
 
 from .exceptions import CostCategoryNotFound
 
@@ -209,5 +210,8 @@ class CostExplorerBackend(BaseBackend):
 
 
 ce_backends = BackendDict(
-    CostExplorerBackend, "ce", use_boto3_regions=False, additional_regions=["global"]
+    CostExplorerBackend,
+    "ce",
+    use_boto3_regions=False,
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/ce/responses.py
+++ b/moto/ce/responses.py
@@ -13,7 +13,7 @@ class CostExplorerResponse(BaseResponse):
     @property
     def ce_backend(self) -> CostExplorerBackend:
         """Return backend instance specific for this region."""
-        return ce_backends[self.current_account]["global"]
+        return ce_backends[self.current_account][self.partition]
 
     def create_cost_category_definition(self) -> str:
         params = json.loads(self.body)

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -17,6 +17,7 @@ from moto.core.utils import (
 from moto.moto_api._internal import mock_random
 from moto.organizations.models import OrganizationsBackend, organizations_backends
 from moto.sns.models import sns_backends
+from moto.utilities.utils import get_partition
 
 from .custom_model import CustomModel
 from .exceptions import StackSetNotEmpty, StackSetNotFoundException, ValidationError
@@ -59,7 +60,12 @@ class FakeStackSet(BaseModel):
         self.execution_role = execution_role or "AWSCloudFormationStackSetExecutionRole"
         self.status = "ACTIVE"
         self.instances = FakeStackInstances(
-            account_id, template, parameters, self.id, self.name
+            account_id=account_id,
+            region=region,
+            template=template,
+            parameters=parameters,
+            stackset_id=self.id,
+            stackset_name=self.name,
         )
         self.stack_instances = self.instances.stack_instances
         self.operations: List[Dict[str, Any]] = []
@@ -281,12 +287,14 @@ class FakeStackInstances(BaseModel):
     def __init__(
         self,
         account_id: str,
+        region: str,
         template: str,
         parameters: Dict[str, str],
         stackset_id: str,
         stackset_name: str,
     ):
         self.account_id = account_id
+        self.partition = get_partition(region)
         self.template = template
         self.parameters = parameters or {}
         self.stackset_id = stackset_id
@@ -296,7 +304,7 @@ class FakeStackInstances(BaseModel):
 
     @property
     def org_backend(self) -> OrganizationsBackend:
-        return organizations_backends[self.account_id]["global"]
+        return organizations_backends[self.account_id][self.partition]
 
     def create_instances(
         self,
@@ -565,7 +573,11 @@ class FakeStack(CloudFormationModel):
         ]
         properties = cloudformation_json["Properties"]
 
-        template_body = get_stack_from_s3_url(properties["TemplateURL"], account_id)
+        template_body = get_stack_from_s3_url(
+            properties["TemplateURL"],
+            account_id=account_id,
+            partition=get_partition(region_name),
+        )
         parameters = properties.get("Parameters", {})
 
         return cf_backend.create_stack(

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -60,6 +60,7 @@ from moto.sqs import models as sqs_models  # noqa  # pylint: disable=all
 from moto.ssm import models as ssm_models  # noqa  # pylint: disable=all
 from moto.ssm import ssm_backends
 from moto.stepfunctions import models as sfn_models  # noqa  # pylint: disable=all
+from moto.utilities.utils import get_partition
 
 # End ugly list of imports
 from .exceptions import (
@@ -608,7 +609,9 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
                 if name == "AWS::Include":
                     location = params["Location"]
                     bucket_name, name = bucket_and_name_from_url(location)
-                    key = s3_backends[self._account_id]["global"].get_object(
+                    key = s3_backends[self._account_id][
+                        get_partition(self._region_name)
+                    ].get_object(
                         bucket_name,  # type: ignore[arg-type]
                         name,
                     )

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -53,7 +53,9 @@ class CloudFormationResponse(BaseResponse):
         return cls.dispatch(request=request, full_url=full_url, headers=headers)
 
     def _get_stack_from_s3_url(self, template_url: str) -> str:
-        return get_stack_from_s3_url(template_url, account_id=self.current_account)
+        return get_stack_from_s3_url(
+            template_url, account_id=self.current_account, partition=self.partition
+        )
 
     def _get_params_from_list(
         self, parameters_list: List[Dict[str, Any]]

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -90,7 +90,7 @@ def validate_template_cfn_lint(template: str) -> List[Any]:
     return matches
 
 
-def get_stack_from_s3_url(template_url: str, account_id: str) -> str:
+def get_stack_from_s3_url(template_url: str, account_id: str, partition: str) -> str:
     from moto.s3.models import s3_backends
 
     template_url_parts = urlparse(template_url)
@@ -109,5 +109,5 @@ def get_stack_from_s3_url(template_url: str, account_id: str) -> str:
             bucket_name = template_url_parts.netloc.split(".")[0]
             key_name = template_url_parts.path.lstrip("/")
 
-    key = s3_backends[account_id]["global"].get_object(bucket_name, key_name)
+    key = s3_backends[account_id][partition].get_object(bucket_name, key_name)
     return key.value.decode("utf-8")  # type: ignore[union-attr]

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -7,6 +7,7 @@ from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.tagging_service import TaggingService
+from moto.utilities.utils import PARTITION_NAMES
 
 from .exceptions import (
     DistributionAlreadyExists,
@@ -436,5 +437,5 @@ cloudfront_backends = BackendDict(
     CloudFrontBackend,
     "cloudfront",
     use_boto3_regions=False,
-    additional_regions=["global"],
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/cloudfront/responses.py
+++ b/moto/cloudfront/responses.py
@@ -19,7 +19,7 @@ class CloudFrontResponse(BaseResponse):
 
     @property
     def backend(self) -> CloudFrontBackend:
-        return cloudfront_backends[self.current_account]["global"]
+        return cloudfront_backends[self.current_account][self.partition]
 
     def create_distribution(self) -> TYPE_RESPONSE:
         params = self._get_xml_body()

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -91,6 +91,7 @@ class Trail(BaseModel):
     ):
         self.account_id = account_id
         self.region_name = region_name
+        self.partition = get_partition(region_name)
         self.trail_name = trail_name
         self.bucket_name = bucket_name
         self.s3_key_prefix = s3_key_prefix
@@ -136,7 +137,7 @@ class Trail(BaseModel):
         from moto.s3.models import s3_backends
 
         try:
-            s3_backends[self.account_id]["global"].get_bucket(self.bucket_name)
+            s3_backends[self.account_id][self.partition].get_bucket(self.bucket_name)
         except Exception:
             raise S3BucketDoesNotExistException(
                 f"S3 bucket {self.bucket_name} does not exist!"

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -449,7 +449,11 @@ class CloudWatchBackend(BaseBackend):
         providers = CloudWatchMetricProvider.__subclasses__()
         md = []
         for provider in providers:
-            md.extend(provider.get_cloudwatch_metrics(self.account_id))
+            md.extend(
+                provider.get_cloudwatch_metrics(
+                    self.account_id, region=self.region_name
+                )
+            )
         return md
 
     def put_metric_alarm(

--- a/moto/codepipeline/models.py
+++ b/moto/codepipeline/models.py
@@ -79,7 +79,7 @@ class CodePipelineBackend(BaseBackend):
 
     @property
     def iam_backend(self) -> IAMBackend:
-        return iam_backends[self.account_id]["global"]
+        return iam_backends[self.account_id][self.partition]
 
     def create_pipeline(
         self, pipeline: Dict[str, Any], tags: List[Dict[str, str]]

--- a/moto/config/responses.py
+++ b/moto/config/responses.py
@@ -118,12 +118,11 @@ class ConfigResponse(BaseResponse):
 
     def list_discovered_resources(self) -> str:
         schema = self.config_backend.list_discovered_resources(
-            self._get_param("resourceType"),
-            self.region,
-            self._get_param("resourceIds"),
-            self._get_param("resourceName"),
-            self._get_param("limit"),
-            self._get_param("nextToken"),
+            resource_type=self._get_param("resourceType"),
+            resource_ids=self._get_param("resourceIds"),
+            resource_name=self._get_param("resourceName"),
+            limit=self._get_param("limit"),
+            next_token=self._get_param("nextToken"),
         )
         return json.dumps(schema)
 

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 from boto3 import Session
 
 from moto.settings import allow_unknown_region, enable_iso_regions
+from moto.utilities.utils import get_partition
 
 from .model_instances import model_data
 from .responses import TYPE_RESPONSE
@@ -54,6 +55,7 @@ class BaseBackend:
     def __init__(self, region_name: str, account_id: str):
         self.region_name = region_name
         self.account_id = account_id
+        self.partition = get_partition(region_name)
 
     def reset(self) -> None:
         region_name = self.region_name
@@ -261,6 +263,8 @@ class AccountSpecificBackend(Dict[str, SERVICE_BACKEND]):
             region_specific_backend.reset()
 
     def __contains__(self, region: str) -> bool:  # type: ignore[override]
+        if region == "global":
+            region = "aws"
         return region in self.regions or region in self.keys()
 
     def __delitem__(self, key: str) -> None:
@@ -276,6 +280,13 @@ class AccountSpecificBackend(Dict[str, SERVICE_BACKEND]):
         super().__setitem__(key, value)
 
     def __getitem__(self, region_name: str) -> SERVICE_BACKEND:
+        # Some services, like S3, used to be truly global - meaning one Backend serving all
+        # Now that we support partitions (AWS, AWS-CN, AWS-GOV, etc), there will be one backend per partition
+        # Because the concept of 'region' doesn't exist in a global service, we use the partition name to keep the backends separate
+        # We used to use the term 'global' in lieu of a region name, and users may still use this
+        # It should resolve to 'aws', to ensure consistency
+        if region_name == "global":
+            region_name = "aws"
         if region_name in self.keys():
             return super().__getitem__(region_name)
         # Create the backend for a specific region

--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -67,7 +67,7 @@ class BotocoreStubber:
                     if "us-east-1" in backend_dict[DEFAULT_ACCOUNT_ID]:
                         backend = backend_dict[DEFAULT_ACCOUNT_ID]["us-east-1"]
                     else:
-                        backend = backend_dict[DEFAULT_ACCOUNT_ID]["global"]
+                        backend = backend_dict[DEFAULT_ACCOUNT_ID]["aws"]
                 else:
                     backend = backend_dict["global"]
 

--- a/moto/core/common_models.py
+++ b/moto/core/common_models.py
@@ -104,6 +104,7 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
     def list_config_service_resources(
         self,
         account_id: str,
+        partition: str,
         resource_ids: Optional[List[str]],
         resource_name: Optional[str],
         limit: int,
@@ -164,6 +165,7 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
     def get_config_resource(
         self,
         account_id: str,
+        partition: str,
         resource_id: str,
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
@@ -200,5 +202,5 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
 class CloudWatchMetricProvider:
     @staticmethod
     @abstractmethod
-    def get_cloudwatch_metrics(account_id: str) -> Any:  # type: ignore[misc]
+    def get_cloudwatch_metrics(account_id: str, region: str) -> Any:  # type: ignore[misc]
         pass

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -38,7 +38,7 @@ from moto.core.utils import (
     utcfromtimestamp,
 )
 from moto.utilities.aws_headers import gen_amzn_requestid_long
-from moto.utilities.utils import load_resource, load_resource_as_bytes
+from moto.utilities.utils import get_partition, load_resource, load_resource_as_bytes
 
 log = logging.getLogger(__name__)
 
@@ -423,6 +423,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         self.data = querystring
         self.method = request.method
         self.region = self.get_region_from_url(request, full_url)
+        self.partition = get_partition(self.region)
         self.uri_match: Optional[re.Match[str]] = None
 
         self.headers = request.headers

--- a/moto/dynamodb/models/table_import.py
+++ b/moto/dynamodb/models/table_import.py
@@ -26,7 +26,8 @@ class TableImport(Thread):
         compression_type: Optional[str],
     ):
         super().__init__()
-        self.arn = f"arn:{get_partition(region_name)}:dynamodb:{region_name}:{account_id}:table/{table_name}/import/{str(uuid4()).replace('-', '')}"
+        self.partition = get_partition(region_name)
+        self.arn = f"arn:{self.partition}:dynamodb:{region_name}:{account_id}:table/{table_name}/import/{str(uuid4()).replace('-', '')}"
         self.status = "IN_PROGRESS"
         self.account_id = account_id
         self.s3_source = s3_source
@@ -56,7 +57,7 @@ class TableImport(Thread):
         try:
             from moto.s3.models import s3_backends
 
-            s3_backend = s3_backends[self.account_id]["global"]
+            s3_backend = s3_backends[self.account_id][self.partition]
             bucket = s3_backend.buckets[s3_bucket_name]
         except KeyError:
             self.status = "FAILED"

--- a/moto/dynamodb_v20111205/models.py
+++ b/moto/dynamodb_v20111205/models.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
+from moto.utilities.utils import PARTITION_NAMES
 
 from .comparisons import get_comparison_func
 
@@ -397,5 +398,5 @@ dynamodb_backends = BackendDict(
     DynamoDBBackend,
     "dynamodb_v20111205",
     use_boto3_regions=False,
-    additional_regions=["global"],
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/dynamodb_v20111205/responses.py
+++ b/moto/dynamodb_v20111205/responses.py
@@ -44,7 +44,7 @@ class DynamoHandler(BaseResponse):
 
     @property
     def backend(self) -> DynamoDBBackend:
-        return dynamodb_backends[self.current_account]["global"]
+        return dynamodb_backends[self.current_account][self.partition]
 
     def list_tables(self) -> str:
         body = self.body

--- a/moto/ec2/models/flow_logs.py
+++ b/moto/ec2/models/flow_logs.py
@@ -228,7 +228,7 @@ class FlowLogsBackend:
 
                 arn = log_destination.split(":", 5)[5]
                 try:
-                    s3_backends[self.account_id]["global"].get_bucket(arn)  # type: ignore[attr-defined]
+                    s3_backends[self.account_id][self.partition].get_bucket(arn)  # type: ignore[attr-defined]
                 except MissingBucket:
                     # Instead of creating FlowLog report
                     # the unsuccessful status for the

--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -51,8 +51,9 @@ class IamInstanceProfileAssociationBackend:
 
         instance_profile = filter_iam_instance_profiles(
             self.account_id,  # type: ignore[attr-defined]
-            iam_instance_profile_arn,
-            iam_instance_profile_name,
+            partition=self.partition,  # type: ignore[attr-defined]
+            iam_instance_profile_arn=iam_instance_profile_arn,
+            iam_instance_profile_name=iam_instance_profile_name,
         )
 
         if instance_id in self.iam_instance_profile_associations.keys():
@@ -128,8 +129,9 @@ class IamInstanceProfileAssociationBackend:
     ) -> IamInstanceProfileAssociation:
         instance_profile = filter_iam_instance_profiles(
             self.account_id,  # type: ignore[attr-defined]
-            iam_instance_profile_arn,
-            iam_instance_profile_name,
+            partition=self.partition,  # type: ignore[attr-defined]
+            iam_instance_profile_arn=iam_instance_profile_arn,
+            iam_instance_profile_name=iam_instance_profile_name,
         )
 
         iam_instance_profile_association = None

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from moto.core.base_backend import BaseBackend
 from moto.core.common_models import CloudFormationModel
+from moto.utilities.utils import get_partition
 
 from ..exceptions import (
     CidrLimitExceeded,
@@ -1034,8 +1035,9 @@ class VPCBackend:
                     if service:
                         DEFAULT_VPC_ENDPOINT_SERVICES[region].extend(service)
 
-                if "global" in account_backend:
-                    service = account_backend["global"].default_vpc_endpoint_service(
+                partition = get_partition(region)
+                if partition in account_backend:
+                    service = account_backend[partition].default_vpc_endpoint_service(
                         region, zones
                     )
                     if service:

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -106,6 +106,7 @@ class InstanceResponse(EC2BaseResponse):
             # Validate the profile exists, before we error_on_dryrun and run_instances
             filter_iam_instance_profiles(
                 self.current_account,
+                partition=self.partition,
                 iam_instance_profile_arn=iam_instance_profile_arn,
                 iam_instance_profile_name=iam_instance_profile_name,
             )

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -774,21 +774,23 @@ def filter_iam_instance_profile_associations(
 
 def filter_iam_instance_profiles(
     account_id: str,
+    partition: str,
     iam_instance_profile_arn: Optional[str],
     iam_instance_profile_name: Optional[str],
 ) -> Any:
     instance_profile = None
     instance_profile_by_name = None
     instance_profile_by_arn = None
+    backend = iam_backends[account_id][partition]
     if iam_instance_profile_name:
-        instance_profile_by_name = iam_backends[account_id][
-            "global"
-        ].get_instance_profile(iam_instance_profile_name)
+        instance_profile_by_name = backend.get_instance_profile(
+            iam_instance_profile_name
+        )
         instance_profile = instance_profile_by_name
     if iam_instance_profile_arn:
-        instance_profile_by_arn = iam_backends[account_id][
-            "global"
-        ].get_instance_profile_by_arn(iam_instance_profile_arn)
+        instance_profile_by_arn = backend.get_instance_profile_by_arn(
+            iam_instance_profile_arn
+        )
         instance_profile = instance_profile_by_arn
     # We would prefer instance profile that we found by arn
     if iam_instance_profile_arn and iam_instance_profile_name:

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1875,7 +1875,7 @@ Member must satisfy regular expression pattern: {expression}"
 
         from moto.iam import iam_backends
 
-        cert = iam_backends[self.account_id]["global"].get_certificate_by_arn(
+        cert = iam_backends[self.account_id][self.partition].get_certificate_by_arn(
             certificate_arn
         )
         if cert is not None:

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -470,7 +470,7 @@ class FirehoseBackend(BaseBackend):
 
         batched_data = b"".join([b64decode(r["Data"]) for r in records])
         try:
-            s3_backends[self.account_id]["global"].put_object(
+            s3_backends[self.account_id][self.partition].put_object(
                 bucket_name, object_path, batched_data
             )
         except Exception as exc:

--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -40,6 +40,7 @@ from moto.s3.exceptions import (
     S3SignatureDoesNotMatchError,
 )
 from moto.sts.models import sts_backends
+from moto.utilities.utils import get_partition
 
 from .models import IAMBackend, Policy, iam_backends
 
@@ -47,21 +48,38 @@ log = logging.getLogger(__name__)
 
 
 def create_access_key(
-    account_id: str, access_key_id: str, headers: Dict[str, str]
+    account_id: str, partition: str, access_key_id: str, headers: Dict[str, str]
 ) -> Union["IAMUserAccessKey", "AssumedRoleAccessKey"]:
     if access_key_id.startswith("AKIA") or "X-Amz-Security-Token" not in headers:
-        return IAMUserAccessKey(account_id, access_key_id, headers)
+        return IAMUserAccessKey(
+            account_id=account_id,
+            partition=partition,
+            access_key_id=access_key_id,
+            headers=headers,
+        )
     else:
-        return AssumedRoleAccessKey(account_id, access_key_id, headers)
+        return AssumedRoleAccessKey(
+            account_id=account_id,
+            partition=partition,
+            access_key_id=access_key_id,
+            headers=headers,
+        )
 
 
 class IAMUserAccessKey:
     @property
     def backend(self) -> IAMBackend:
-        return iam_backends[self.account_id]["global"]
+        return iam_backends[self.account_id][self.partition]
 
-    def __init__(self, account_id: str, access_key_id: str, headers: Dict[str, str]):
+    def __init__(
+        self,
+        account_id: str,
+        partition: str,
+        access_key_id: str,
+        headers: Dict[str, str],
+    ):
         self.account_id = account_id
+        self.partition = partition
         iam_users = self.backend.list_users("/", None, None)
 
         for iam_user in iam_users:
@@ -119,11 +137,18 @@ class IAMUserAccessKey:
 class AssumedRoleAccessKey:
     @property
     def backend(self) -> IAMBackend:
-        return iam_backends[self.account_id]["global"]
+        return iam_backends[self.account_id][self.partition]
 
-    def __init__(self, account_id: str, access_key_id: str, headers: Dict[str, str]):
+    def __init__(
+        self,
+        account_id: str,
+        partition: str,
+        access_key_id: str,
+        headers: Dict[str, str],
+    ):
         self.account_id = account_id
-        for assumed_role in sts_backends[account_id]["global"].assumed_roles:
+        self.partition = partition
+        for assumed_role in sts_backends[account_id][partition].assumed_roles:
             if assumed_role.access_key_id == access_key_id:
                 self._access_key_id = access_key_id
                 self._secret_access_key = assumed_role.secret_access_key
@@ -206,6 +231,7 @@ class IAMRequestBase(object, metaclass=ABCMeta):
         try:
             self._access_key = create_access_key(
                 account_id=self.account_id,
+                partition=get_partition(self._region),
                 access_key_id=credential_data[0],
                 headers=headers,
             )

--- a/moto/iam/config.py
+++ b/moto/iam/config.py
@@ -12,6 +12,7 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
     def list_config_service_resources(
         self,
         account_id: str,
+        partition: str,
         resource_ids: Optional[List[str]],
         resource_name: Optional[str],
         limit: int,
@@ -26,7 +27,7 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
         # Stored in moto backend with the AWS-assigned random string like "AROA0BSVNSZKXVHS00SBJ"
 
         # Grab roles from backend; need the full values since names and id's are different
-        role_list = list(self.backends[account_id]["global"].roles.values())
+        role_list = list(self.backends[account_id][partition].roles.values())
 
         if not role_list:
             return [], None
@@ -133,12 +134,13 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
     def get_config_resource(
         self,
         account_id: str,
+        partition: str,
         resource_id: str,
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
-        role = self.backends[account_id]["global"].roles.get(resource_id)
+        role = self.backends[account_id][partition].roles.get(resource_id)
 
         if not role:
             return None
@@ -164,6 +166,7 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
     def list_config_service_resources(
         self,
         account_id: str,
+        partition: str,
         resource_ids: Optional[List[str]],
         resource_name: Optional[str],
         limit: int,
@@ -178,7 +181,7 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
         # Stored in moto backend with the arn like "arn:aws:iam::123456789012:policy/my-development-policy"
 
         policy_list = list(
-            self.backends[account_id]["global"].managed_policies.values()
+            self.backends[account_id][partition].managed_policies.values()
         )
 
         # We don't want to include AWS Managed Policies. This technically needs to
@@ -305,6 +308,7 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
     def get_config_resource(
         self,
         account_id: str,
+        partition: str,
         resource_id: str,
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
@@ -313,8 +317,10 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
         # policies are listed in the backend as arns, but we have to accept the PolicyID as the resource_id
         # we'll make a really crude search for it
         policy = None
-        for arn in self.backends[account_id]["global"].managed_policies.keys():
-            policy_candidate = self.backends[account_id]["global"].managed_policies[arn]
+        for arn in self.backends[account_id][partition].managed_policies.keys():
+            policy_candidate = self.backends[account_id][partition].managed_policies[
+                arn
+            ]
             if policy_candidate.id == resource_id:
                 policy = policy_candidate
                 break

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -9,7 +9,7 @@ class IamResponse(BaseResponse):
 
     @property
     def backend(self) -> IAMBackend:
-        return iam_backends[self.current_account]["global"]
+        return iam_backends[self.current_account][self.partition]
 
     def attach_role_policy(self) -> str:
         policy_arn = self._get_param("PolicyArn")

--- a/moto/instance_metadata/models.py
+++ b/moto/instance_metadata/models.py
@@ -1,4 +1,5 @@
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.utilities.utils import PARTITION_NAMES
 
 
 class InstanceMetadataBackend(BaseBackend):
@@ -9,5 +10,5 @@ instance_metadata_backends = BackendDict(
     InstanceMetadataBackend,
     "instance_metadata",
     use_boto3_regions=False,
-    additional_regions=["global"],
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1243,7 +1243,7 @@ class LogsBackend(BaseBackend):
         to: int,
     ) -> str:
         try:
-            s3_backends[self.account_id]["global"].get_bucket(destination)
+            s3_backends[self.account_id][self.partition].get_bucket(destination)
         except MissingBucket:
             raise InvalidParameterException(
                 "The given bucket does not exist. Please make sure the bucket is valid."
@@ -1261,7 +1261,7 @@ class LogsBackend(BaseBackend):
             to,
         )
 
-        s3_backends[self.account_id]["global"].put_object(
+        s3_backends[self.account_id][self.partition].put_object(
             bucket_name=destination,
             key_name="aws-logs-write-test",
             value=b"Permission Check Successful",
@@ -1287,7 +1287,7 @@ class LogsBackend(BaseBackend):
                 )
                 folder = str(mock_random.uuid4()) + "/" + stream_name.replace("/", "-")
                 key_name = f"{destinationPrefix}/{folder}/000000.gz"
-                s3_backends[self.account_id]["global"].put_object(
+                s3_backends[self.account_id][self.partition].put_object(
                     bucket_name=destination,
                     key_name=key_name,
                     value=gzip_compress(raw_logs.encode("utf-8")),

--- a/moto/moto_proxy/proxy3.py
+++ b/moto/moto_proxy/proxy3.py
@@ -52,7 +52,7 @@ class MotoRequestHandler:
             if "us-east-1" in backend_dict[DEFAULT_ACCOUNT_ID]:
                 backend = backend_dict[DEFAULT_ACCOUNT_ID]["us-east-1"]
             else:
-                backend = backend_dict[DEFAULT_ACCOUNT_ID]["global"]
+                backend = backend_dict[DEFAULT_ACCOUNT_ID]["aws"]
         else:
             backend = backend_dict["global"]
 

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -284,7 +284,7 @@ def create_backend_app(service: backends.SERVICE_NAMES) -> Flask:
         if "us-east-1" in backend_dict[DEFAULT_ACCOUNT_ID]:
             backend = backend_dict[DEFAULT_ACCOUNT_ID]["us-east-1"]
         else:
-            backend = backend_dict[DEFAULT_ACCOUNT_ID]["global"]
+            backend = backend_dict[DEFAULT_ACCOUNT_ID]["aws"]
     else:
         backend = backend_dict["global"]
 

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -23,7 +23,7 @@ from moto.organizations.exceptions import (
     TargetNotFoundException,
 )
 from moto.utilities.paginator import paginate
-from moto.utilities.utils import get_partition
+from moto.utilities.utils import PARTITION_NAMES, get_partition
 
 from .utils import PAGINATION_MODEL
 
@@ -958,5 +958,5 @@ organizations_backends = BackendDict(
     OrganizationsBackend,
     "organizations",
     use_boto3_regions=False,
-    additional_regions=["global"],
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/organizations/responses.py
+++ b/moto/organizations/responses.py
@@ -12,7 +12,7 @@ class OrganizationsResponse(BaseResponse):
 
     @property
     def organizations_backend(self) -> OrganizationsBackend:
-        return organizations_backends[self.current_account]["global"]
+        return organizations_backends[self.current_account][self.partition]
 
     @property
     def request_params(self) -> Dict[str, Any]:  # type: ignore[misc]

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -42,6 +42,7 @@ class ResourceShare(BaseModel):
     def __init__(self, account_id: str, region: str, **kwargs: Any):
         self.account_id = account_id
         self.region = region
+        self.partition = get_partition(region)
 
         self.allow_external_principals = kwargs.get("allowExternalPrincipals", True)
         self.arn = f"arn:{get_partition(self.region)}:ram:{self.region}:{account_id}:resource-share/{random.uuid4()}"
@@ -56,7 +57,7 @@ class ResourceShare(BaseModel):
 
     @property
     def organizations_backend(self) -> OrganizationsBackend:
-        return organizations_backends[self.account_id]["global"]
+        return organizations_backends[self.account_id][self.partition]
 
     def add_principals(self, principals: List[str]) -> None:
         for principal in principals:
@@ -157,7 +158,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
     @property
     def organizations_backend(self) -> OrganizationsBackend:
-        return organizations_backends[self.account_id]["global"]
+        return organizations_backends[self.account_id][self.partition]
 
     def create_resource_share(self, **kwargs: Any) -> Dict[str, Any]:
         resource = ResourceShare(self.account_id, self.region_name, **kwargs)

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -44,7 +44,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     @property
     def s3_backend(self) -> S3Backend:
-        return s3_backends[self.account_id]["global"]
+        return s3_backends[self.account_id][self.partition]
 
     @property
     def ec2_backend(self) -> Any:  # type: ignore[misc]

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -31,7 +31,7 @@ from moto.route53.exceptions import (
     ResourceRecordAlreadyExists,
 )
 from moto.utilities.paginator import paginate
-from moto.utilities.utils import get_partition
+from moto.utilities.utils import PARTITION_NAMES, get_partition
 
 from .utils import PAGINATION_MODEL
 
@@ -139,7 +139,7 @@ class HealthCheck(CloudFormationModel):
             "request_interval": properties.get("RequestInterval"),
             "failure_threshold": properties.get("FailureThreshold"),
         }
-        backend = route53_backends[account_id]["global"]
+        backend = route53_backends[account_id][get_partition(region_name)]
         health_check = backend.create_health_check(
             caller_reference=resource_name, health_check_args=health_check_args
         )
@@ -235,7 +235,7 @@ class RecordSet(CloudFormationModel):
         properties = cloudformation_json["Properties"]
 
         zone_name = properties.get("HostedZoneName")
-        backend = route53_backends[account_id]["global"]
+        backend = route53_backends[account_id][get_partition(region_name)]
         hosted_zone = backend.get_hosted_zone_by_name(zone_name) if zone_name else None
         if hosted_zone is None:
             hosted_zone = backend.get_hosted_zone(properties["HostedZoneId"])
@@ -271,7 +271,7 @@ class RecordSet(CloudFormationModel):
         properties = cloudformation_json["Properties"]
 
         zone_name = properties.get("HostedZoneName")
-        backend = route53_backends[account_id]["global"]
+        backend = route53_backends[account_id][get_partition(region_name)]
         hosted_zone = backend.get_hosted_zone_by_name(zone_name) if zone_name else None
         if hosted_zone is None:
             hosted_zone = backend.get_hosted_zone(properties["HostedZoneId"])
@@ -285,13 +285,9 @@ class RecordSet(CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.name
 
-    def delete(
-        self,
-        account_id: str,
-        region: str,  # pylint: disable=unused-argument
-    ) -> None:
+    def delete(self, account_id: str, region: str) -> None:
         """Not exposed as part of the Route 53 API - used for CloudFormation"""
-        backend = route53_backends[account_id]["global"]
+        backend = route53_backends[account_id][get_partition(region)]
         hosted_zone = (
             backend.get_hosted_zone_by_name(self.hosted_zone_name)
             if self.hosted_zone_name
@@ -454,9 +450,9 @@ class FakeZone(CloudFormationModel):
         region_name: str,
         **kwargs: Any,
     ) -> "FakeZone":
-        hosted_zone = route53_backends[account_id]["global"].create_hosted_zone(
-            resource_name, private_zone=False
-        )
+        hosted_zone = route53_backends[account_id][
+            get_partition(region_name)
+        ].create_hosted_zone(resource_name, private_zone=False)
         return hosted_zone
 
 
@@ -490,7 +486,7 @@ class RecordSetGroup(CloudFormationModel):
         properties = cloudformation_json["Properties"]
 
         zone_name = properties.get("HostedZoneName")
-        backend = route53_backends[account_id]["global"]
+        backend = route53_backends[account_id][get_partition(region_name)]
         hosted_zone = backend.get_hosted_zone_by_name(zone_name) if zone_name else None
         if hosted_zone is None:
             hosted_zone = backend.get_hosted_zone(properties["HostedZoneId"])
@@ -987,5 +983,8 @@ class Route53Backend(BaseBackend):
 
 
 route53_backends = BackendDict(
-    Route53Backend, "route53", use_boto3_regions=False, additional_regions=["global"]
+    Route53Backend,
+    "route53",
+    use_boto3_regions=False,
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -34,7 +34,7 @@ class Route53(BaseResponse):
 
     @property
     def backend(self) -> Route53Backend:
-        return route53_backends[self.current_account]["global"]
+        return route53_backends[self.current_account][self.partition]
 
     def create_hosted_zone(self) -> TYPE_RESPONSE:
         vpcid = None

--- a/moto/route53domains/models.py
+++ b/moto/route53domains/models.py
@@ -5,6 +5,7 @@ from moto.core.base_backend import BackendDict, BaseBackend
 from moto.route53 import route53_backends
 from moto.route53.models import Route53Backend
 from moto.utilities.paginator import paginate
+from moto.utilities.utils import PARTITION_NAMES
 
 from .exceptions import (
     DomainLimitExceededException,
@@ -47,7 +48,9 @@ class Route53DomainsBackend(BaseBackend):
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.__route53_backend: Route53Backend = route53_backends[account_id]["global"]
+        self.__route53_backend: Route53Backend = route53_backends[account_id][
+            self.partition
+        ]
         self.__domains: Dict[str, Route53Domain] = {}
         self.__operations: Dict[str, Route53DomainsOperation] = {}
 
@@ -296,5 +299,5 @@ route53domains_backends = BackendDict(
     Route53DomainsBackend,
     "route53domains",
     use_boto3_regions=False,
-    additional_regions=["global"],
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/route53domains/responses.py
+++ b/moto/route53domains/responses.py
@@ -12,7 +12,7 @@ class Route53DomainsResponse(BaseResponse):
 
     @property
     def route53domains_backend(self) -> Route53DomainsBackend:
-        return route53domains_backends[self.current_account]["global"]
+        return route53domains_backends[self.current_account][self.partition]
 
     def register_domain(self) -> str:
         domain_name = self._get_param("DomainName")

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -21,6 +21,7 @@ from moto.s3bucket_path.utils import (
 from moto.s3bucket_path.utils import (
     parse_key_name as bucketpath_parse_key_name,
 )
+from moto.utilities.utils import get_partition
 
 from .exceptions import (
     AccessForbidden,
@@ -174,7 +175,7 @@ class S3Response(BaseResponse):
 
     @property
     def backend(self) -> S3Backend:
-        return s3_backends[self.current_account]["global"]
+        return s3_backends[self.current_account][get_partition(self.region)]
 
     @property
     def should_autoescape(self) -> bool:
@@ -257,9 +258,9 @@ class S3Response(BaseResponse):
             from moto.s3control import s3control_backends
 
             ap_name = bucket_name[: -(len(self.current_account) + 1)]
-            ap = s3control_backends[self.current_account]["global"].get_access_point(
-                self.current_account, ap_name
-            )
+            ap = s3control_backends[self.current_account][
+                self.partition
+            ].get_access_point(self.current_account, ap_name)
             bucket_name = ap.bucket
 
         return bucket_name

--- a/moto/s3control/config.py
+++ b/moto/s3control/config.py
@@ -14,6 +14,7 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
     def list_config_service_resources(
         self,
         account_id: str,
+        partition: str,
         resource_ids: Optional[List[str]],
         resource_name: Optional[str],
         limit: int,
@@ -36,12 +37,12 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
         if resource_ids:
             for resource_id in resource_ids:
                 if account_id == resource_id:
-                    pab = self.backends[account_id]["global"].public_access_block
+                    pab = self.backends[account_id][partition].public_access_block
                     break
 
         # Otherwise, just grab the one from the backend:
         if not resource_ids:
-            pab = self.backends[account_id]["global"].public_access_block
+            pab = self.backends[account_id][partition].public_access_block
 
         # If it's not present, then return nothing
         if not pab:
@@ -97,13 +98,14 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
     def get_config_resource(
         self,
         account_id: str,
+        partition: str,
         resource_id: str,
         resource_name: Optional[str] = None,
         backend_region: Optional[str] = None,
         resource_region: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         # Do we even have this defined?
-        backend = self.backends[account_id]["global"]
+        backend = self.backends[account_id][partition]
         if not backend.public_access_block:
             return None
 

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -11,6 +11,7 @@ from moto.s3.exceptions import (
     WrongPublicAccessBlockAccountIdError,
 )
 from moto.s3.models import PublicAccessBlock
+from moto.utilities.utils import PARTITION_NAMES
 
 from .exceptions import AccessPointNotFound, AccessPointPolicyNotFound
 
@@ -142,5 +143,5 @@ s3control_backends = BackendDict(
     S3ControlBackend,
     "s3control",
     use_boto3_regions=False,
-    additional_regions=["global"],
+    additional_regions=PARTITION_NAMES,
 )

--- a/moto/s3control/responses.py
+++ b/moto/s3control/responses.py
@@ -16,7 +16,7 @@ class S3ControlResponse(BaseResponse):
 
     @property
     def backend(self) -> S3ControlBackend:
-        return s3control_backends[self.current_account]["global"]
+        return s3control_backends[self.current_account][self.partition]
 
     def get_public_access_block(self) -> str:
         account_id = self.headers.get("x-amz-account-id")

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -2674,7 +2674,9 @@ class SageMakerModelBackend(BaseBackend):
 
         if pipeline_definition_s3_location:
             pipeline_definition = load_pipeline_definition_from_s3(  # type: ignore
-                pipeline_definition_s3_location, self.account_id
+                pipeline_definition_s3_location,
+                account_id=self.account_id,
+                partition=self.partition,
             )
 
         pipeline = FakePipeline(
@@ -2716,7 +2718,9 @@ class SageMakerModelBackend(BaseBackend):
                     self.pipelines[
                         pipeline_name
                     ].pipeline_definition = load_pipeline_definition_from_s3(  # type: ignore
-                        attr_value, self.account_id
+                        attr_value,
+                        self.account_id,
+                        partition=self.partition,
                     )
                     continue
                 setattr(self.pipelines[pipeline_name], attr_key, attr_value)

--- a/moto/sagemaker/utils.py
+++ b/moto/sagemaker/utils.py
@@ -40,9 +40,9 @@ def get_pipeline_execution_from_arn(
 
 
 def load_pipeline_definition_from_s3(
-    pipeline_definition_s3_location: Dict[str, Any], account_id: str
+    pipeline_definition_s3_location: Dict[str, Any], account_id: str, partition: str
 ) -> Dict[str, Any]:
-    s3_backend = s3_backends[account_id]["global"]
+    s3_backend = s3_backends[account_id][partition]
     result = s3_backend.get_object(
         bucket_name=pipeline_definition_s3_location["Bucket"],
         key_name=pipeline_definition_s3_location["ObjectKey"],

--- a/moto/sagemakerruntime/models.py
+++ b/moto/sagemakerruntime/models.py
@@ -89,7 +89,7 @@ class SageMakerRuntimeBackend(BaseBackend):
         output_location = "response.json"
         from moto.s3.models import s3_backends
 
-        s3_backend = s3_backends[self.account_id]["global"]
+        s3_backend = s3_backends[self.account_id][self.partition]
         s3_backend.create_bucket(output_bucket, region_name=self.region_name)
         s3_backend.put_object(output_bucket, output_location, value=output)
         self.async_results[endpoint_name][input_location] = (

--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -14,7 +14,7 @@ from moto.sts.utils import (
     random_assumed_role_id,
     random_session_token,
 )
-from moto.utilities.utils import get_partition
+from moto.utilities.utils import PARTITION_NAMES, get_partition
 
 
 class Token(BaseModel):
@@ -53,6 +53,7 @@ class AssumedRole(BaseModel):
         self.access_key_id = access_key.access_key_id
         self.secret_access_key = access_key.secret_access_key
         self.session_token = random_session_token()
+        self.partition = get_partition(region_name)
 
     @property
     def expiration_ISO8601(self) -> str:
@@ -60,7 +61,7 @@ class AssumedRole(BaseModel):
 
     @property
     def user_id(self) -> str:
-        iam_backend = iam_backends[self.account_id]["global"]
+        iam_backend = iam_backends[self.account_id][self.partition]
         try:
             role_id = iam_backend.get_role_by_arn(arn=self.role_arn).id
         except Exception:
@@ -108,7 +109,7 @@ class STSBackend(BaseBackend):
             external_id=external_id,
         )
         access_key.role_arn = role_arn
-        account_backend = sts_backends[account_id]["global"]
+        account_backend = sts_backends[account_id][get_partition(region_name)]
         account_backend.assumed_roles.append(role)
         return role
 
@@ -179,7 +180,7 @@ class STSBackend(BaseBackend):
         if assumed_role:
             return assumed_role.user_id, assumed_role.arn, assumed_role.account_id
 
-        iam_backend = iam_backends[self.account_id]["global"]
+        iam_backend = iam_backends[self.account_id][self.partition]
         user = iam_backend.get_user_from_access_key_id(access_key_id)
         if user:
             return user.id, user.arn, user.account_id
@@ -196,10 +197,10 @@ class STSBackend(BaseBackend):
             account_id = account_id_match.group(1)
         else:
             account_id = self.account_id
-        iam_backend = iam_backends[account_id]["global"]
+        iam_backend = iam_backends[account_id][self.partition]
         return account_id, iam_backend.create_temp_access_key()
 
 
 sts_backends = BackendDict(
-    STSBackend, "sts", use_boto3_regions=False, additional_regions=["global"]
+    STSBackend, "sts", use_boto3_regions=False, additional_regions=PARTITION_NAMES
 )

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -12,7 +12,7 @@ class TokenResponse(BaseResponse):
 
     @property
     def backend(self) -> STSBackend:
-        return sts_backends[self.current_account]["global"]
+        return sts_backends[self.current_account][self.partition]
 
     def _determine_resource(self) -> str:
         if "AssumeRole" in self.querystring.get("Action", []):

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -3,19 +3,22 @@ import json
 import pkgutil
 from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Tuple, TypeVar
 
+REGION_PREFIX_TO_PARTITION = {
+    # (region prefix, aws partition)
+    "cn-": "aws-cn",
+    "us-gov-": "aws-us-gov",
+    "us-iso-": "aws-iso",
+    "us-isob-": "aws-iso-b",
+}
+PARTITION_NAMES = list(REGION_PREFIX_TO_PARTITION.values()) + ["aws"]
+
 
 def get_partition(region: str) -> str:
-    valid_matches = [
-        # (region prefix, aws partition)
-        ("cn-", "aws-cn"),
-        ("us-gov-", "aws-us-gov"),
-        ("us-iso-", "aws-iso"),
-        ("us-isob-", "aws-iso-b"),
-    ]
-
-    for prefix, partition in valid_matches:
+    if region in PARTITION_NAMES:
+        return region
+    for prefix in REGION_PREFIX_TO_PARTITION:
         if region.startswith(prefix):
-            return partition
+            return REGION_PREFIX_TO_PARTITION[prefix]
     return "aws"
 
 

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -7,6 +7,7 @@ from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
+from moto.utilities.utils import PARTITION_NAMES
 
 from .exceptions import (
     WAFNonexistentItemException,
@@ -421,5 +422,5 @@ class WAFV2Backend(BaseBackend):
 
 
 wafv2_backends = BackendDict(
-    WAFV2Backend, "waf-regional", additional_regions=["global"]
+    WAFV2Backend, "waf-regional", additional_regions=PARTITION_NAMES
 )

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -1,3 +1,6 @@
+from moto.utilities.utils import PARTITION_NAMES
+
+
 def make_arn_for_wacl(
     name: str, account_id: str, region_name: str, wacl_id: str, scope: str
 ) -> str:
@@ -24,5 +27,8 @@ def make_arn(
         scope = "regional"
     elif scope == "CLOUDFRONT":
         scope = "global"
+
+    if region_name in PARTITION_NAMES:
+        region_name = "global"
 
     return f"arn:aws:wafv2:{region_name}:{account_id}:{scope}/{resource}/{name}/{_id}"

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -49,7 +49,7 @@ def test_lambda_regions(region):
     function = client.create_function(
         FunctionName=function_name,
         Runtime=PYTHON_VERSION,
-        Role=get_role_name(),
+        Role=get_role_name(region),
         Handler="lambda_function.lambda_handler",
         Code={"ZipFile": get_test_zip_file1()},
     )

--- a/tests/test_awslambda/utilities.py
+++ b/tests/test_awslambda/utilities.py
@@ -182,9 +182,9 @@ def create_invalid_lambda(role):
     return err
 
 
-def get_role_name():
+def get_role_name(region=None):
     with mock_aws():
-        iam = boto3.client("iam", region_name=_lambda_region)
+        iam = boto3.client("iam", region_name=region or _lambda_region)
         while True:
             try:
                 return iam.get_role(RoleName="my-role")["Role"]["Arn"]

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -3515,7 +3515,7 @@ def test_role_list_config_discovered_resources():
 
     # Without any roles
     assert role_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     ) == (
         [],
         None,
@@ -3541,7 +3541,7 @@ def test_role_list_config_discovered_resources():
     assert len(roles) == num_roles
 
     result = role_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     )[0]
     assert len(result) == num_roles
 
@@ -3554,13 +3554,13 @@ def test_role_list_config_discovered_resources():
 
     # test passing list of resource ids
     resource_ids = role_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, [roles[0]["id"], roles[1]["id"]], None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", [roles[0]["id"], roles[1]["id"]], None, 100, None
     )[0]
     assert len(resource_ids) == 2
 
     # test passing a single resource name
     resource_name = role_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, roles[0]["name"], 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, roles[0]["name"], 100, None
     )[0]
     assert len(resource_name) == 1
     assert resource_name[0]["id"] == roles[0]["id"]
@@ -3569,6 +3569,7 @@ def test_role_list_config_discovered_resources():
     # test passing a single resource name AND some resource id's
     both_filter_good = role_config_query.list_config_service_resources(
         DEFAULT_ACCOUNT_ID,
+        "aws",
         [roles[0]["id"], roles[1]["id"]],
         roles[0]["name"],
         100,
@@ -3580,6 +3581,7 @@ def test_role_list_config_discovered_resources():
 
     both_filter_bad = role_config_query.list_config_service_resources(
         DEFAULT_ACCOUNT_ID,
+        "aws",
         [roles[0]["id"], roles[1]["id"]],
         roles[2]["name"],
         100,
@@ -3596,9 +3598,11 @@ def test_role_config_dict():
     from moto.iam.utils import random_policy_id, random_role_id
 
     # Without any roles
-    assert not role_config_query.get_config_resource(DEFAULT_ACCOUNT_ID, "something")
+    assert not role_config_query.get_config_resource(
+        DEFAULT_ACCOUNT_ID, partition="aws", resource_id="something"
+    )
     assert role_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     ) == (
         [],
         None,
@@ -3630,7 +3634,7 @@ def test_role_config_dict():
     )
 
     policy_id = policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     )[0][0]["id"]
     assert len(policy_id) == len(random_policy_id())
 
@@ -3646,7 +3650,7 @@ def test_role_config_dict():
     )
 
     plain_role = role_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     )[0][0]
     assert plain_role is not None
     assert len(plain_role["id"]) == len(random_role_id(DEFAULT_ACCOUNT_ID))
@@ -3664,7 +3668,7 @@ def test_role_config_dict():
     assume_role = next(
         role
         for role in role_config_query.list_config_service_resources(
-            DEFAULT_ACCOUNT_ID, None, None, 100, None
+            DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
         )[0]
         if role["id"] not in [plain_role["id"]]
     )
@@ -3685,7 +3689,7 @@ def test_role_config_dict():
     assume_and_permission_boundary_role = next(
         role
         for role in role_config_query.list_config_service_resources(
-            DEFAULT_ACCOUNT_ID, None, None, 100, None
+            DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
         )[0]
         if role["id"] not in [plain_role["id"], assume_role["id"]]
     )
@@ -3711,7 +3715,7 @@ def test_role_config_dict():
     role_with_attached_policy = next(
         role
         for role in role_config_query.list_config_service_resources(
-            DEFAULT_ACCOUNT_ID, None, None, 100, None
+            DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
         )[0]
         if role["id"]
         not in [
@@ -3746,7 +3750,7 @@ def test_role_config_dict():
     role_with_inline_policy = next(
         role
         for role in role_config_query.list_config_service_resources(
-            DEFAULT_ACCOUNT_ID, None, None, 100, None
+            DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
         )[0]
         if role["id"]
         not in [
@@ -4116,7 +4120,7 @@ def test_policy_list_config_discovered_resources():
 
     # Without any policies
     assert policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     ) == (
         [],
         None,
@@ -4155,7 +4159,7 @@ def test_policy_list_config_discovered_resources():
         assert backend_key.startswith("arn:aws:iam::")
 
     result = policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     )[0]
     assert len(result) == num_policies
 
@@ -4167,13 +4171,18 @@ def test_policy_list_config_discovered_resources():
 
     # test passing list of resource ids
     resource_ids = policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, [policies[0]["id"], policies[1]["id"]], None, 100, None
+        DEFAULT_ACCOUNT_ID,
+        "aws",
+        [policies[0]["id"], policies[1]["id"]],
+        None,
+        100,
+        None,
     )[0]
     assert len(resource_ids) == 2
 
     # test passing a single resource name
     resource_name = policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, policies[0]["name"], 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, policies[0]["name"], 100, None
     )[0]
     assert len(resource_name) == 1
     assert resource_name[0]["id"] == policies[0]["id"]
@@ -4182,6 +4191,7 @@ def test_policy_list_config_discovered_resources():
     # test passing a single resource name AND some resource id's
     both_filter_good = policy_config_query.list_config_service_resources(
         DEFAULT_ACCOUNT_ID,
+        "aws",
         [policies[0]["id"], policies[1]["id"]],
         policies[0]["name"],
         100,
@@ -4193,6 +4203,7 @@ def test_policy_list_config_discovered_resources():
 
     both_filter_bad = policy_config_query.list_config_service_resources(
         DEFAULT_ACCOUNT_ID,
+        "aws",
         [policies[0]["id"], policies[1]["id"]],
         policies[2]["name"],
         100,
@@ -4210,10 +4221,10 @@ def test_policy_config_dict():
 
     # Without any roles
     assert not policy_config_query.get_config_resource(
-        DEFAULT_ACCOUNT_ID, "arn:aws:iam::123456789012:policy/basic_policy"
+        DEFAULT_ACCOUNT_ID, "aws", "arn:aws:iam::123456789012:policy/basic_policy"
     )
     assert policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     ) == (
         [],
         None,
@@ -4244,13 +4255,13 @@ def test_policy_config_dict():
     )
 
     policy_id = policy_config_query.list_config_service_resources(
-        DEFAULT_ACCOUNT_ID, None, None, 100, None
+        DEFAULT_ACCOUNT_ID, "aws", None, None, 100, None
     )[0][0]["id"]
     assert len(policy_id) == len(random_policy_id())
 
     assert policy_arn == "arn:aws:iam::123456789012:policy/basic_policy"
     assert (
-        policy_config_query.get_config_resource(DEFAULT_ACCOUNT_ID, policy_id)
+        policy_config_query.get_config_resource(DEFAULT_ACCOUNT_ID, "aws", policy_id)
         is not None
     )
 

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -45,7 +45,9 @@ class MyModel:
 @mock_aws
 def test_keys_are_pickleable():
     """Keys must be pickleable due to boto3 implementation details."""
-    key = s3model.FakeKey("name", b"data!", account_id=DEFAULT_ACCOUNT_ID)
+    key = s3model.FakeKey(
+        "name", b"data!", account_id=DEFAULT_ACCOUNT_ID, region_name="us-east-1"
+    )
     assert key.value == b"data!"
 
     pickled = pickle.dumps(key)

--- a/tests/test_s3/test_s3_file_handles.py
+++ b/tests/test_s3/test_s3_file_handles.py
@@ -335,7 +335,11 @@ def test_verify_key_can_be_copied_after_disposing():
     # This test verifies the copy-operation succeeds, it will just not
     # have any data.
     key = s3model.FakeKey(
-        name="test", bucket_name="bucket", value="sth", account_id=DEFAULT_ACCOUNT_ID
+        name="test",
+        bucket_name="bucket",
+        value="sth",
+        account_id=DEFAULT_ACCOUNT_ID,
+        region_name="us-east-1",
     )
     assert not key._value_buffer.closed
     key.dispose()

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -53,12 +53,16 @@ def test_default_key_buffer_size():
 
     os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = "2"  # 2 bytes
     assert get_s3_default_key_buffer_size() == 2
-    fake_key = s3model.FakeKey("a", os.urandom(1), account_id=DEFAULT_ACCOUNT_ID)
+    fake_key = s3model.FakeKey(
+        "a", os.urandom(1), account_id=DEFAULT_ACCOUNT_ID, region_name="us-east-1"
+    )
     assert fake_key._value_buffer._rolled is False
 
     os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = "1"  # 1 byte
     assert get_s3_default_key_buffer_size() == 1
-    fake_key = s3model.FakeKey("a", os.urandom(3), account_id=DEFAULT_ACCOUNT_ID)
+    fake_key = s3model.FakeKey(
+        "a", os.urandom(3), account_id=DEFAULT_ACCOUNT_ID, region_name="us-east-1"
+    )
     assert fake_key._value_buffer._rolled is True
 
     # if no MOTO_S3_DEFAULT_KEY_BUFFER_SIZE env variable is present the

--- a/tests/test_s3/test_s3_notifications.py
+++ b/tests/test_s3/test_s3_notifications.py
@@ -83,7 +83,10 @@ def test_send_event_bridge_message():
     logs_client.create_log_group(logGroupName=log_group_name)
     mocked_bucket = FakeBucket(str(uuid4()), ACCOUNT_ID, REGION_NAME)
     mocked_key = FakeKey(
-        "test-key", bytes("test content", encoding="utf-8"), ACCOUNT_ID
+        "test-key",
+        bytes("test content", encoding="utf-8"),
+        ACCOUNT_ID,
+        region_name=REGION_NAME,
     )
 
     # do nothing if event target does not exists.

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -294,6 +294,7 @@ def test_load_pipeline_definition_from_s3():
                     "ObjectKey": object_key,
                 },
                 account_id=ACCOUNT_ID,
+                partition="aws",
             )
     assert observed_pipeline_definition == pipeline_definition
 

--- a/tests/test_sts/test_sts.py
+++ b/tests/test_sts/test_sts.py
@@ -694,7 +694,7 @@ def test_get_caller_identity_with_assumed_role_credentials(region, partition):
 
     identity = boto3.client(
         "sts",
-        region_name="us-east-1",
+        region_name=region,
         aws_access_key_id=access_key["AccessKeyId"],
         aws_secret_access_key=access_key["SecretAccessKey"],
     ).get_caller_identity()


### PR DESCRIPTION
Related to #7699

Regional services have their data stored in a `BackendDict[ACCOUNT_ID][REGION]`
Global services (like S3) would use a magic `global` key instead: `BackendDict[ACCOUNT_ID]["global"]`

These services are not truly global though - data in the regular AWS partition is separate from the data in the AWS China/AWS GOV/etc partitions.
This PR changes all references to the magic `global` to use the partition name instead: 
`BackendDict[ACCOUNT_ID][aws|aws-cn|aws-gov|etc]`

Existing users will sometimes import backends manually, and also refer to `BackendDict[ACCOUNT_ID]["global"]`. This will now resolve to `BackendDict[ACCOUNT_ID]["aws"]` for backwards compatibility.

The Moto API still uses a single `global` backend. Operations in the Moto API either call a specific service, or deal with configuration issues - there is no point in partitioning either.