### PR TITLE
Fit service name for sso-admin

### DIFF
--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -543,4 +543,4 @@ class SSOAdminBackend(BaseBackend):
         raise ResourceNotFoundException
 
 
-ssoadmin_backends = BackendDict(SSOAdminBackend, "sso")
+ssoadmin_backends = BackendDict(SSOAdminBackend, "sso-admin")


### PR DESCRIPTION
This small PR fixes the service name passed to the `BackendDict` for the SSO Admin service.