### PR TITLE
Prep release 5.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 Moto Changelog
 ==============
 
+5.0.8
+-----
+Docker Digest for 5.0.8: <autopopulateddigest>
+
+    General:
+        * Improved support for non-generic partitions (China, GovCloud, ISO-regions). 
+          All ARN's now contain the correct partition for resources created in those regions.
+
+    New Services:
+        * NetworkManager:
+            * create_global_network()
+            * describe_global_networks()
+            * create_core_network()
+            * create_global_network()
+            * delete_core_network()
+            * list_core_networks()
+            * get_core_network()
+            * tag_resource()
+            * untag_resource()
+
+    Miscellaneous:
+        * ResilienceHub: list_app_assessments() can now return pre-configured results
+        * ResourceGroupTagging: get_resources() now returns results when filtering on "lambda:function"
+        * S3: delete_object_tagging()/put_object_tagging() now send an EventBridge notification
+
+
 5.0.7
 -----
 Docker Digest for 5.0.7: _sha256:81ac52ff74b0bf0f4957ee4260e6a7e75d66c9e5d040ed4f721a5500b873c88a_

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3379,7 +3379,7 @@
 
 ## events
 <details>
-<summary>80% implemented</summary>
+<summary>78% implemented</summary>
 
 - [ ] activate_event_source
 - [X] cancel_replay
@@ -3437,6 +3437,7 @@
 - [X] update_archive
 - [X] update_connection
 - [ ] update_endpoint
+- [ ] update_event_bus
 </details>
 
 ## firehose
@@ -4673,7 +4674,7 @@
 
 ## lakeformation
 <details>
-<summary>37% implemented</summary>
+<summary>36% implemented</summary>
 
 - [X] add_lf_tags_to_resource
 - [ ] assume_decorated_role_with_saml
@@ -4696,6 +4697,7 @@
 - [ ] describe_transaction
 - [ ] extend_transaction
 - [ ] get_data_cells_filter
+- [ ] get_data_lake_principal
 - [X] get_data_lake_settings
 - [ ] get_effective_permissions_for_path
 - [X] get_lf_tag
@@ -5248,6 +5250,97 @@
 - [ ] stop_db_cluster
 </details>
 
+## networkmanager
+<details>
+<summary>9% implemented</summary>
+
+- [ ] accept_attachment
+- [ ] associate_connect_peer
+- [ ] associate_customer_gateway
+- [ ] associate_link
+- [ ] associate_transit_gateway_connect_peer
+- [ ] create_connect_attachment
+- [ ] create_connect_peer
+- [ ] create_connection
+- [X] create_core_network
+- [ ] create_device
+- [X] create_global_network
+- [ ] create_link
+- [ ] create_site
+- [ ] create_site_to_site_vpn_attachment
+- [ ] create_transit_gateway_peering
+- [ ] create_transit_gateway_route_table_attachment
+- [ ] create_vpc_attachment
+- [ ] delete_attachment
+- [ ] delete_connect_peer
+- [ ] delete_connection
+- [X] delete_core_network
+- [ ] delete_core_network_policy_version
+- [ ] delete_device
+- [ ] delete_global_network
+- [ ] delete_link
+- [ ] delete_peering
+- [ ] delete_resource_policy
+- [ ] delete_site
+- [ ] deregister_transit_gateway
+- [X] describe_global_networks
+- [ ] disassociate_connect_peer
+- [ ] disassociate_customer_gateway
+- [ ] disassociate_link
+- [ ] disassociate_transit_gateway_connect_peer
+- [ ] execute_core_network_change_set
+- [ ] get_connect_attachment
+- [ ] get_connect_peer
+- [ ] get_connect_peer_associations
+- [ ] get_connections
+- [X] get_core_network
+- [ ] get_core_network_change_events
+- [ ] get_core_network_change_set
+- [ ] get_core_network_policy
+- [ ] get_customer_gateway_associations
+- [ ] get_devices
+- [ ] get_link_associations
+- [ ] get_links
+- [ ] get_network_resource_counts
+- [ ] get_network_resource_relationships
+- [ ] get_network_resources
+- [ ] get_network_routes
+- [ ] get_network_telemetry
+- [ ] get_resource_policy
+- [ ] get_route_analysis
+- [ ] get_site_to_site_vpn_attachment
+- [ ] get_sites
+- [ ] get_transit_gateway_connect_peer_associations
+- [ ] get_transit_gateway_peering
+- [ ] get_transit_gateway_registrations
+- [ ] get_transit_gateway_route_table_attachment
+- [ ] get_vpc_attachment
+- [ ] list_attachments
+- [ ] list_connect_peers
+- [ ] list_core_network_policy_versions
+- [X] list_core_networks
+- [ ] list_organization_service_access_status
+- [ ] list_peerings
+- [ ] list_tags_for_resource
+- [ ] put_core_network_policy
+- [ ] put_resource_policy
+- [ ] register_transit_gateway
+- [ ] reject_attachment
+- [ ] restore_core_network_policy_version
+- [ ] start_organization_service_access_update
+- [ ] start_route_analysis
+- [X] tag_resource
+- [X] untag_resource
+- [ ] update_connection
+- [ ] update_core_network
+- [ ] update_device
+- [ ] update_global_network
+- [ ] update_link
+- [ ] update_network_resource_metadata
+- [ ] update_site
+- [ ] update_vpc_attachment
+</details>
+
 ## opensearch
 <details>
 <summary>15% implemented</summary>
@@ -5796,6 +5889,7 @@
 - [ ] describe_iam_policy_assignment
 - [ ] describe_ingestion
 - [ ] describe_ip_restriction
+- [ ] describe_key_registration
 - [ ] describe_namespace
 - [ ] describe_refresh_schedule
 - [ ] describe_role_custom_permission
@@ -5878,6 +5972,7 @@
 - [ ] update_iam_policy_assignment
 - [ ] update_identity_propagation_config
 - [ ] update_ip_restriction
+- [ ] update_key_registration
 - [ ] update_public_sharing_settings
 - [ ] update_refresh_schedule
 - [ ] update_role_custom_permission
@@ -8396,6 +8491,7 @@
 - m2
 - machinelearning
 - macie2
+- mailmanager
 - managedblockchain-query
 - marketplace-agreement
 - marketplace-catalog
@@ -8420,7 +8516,6 @@
 - neptune-graph
 - neptunedata
 - network-firewall
-- networkmanager
 - networkmonitor
 - nimble
 - oam

--- a/docs/docs/services/events.rst
+++ b/docs/docs/services/events.rst
@@ -86,4 +86,5 @@ events
 - [X] update_archive
 - [X] update_connection
 - [ ] update_endpoint
+- [ ] update_event_bus
 

--- a/docs/docs/services/lakeformation.rst
+++ b/docs/docs/services/lakeformation.rst
@@ -35,6 +35,7 @@ lakeformation
 - [ ] describe_transaction
 - [ ] extend_transaction
 - [ ] get_data_cells_filter
+- [ ] get_data_lake_principal
 - [X] get_data_lake_settings
 - [ ] get_effective_permissions_for_path
 - [X] get_lf_tag

--- a/docs/docs/services/networkmanager.rst
+++ b/docs/docs/services/networkmanager.rst
@@ -1,0 +1,104 @@
+.. _implementedservice_networkmanager:
+
+.. |start-h3| raw:: html
+
+    <h3>
+
+.. |end-h3| raw:: html
+
+    </h3>
+
+==============
+networkmanager
+==============
+
+.. autoclass:: moto.networkmanager.models.NetworkManagerBackend
+
+|start-h3| Implemented features for this service |end-h3|
+
+- [ ] accept_attachment
+- [ ] associate_connect_peer
+- [ ] associate_customer_gateway
+- [ ] associate_link
+- [ ] associate_transit_gateway_connect_peer
+- [ ] create_connect_attachment
+- [ ] create_connect_peer
+- [ ] create_connection
+- [X] create_core_network
+- [ ] create_device
+- [X] create_global_network
+- [ ] create_link
+- [ ] create_site
+- [ ] create_site_to_site_vpn_attachment
+- [ ] create_transit_gateway_peering
+- [ ] create_transit_gateway_route_table_attachment
+- [ ] create_vpc_attachment
+- [ ] delete_attachment
+- [ ] delete_connect_peer
+- [ ] delete_connection
+- [X] delete_core_network
+- [ ] delete_core_network_policy_version
+- [ ] delete_device
+- [ ] delete_global_network
+- [ ] delete_link
+- [ ] delete_peering
+- [ ] delete_resource_policy
+- [ ] delete_site
+- [ ] deregister_transit_gateway
+- [X] describe_global_networks
+- [ ] disassociate_connect_peer
+- [ ] disassociate_customer_gateway
+- [ ] disassociate_link
+- [ ] disassociate_transit_gateway_connect_peer
+- [ ] execute_core_network_change_set
+- [ ] get_connect_attachment
+- [ ] get_connect_peer
+- [ ] get_connect_peer_associations
+- [ ] get_connections
+- [X] get_core_network
+- [ ] get_core_network_change_events
+- [ ] get_core_network_change_set
+- [ ] get_core_network_policy
+- [ ] get_customer_gateway_associations
+- [ ] get_devices
+- [ ] get_link_associations
+- [ ] get_links
+- [ ] get_network_resource_counts
+- [ ] get_network_resource_relationships
+- [ ] get_network_resources
+- [ ] get_network_routes
+- [ ] get_network_telemetry
+- [ ] get_resource_policy
+- [ ] get_route_analysis
+- [ ] get_site_to_site_vpn_attachment
+- [ ] get_sites
+- [ ] get_transit_gateway_connect_peer_associations
+- [ ] get_transit_gateway_peering
+- [ ] get_transit_gateway_registrations
+- [ ] get_transit_gateway_route_table_attachment
+- [ ] get_vpc_attachment
+- [ ] list_attachments
+- [ ] list_connect_peers
+- [ ] list_core_network_policy_versions
+- [X] list_core_networks
+- [ ] list_organization_service_access_status
+- [ ] list_peerings
+- [ ] list_tags_for_resource
+- [ ] put_core_network_policy
+- [ ] put_resource_policy
+- [ ] register_transit_gateway
+- [ ] reject_attachment
+- [ ] restore_core_network_policy_version
+- [ ] start_organization_service_access_update
+- [ ] start_route_analysis
+- [X] tag_resource
+- [X] untag_resource
+- [ ] update_connection
+- [ ] update_core_network
+- [ ] update_device
+- [ ] update_global_network
+- [ ] update_link
+- [ ] update_network_resource_metadata
+- [ ] update_site
+- [ ] update_vpc_attachment
+

--- a/docs/docs/services/quicksight.rst
+++ b/docs/docs/services/quicksight.rst
@@ -91,6 +91,7 @@ quicksight
 - [ ] describe_iam_policy_assignment
 - [ ] describe_ingestion
 - [ ] describe_ip_restriction
+- [ ] describe_key_registration
 - [ ] describe_namespace
 - [ ] describe_refresh_schedule
 - [ ] describe_role_custom_permission
@@ -190,6 +191,7 @@ quicksight
 - [ ] update_iam_policy_assignment
 - [ ] update_identity_propagation_config
 - [ ] update_ip_restriction
+- [ ] update_key_registration
 - [ ] update_public_sharing_settings
 - [ ] update_refresh_schedule
 - [ ] update_role_custom_permission

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -90,7 +90,10 @@ def _get_method_urls(service_name: str, region: str) -> Dict[str, Dict[str, str]
     for op_name in op_names:
         op_model = conn._service_model.operation_model(op_name)
         _method = op_model.http["method"]
-        uri_regexp = BaseResponse.uri_to_regexp(op_model.http["requestUri"])
+        request_uri = op_model.http["requestUri"]
+        if service_name == "route53" and request_uri.endswith("/rrset/"):
+            request_uri += "?"
+        uri_regexp = BaseResponse.uri_to_regexp(request_uri)
         method_urls[_method][uri_regexp] = op_model.name
 
     return method_urls

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     boto3>=1.9.201
     botocore>=1.14.0
     cryptography>=3.3.1
-    requests>=2.5,<2.32.0
+    requests>=2.5
     xmltodict
     werkzeug>=0.5,!=2.2.0,!=2.2.1
     python-dateutil<3.0.0,>=2.1


### PR DESCRIPTION
Reverts ##7713 and #7715 - now that there is a new Docker release, the latest requests-module no longer breaks. (https://github.com/docker/docker-py/issues/3256)

A few days ago the `aws` terraform provider was updated from `5.50.0` to `5.51.0`. This broke our Terraform tests for ACM and Route53. More specifically, a call to `ChangeResourceRecordSets` suddenly no longer worked.

The underlying problem is that Terraform used to make a POST request to `/2013-04-01/hostedzone/<id>/rrset/`, but with the `5.51.0` release would make a request to `/2013-04-01/hostedzone/<id>/rrset` (without trailing slash).

It's safe to assume that AWS allows both versions, so this PR also changes our logic to also allow both versions of this particular URL.

(A first iteration made all leading slashes optional, to make it a more general solution - but that broke URL interception for the Backup-service)