### PR TITLE
Admin: Fix AWS parity tests

### DIFF
--- a/tests/test_dynamodb/test_dynamodb_update_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_update_expressions.py
@@ -160,8 +160,8 @@ def test_update_item_add_empty_set(table_name=None):
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
-        err["Message"]
-        == "ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An string set  may not be empty"
+        "ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An string set  may not be empty"
+        in err["Message"]
     )
 
     assert dynamodb.scan(TableName=table_name)["Items"] == [{"pk": {"S": "foo"}}]

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -1,4 +1,5 @@
 import json
+from time import sleep
 from unittest import SkipTest
 from unittest.mock import patch
 from uuid import uuid4
@@ -620,6 +621,11 @@ def test_put_logging_w_bucket_policy_no_prefix(bucket_name=None):
         },
     )
     result = s3_client.get_bucket_logging(Bucket=bucket_name)
+    # Logging Config is not immediately available
+    for _ in range(5):
+        if "LoggingEnabled" not in result:
+            sleep(1)
+            result = s3_client.get_bucket_logging(Bucket=bucket_name)
     assert result["LoggingEnabled"]["TargetBucket"] == log_bucket_name
     assert result["LoggingEnabled"]["TargetPrefix"] == ""
 
@@ -657,6 +663,11 @@ def test_put_logging_w_bucket_policy_w_prefix(bucket_name=None):
         },
     )
     result = s3_client.get_bucket_logging(Bucket=bucket_name)
+    # Logging Config is not immediately available
+    for _ in range(5):
+        if "LoggingEnabled" not in result:
+            sleep(1)
+            result = s3_client.get_bucket_logging(Bucket=bucket_name)
     assert result["LoggingEnabled"]["TargetBucket"] == log_bucket_name
     assert result["LoggingEnabled"]["TargetPrefix"] == prefix
 

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -512,9 +512,9 @@ def test_publish_to_deleted_platform_endpoint(api_key=None):
             == f"Invalid parameter: Endpoint Reason: Endpoint does not exist for endpoint arn{endpoint_arn}"
         )
     finally:
-        if application_arn is not None:
+        if topic_arn is not None:
             conn.delete_topic(TopicArn=topic_arn)
-
+        if application_arn is not None:
             conn.delete_platform_application(PlatformApplicationArn=application_arn)
 
 


### PR DESCRIPTION
DynamoDB: The AWS error message has a bit more information, so we can't match on equality
S3: The `put_bucket_logging` is async, so there may be a small delay before the `LoggingConfig` is available
SNS: Fix the error handling - the old implementation would attempt to use the `application_arn` before it was defined, if a command failed for any reason