### PR TITLE
Fix BackendDict instantiation service names

### DIFF
--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -673,4 +673,6 @@ class FakeScheduledAction(BaseModel):
         self.end_time = end_time
 
 
-applicationautoscaling_backends = BackendDict(ApplicationAutoscalingBackend, "application-autoscaling")
+applicationautoscaling_backends = BackendDict(
+    ApplicationAutoscalingBackend, "application-autoscaling"
+)

--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -673,4 +673,4 @@ class FakeScheduledAction(BaseModel):
         self.end_time = end_time
 
 
-applicationautoscaling_backends = BackendDict(ApplicationAutoscalingBackend, "ec2")
+applicationautoscaling_backends = BackendDict(ApplicationAutoscalingBackend, "application-autoscaling")

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -665,5 +665,4 @@ class ELBBackend(BaseBackend):
         return load_balancer.subnets
 
 
-# Use the same regions as EC2
-elb_backends = BackendDict(ELBBackend, "ec2")
+elb_backends = BackendDict(ELBBackend, "elb")

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1979,4 +1979,4 @@ Member must satisfy regular expression pattern: {expression}"
         return resource
 
 
-elbv2_backends = BackendDict(ELBv2Backend, "ec2")
+elbv2_backends = BackendDict(ELBv2Backend, "elbv2")

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -221,4 +221,4 @@ class IoTDataPlaneBackend(BaseBackend):
         ]
 
 
-iotdata_backends = BackendDict(IoTDataPlaneBackend, "iot")
+iotdata_backends = BackendDict(IoTDataPlaneBackend, "iot-data")

--- a/moto/opsworks/models.py
+++ b/moto/opsworks/models.py
@@ -630,4 +630,4 @@ class OpsWorksBackend(BaseBackend):
         self.instances[instance_id].start()
 
 
-opsworks_backends = BackendDict(OpsWorksBackend, "ec2")
+opsworks_backends = BackendDict(OpsWorksBackend, "opsworks")

--- a/moto/signer/models.py
+++ b/moto/signer/models.py
@@ -212,6 +212,4 @@ class SignerBackend(BaseBackend):
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 
-# Using the lambda-regions
-# boto3.Session().get_available_regions("signer") still returns an empty list
-signer_backends = BackendDict(SignerBackend, "lambda")
+signer_backends = BackendDict(SignerBackend, "signer")


### PR DESCRIPTION
This PR updates certain BackendDict initialisations so that they use proper Botocore service name.

Earlier, these services used `ec2` or `lambda` since `boto3.Session().get_available_regions(...)` used to return an empty list.

There are still a few instantiations remaining that were not updated for the above reason, these are:
- `redshiftdata` should use `redshift-data`
- `apigatewaymanagementapi` should use `apigatewaymanagementapi`
- `bedrockagent`
- `ec2instanceconnect` should use `ec2-instance-connect`