### PR TITLE
EC2: Fix inconsistent private/public key pair attribute

### DIFF
--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -23,14 +23,16 @@ class KeyPair(TaggedEC2Resource):
         self,
         name: str,
         fingerprint: str,
-        material: str,
+        public_material: str,
+        private_material: Optional[str],
         tags: Dict[str, str],
         ec2_backend: Any,
     ):
         self.id = random_key_pair_id()
         self.name = name
-        self.fingerprint = fingerprint
-        self.material = material
+        self.fingerprint = fingerprint  # public key fingerprint
+        self.public_material = public_material  # public key in OpenSSH format
+        self.private_material = private_material  # PEM encoded private key
         self.create_time = utcnow()
         self.ec2_backend = ec2_backend
         self.add_tags(tags or {})
@@ -108,7 +110,8 @@ class KeyPairBackend:
         fingerprint = public_key_fingerprint(public_key)
         keypair = KeyPair(
             key_name,
-            material=public_key_material,
+            public_material=public_key_material,
+            private_material=None,
             fingerprint=fingerprint,
             tags=tags,
             ec2_backend=self,

--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -23,16 +23,16 @@ class KeyPair(TaggedEC2Resource):
         self,
         name: str,
         fingerprint: str,
-        public_material: str,
-        private_material: Optional[str],
+        material: Optional[str],
+        material_public: str,
         tags: Dict[str, str],
         ec2_backend: Any,
     ):
         self.id = random_key_pair_id()
         self.name = name
         self.fingerprint = fingerprint  # public key fingerprint
-        self.public_material = public_material  # public key in OpenSSH format
-        self.private_material = private_material  # PEM encoded private key
+        self.material = material  # PEM encoded private key
+        self.material_public = material_public  # public key in OpenSSH format
         self.create_time = utcnow()
         self.ec2_backend = ec2_backend
         self.add_tags(tags or {})
@@ -110,8 +110,8 @@ class KeyPairBackend:
         fingerprint = public_key_fingerprint(public_key)
         keypair = KeyPair(
             key_name,
-            public_material=public_key_material,
-            private_material=None,
+            material_public=public_key_material,
+            material=None,
             fingerprint=fingerprint,
             tags=tags,
             ec2_backend=self,

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -63,7 +63,7 @@ CREATE_KEY_PAIR_RESPONSE = """<CreateKeyPairResponse xmlns="http://ec2.amazonaws
    <keyPairId>{{ keypair.id }}</keyPairId>
    <keyName>{{ keypair.name }}</keyName>
    <keyFingerprint>{{ keypair.fingerprint }}</keyFingerprint>
-   <keyMaterial>{{ keypair.material }}</keyMaterial>
+   <keyMaterial>{{ keypair.private_material }}</keyMaterial>
    {% if keypair.get_tags() %}
    <tagSet>
      {% for tag in keypair.get_tags() %}

--- a/moto/ec2/responses/key_pairs.py
+++ b/moto/ec2/responses/key_pairs.py
@@ -63,7 +63,7 @@ CREATE_KEY_PAIR_RESPONSE = """<CreateKeyPairResponse xmlns="http://ec2.amazonaws
    <keyPairId>{{ keypair.id }}</keyPairId>
    <keyName>{{ keypair.name }}</keyName>
    <keyFingerprint>{{ keypair.fingerprint }}</keyFingerprint>
-   <keyMaterial>{{ keypair.private_material }}</keyMaterial>
+   <keyMaterial>{{ keypair.material }}</keyMaterial>
    {% if keypair.get_tags() %}
    <tagSet>
      {% for tag in keypair.get_tags() %}

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -578,8 +578,8 @@ def random_ed25519_key_pair() -> Dict[str, str]:
 
     return {
         "fingerprint": fingerprint,
-        "private_material": private_key_material.decode("ascii"),
-        "public_material": public_key_material,
+        "material": private_key_material.decode("ascii"),
+        "material_public": public_key_material,
     }
 
 
@@ -601,8 +601,8 @@ def random_rsa_key_pair() -> Dict[str, str]:
 
     return {
         "fingerprint": fingerprint,
-        "private_material": private_key_material.decode("ascii"),
-        "public_material": public_key_material,
+        "material": private_key_material.decode("ascii"),
+        "material_public": public_key_material,
     }
 
 

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -579,7 +579,7 @@ def random_ed25519_key_pair() -> Dict[str, str]:
     return {
         "fingerprint": fingerprint,
         "material": private_key_material.decode("ascii"),
-        "material_public": public_key_material,
+        "material_public": public_key_material.decode("ascii"),
     }
 
 
@@ -602,7 +602,7 @@ def random_rsa_key_pair() -> Dict[str, str]:
     return {
         "fingerprint": fingerprint,
         "material": private_key_material.decode("ascii"),
-        "material_public": public_key_material,
+        "material_public": public_key_material.decode("ascii"),
     }
 
 

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -569,11 +569,17 @@ def random_ed25519_key_pair() -> Dict[str, str]:
         format=serialization.PrivateFormat.OpenSSH,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    fingerprint = public_key_fingerprint(private_key.public_key())
+    public_key = private_key.public_key()
+    public_key_material = public_key.public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )
+    fingerprint = public_key_fingerprint(public_key)
 
     return {
         "fingerprint": fingerprint,
-        "material": private_key_material.decode("ascii"),
+        "private_material": private_key_material.decode("ascii"),
+        "public_material": public_key_material,
     }
 
 
@@ -586,11 +592,17 @@ def random_rsa_key_pair() -> Dict[str, str]:
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    fingerprint = public_key_fingerprint(private_key.public_key())
+    public_key = private_key.public_key()
+    public_key_material = public_key.public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )
+    fingerprint = public_key_fingerprint(public_key)
 
     return {
         "fingerprint": fingerprint,
-        "material": private_key_material.decode("ascii"),
+        "private_material": private_key_material.decode("ascii"),
+        "public_material": public_key_material,
     }
 
 


### PR DESCRIPTION
Currently in the internal representation for EC2 Key Pairs, the `KeyPair` class defines an attribute `material`. However this attribute is not consistently used.

If the key pair object is created using `ImportKeyPair`, `material` contains the base64 encoded public key. If the key pair is created using `CreateKeyPair`, `material` contains the PEM encoded private key.

This PR introduces makes changes such that `material` always contains the private key material (wherever applicable) and adds a new attribute `material_public` always contains the public key in OpenSSH format. There is no impact on the external API.