### PR TITLE
EC2: describe_images() - feat: support filtering images by ExecutableUsers=['self']

### DIFF
--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -274,18 +274,21 @@ class AmiBackend:
         else:
             # Limit images by launch permissions
             if exec_users:
-                # support filtering by ExecutableUsers=['self']
-                if "self" in exec_users:
-                    exec_users = list(
-                        map(lambda o: self.account_id if o == "self" else o, exec_users)  # type: ignore[attr-defined]
-                    )
-
                 tmp_images = []
                 for ami in images:
-                    for user_id in exec_users:
-                        for lp in ami.launch_permissions:
-                            if lp.get("UserId") == user_id:
-                                tmp_images.append(ami)
+                    if ami.is_public:
+                        tmp_images.append(ami)
+                    else:
+                        # support filtering by ExecutableUsers=['self']
+                        if "self" in exec_users:
+                            exec_users = list(
+                                map(lambda o: self.account_id if o == "self" else o, exec_users)  # type: ignore[attr-defined]
+                            )
+
+                        for user_id in exec_users:
+                            for lp in ami.launch_permissions:
+                                if lp.get("UserId") == user_id:
+                                    tmp_images.append(ami)
                 images = tmp_images
 
             # Limit by owner ids

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -282,7 +282,10 @@ class AmiBackend:
                         # support filtering by ExecutableUsers=['self']
                         if "self" in exec_users:
                             exec_users = list(
-                                map(lambda o: self.account_id if o == "self" else o, exec_users)  # type: ignore[attr-defined]
+                                map(
+                                    lambda o: self.account_id if o == "self" else o,  # type: ignore[attr-defined]
+                                    exec_users,
+                                )
                             )
 
                         for user_id in exec_users:

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -274,6 +274,12 @@ class AmiBackend:
         else:
             # Limit images by launch permissions
             if exec_users:
+                # support filtering by ExecutableUsers=['self']
+                if "self" in exec_users:
+                    exec_users = list(
+                        map(lambda o: self.account_id if o == "self" else o, exec_users)  # type: ignore[attr-defined]
+                    )
+
                 tmp_images = []
                 for ami in images:
                     for user_id in exec_users:

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -281,12 +281,9 @@ class AmiBackend:
                     else:
                         # support filtering by ExecutableUsers=['self']
                         if "self" in exec_users:
-                            exec_users = list(
-                                map(
-                                    lambda o: self.account_id if o == "self" else o,  # type: ignore[attr-defined]
-                                    exec_users,
-                                )
-                            )
+                            exec_users = list(set(exec_users))
+                            exec_users.remove("self")
+                            exec_users.append(self.account_id)  # type: ignore[attr-defined]
 
                         for user_id in exec_users:
                             for lp in ami.launch_permissions:


### PR DESCRIPTION
This adds a missing mapping on `self` to the current `account_id` for the `describe_images` `exec_users` endpoint parameter, as well as a check bypass for public images.

Similar to the `Owners` field, `ExecutableUsers` can be filtered by `self` (ref: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html#API_DescribeImages_RequestParameters)

Currently, filtering images with `exec_users=["self"]` returns an empty list, even when having public images.


