### PR TITLE
CognitoIDP: feat: support pagination for admin_list_groups_by_user

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1212,6 +1212,7 @@ class CognitoIdpBackend(BaseBackend):
         group = self.get_group(user_pool_id, group_name)
         return list(filter(lambda user: user in group.users, user_pool.users.values()))
 
+    @paginate(pagination_model=PAGINATION_MODEL)
     def admin_list_groups_for_user(
         self, user_pool_id: str, username: str
     ) -> List[CognitoIdpGroup]:

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -307,8 +307,15 @@ class CognitoIdpResponse(BaseResponse):
     def admin_list_groups_for_user(self) -> str:
         username = self._get_param("Username")
         user_pool_id = self._get_param("UserPoolId")
-        groups = self.backend.admin_list_groups_for_user(user_pool_id, username)
-        return json.dumps({"Groups": [group.to_json() for group in groups]})
+        limit = self._get_param("Limit")
+        token = self._get_param("NextToken")
+        groups, token = self.backend.admin_list_groups_for_user(
+            user_pool_id, username, limit=limit, next_token=token
+        )
+        response = {"Groups": [group.to_json() for group in groups]}
+        if token:
+            response["NextToken"] = token
+        return json.dumps(response)
 
     def admin_remove_user_from_group(self) -> str:
         user_pool_id = self._get_param("UserPoolId")

--- a/moto/cognitoidp/utils.py
+++ b/moto/cognitoidp/utils.py
@@ -44,6 +44,12 @@ PAGINATION_MODEL = {
         "limit_default": 60,
         "unique_attribute": "group_name",
     },
+    "admin_list_groups_for_user": {
+        "input_token": "next_token",
+        "limit_key": "limit",
+        "limit_default": 60,
+        "unique_attribute": "group_name",
+    },
     "list_users_in_group": {
         "input_token": "next_token",
         "limit_key": "limit",


### PR DESCRIPTION
# Description

boto3 supports pagination for `admin_list_groups_by_user`. This commit adds the same flags (Limit and NextToken) to the moto cognitoidp module.
See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cognito-idp/client/admin_list_groups_for_user.html

# Testing

Unit tests for pagination are added as part of the pull request. Most of this is just copied over code from list_groups with modifications for adjusting to the `admin_list_groups_by_user` API.