### PR TITLE
elbv2: add client_keep_alive.seconds to modify load balancer attributes

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -604,6 +604,7 @@ class FakeLoadBalancer(CloudFormationModel):
         "connection_logs.s3.bucket",
         "connection_logs.s3.enabled",
         "connection_logs.s3.prefix",
+        "client_keep_alive.seconds",
         "deletion_protection.enabled",
         "dns_record.client_routing_policy",
         "idle_timeout.timeout_seconds",

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -1247,6 +1247,27 @@ def test_modify_load_balancer_attributes_crosszone_enabled():
 
 
 @mock_aws
+def test_modify_load_balancer_attributes_client_keep_alive():
+    response, _, _, _, _, client = create_load_balancer()
+    arn = response["LoadBalancers"][0]["LoadBalancerArn"]
+
+    client.modify_load_balancer_attributes(
+        LoadBalancerArn=arn,
+        Attributes=[{"Key": "client_keep_alive.seconds", "Value": "600"}],
+    )
+
+    # Check its 600 not the default value 3600
+    response = client.describe_load_balancer_attributes(LoadBalancerArn=arn)
+    client_keep_alive = list(
+        filter(
+            lambda item: item["Key"] == "client_keep_alive.seconds",
+            response["Attributes"],
+        )
+    )[0]
+    assert client_keep_alive["Value"] == "600"
+
+
+@mock_aws
 def test_modify_load_balancer_attributes_routing_http_drop_invalid_header_fields_enabled():
     response, _, _, _, _, client = create_load_balancer()
     arn = response["LoadBalancers"][0]["LoadBalancerArn"]


### PR DESCRIPTION
As per the current implementation if we use `client_keep_alive.seconds` in `elbv2` we get `InvalidConfigurationRequest` error thrown. 

This PR adds `client_keep_alive.seconds ` attribute to the `modify_load_balancer_attributes` handler and writes a test to verify the changes. 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-loadbalancer-loadbalancerattribute.html