### PR TITLE
Fix cfn-lint breaking changes

### DIFF
--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -1,4 +1,3 @@
-import os
 import string
 from typing import Any, List
 from urllib.parse import urlparse
@@ -59,24 +58,10 @@ def yaml_tag_constructor(loader: Any, tag: Any, node: Any) -> Any:
 
 def validate_template_cfn_lint(template: str) -> List[Any]:
     # Importing cfnlint adds a significant overhead, so we keep it local
-    from cfnlint import core, decode
-
-    # Save the template to a temporary file -- cfn-lint requires a file
-    filename = "file.tmp"
-    with open(filename, "w") as file:
-        file.write(template)
-    abs_filename = os.path.abspath(filename)
-
-    # decode handles both yaml and json
-    try:
-        template, matches = decode.decode(abs_filename, False)
-    except TypeError:
-        # As of cfn-lint 0.39.0, the second argument (ignore_bad_template) was dropped
-        # https://github.com/aws-cloudformation/cfn-python-lint/pull/1580
-        template, matches = decode.decode(abs_filename)
+    from cfnlint import api, config, core
 
     # Set cfn-lint to info
-    core.configure_logging(None)
+    config.configure_logging(None, False)
 
     # Initialize the ruleset to be applied (no overrules, no excludes)
     rules = core.get_rules([], [], [])
@@ -85,9 +70,7 @@ def validate_template_cfn_lint(template: str) -> List[Any]:
     regions = ["us-east-1"]
 
     # Process all the rules and gather the errors
-    matches = core.run_checks(abs_filename, template, rules, regions)
-
-    return matches
+    return api.lint(template, rules, regions)
 
 
 def get_stack_from_s3_url(template_url: str, account_id: str, partition: str) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ all =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=1.3.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -65,7 +65,7 @@ proxy =
     docker>=2.5.1
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=1.3.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -80,7 +80,7 @@ server =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=1.3.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -115,7 +115,7 @@ cloudformation =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=1.3.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -204,7 +204,7 @@ resourcegroupstaggingapi =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=0.40.0
+    cfn-lint>=1.3.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ all =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=1.3.0
+    cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -65,7 +65,7 @@ proxy =
     docker>=2.5.1
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=1.3.0
+    cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -80,7 +80,7 @@ server =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=1.3.0
+    cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -115,7 +115,7 @@ cloudformation =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=1.3.0
+    cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2
@@ -204,7 +204,7 @@ resourcegroupstaggingapi =
     docker>=3.0.0
     graphql-core
     PyYAML>=5.1
-    cfn-lint>=1.3.0
+    cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
     jsondiff>=1.1.2

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -69,7 +69,7 @@ def test_boto3_json_invalid_missing_resource():
     err = exc.value.response["Error"]
     assert (
         err["Message"]
-        == "Stack with id Missing top level template section Resources does not exist"
+        == "Stack with id 'Resources' is a required property does not exist"
     )
 
 
@@ -124,5 +124,5 @@ def test_boto3_yaml_invalid_missing_resource():
     err = exc.value.response["Error"]
     assert (
         err["Message"]
-        == "Stack with id Missing top level template section Resources does not exist"
+        == "Stack with id 'Resources' is a required property does not exist"
     )

--- a/tests/test_cloudformation/test_validate.py
+++ b/tests/test_cloudformation/test_validate.py
@@ -69,7 +69,10 @@ def test_boto3_json_invalid_missing_resource():
     err = exc.value.response["Error"]
     assert (
         err["Message"]
-        == "Stack with id 'Resources' is a required property does not exist"
+        in (
+            "Stack with id Missing top level template section Resources does not exist",  # cfn-lint 0.x
+            "Stack with id 'Resources' is a required property does not exist",  # cfn-lint 1.x
+        )
     )
 
 
@@ -124,5 +127,8 @@ def test_boto3_yaml_invalid_missing_resource():
     err = exc.value.response["Error"]
     assert (
         err["Message"]
-        == "Stack with id 'Resources' is a required property does not exist"
+        in (
+            "Stack with id Missing top level template section Resources does not exist",  # cfn-lint 0.x
+            "Stack with id 'Resources' is a required property does not exist",  # cfn-lint 1.x
+        )
     )


### PR DESCRIPTION
[cfn-lint 1.3.0](https://pypi.org/project/cfn-lint/1.3.0) was released on 2024-06-19.

Currently Moto pins it as `cfn-lint>=0.40.0` which causes the latest version to be picked up and integration to break.

This PR fixes the breaking changes and updates its usage.