### PR TITLE
elbv2: check for too many certificates

### DIFF
--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -47,6 +47,14 @@ class TooManyTagsError(ELBClientError):
         )
 
 
+class TooManyCertificatesError(ELBClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "TooManyCertificates",
+            "You've reached the limit on the number of certificates per load balancer",
+        )
+
+
 class BadHealthCheckDefinition(ELBClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -37,6 +37,7 @@ from .exceptions import (
     RuleNotFoundError,
     SubnetNotFoundError,
     TargetGroupNotFoundError,
+    TooManyCertificatesError,
     TooManyTagsError,
     ValidationError,
 )
@@ -1942,6 +1943,9 @@ Member must satisfy regular expression pattern: {expression}"
         listener = self.describe_listeners(load_balancer_arn=None, listener_arns=[arn])[
             0
         ]
+        # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html
+        if len(certificates) + len(listener.certificates) > 25:
+            raise TooManyCertificatesError()
         listener.certificates.extend([c["certificate_arn"] for c in certificates])
         return listener.certificates
 

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -680,6 +680,7 @@ class ELBV2Response(BaseResponse):
             "network-load-balancers": 20,
             "targets-per-network-load-balancer": 200,
             "listeners-per-network-load-balancer": 50,
+            "certificates-per-application-load-balancer": 25,
         }
 
         template = self.response_template(DESCRIBE_LIMITS_TEMPLATE)

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -1582,6 +1582,12 @@ def test_add_listener_certificate():
     ]
     assert len(certs) == 0
 
+    with pytest.raises(ClientError) as exc:
+        client.add_listener_certificates(
+            ListenerArn=listener_arn, Certificates=[{"CertificateArn": google_arn}] * 50
+        )
+    assert exc.value.response["Error"]["Code"] == "TooManyCertificates"
+
 
 @mock_aws
 def test_forward_config_action():


### PR DESCRIPTION
Attaching too many certificates to a load balancer listener (with the `AddListenerCertificates` operation) should raise a `TooManyCertificatesException`. This check is not currently implemented.

25 seems to be the limit as per [AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html).