### PR TITLE
EC2: run_instances() can now use $Default or $Latest  launch template version

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -935,5 +935,5 @@ class InstanceBackend:
             )[0]
         )
         version = launch_template_arg.get("Version", template.latest_version_number)
-        template_version = template.get_version(int(version))
+        template_version = template.get_version(version)
         return template_version


### PR DESCRIPTION
### Issue Description
When using the `run_instances` method in moto and specifying the version as `$Default` or `$Latest`, an error occurs. This issue prevents users from running instances with the `$Default` or `$Latest` version.

### Steps to Reproduce

This is a complete test which reproduces the issue.

```python
from moto import mock_aws
import boto3
import traceback
@mock_aws
def test():
    client = boto3.client('ec2', region_name='us-west-1')
    launch_template = client.create_launch_template(
        LaunchTemplateName='test',
        VersionDescription='test',
        LaunchTemplateData={
            'InstanceType': 't2.micro',

        }
    )
    launch_template_id = launch_template['LaunchTemplate']['LaunchTemplateId']
    try:
        response = client.run_instances(
            LaunchTemplate={
                'LaunchTemplateId': launch_template_id,
                "Version": "$Default"
            },
            MinCount=1,
            MaxCount=1,
        )
    except Exception as e:
        print(e)
        print(traceback.format_exc())
    assert False
```

Running the above code results in this message:
```txt
invalid literal for int() with base 10: '$Default'
Traceback (most recent call last):
  File "/Users/kosekiyuuta/koseki/python/test.py", line 17, in test
    response = client.run_instances(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 565, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 1001, in _make_api_call
    http, parsed_response = self._make_request(
                            ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/client.py", line 1027, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/endpoint.py", line 119, in make_request
    return self._send_request(request_dict, operation_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/endpoint.py", line 202, in _send_request
    while self._needs_retry(
          ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/endpoint.py", line 354, in _needs_retry
    responses = self._event_emitter.emit(
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
               ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/retryhandler.py", line 207, in __call__
    if self._checker(**checker_kwargs):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/retryhandler.py", line 284, in __call__
    should_retry = self._should_retry(
                   ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/retryhandler.py", line 307, in _should_retry
    return self._checker(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/retryhandler.py", line 363, in __call__
    checker_response = checker(
                       ^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/retryhandler.py", line 247, in __call__
    return self._check_caught_exception(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/retryhandler.py", line 416, in _check_caught_exception
    raise caught_exception
  File "/usr/local/lib/python3.11/site-packages/botocore/endpoint.py", line 278, in _do_get_response
    responses = self._event_emitter.emit(event_name, request=request)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
               ^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/core/botocore_stubber.py", line 37, in __call__
    response = self.process_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/core/botocore_stubber.py", line 84, in process_request
    status, headers, body = method_to_execute(
                            ^^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/core/responses.py", line 290, in dispatch
    return cls()._dispatch(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/core/responses.py", line 501, in _dispatch
    return self.call_action()
           ^^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/core/responses.py", line 587, in call_action
    response = method()
               ^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/ec2/responses/instances.py", line 116, in run_instances
    new_reservation = self.ec2_backend.run_instances(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/ec2/models/instances.py", line 694, in run_instances
    new_instance = Instance(
                   ^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/ec2/models/instances.py", line 93, in __init__
    template_version = ec2_backend._get_template_from_args(launch_template_arg)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kosekiyuuta/koseki/moto/moto/ec2/models/instances.py", line 938, in _get_template_from_args
    template_version = template.get_version(int(version))
                                            ^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '$Default'
```

### Cause of the Error
The error is caused by the following processing at line 938 in `moto/ec2/models/instances.py`

```python 
 def _get_template_from_args(
        self, launch_template_arg: Dict[str, Any]
    ) -> LaunchTemplateVersion:
        template = (
            self.describe_launch_templates(  # type: ignore[attr-defined]
                template_ids=[launch_template_arg["LaunchTemplateId"]]
            )[0]
            if "LaunchTemplateId" in launch_template_arg
            else self.describe_launch_templates(  # type: ignore[attr-defined]
                template_names=[launch_template_arg["LaunchTemplateName"]]
            )[0]
        )
        version = launch_template_arg.get("Version", template.latest_version_number)
>        template_version = template.get_version(int(version))
        return template_version
```

### Fix Details

Based on the code at line line 85 to 90 of `moto/ec2/models/launch_templates.py`, it seems that the conversion to `int` is already handled. Therefore, I believe that the conversion at the relevant line is unnecessary.

```python
def get_version(self, num: Any) -> LaunchTemplateVersion:
    if str(num).lower() == "$latest":
        return self.versions[-1]
    if str(num).lower() == "$default":
        return self.default_version()
>    return self.versions[int(num) - 1]
```

### Proposed Fix

I have modified the relevant line to remove the unnecessary conversion, ensuring that the `$Default` or `$Latest` version is correctly handled.

Please review the changes and provide feedback, as I'm still relatively new to posting pull requests. Thank you!
