### PR TITLE
DynamoDB: transact_write_items() should validate set clauses, not actions

### DIFF
--- a/moto/dynamodb/parsing/ast_nodes.py
+++ b/moto/dynamodb/parsing/ast_nodes.py
@@ -40,7 +40,8 @@ class Node(metaclass=abc.ABCMeta):
             if len(set_attributes) != len(set(set_attributes)):
                 raise DuplicateUpdateExpression(set_attributes)
 
-            if limit_set_actions and len(set_actions) > 1:
+            set_clauses = self.find_clauses([UpdateExpressionSetClause])
+            if limit_set_actions and len(set_clauses) > 1:
                 raise MockValidationException(
                     'Invalid UpdateExpression: The "SET" section can only be used once in an update expression;'
                 )


### PR DESCRIPTION
Fixes #7817 

`SET action1, action2` is allowed. `SET action1 SET action2` is not allowed.

So when validating this, we need to count the number of clauses (SET statements)  - not the number of actions ([action1, action2]).

