### PR TITLE
EC2: Fix security group rule enumeration

### DIFF
--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -278,12 +278,8 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
         {% for rule in rules %}
           {% for ip_range in rule.ip_ranges %}
             <item>
-                {% if rule.from_port is not none %}
-                  <fromPort>{{ rule.from_port }}</fromPort>
-                {% endif %}
-                {% if rule.to_port is not none %}
-                  <toPort>{{ rule.to_port }}</toPort>
-                {% endif %}
+                <fromPort>{{ rule.from_port if rule.from_port is not none else -1 }}</fromPort>
+                <toPort>{{ rule.to_port if rule.to_port is not none else -1 }}</toPort>
                 <cidrIpv4>{{ ip_range['CidrIp'] }}</cidrIpv4>
                 <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
                 <groupId>{{ rule.group_id }}</groupId>

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -276,19 +276,19 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
   <requestId>{{ request_id }}</requestId>
   <securityGroupRuleSet>
         {% for rule in rules %}
+          {% for ip_range in rule.ip_ranges %}
             <item>
                 {% if rule.from_port is not none %}
-                <fromPort>{{ rule.from_port }}</fromPort>
+                  <fromPort>{{ rule.from_port }}</fromPort>
                 {% endif %}
                 {% if rule.to_port is not none %}
                   <toPort>{{ rule.to_port }}</toPort>
                 {% endif %}
-                {% if rule.ip_ranges %}
-                  <cidrIpv4>{{ rule.ip_ranges[0]['CidrIp'] }}</cidrIpv4>
-                {% endif %}
+                <cidrIpv4>{{ ip_range['CidrIp'] }}</cidrIpv4>
                 <ipProtocol>{{ rule.ip_protocol }}</ipProtocol>
                 <groupId>{{ rule.group_id }}</groupId>
                 <groupOwnerId>{{ rule.owner_id }}</groupOwnerId>
+                <description>{{ ip_range['Description'] }}</description>
                 <isEgress>{{ 'true' if rule.is_egress else 'false' }}</isEgress>
                 <securityGroupRuleId>{{ rule.id }}</securityGroupRuleId>
                 <tagSet>
@@ -300,6 +300,7 @@ DESCRIBE_SECURITY_GROUP_RULES_RESPONSE = """
                 {% endfor %}
                 </tagSet> 
             </item>
+          {% endfor %}
         {% endfor %}
   </securityGroupRuleSet>
 </DescribeSecurityGroupRulesResponse>"""

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -854,11 +854,11 @@ def test_description_in_ip_permissions():
     result = conn.describe_security_group_rules(
         Filters=[{"Name": "group-id", "Values": [sg["GroupId"]]}]
     )
-    assert len(result['SecurityGroupRules']) == 3
-    assert result['SecurityGroupRules'][0]['Description'] == 'austin'
-    assert result['SecurityGroupRules'][0]['CidrIpv4'] == '1.2.3.4/32'
-    assert result['SecurityGroupRules'][1]['Description'] == 'powers'
-    assert result['SecurityGroupRules'][1]['CidrIpv4'] == '2.3.4.5/32'
+    assert len(result["SecurityGroupRules"]) == 3
+    assert result["SecurityGroupRules"][0]["Description"] == "austin"
+    assert result["SecurityGroupRules"][0]["CidrIpv4"] == "1.2.3.4/32"
+    assert result["SecurityGroupRules"][1]["Description"] == "powers"
+    assert result["SecurityGroupRules"][1]["CidrIpv4"] == "2.3.4.5/32"
 
     result = conn.describe_security_groups(GroupIds=[sg["GroupId"]])
     group = result["SecurityGroups"][0]

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -841,18 +841,33 @@ def test_description_in_ip_permissions():
             "IpProtocol": "tcp",
             "FromPort": 27017,
             "ToPort": 27017,
-            "IpRanges": [{"CidrIp": "1.2.3.4/32", "Description": "testDescription"}],
+            "IpRanges": [
+                {"CidrIp": "1.2.3.4/32", "Description": "austin"},
+                {"CidrIp": "2.3.4.5/32", "Description": "powers"},
+            ],
         }
     ]
     conn.authorize_security_group_ingress(
         GroupId=sg["GroupId"], IpPermissions=ip_permissions
     )
 
+    result = conn.describe_security_group_rules(
+        Filters=[{"Name": "group-id", "Values": [sg["GroupId"]]}]
+    )
+    assert len(result['SecurityGroupRules']) == 3
+    assert result['SecurityGroupRules'][0]['Description'] == 'austin'
+    assert result['SecurityGroupRules'][0]['CidrIpv4'] == '1.2.3.4/32'
+    assert result['SecurityGroupRules'][1]['Description'] == 'powers'
+    assert result['SecurityGroupRules'][1]['CidrIpv4'] == '2.3.4.5/32'
+
     result = conn.describe_security_groups(GroupIds=[sg["GroupId"]])
     group = result["SecurityGroups"][0]
 
-    assert group["IpPermissions"][0]["IpRanges"][0]["Description"] == "testDescription"
+    assert group["IpPermissions"][0]["IpRanges"][0]["Description"] == "austin"
     assert group["IpPermissions"][0]["IpRanges"][0]["CidrIp"] == "1.2.3.4/32"
+
+    assert group["IpPermissions"][0]["IpRanges"][1]["Description"] == "powers"
+    assert group["IpPermissions"][0]["IpRanges"][1]["CidrIp"] == "2.3.4.5/32"
 
     sg = conn.create_security_group(
         GroupName="sg2", Description="Test security group sg1", VpcId=vpc.id

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -840,7 +840,7 @@ def test_description_in_ip_permissions():
         {
             "IpProtocol": "tcp",
             "FromPort": 27017,
-            "ToPort": 27017,
+            "ToPort": 27018,
             "IpRanges": [
                 {"CidrIp": "1.2.3.4/32", "Description": "austin"},
                 {"CidrIp": "2.3.4.5/32", "Description": "powers"},
@@ -855,10 +855,23 @@ def test_description_in_ip_permissions():
         Filters=[{"Name": "group-id", "Values": [sg["GroupId"]]}]
     )
     assert len(result["SecurityGroupRules"]) == 3
+
     assert result["SecurityGroupRules"][0]["Description"] == "austin"
     assert result["SecurityGroupRules"][0]["CidrIpv4"] == "1.2.3.4/32"
+    assert result["SecurityGroupRules"][0]["IsEgress"] is False
+    assert result["SecurityGroupRules"][0]["FromPort"] == 27017
+    assert result["SecurityGroupRules"][0]["ToPort"] == 27018
+
     assert result["SecurityGroupRules"][1]["Description"] == "powers"
     assert result["SecurityGroupRules"][1]["CidrIpv4"] == "2.3.4.5/32"
+    assert result["SecurityGroupRules"][1]["IsEgress"] is False
+    assert result["SecurityGroupRules"][1]["FromPort"] == 27017
+    assert result["SecurityGroupRules"][1]["ToPort"] == 27018
+
+    assert result["SecurityGroupRules"][2]["Description"] == ""
+    assert result["SecurityGroupRules"][2]["IsEgress"] is True
+    assert result["SecurityGroupRules"][2]["FromPort"] == -1
+    assert result["SecurityGroupRules"][2]["ToPort"] == -1
 
     result = conn.describe_security_groups(GroupIds=[sg["GroupId"]])
     group = result["SecurityGroups"][0]
@@ -876,9 +889,9 @@ def test_description_in_ip_permissions():
     ip_permissions = [
         {
             "IpProtocol": "tcp",
-            "FromPort": 27017,
-            "ToPort": 27017,
-            "IpRanges": [{"CidrIp": "1.2.3.4/32"}],
+            "FromPort": 27019,
+            "ToPort": 27019,
+            "IpRanges": [{"CidrIp": "3.4.5.6/32"}],
         }
     ]
     conn.authorize_security_group_ingress(
@@ -889,7 +902,7 @@ def test_description_in_ip_permissions():
     group = result["SecurityGroups"][0]
 
     assert group["IpPermissions"][0]["IpRanges"][0].get("Description") is None
-    assert group["IpPermissions"][0]["IpRanges"][0]["CidrIp"] == "1.2.3.4/32"
+    assert group["IpPermissions"][0]["IpRanges"][0]["CidrIp"] == "3.4.5.6/32"
 
 
 @mock_aws


### PR DESCRIPTION
It was reported that [`DescribeSecurityGroupRules`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroupRules.html) does not return the `Description` field, see https://github.com/localstack/localstack/issues/8985.

Furthermore it was observed that the response is incorrectly constructed if the rules were adding to the security group using the [`IpPermission`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpPermission.html) objects:

```text
$ security_group_id=$(awslocal ec2 create-security-group --group-name example --description "Example security group" | jq -r .GroupId)

$ awslocal ec2 authorize-security-group-ingress --group-id "${security_group_id}" \
  --ip-permissions 'IpProtocol=tcp,FromPort=1111,ToPort=1111,IpRanges=[{CidrIp=127.0.0.1/32,Description=first-range},{CidrIp=127.0.0.2/32,Description=second-range}]'

$ awslocal ec2 describe-security-group-rules --filters "Name=group-id,Values=${security_group_id}"
{
    "SecurityGroupRules": [
        {
            "SecurityGroupRuleId": "sgr-bffc7c346b7639f8c",
            "GroupId": "sg-ab18766880b58bc1a",
            "GroupOwnerId": "000000000000",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 1111,
            "ToPort": 1111,
            "CidrIpv4": "127.0.0.1/32",
            "Tags": []
        },
        {
            "SecurityGroupRuleId": "sgr-870c183b5a2176fc8",
            "GroupId": "sg-ab18766880b58bc1a",
            "GroupOwnerId": "000000000000",
            "IsEgress": true,
            "IpProtocol": "-1",
            "CidrIpv4": "0.0.0.0/0",
            "Tags": []
        }
    ]
}
```
The correct response must include one rule per IP range as follows (verified against AWS):
```text
{
    "SecurityGroupRules": [
        {
            "SecurityGroupRuleId": "sgr-0d678122d6b696215",
            "GroupId": "sg-0dd0742319446e450",
            "GroupOwnerId": "623948600419",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 1111,
            "ToPort": 1111,
            "CidrIpv4": "127.0.0.2/32",
            "Description": "second-range",
            "Tags": []
        },
        {
            "SecurityGroupRuleId": "sgr-061f28ce42dea9209",
            "GroupId": "sg-0dd0742319446e450",
            "GroupOwnerId": "623948600419",
            "IsEgress": true,
            "IpProtocol": "-1",
            "FromPort": -1,
            "ToPort": -1,
            "CidrIpv4": "0.0.0.0/0",
            "Tags": []
        },
        {
            "SecurityGroupRuleId": "sgr-0baed3b39a3929eb2",
            "GroupId": "sg-0dd0742319446e450",
            "GroupOwnerId": "623948600419",
            "IsEgress": false,
            "IpProtocol": "tcp",
            "FromPort": 1111,
            "ToPort": 1111,
            "CidrIpv4": "127.0.0.1/32",
            "Description": "first-range",
            "Tags": []
        }
    ]
}
```

This PR fixes the `DescribeSecurityGroupRules` operation:
- Adds the `description` field
- Correctly enumerates and constructs the list of rules
- Makes the `FromPort` and `ToPort` fields to return -1 if not set