### PR TITLE
S3: Fix bucket policy enforcement for s3:PutObject when creating new objects

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1315,16 +1315,17 @@ class S3Response(BaseResponse):
             if bucket_permissions == PermissionResult.DENIED:
                 return 403, {}, ""
 
-            # If the request is not authorized, and not signed,
-            # that means that the action should be allowed for anonymous users
-            if key and not authorized_request and not signed_url:
-                # We already know that the bucket permissions do not explicitly deny this
-                # So bucket permissions are either not set, or do not explicitly allow
-                # Next check is to see if the ACL of the individual key allows this action
-                if bucket_permissions != PermissionResult.PERMITTED and (
-                    key.acl and not key.acl.public_read
-                ):
-                    return 403, {}, ""
+            if key:
+                # If the request is not authorized, and not signed,
+                # that means that the action should be allowed for anonymous users
+                if not authorized_request and not signed_url:
+                    # We already know that the bucket permissions do not explicitly deny this
+                    # So bucket permissions are either not set, or do not explicitly allow
+                    # Next check is to see if the ACL of the individual key allows this action
+                    if bucket_permissions != PermissionResult.PERMITTED and (
+                        key.acl and not key.acl.public_read
+                    ):
+                        return 403, {}, ""
             elif signed_url and not authorized_request:
                 # coming in from requests.get(s3.generate_presigned_url())
                 if self._invalid_headers(request.url, dict(request.headers)):

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1299,7 +1299,9 @@ class S3Response(BaseResponse):
             bucket = self.backend.get_bucket(bucket_name)
         except S3ClientError:
             key = bucket = None
-        if key:
+
+        # Enforces policy when creating new objects, `if key` does not https://github.com/getmoto/moto/issues/7837
+        if bucket:
             resource = f"arn:{bucket.partition}:s3:::{bucket_name}/{key_name}"  # type: ignore[union-attr]
 
             # Authorization Workflow
@@ -1315,7 +1317,7 @@ class S3Response(BaseResponse):
 
             # If the request is not authorized, and not signed,
             # that means that the action should be allowed for anonymous users
-            if not authorized_request and not signed_url:
+            if key and not authorized_request and not signed_url:
                 # We already know that the bucket permissions do not explicitly deny this
                 # So bucket permissions are either not set, or do not explicitly allow
                 # Next check is to see if the ACL of the individual key allows this action
@@ -1323,11 +1325,10 @@ class S3Response(BaseResponse):
                     key.acl and not key.acl.public_read
                 ):
                     return 403, {}, ""
-
-        elif signed_url and not authorized_request:
-            # coming in from requests.get(s3.generate_presigned_url())
-            if self._invalid_headers(request.url, dict(request.headers)):
-                return 403, {}, S3_INVALID_PRESIGNED_PARAMETERS
+            elif signed_url and not authorized_request:
+                # coming in from requests.get(s3.generate_presigned_url())
+                if self._invalid_headers(request.url, dict(request.headers)):
+                    return 403, {}, S3_INVALID_PRESIGNED_PARAMETERS
 
         body = self.body or b""
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1326,10 +1326,10 @@ class S3Response(BaseResponse):
                         key.acl and not key.acl.public_read
                     ):
                         return 403, {}, ""
-            elif signed_url and not authorized_request:
-                # coming in from requests.get(s3.generate_presigned_url())
-                if self._invalid_headers(request.url, dict(request.headers)):
-                    return 403, {}, S3_INVALID_PRESIGNED_PARAMETERS
+        if not key and signed_url and not authorized_request:
+            # coming in from requests.get(s3.generate_presigned_url())
+            if self._invalid_headers(request.url, dict(request.headers)):
+                return 403, {}, S3_INVALID_PRESIGNED_PARAMETERS
 
         body = self.body or b""
 

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -70,7 +70,8 @@ class TestBucketPolicy:
 
         assert requests.get(self.key_name).status_code == unauthorized_status
 
-    def test_block_put_object(self):
+    @pytest.mark.parametrize("key", ["test_txt", "new_txt"], ids=["update_object", "create_object"])
+    def test_block_put_object(self, key):
         # Block Put-access
         self._put_policy(**{"effect": "Deny", "actions": ["s3:PutObject"]})
 
@@ -79,7 +80,7 @@ class TestBucketPolicy:
 
         # But Put (via boto3 or requests) is not allowed
         with pytest.raises(ClientError) as exc:
-            self.client.put_object(Bucket="mybucket", Key="test_txt", Body="new data")
+            self.client.put_object(Bucket="mybucket", Key=key, Body="new data")
         err = exc.value.response["Error"]
         assert err["Message"] == "Forbidden"
 

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -70,7 +70,9 @@ class TestBucketPolicy:
 
         assert requests.get(self.key_name).status_code == unauthorized_status
 
-    @pytest.mark.parametrize("key", ["test_txt", "new_txt"], ids=["update_object", "create_object"])
+    @pytest.mark.parametrize(
+        "key", ["test_txt", "new_txt"], ids=["update_object", "create_object"]
+    )
     def test_block_put_object(self, key):
         # Block Put-access
         self._put_policy(**{"effect": "Deny", "actions": ["s3:PutObject"]})


### PR DESCRIPTION
Previously, policy enforcement for s3:PutObject only occurred if the key already existed (`if key:`), I changed this to (`if bucket:`) and now policy enforcement works when creating new objects too

I don't know if I broke anything or if I did something terribly wrong, but all the S3 tests pass

Fixes #7837 