### PR TITLE
Fix creation of random token in events model.

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import sys
+import base64
 import warnings
 from collections import OrderedDict
 from enum import Enum, unique
@@ -1033,7 +1034,7 @@ class EventsBackend(BaseBackend):
         )
 
     def _gen_next_token(self, index: int) -> str:
-        token = os.urandom(128).encode("base64")  # type: ignore
+        token = base64.b64encode(os.urandom(128)).decode('utf-8')
         self.next_tokens[token] = index
         return token
 


### PR DESCRIPTION
wrt https://github.com/getmoto/moto/issues/3780#issuecomment-2222182309

I tested this patch with my localstack instance and now all works as expected. I.e. I no longer get this exception:
```
localstack-main   |   File "/opt/code/localstack/.venv/lib/python3.11/site-packages/moto/events/models.py", line 1036, in _gen_next_token
localstack-main   |     token = os.urandom(128).encode("base64")  # type: ignore
localstack-main   |             ^^^^^^^^^^^^^^^^^^^^^^
localstack-main   | AttributeError: 'bytes' object has no attribute 'encode'
```