### PR TITLE
Events: list_targets_by_rule() pagination

### DIFF
--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -159,9 +159,10 @@ class EventsHandler(BaseResponse):
             return self.error("ValidationException", "Parameter Rule is required.")
 
         try:
-            targets = self.events_backend.list_targets_by_rule(
-                rule_name, event_bus_arn, next_token, limit
+            target_page, token = self.events_backend.list_targets_by_rule(
+                rule_name, event_bus_arn, next_token=next_token, limit=limit
             )
+            targets = {"Targets": target_page, "NextToken": token}
         except KeyError:
             return self.error(
                 "ResourceNotFoundException", "Rule " + rule_name + " does not exist."

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -38,6 +38,13 @@ PAGINATION_MODEL = {
         "unique_attribute": "arn",
         "fail_on_invalid_token": False,
     },
+    "list_targets_by_rule": {
+        "input_token": "next_token",
+        "limit_key": "limit",
+        "limit_default": 50,
+        "unique_attribute": "Arn",
+        "fail_on_invalid_token": False,
+    },
 }
 
 _BASE_EVENT_MESSAGE: EventMessageType = {

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -356,6 +356,21 @@ def test_list_targets_by_rule():
 
 
 @mock_aws
+def test_list_targets_by_rule_pagination():
+    rule_name = "test1"
+    client = generate_environment()
+    page1 = client.list_targets_by_rule(Rule=rule_name, Limit=1)
+    assert len(page1["Targets"]) == 1
+    assert "NextToken" in page1
+
+    page2 = client.list_targets_by_rule(Rule=rule_name, NextToken=page1["NextToken"])
+    assert len(page2["Targets"]) == 5
+
+    large_page = client.list_targets_by_rule(Rule=rule_name, Limit=4)
+    assert len(large_page["Targets"]) == 4
+
+
+@mock_aws
 def test_list_targets_by_rule_for_different_event_bus():
     client = generate_environment()
 


### PR DESCRIPTION
Supercedes #7842 

We now use the `@paginate`-decorator, instead of relying on custom pagination logic. Also adds a test to verify this feature now works properly.