### PR TITLE
S3: head_object()/get_object() now support the PartNumber for regular keys

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -481,6 +481,13 @@ class InvalidRange(S3ClientError):
         )
 
 
+class RangeNotSatisfiable(S3ClientError):
+    code = 416
+
+    def __init__(self) -> None:
+        super().__init__(RangeNotSatisfiable.code, "Requested Range Not Satisfiable")
+
+
 class InvalidContinuationToken(S3ClientError):
     code = 400
 

--- a/tests/test_s3/__init__.py
+++ b/tests/test_s3/__init__.py
@@ -23,7 +23,7 @@ def s3_aws_verified(func):
     """
 
     @wraps(func)
-    def pagination_wrapper():
+    def pagination_wrapper(**kwargs):
         bucket_name = str(uuid4())
 
         allow_aws_request = (
@@ -32,13 +32,13 @@ def s3_aws_verified(func):
 
         if allow_aws_request:
             print(f"Test {func} will create {bucket_name}")  # noqa: T201
-            resp = create_bucket_and_test(bucket_name)
+            resp = create_bucket_and_test(bucket_name, **kwargs)
         else:
             with mock_aws():
-                resp = create_bucket_and_test(bucket_name)
+                resp = create_bucket_and_test(bucket_name, **kwargs)
         return resp
 
-    def create_bucket_and_test(bucket_name):
+    def create_bucket_and_test(bucket_name, **kwargs):
         client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
 
         client.create_bucket(Bucket=bucket_name)
@@ -47,7 +47,7 @@ def s3_aws_verified(func):
             Tagging={"TagSet": [{"Key": "environment", "Value": "moto_tests"}]},
         )
         try:
-            resp = func(bucket_name)
+            resp = func(**kwargs, bucket_name=bucket_name)
         finally:
             ### CLEANUP ###
 

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -39,7 +39,7 @@ def test_copy_key_boto3(key_name):
 
 @pytest.mark.aws_verified
 @s3_aws_verified
-def test_copy_key_boto3_with_args(bucket=None):
+def test_copy_key_boto3_with_args(bucket_name=None):
     # Setup
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
@@ -47,13 +47,13 @@ def test_copy_key_boto3_with_args(bucket=None):
     new_key = "new_key"
     expected_hash = "qz0H8xacy9DtbEtF3iFRn5+TjHLSQSSZiquUnOg7tRs="
 
-    key = s3_resource.Object(bucket, key_name)
+    key = s3_resource.Object(bucket_name, key_name)
     key.put(Body=b"some value")
 
     # Execute
-    key2 = s3_resource.Object(bucket, new_key)
+    key2 = s3_resource.Object(bucket_name, new_key)
     key2.copy(
-        CopySource={"Bucket": bucket, "Key": key_name},
+        CopySource={"Bucket": bucket_name, "Key": key_name},
         ExtraArgs={
             "ChecksumAlgorithm": "SHA256",
             "WebsiteRedirectLocation": "http://getmoto.org/",
@@ -62,20 +62,20 @@ def test_copy_key_boto3_with_args(bucket=None):
 
     # Verify
     resp = client.get_object_attributes(
-        Bucket=bucket, Key=new_key, ObjectAttributes=["Checksum"]
+        Bucket=bucket_name, Key=new_key, ObjectAttributes=["Checksum"]
     )
 
     assert "Checksum" in resp
     assert "ChecksumSHA256" in resp["Checksum"]
     assert resp["Checksum"]["ChecksumSHA256"] == expected_hash
 
-    obj = client.get_object(Bucket=bucket, Key=new_key)
+    obj = client.get_object(Bucket=bucket_name, Key=new_key)
     assert obj["WebsiteRedirectLocation"] == "http://getmoto.org/"
 
     # Verify in place
     copy_in_place = client.copy_object(
-        Bucket=bucket,
-        CopySource=f"{bucket}/{new_key}",
+        Bucket=bucket_name,
+        CopySource=f"{bucket_name}/{new_key}",
         Key=new_key,
         ChecksumAlgorithm="SHA256",
         MetadataDirective="REPLACE",
@@ -87,7 +87,7 @@ def test_copy_key_boto3_with_args(bucket=None):
 
 @pytest.mark.aws_verified
 @s3_aws_verified
-def test_copy_key_boto3_with_args__using_multipart(bucket=None):
+def test_copy_key_boto3_with_args__using_multipart(bucket_name=None):
     # Setup
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
@@ -95,13 +95,13 @@ def test_copy_key_boto3_with_args__using_multipart(bucket=None):
     new_key = "new_key"
     expected_hash = "DnKotDi4EtYGwNMDKmnR6SqH3bWVOlo2BC+tsz9rHqw="
 
-    key = s3_resource.Object(bucket, key_name)
+    key = s3_resource.Object(bucket_name, key_name)
     key.put(Body=b"some value")
 
     # Execute
-    key2 = s3_resource.Object(bucket, new_key)
+    key2 = s3_resource.Object(bucket_name, new_key)
     key2.copy(
-        CopySource={"Bucket": bucket, "Key": key_name},
+        CopySource={"Bucket": bucket_name, "Key": key_name},
         ExtraArgs={
             "ChecksumAlgorithm": "SHA256",
             "WebsiteRedirectLocation": "http://getmoto.org/",
@@ -111,14 +111,14 @@ def test_copy_key_boto3_with_args__using_multipart(bucket=None):
 
     # Verify
     resp = client.get_object_attributes(
-        Bucket=bucket, Key=new_key, ObjectAttributes=["Checksum"]
+        Bucket=bucket_name, Key=new_key, ObjectAttributes=["Checksum"]
     )
 
     assert "Checksum" in resp
     assert "ChecksumSHA256" in resp["Checksum"]
     assert resp["Checksum"]["ChecksumSHA256"] == expected_hash
 
-    obj = client.get_object(Bucket=bucket, Key=new_key)
+    obj = client.get_object(Bucket=bucket_name, Key=new_key)
     assert obj["WebsiteRedirectLocation"] == "http://getmoto.org/"
 
 

--- a/tests/test_s3/test_s3_list_objects.py
+++ b/tests/test_s3/test_s3_list_objects.py
@@ -10,7 +10,7 @@ from . import s3_aws_verified
 
 @pytest.mark.aws_verified
 @s3_aws_verified
-def test_s3_filter_with_manual_marker(name=None) -> None:
+def test_s3_filter_with_manual_marker(bucket_name=None) -> None:
     """
     Batch manually:
     1. Get list of all items, but only take first 5
@@ -22,7 +22,7 @@ def test_s3_filter_with_manual_marker(name=None) -> None:
 
     This test verifies that it is possible to pass an existing key-name as the Marker-attribute
     """
-    bucket = boto3.resource("s3", "us-east-1").Bucket(name)
+    bucket = boto3.resource("s3", "us-east-1").Bucket(bucket_name)
 
     def batch_from(marker: str, *, batch_size: int):
         first: str | None = None


### PR DESCRIPTION
Fixes #7779 

If we call `get_object(.., PartNumber=x)` on a multipart upload, we should probably return only that specific part - but that's not yet implemented.
For now, we only support `PartNumber=1` on an entire key, and treat it as a RangeRequest for the entire key (just like AWS does).