### PR TITLE
DynamoDB uses <> for not equal

### DIFF
--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -118,6 +118,7 @@ COMPARISON_FUNCS = {
     "=": EQ_FUNCTION,
     "NE": NE_FUNCTION,
     "!=": NE_FUNCTION,
+    "<>": NE_FUNCTION,
     "LE": LE_FUNCTION,
     "<=": LE_FUNCTION,
     "LT": LT_FUNCTION,

--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -107,7 +107,9 @@ def parse_expression(
                     current_phrase, current_phrase
                 )
             current_phrase = ""
-            if crnt_char in ["<", ">"] and tokenizer.peek() == "=":
+            if (crnt_char in ["<", ">"] and tokenizer.peek() == "=") or (
+                crnt_char == "<" and tokenizer.peek() == ">"
+            ):
                 comparison = crnt_char + tokenizer.__next__()
             else:
                 comparison = crnt_char


### PR DESCRIPTION
Parse `<>` as `NOT EQUAL` in DynamoDB key condition expression.