### PR TITLE
ACM: Enforce ExportCertificate constraints, and issue Private CA certificates via RequestCertificate

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -213,14 +213,10 @@ class CertBundle(BaseModel):
             encryption_algorithm=serialization.NoEncryption(),
         )
 
-        cert_type = "AMAZON_ISSUED"
-        if cert_auth_arn is not None:
-            cert_type = "PRIVATE"
-
         return cls(
             certificate=cert_armored,
             private_key=private_key,
-            cert_type=cert_type,
+            cert_type="PRIVATE" if cert_authority_arn is not None else "AMAZON_ISSUED",
             cert_status="PENDING_VALIDATION",
             cert_authority_arn=cert_auth_arn,
             account_id=account_id,

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -123,7 +123,7 @@ class CertBundle(BaseModel):
         arn: Optional[str] = None,
         cert_type: str = "IMPORTED",
         cert_status: str = "ISSUED",
-        cert_authority_arn: Optional[str] = None
+        cert_authority_arn: Optional[str] = None,
     ):
         self.created_at = utcnow()
         self.cert = certificate
@@ -572,8 +572,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         cert_bundle = self.get_certificate(certificate_arn)
         if cert_bundle.type != "PRIVATE":
             raise AWSValidationException(
-                "Certificate ARN: %s is not a private certificate"
-                % (certificate_arn)
+                "Certificate ARN: %s is not a private certificate" % (certificate_arn)
             )
         certificate = cert_bundle.cert.decode()
         certificate_chain = cert_bundle.chain.decode()

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -123,7 +123,7 @@ class CertBundle(BaseModel):
         arn: Optional[str] = None,
         cert_type: str = "IMPORTED",
         cert_status: str = "ISSUED",
-        cert_auth_arn: Optional[str] = None
+        cert_authority_arn: Optional[str] = None
     ):
         self.created_at = utcnow()
         self.cert = certificate
@@ -133,7 +133,7 @@ class CertBundle(BaseModel):
         self.tags = TagHolder()
         self.type = cert_type  # Should really be an enum
         self.status = cert_status  # Should really be an enum
-        self.cert_auth_arn = cert_auth_arn
+        self.cert_authority_arn = cert_auth_arn
         self.in_use_by: List[str] = []
 
         # Takes care of PEM checking
@@ -160,7 +160,7 @@ class CertBundle(BaseModel):
         account_id: str,
         region: str,
         sans: Optional[List[str]] = None,
-        cert_auth_arn: Optional[str] = None,
+        cert_authority_arn: Optional[str] = None,
     ) -> "CertBundle":
         unique_sans: Set[str] = set(sans) if sans else set()
 
@@ -222,7 +222,7 @@ class CertBundle(BaseModel):
             private_key=private_key,
             cert_type=cert_type,
             cert_status="PENDING_VALIDATION",
-            cert_auth_arn=cert_auth_arn,
+            cert_authority_arn=cert_auth_arn,
             account_id=account_id,
             region=region,
         )
@@ -365,8 +365,8 @@ class CertBundle(BaseModel):
             }
         }
 
-        if self.cert_auth_arn is not None:
-            result["Certificate"]["CertificateAuthorityArn"] = self.cert_auth_arn
+        if self.cert_authority_arn is not None:
+            result["Certificate"]["CertificateAuthorityArn"] = self.cert_authority_arn
 
         domain_names = set(sans + [self.common_name])
         validation_options = []
@@ -526,7 +526,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         idempotency_token: str,
         subject_alt_names: List[str],
         tags: List[Dict[str, str]],
-        cert_auth_arn: Optional[str] = None,
+        cert_authority_arn: Optional[str] = None,
     ) -> str:
         """
         The parameter DomainValidationOptions has not yet been implemented
@@ -541,7 +541,7 @@ class AWSCertificateManagerBackend(BaseBackend):
             account_id=self.account_id,
             region=self.region_name,
             sans=subject_alt_names,
-            cert_auth_arn=cert_auth_arn,
+            cert_authority_arn=cert_auth_arn,
         )
         if idempotency_token is not None:
             self._set_idempotency_token_arn(idempotency_token, cert.arn)

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -133,7 +133,7 @@ class CertBundle(BaseModel):
         self.tags = TagHolder()
         self.type = cert_type  # Should really be an enum
         self.status = cert_status  # Should really be an enum
-        self.cert_authority_arn = cert_auth_arn
+        self.cert_authority_arn = cert_authority_arn
         self.in_use_by: List[str] = []
 
         # Takes care of PEM checking
@@ -218,7 +218,7 @@ class CertBundle(BaseModel):
             private_key=private_key,
             cert_type="PRIVATE" if cert_authority_arn is not None else "AMAZON_ISSUED",
             cert_status="PENDING_VALIDATION",
-            cert_authority_arn=cert_auth_arn,
+            cert_authority_arn=cert_authority_arn,
             account_id=account_id,
             region=region,
         )
@@ -537,7 +537,7 @@ class AWSCertificateManagerBackend(BaseBackend):
             account_id=self.account_id,
             region=self.region_name,
             sans=subject_alt_names,
-            cert_authority_arn=cert_auth_arn,
+            cert_authority_arn=cert_authority_arn,
         )
         if idempotency_token is not None:
             self._set_idempotency_token_arn(idempotency_token, cert.arn)

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -387,7 +387,8 @@ class CertBundle(BaseModel):
                 }
             )
 
-        result["Certificate"]["DomainValidationOptions"] = validation_options
+        if self.type == "AMAZON_ISSUED":
+            result["Certificate"]["DomainValidationOptions"] = validation_options
 
         if self.type == "IMPORTED":
             result["Certificate"]["ImportedAt"] = datetime_to_epoch(self.created_at)

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -176,6 +176,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         idempotency_token = self._get_param("IdempotencyToken")
         subject_alt_names = self._get_param("SubjectAlternativeNames")
         tags = self._get_param("Tags")  # Optional
+        cert_auth_arn = self._get_param("CertificateAuthorityArn") # Optional
 
         if subject_alt_names is not None and len(subject_alt_names) > 10:
             # There is initial AWS limit of 10
@@ -192,6 +193,7 @@ class AWSCertificateManagerResponse(BaseResponse):
             idempotency_token,
             subject_alt_names,
             tags,
+            cert_auth_arn,
         )
 
         return json.dumps({"CertificateArn": arn})

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -176,7 +176,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         idempotency_token = self._get_param("IdempotencyToken")
         subject_alt_names = self._get_param("SubjectAlternativeNames")
         tags = self._get_param("Tags")  # Optional
-        cert_auth_arn = self._get_param("CertificateAuthorityArn") # Optional
+        cert_authority_arn = self._get_param("CertificateAuthorityArn") # Optional
 
         if subject_alt_names is not None and len(subject_alt_names) > 10:
             # There is initial AWS limit of 10
@@ -193,7 +193,7 @@ class AWSCertificateManagerResponse(BaseResponse):
             idempotency_token,
             subject_alt_names,
             tags,
-            cert_auth_arn,
+            cert_authority_arn,
         )
 
         return json.dumps({"CertificateArn": arn})

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -176,7 +176,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         idempotency_token = self._get_param("IdempotencyToken")
         subject_alt_names = self._get_param("SubjectAlternativeNames")
         tags = self._get_param("Tags")  # Optional
-        cert_authority_arn = self._get_param("CertificateAuthorityArn") # Optional
+        cert_authority_arn = self._get_param("CertificateAuthorityArn")  # Optional
 
         if subject_alt_names is not None and len(subject_alt_names) > 10:
             # There is initial AWS limit of 10

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -170,7 +170,7 @@ def test_delete_certificate():
 @mock_aws
 def test_describe_certificate():
     client = boto3.client("acm", region_name="eu-central-1")
-    arn = _import_cert(client)
+    arn = client.request_certificate(DomainName=SERVER_COMMON_NAME)
 
     try:
         resp = client.describe_certificate(CertificateArn=arn)
@@ -178,10 +178,10 @@ def test_describe_certificate():
         pytest.skip("This test requires 64-bit time_t")
     assert resp["Certificate"]["CertificateArn"] == arn
     assert resp["Certificate"]["DomainName"] == SERVER_COMMON_NAME
-    assert resp["Certificate"]["Issuer"] == "Moto"
+    assert resp["Certificate"]["Issuer"] == "Amazon"
     assert resp["Certificate"]["KeyAlgorithm"] == "RSA_2048"
-    assert resp["Certificate"]["Status"] == "ISSUED"
-    assert resp["Certificate"]["Type"] == "IMPORTED"
+    assert resp["Certificate"]["Status"] == "PENDING_VALIDATION"
+    assert resp["Certificate"]["Type"] == "AMAZON_ISSUED"
     assert resp["Certificate"]["RenewalEligibility"] == "INELIGIBLE"
     assert "Options" in resp["Certificate"]
 

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -28,12 +28,19 @@ SERVER_COMMON_NAME = "*.moto.com"
 SERVER_CRT_BAD = get_resource("star_moto_com-bad.pem")
 SERVER_KEY = get_resource("star_moto_com.key")
 BAD_ARN = f"arn:aws:acm:us-east-2:{ACCOUNT_ID}:certificate/_0000000-0000-0000-0000-000000000000"
+CERT_AUTH_ARN = f"arn:aws:acm-pca:eu-central-1:{ACCOUNT_ID}:certificate-authority/12345678-1234-1234-1234-123456789012"
 
 
 def _import_cert(client):
     response = client.import_certificate(
         Certificate=SERVER_CRT, PrivateKey=SERVER_KEY, CertificateChain=CA_CRT
     )
+    return response["CertificateArn"]
+
+
+def _pca_cert(client):
+    response = client.request_certificate(DomainName=SERVER_COMMON_NAME,
+            CertificateAuthorityArn=CERT_AUTH_ARN)
     return response["CertificateArn"]
 
 
@@ -194,25 +201,73 @@ def test_describe_certificate_with_bad_arn():
 
 
 @mock_aws
-def test_export_certificate():
+def test_describe_certificate_with_imported_cert():
     client = boto3.client("acm", region_name="eu-central-1")
     arn = _import_cert(client)
 
-    resp = client.export_certificate(CertificateArn=arn, Passphrase="pass")
-    assert resp["Certificate"] == SERVER_CRT.decode()
-    assert resp["CertificateChain"] == CA_CRT.decode() + "\n" + AWS_ROOT_CA.decode()
+    try:
+        resp = client.describe_certificate(CertificateArn=arn)
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
+    assert resp["Certificate"]["CertificateArn"] == arn
+    assert resp["Certificate"]["DomainName"] == SERVER_COMMON_NAME
+    assert resp["Certificate"]["Issuer"] == "Moto"
+    assert resp["Certificate"]["KeyAlgorithm"] == "RSA_2048"
+    assert resp["Certificate"]["Status"] == "ISSUED"
+    assert resp["Certificate"]["Type"] == "IMPORTED"
+    assert resp["Certificate"]["RenewalEligibility"] == "INELIGIBLE"
+    assert "Options" in resp["Certificate"]
+
+    assert "DomainValidationOptions" not in resp["Certificate"]
+
+
+@mock_aws
+def test_describe_certificate_with_pca_cert():
+    client = boto3.client("acm", region_name="eu-central-1")
+    arn = _pca_cert(client)
+    try:
+        resp = client.describe_certificate(CertificateArn=arn)
+    except OverflowError:
+        pytest.skip("This test requires 64-bit time_t")
+    assert resp["Certificate"]["CertificateArn"] == arn
+    assert resp["Certificate"]["DomainName"] == SERVER_COMMON_NAME
+    assert resp["Certificate"]["Issuer"] == "Amazon"
+    assert resp["Certificate"]["KeyAlgorithm"] == "RSA_2048"
+    assert resp["Certificate"]["Status"] == "PENDING_VALIDATION"
+    assert resp["Certificate"]["Type"] == "PRIVATE"
+    assert resp["Certificate"]["RenewalEligibility"] == "INELIGIBLE"
+    assert "Options" in resp["Certificate"]
+    assert resp["Certificate"]["CertificateAuthorityArn"] == CERT_AUTH_ARN
+    assert "DomainValidationOptions" not in resp["Certificate"]
+
+@mock_aws
+def test_export_certificate_with_pca_cert():
+    client = boto3.client("acm", region_name="eu-central-1")
+    arn = _pca_cert(client)
+    resp = client.export_certificate(CertificateArn=arn, Passphrase="passphrase")
+    assert "CertificateChain" in resp
+    assert "Certificate" in resp
     assert "PrivateKey" in resp
 
-    key = serialization.load_pem_private_key(
-        bytes(resp["PrivateKey"], "utf-8"), password=b"pass", backend=default_backend()
-    )
+@mock_aws
+def test_export_certificate_with_imported_cert():
+    client = boto3.client("acm", region_name="eu-central-1")
+    arn = _import_cert(client)
 
-    private_key = key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    assert private_key == SERVER_KEY
+    with pytest.raises(ClientError) as err:
+        resp = client.export_certificate(CertificateArn=arn, Passphrase="passphrase")
+    assert err.value.response["Error"]["Code"] == "ValidationException"
+    assert "is not a private certificate" in err.value.response["Error"]["Message"]
+
+@mock_aws
+def test_export_certificate_with_short_passphrase():
+    client = boto3.client("acm", region_name="eu-central-1")
+    arn = _pca_cert(client)
+
+    with pytest.raises(ClientError) as err:
+        resp = client.export_certificate(CertificateArn=arn, Passphrase="")
+    assert err.value.response["Error"]["Code"] == "ValidationException"
+    assert "passphrase" in err.value.response["Error"]["Message"]
 
 
 @mock_aws
@@ -468,6 +523,16 @@ def test_request_certificate_with_optional_arguments():
     arn_4 = resp["CertificateArn"]
 
     assert arn_1 != arn_4  # if tags are matched, ACM would have returned same arn
+
+@mock_aws
+def test_request_certificate_with_certificate_authority():
+    client = boto3.client("acm", region_name="eu-central-1")
+
+    resp = client.request_certificate(
+        DomainName="example.com",
+        CertificateAuthorityArn="arn:aws:acm-pca:eu-central-1:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012",
+    )
+    assert "CertificateArn" in resp
 
 
 @mock_aws

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -170,7 +170,7 @@ def test_delete_certificate():
 @mock_aws
 def test_describe_certificate():
     client = boto3.client("acm", region_name="eu-central-1")
-    arn = client.request_certificate(DomainName=SERVER_COMMON_NAME)
+    arn = client.request_certificate(DomainName=SERVER_COMMON_NAME)["CertificateArn"]
 
     try:
         resp = client.describe_certificate(CertificateArn=arn)


### PR DESCRIPTION
Closes #7858 

This PR checks the constraints on ExportCertificate as Amazon does, and only allows exporting private certificates.

Additionally, this enables creating private certificates via the RequestCertificate call.

Ideally those certificates would also enter the ISSUED state before they could be exported, but this is a start to begin supporting ACM/PCA interactions correctly.