### PR TITLE
RDS: Fix Error Codes

### DIFF
--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -160,7 +160,7 @@ class DBClusterSnapshotAlreadyExistsError(RDSClientError):
 class ExportTaskAlreadyExistsError(RDSClientError):
     def __init__(self, export_task_identifier: str):
         super().__init__(
-            "ExportTaskAlreadyExistsFault",
+            "ExportTaskAlreadyExists",
             f"Cannot start export task because a task with the identifier {export_task_identifier} already exists.",
         )
 
@@ -168,7 +168,7 @@ class ExportTaskAlreadyExistsError(RDSClientError):
 class ExportTaskNotFoundError(RDSClientError):
     def __init__(self, export_task_identifier: str):
         super().__init__(
-            "ExportTaskNotFoundFault",
+            "ExportTaskNotFound",
             f"Cannot cancel export task because a task with the identifier {export_task_identifier} is not exist.",
         )
 
@@ -184,7 +184,7 @@ class InvalidExportSourceStateError(RDSClientError):
 class SubscriptionAlreadyExistError(RDSClientError):
     def __init__(self, subscription_name: str):
         super().__init__(
-            "SubscriptionAlreadyExistFault",
+            "SubscriptionAlreadyExist",
             f"Subscription {subscription_name} already exists.",
         )
 
@@ -192,7 +192,7 @@ class SubscriptionAlreadyExistError(RDSClientError):
 class SubscriptionNotFoundError(RDSClientError):
     def __init__(self, subscription_name: str):
         super().__init__(
-            "SubscriptionNotFoundFault", f"Subscription {subscription_name} not found."
+            "SubscriptionNotFound", f"Subscription {subscription_name} not found."
         )
 
 

--- a/tests/test_rds/test_rds_event_subscriptions.py
+++ b/tests/test_rds/test_rds_event_subscriptions.py
@@ -74,7 +74,7 @@ def test_create_event_fail_already_exists():
 
     err = ex.value.response["Error"]
 
-    assert err["Code"] == "SubscriptionAlreadyExistFault"
+    assert err["Code"] == "SubscriptionAlreadyExist"
     assert err["Message"] == "Subscription db-primary-1-events already exists."
 
 
@@ -85,7 +85,7 @@ def test_delete_event_subscription_fails_unknown_subscription():
         client.delete_event_subscription(SubscriptionName="my-db-events")
 
     err = ex.value.response["Error"]
-    assert err["Code"] == "SubscriptionNotFoundFault"
+    assert err["Code"] == "SubscriptionNotFound"
     assert err["Message"] == "Subscription my-db-events not found."
 
 
@@ -133,5 +133,5 @@ def test_describe_event_subscriptions_fails_unknown_subscription():
 
     err = ex.value.response["Error"]
 
-    assert err["Code"] == "SubscriptionNotFoundFault"
+    assert err["Code"] == "SubscriptionNotFound"
     assert err["Message"] == "Subscription my-db-events not found."

--- a/tests/test_rds/test_rds_export_tasks.py
+++ b/tests/test_rds/test_rds_export_tasks.py
@@ -142,7 +142,7 @@ def test_start_export_task_fail_already_exists():
         )
 
     err = ex.value.response["Error"]
-    assert err["Code"] == "ExportTaskAlreadyExistsFault"
+    assert err["Code"] == "ExportTaskAlreadyExists"
     assert err["Message"] == (
         "Cannot start export task because a task with the identifier "
         "export-snapshot-1 already exists."
@@ -156,7 +156,7 @@ def test_cancel_export_task_fails_unknown_task():
         client.cancel_export_task(ExportTaskIdentifier="export-snapshot-1")
 
     err = ex.value.response["Error"]
-    assert err["Code"] == "ExportTaskNotFoundFault"
+    assert err["Code"] == "ExportTaskNotFound"
     assert err["Message"] == (
         "Cannot cancel export task because a task with the identifier "
         "export-snapshot-1 is not exist."
@@ -207,7 +207,7 @@ def test_describe_export_tasks_fails_unknown_task():
         client.describe_export_tasks(ExportTaskIdentifier="export-snapshot-1")
 
     err = ex.value.response["Error"]
-    assert err["Code"] == "ExportTaskNotFoundFault"
+    assert err["Code"] == "ExportTaskNotFound"
     assert err["Message"] == (
         "Cannot cancel export task because a task with the identifier "
         "export-snapshot-1 is not exist."


### PR DESCRIPTION
These exceptions were all using the botocore Shape name instead of the actual AWS error code.

Example for reference:
https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteEventSubscription.html