### PR TITLE
Enable pytest colored output in GitHub workflow runs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools >= 40.6.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+addopts = "--color=yes"
+
 [tool.ruff.lint]
 ignore = ["E501"]
 extend-select = ["I", "T201", "T203"]


### PR DESCRIPTION
The default setting does not use color if it doesn't detect a terminal.