### PR TITLE
IoT: Set Certificate ID to SHA256 hexdigest of DER.

### DIFF
--- a/docs/docs/configuration/index.rst
+++ b/docs/docs/configuration/index.rst
@@ -23,6 +23,7 @@ If you are using the decorators, some options are configurable within the decora
         },
         "iam": {"load_aws_managed_policies": False},
         "stepfunctions": {"execute_state_machine": True},
+        "iot": {"use_valid_cert": True},
     })
 
 
@@ -56,6 +57,16 @@ AWS Managed Policies
 Moto comes bundled with all Managed Policies that AWS exposes, which are updated regularly. However, they are not loaded unless specifically requested for performance reasons.
 
 Set `"iam": {"load_aws_managed_policies": True}` to load these policies for a single test.
+
+IoT Certificates Validity and Certificate ID computation
+-------------------------
+The IoT Client API's for certificates require a valid certificate
+in order to compute the certificate ID properly.
+Previous releases computed the certificate ID incorrectly based on
+the PEM cert.  The algorithm now computes the certificate ID correctly using
+the sha256 of the DER cert.  For the previous behavior,
+to run with invalid certificates and use the previous
+incorrect cert ID computation, set `"iot": {"use_valid_cert": False}`
 
 Configuring MotoServer
 ----------------------

--- a/docs/docs/configuration/index.rst
+++ b/docs/docs/configuration/index.rst
@@ -23,7 +23,7 @@ If you are using the decorators, some options are configurable within the decora
         },
         "iam": {"load_aws_managed_policies": False},
         "stepfunctions": {"execute_state_machine": True},
-        "iot": {"use_valid_cert": True},
+        "iot": {"use_valid_cert": False},
     })
 
 
@@ -60,13 +60,21 @@ Set `"iam": {"load_aws_managed_policies": True}` to load these policies for a si
 
 IoT Certificates Validity and Certificate ID computation
 -------------------------
-The IoT Client API's for certificates require a valid certificate
-in order to compute the certificate ID properly.
-Previous releases computed the certificate ID incorrectly based on
-the PEM cert.  The algorithm now computes the certificate ID correctly using
-the sha256 of the DER cert.  For the previous behavior,
-to run with invalid certificates and use the previous
-incorrect cert ID computation, set `"iot": {"use_valid_cert": False}`
+The IoT Client implementation for certificates, by default,
+computes the certificate ID incorrectly based on the
+sha256 hash of the certificate in PEM encoding and does not require a
+valid certificate.
+
+We now support proper certificate ID generation using 
+the sha256 of the DER certificate to ensure correct behavior for tests that
+use valid certificates.  To enable the correct
+certificate ID generation algorithm, set `"iot": {"use_valid_cert": True}`
+
+In the next major release we recommend changing the default to `True`
+which would a breaking change for tests that do not use valid certificates.
+For future compatiblity, update any existing code that does not use real
+certificates to explicitly set `use_valid_cert` to `False`
+
 
 Configuring MotoServer
 ----------------------

--- a/moto/core/config.py
+++ b/moto/core/config.py
@@ -25,6 +25,10 @@ class _sfn_config(TypedDict, total=False):
     execute_state_machine: bool
 
 
+class _iot_config(TypedDict, total=False):
+    use_valid_cert: bool
+
+
 DefaultConfig = TypedDict(
     "DefaultConfig",
     {
@@ -33,6 +37,7 @@ DefaultConfig = TypedDict(
         "lambda": _docker_config,
         "iam": _iam_config,
         "stepfunctions": _sfn_config,
+        "iot": _iot_config,
     },
     total=False,
 )
@@ -47,6 +52,7 @@ default_user_config: DefaultConfig = {
     },
     "iam": {"load_aws_managed_policies": False},
     "stepfunctions": {"execute_state_machine": False},
+    "iot": {"use_valid_cert": True},
 }
 
 

--- a/moto/core/config.py
+++ b/moto/core/config.py
@@ -52,7 +52,7 @@ default_user_config: DefaultConfig = {
     },
     "iam": {"load_aws_managed_policies": False},
     "stepfunctions": {"execute_state_machine": False},
-    "iot": {"use_valid_cert": True},
+    "iot": {"use_valid_cert": False},
 }
 
 

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -193,5 +193,9 @@ def load_iam_aws_managed_policies() -> bool:
     )
 
 
+#
+# NOTE:  Recommend the next major release to set this to True for proper
+# default behavior
+#
 def iot_use_valid_cert() -> bool:
-    return default_user_config.get("iot", {}).get("use_valid_cert", True)
+    return default_user_config.get("iot", {}).get("use_valid_cert", False)

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -191,3 +191,7 @@ def load_iam_aws_managed_policies() -> bool:
         is True
         or os.environ.get("MOTO_IAM_LOAD_MANAGED_POLICIES", "").lower() == "true"
     )
+
+
+def iot_use_valid_cert() -> bool:
+    return default_user_config.get("iot", {}).get("use_valid_cert", True)

--- a/tests/test_iot/test_iot_ca_certificates.py
+++ b/tests/test_iot/test_iot_ca_certificates.py
@@ -8,8 +8,7 @@ from moto import mock_aws
 @mock_aws(config={"iot": {"use_valid_cert": False}})
 def test_register_ca_certificate_simple_invalid_cert():
     """
-    Original test case with invalid cert.  If users don't want to
-    provide a valid cert, they can set "use_valid_cert" to False
+    Original test case with invalid cert.
     """
     client = boto3.client("iot", region_name="us-east-1")
 
@@ -23,7 +22,7 @@ def test_register_ca_certificate_simple_invalid_cert():
 
 
 @pytest.fixture(name="make_cert")
-@mock_aws
+@mock_aws(config={"iot": {"use_valid_cert": True}})
 def fixture_make_cert():
     """
     Create a valid cert for testing
@@ -32,7 +31,7 @@ def fixture_make_cert():
     return client.create_keys_and_certificate(setAsActive=False)
 
 
-@mock_aws
+@mock_aws(config={"iot": {"use_valid_cert": True}})
 def test_register_ca_certificate_simple(make_cert):
     client = boto3.client("iot", region_name="us-east-1")
     certInfo = make_cert


### PR DESCRIPTION
Previous algorithm was based on the PEM format and produced an incorrect certificate ID.
Includes configurable certificate validity for backwards compatibility.