### PR TITLE
Admin: Fix MyPy 1.11.0 compatibility

### DIFF
--- a/moto/awslambda/utils.py
+++ b/moto/awslambda/utils.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Type, Union
 
 from moto.utilities.utils import PARTITION_NAMES, get_partition
 
@@ -22,7 +22,7 @@ make_layer_arn = partial(make_arn, "layer")
 
 
 def make_ver_arn(
-    resource_type: str, region: str, account: str, name: str, version: str = "1"
+    resource_type: str, region: str, account: str, name: str, version: Any = "1"
 ) -> str:
     arn = make_arn(resource_type, region, account, name)
     return f"{arn}:{version}"
@@ -32,7 +32,7 @@ make_function_ver_arn = partial(make_ver_arn, "function")
 make_layer_ver_arn = partial(make_ver_arn, "layer")
 
 
-def split_arn(arn_type: Callable[[str, str, str, str], str], arn: str) -> Any:
+def split_arn(arn_type: Union[Type[ARN], Type[LAYER_ARN]], arn: str) -> Any:
     for partition in PARTITION_NAMES:
         arn = arn.replace(f"arn:{partition}:lambda:", "")
 

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -688,7 +688,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
             self.lazy_condition_map[condition_name] = functools.partial(
                 parse_condition,
                 condition,
-                self._parsed_resources,
+                self._parsed_resources,  # type: ignore
                 self.lazy_condition_map,
             )
 

--- a/moto/moto_proxy/proxy3.py
+++ b/moto/moto_proxy/proxy3.py
@@ -165,7 +165,7 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             boundary = self.headers["Content-Type"].split("boundary=")[-1]
             req_body, form_data = get_body_from_form_data(req_body, boundary)  # type: ignore
             for key, val in form_data.items():
-                self.headers[key] = [val]
+                self.headers[key] = [val]  # type: ignore
         else:
             form_data = {}
 


### PR DESCRIPTION
MyPy 1.11.0 contains some improvements in how partial functions are typed. This PR is mostly adding `type: ignore`-s to make the build work again - doing a deep dive into how to fix the typing properly would require a lot of time.

This also fixes compatibility with `cryptography-43.0.0`, as the CommonName is now a required field when issuing a certificate - and Moto (erroneously) used an empty string as value.