### PR TITLE
firehose: Fix S3 object path prefix formatting when prefix is empty

### DIFF
--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -445,7 +445,7 @@ class FirehoseBackend(BaseBackend):
         # Path prefix pattern: myApp/YYYY/MM/DD/HH/
         # Object name pattern:
         # DeliveryStreamName-DeliveryStreamVersion-YYYY-MM-DD-HH-MM-SS-RandomString
-        prefix = f"{prefix}{'' if prefix.endswith('/') else '/'}"
+        prefix = f"{prefix}{'' if prefix.endswith('/') or prefix == '' else '/'}"
         now = utcnow()
         return (
             f"{prefix}{now.strftime('%Y/%m/%d/%H')}/"

--- a/tests/test_firehose/test_firehose_put.py
+++ b/tests/test_firehose/test_firehose_put.py
@@ -1,5 +1,7 @@
 """Unit tests verifying put-related delivery stream APIs."""
 
+import re
+
 import boto3
 
 from moto import mock_aws
@@ -143,3 +145,6 @@ def test_put_record_batch_extended_s3_destination():
         Bucket=bucket_name, Key=bucket_objects["Contents"][0]["Key"]
     )
     assert response["Body"].read() == b"onetwothree"
+    assert re.match(
+        r"^[0-9]{4}/[0-9]{2}/[0-9]{2}/[0-9]{2}/", bucket_objects["Contents"][0]["Key"]
+    )


### PR DESCRIPTION
## Issue Description

This pull request addresses a bug in AWS Firehose where the S3 prefix for data delivery defaults to /YYYY/MM/dd/HH instead of YYYY/MM/dd/HH when no prefix is provided. According to the [official documentation](https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html), the expected behavior is that the prefix should be YYYY/MM/dd/HH when no custom prefix is specified.

### Steps to Reproduce

This is a complete test which reproduces the issue.

```python
from moto import mock_aws
import boto3

@mock_aws
def test():
    client = boto3.client('firehose', region_name='us-west-1')
    s3 = boto3.client('s3')
    s3.create_bucket(Bucket='my_bucket')
    client.create_delivery_stream(
        DeliveryStreamName='test-stream',
        DeliveryStreamType='DirectPut',
        S3DestinationConfiguration={
            'RoleARN': 'arn:aws:iam::123456789012:role/firehose_delivery_role',
            'BucketARN': 'arn:aws:s3:::my_bucket',
        }
    )

    client.put_record(
        DeliveryStreamName='test-stream',
        Record={
            'Data': 'hello world\n'
        }
    )

    response = s3.list_objects_v2(Bucket='my_bucket')
    response = s3.list_objects_v2(Bucket='my_bucket')
    # expected output: '2015/04/10/~~~~~'
    # but the actual output is: '/2015/04/10//~~~~~'
    print(response['Contents'][0]['Key'])
```

### Cause of the Error
The issue is caused by the condition used to append a `/` to the prefix (`prefix = f"{prefix}{'' if prefix.endswith('/') else '/'}"`). This logic incorrectly adds a `/` even when the prefix is empty, leading to a generated prefix with a leading `/` when creating the final prefix string using `f"{prefix}{now.strftime('%Y/%m/%d/%H')}/"`.


### Fix
To resolve this issue, the condition has been updated to `prefix = f"{prefix}{'' if prefix.endswith('/') or prefix == '' else '/'}"`. This change ensures that a `/` is not added when the prefix is empty, thereby correcting the default prefix to `YYYY/MM/dd/HH`.

### Questions
I have a question regarding custom S3 prefixes: I noticed that the current implementation does not seem to support custom prefixes. Is there any plan to support custom S3 prefixes in the future? 
