### PR TITLE
Allow non-default partitions in events and resourcegroups regexes

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -32,7 +32,7 @@ from moto.moto_api._internal import mock_random as random
 from moto.utilities.arns import parse_arn
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
-from moto.utilities.utils import get_partition
+from moto.utilities.utils import ARN_PARTITION_REGEX, get_partition
 
 from .utils import _BASE_EVENT_MESSAGE, PAGINATION_MODEL, EventMessageType
 
@@ -1675,7 +1675,9 @@ class EventsBackend(BaseBackend):
         destination: Dict[str, Any],
     ) -> Dict[str, Any]:
         event_bus_arn = destination["Arn"]
-        event_bus_arn_pattern = r"^arn:aws:events:[a-zA-Z0-9-]+:\d{12}:event-bus/"
+        event_bus_arn_pattern = (
+            rf"{ARN_PARTITION_REGEX}:events:[a-zA-Z0-9-]+:\d{{12}}:event-bus/"
+        )
         if not re.match(event_bus_arn_pattern, event_bus_arn):
             raise ValidationException(
                 "Parameter Destination.Arn is not valid. Reason: Must contain an event bus ARN."

--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.utilities.utils import get_partition
+from moto.utilities.utils import ARN_PARTITION_REGEX, get_partition
 
 from .exceptions import BadRequestException
 
@@ -246,7 +246,7 @@ class ResourceGroupsBackend(BaseBackend):
             if not isinstance(stack_identifier, str):
                 raise invalid_json_exception
             if not re.match(
-                r"^arn:aws:cloudformation:[a-z]{2}-[a-z]+-[0-9]+:[0-9]+:stack/[-0-9A-z]+/[-0-9a-f]+$",
+                rf"{ARN_PARTITION_REGEX}:cloudformation:[a-z]{{2}}-[a-z]+-[0-9]+:[0-9]+:stack/[-0-9A-z]+/[-0-9a-f]+$",
                 stack_identifier,
             ):
                 raise BadRequestException(


### PR DESCRIPTION
## Motivation
With #7716 there were already some changes to support arns with `aws-us-gov` and `aws-cn` (for example) partitions in validation regexes.

However, it seems two were missed, in `events` and `resourcegroups`.

## Changes
* Use the `ARN_PARTITION_REGEX` to make two validation regex compatible with non-default partitions.