### PR TITLE
CognitoIDP: initiate_auth with USERNAME_PASSWORD_AUTH and SMS/Software Token MFA

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1945,6 +1945,13 @@ class CognitoIdpBackend(BaseBackend):
                     "Session": session,
                 }
 
+            if user.sms_mfa_enabled and user.preferred_mfa_setting == "SMS_MFA":
+                return {
+                    "ChallengeName": "SMS_MFA",
+                    "ChallengeParameters": {},
+                    "Session": session,
+                }
+
             access_token, expires_in = user_pool.create_access_token(
                 client_id, username
             )

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1945,6 +1945,16 @@ class CognitoIdpBackend(BaseBackend):
                     "Session": session,
                 }
 
+            if (
+                user.software_token_mfa_enabled
+                and user.preferred_mfa_setting == "SOFTWARE_TOKEN_MFA"
+            ):
+                return {
+                    "ChallengeName": "SOFTWARE_TOKEN_MFA",
+                    "ChallengeParameters": {},
+                    "Session": session,
+                }
+
             if user.sms_mfa_enabled and user.preferred_mfa_setting == "SMS_MFA":
                 return {
                     "ChallengeName": "SMS_MFA",


### PR DESCRIPTION
The initiate_auth call with a AuthFlow of USERNAME_PASSWORD_AUTH was not accounting for SMS MFA and was returning a AuthenticationResult instead of a Challenge as expected.

-- EDIT --
It also was not accounting for software token MFA and not returning a Challenge as expected.