### PR TITLE
ACM: DomainValidationOptions should have SUCCESS-status

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -367,6 +367,7 @@ class CertBundle(BaseModel):
         domain_names = set(sans + [self.common_name])
         validation_options = []
 
+        domain_name_status = "SUCCESS" if self.status == "ISSUED" else self.status
         for san in domain_names:
             resource_record = {
                 "Name": f"_d930b28be6c5927595552b219965053e.{san}.",
@@ -377,7 +378,7 @@ class CertBundle(BaseModel):
                 {
                     "DomainName": san,
                     "ValidationDomain": san,
-                    "ValidationStatus": self.status,
+                    "ValidationStatus": domain_name_status,
                     "ValidationMethod": "DNS",
                     "ResourceRecord": resource_record,
                 }

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-from time import sleep
 from unittest import SkipTest, mock
 
 import boto3
@@ -474,9 +473,11 @@ def test_request_certificate_with_optional_arguments():
     )
 
     # Verify SAN's are still the same, even after the Certificate is validated
-    sleep(2)
+    waiter = client.get_waiter("certificate_validated")
+    waiter.wait(CertificateArn=arn_1, WaiterConfig={"Delay": 1})
+
     for opt in validation_options:
-        opt["ValidationStatus"] = "ISSUED"
+        opt["ValidationStatus"] = "SUCCESS"
     cert = client.describe_certificate(CertificateArn=arn_1)["Certificate"]
     assert cert["DomainValidationOptions"] == validation_options
 


### PR DESCRIPTION
Fixes #7886 