### PR TITLE
DynamoDB: export_table_to_point_in_time() now exports data in correct…

### DIFF
--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -327,6 +327,14 @@ class TableNotFoundException(JsonRESTError):
         super().__init__(err, f"Table not found: {name}")
 
 
+class PointInTimeRecoveryUnavailable(JsonRESTError):
+    def __init__(self, name: str):
+        err = ERROR_TYPE_PREFIX + "PointInTimeRecoveryUnavailableException"
+        super().__init__(
+            err, f"Point in time recovery is not enabled for table '{name}'"
+        )
+
+
 class SourceTableNotFoundException(JsonRESTError):
     def __init__(self, source_table_name: str):
         er = ERROR_TYPE_PREFIX + "SourceTableNotFoundException"

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -315,7 +315,7 @@ class Item(BaseModel):
     def size(self) -> int:
         return sum(bytesize(key) + value.size() for key, value in self.attrs.items())
 
-    def to_json(self) -> Dict[str, Any]:
+    def to_json(self, root_attr_name: str = "Attributes") -> Dict[str, Any]:
         attributes: Dict[str, Any] = {}
         for attribute_key, attribute in self.attrs.items():
             if isinstance(attribute.value, dict):
@@ -333,7 +333,7 @@ class Item(BaseModel):
             else:
                 attributes[attribute_key] = {attribute.type: attribute.value}
 
-        return {"Attributes": attributes}
+        return {root_attr_name: attributes}
 
     def to_regular_json(self) -> Dict[str, Any]:
         attributes = {}

--- a/tests/test_dynamodb/__init__.py
+++ b/tests/test_dynamodb/__init__.py
@@ -32,8 +32,101 @@ def dynamodb_aws_verified(
 
     def inner(func):
         @wraps(func)
-        def pagination_wrapper():
+        def pagination_wrapper(**kwargs):
             table_name = "t" + str(uuid4())[0:6]
+            if create_table:
+                kwargs["table_name"] = table_name
+
+            def create_table_and_test():
+                client = boto3.client("dynamodb", region_name="us-east-1")
+
+                range_type = "N" if numeric_range else "S"
+                gsi_range_type = "N" if numeric_gsi_range else "S"
+                lsi_range_type = "N" if numeric_lsi_range else "S"
+
+                db_kwargs = {
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"}
+                    ],
+                }
+                if add_range or numeric_range:
+                    db_kwargs["KeySchema"].append(
+                        {"AttributeName": "sk", "KeyType": "RANGE"}
+                    )
+                    db_kwargs["AttributeDefinitions"].append(
+                        {"AttributeName": "sk", "AttributeType": range_type}
+                    )
+                if add_gsi:
+                    db_kwargs["GlobalSecondaryIndexes"] = [
+                        {
+                            "IndexName": "test_gsi",
+                            "KeySchema": [
+                                {"AttributeName": "gsi_pk", "KeyType": "HASH"},
+                            ],
+                            "Projection": {"ProjectionType": "ALL"},
+                            "ProvisionedThroughput": {
+                                "ReadCapacityUnits": 1,
+                                "WriteCapacityUnits": 1,
+                            },
+                        }
+                    ]
+                    db_kwargs["AttributeDefinitions"].append(
+                        {"AttributeName": "gsi_pk", "AttributeType": "S"}
+                    )
+                if add_gsi_range or numeric_gsi_range:
+                    db_kwargs["GlobalSecondaryIndexes"] = [
+                        {
+                            "IndexName": "test_gsi",
+                            "KeySchema": [
+                                {"AttributeName": "gsi_pk", "KeyType": "HASH"},
+                                {"AttributeName": "gsi_sk", "KeyType": "RANGE"},
+                            ],
+                            "Projection": {"ProjectionType": "ALL"},
+                            "ProvisionedThroughput": {
+                                "ReadCapacityUnits": 1,
+                                "WriteCapacityUnits": 1,
+                            },
+                        }
+                    ]
+                    db_kwargs["AttributeDefinitions"].append(
+                        {"AttributeName": "gsi_pk", "AttributeType": "S"}
+                    )
+                    db_kwargs["AttributeDefinitions"].append(
+                        {"AttributeName": "gsi_sk", "AttributeType": gsi_range_type}
+                    )
+                if add_lsi or numeric_lsi_range:
+                    db_kwargs["LocalSecondaryIndexes"] = [
+                        {
+                            "IndexName": "test_lsi",
+                            "KeySchema": [
+                                {"AttributeName": "pk", "KeyType": "HASH"},
+                                {"AttributeName": "lsi_sk", "KeyType": "RANGE"},
+                            ],
+                            "Projection": {"ProjectionType": "ALL"},
+                        }
+                    ]
+                    db_kwargs["AttributeDefinitions"].append(
+                        {"AttributeName": "lsi_sk", "AttributeType": lsi_range_type}
+                    )
+                client.create_table(
+                    TableName=kwargs["table_name"],
+                    ProvisionedThroughput={
+                        "ReadCapacityUnits": 1,
+                        "WriteCapacityUnits": 5,
+                    },
+                    Tags=[{"Key": "environment", "Value": "moto_tests"}],
+                    **db_kwargs,
+                )
+                waiter = client.get_waiter("table_exists")
+                waiter.wait(TableName=kwargs["table_name"])
+                try:
+                    resp = func(**kwargs)
+                finally:
+                    ### CLEANUP ###
+                    client.delete_table(TableName=kwargs["table_name"])
+
+                return resp
 
             allow_aws_request = (
                 os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
@@ -42,99 +135,15 @@ def dynamodb_aws_verified(
             if allow_aws_request:
                 if create_table:
                     print(f"Test {func} will create DDB Table {table_name}")  # noqa
-                    return create_table_and_test(table_name)
+                    return create_table_and_test()
                 else:
-                    return func()
+                    return func(**kwargs)
             else:
                 with mock_aws():
                     if create_table:
-                        return create_table_and_test(table_name)
+                        return create_table_and_test()
                     else:
-                        return func()
-
-        def create_table_and_test(table_name):
-            client = boto3.client("dynamodb", region_name="us-east-1")
-
-            range_type = "N" if numeric_range else "S"
-            gsi_range_type = "N" if numeric_gsi_range else "S"
-            lsi_range_type = "N" if numeric_lsi_range else "S"
-
-            kwargs = {
-                "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
-                "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
-            }
-            if add_range or numeric_range:
-                kwargs["KeySchema"].append({"AttributeName": "sk", "KeyType": "RANGE"})
-                kwargs["AttributeDefinitions"].append(
-                    {"AttributeName": "sk", "AttributeType": range_type}
-                )
-            if add_gsi:
-                kwargs["GlobalSecondaryIndexes"] = [
-                    {
-                        "IndexName": "test_gsi",
-                        "KeySchema": [
-                            {"AttributeName": "gsi_pk", "KeyType": "HASH"},
-                        ],
-                        "Projection": {"ProjectionType": "ALL"},
-                        "ProvisionedThroughput": {
-                            "ReadCapacityUnits": 1,
-                            "WriteCapacityUnits": 1,
-                        },
-                    }
-                ]
-                kwargs["AttributeDefinitions"].append(
-                    {"AttributeName": "gsi_pk", "AttributeType": "S"}
-                )
-            if add_gsi_range or numeric_gsi_range:
-                kwargs["GlobalSecondaryIndexes"] = [
-                    {
-                        "IndexName": "test_gsi",
-                        "KeySchema": [
-                            {"AttributeName": "gsi_pk", "KeyType": "HASH"},
-                            {"AttributeName": "gsi_sk", "KeyType": "RANGE"},
-                        ],
-                        "Projection": {"ProjectionType": "ALL"},
-                        "ProvisionedThroughput": {
-                            "ReadCapacityUnits": 1,
-                            "WriteCapacityUnits": 1,
-                        },
-                    }
-                ]
-                kwargs["AttributeDefinitions"].append(
-                    {"AttributeName": "gsi_pk", "AttributeType": "S"}
-                )
-                kwargs["AttributeDefinitions"].append(
-                    {"AttributeName": "gsi_sk", "AttributeType": gsi_range_type}
-                )
-            if add_lsi or numeric_lsi_range:
-                kwargs["LocalSecondaryIndexes"] = [
-                    {
-                        "IndexName": "test_lsi",
-                        "KeySchema": [
-                            {"AttributeName": "pk", "KeyType": "HASH"},
-                            {"AttributeName": "lsi_sk", "KeyType": "RANGE"},
-                        ],
-                        "Projection": {"ProjectionType": "ALL"},
-                    }
-                ]
-                kwargs["AttributeDefinitions"].append(
-                    {"AttributeName": "lsi_sk", "AttributeType": lsi_range_type}
-                )
-            client.create_table(
-                TableName=table_name,
-                ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 5},
-                Tags=[{"Key": "environment", "Value": "moto_tests"}],
-                **kwargs,
-            )
-            waiter = client.get_waiter("table_exists")
-            waiter.wait(TableName=table_name)
-            try:
-                resp = func(table_name)
-            finally:
-                ### CLEANUP ###
-                client.delete_table(TableName=table_name)
-
-            return resp
+                        return func(**kwargs)
 
         return pagination_wrapper
 


### PR DESCRIPTION
The tests have been modified so that they now pass against AWS, and properly clean up any created buckets/tables afterwards.

Logic changes:
 - Table Validation is now done syncronously
 - Format has been changed to:
```
{"hash": "item1", ...}
{"hash": "item1", ...}
```