### PR TITLE
CloudWatch: get_metric_data() now returns everything when querying for Metric Insights Queries

### DIFF
--- a/tests/test_cloudwatch/__init__.py
+++ b/tests/test_cloudwatch/__init__.py
@@ -1,1 +1,28 @@
-# This file is intentionally left blank.
+import os
+from functools import wraps
+
+from moto import mock_aws
+
+
+def cloudwatch_aws_verified(func):
+    """
+    Function that is verified to work against AWS.
+    Can be run against AWS at any time by setting:
+      MOTO_TEST_ALLOW_AWS_REQUEST=true
+
+    If this environment variable is not set, the function runs in a `mock_aws` context.
+    """
+
+    @wraps(func)
+    def pagination_wrapper(**kwargs):
+        allow_aws_request = (
+            os.environ.get("MOTO_TEST_ALLOW_AWS_REQUEST", "false").lower() == "true"
+        )
+
+        if allow_aws_request:
+            return func(**kwargs)
+        else:
+            with mock_aws():
+                return func(**kwargs)
+
+    return pagination_wrapper

--- a/tests/test_cloudwatch/test_cloudwatch_expressions.py
+++ b/tests/test_cloudwatch/test_cloudwatch_expressions.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timedelta, timezone
+from time import sleep
+from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from tests.test_cloudwatch import cloudwatch_aws_verified
 
 
 @mock_aws
@@ -69,3 +72,60 @@ def test_get_metric_data_with_simple_expression():
     assert results[0]["Id"] == "result1"
     assert results[0]["Label"] == "e1"
     assert results[0]["Values"] == [25.0]
+
+
+@cloudwatch_aws_verified
+@pytest.mark.aws_verified
+def test_get_metric_data_with_expressive_expression():
+    cloudwatch = boto3.client("cloudwatch", "eu-west-1")
+    my_namespace = f"Test/FakeNamespace_{str(uuid4())[0:6]}"
+    cloudwatch.put_metric_data(
+        Namespace=my_namespace,
+        MetricData=[
+            {
+                "MetricName": "ApiResponse",
+                "Dimensions": [
+                    {"Name": "Path", "Value": "/my/path"},
+                    {"Name": "Audience", "Value": "my audience"},
+                ],
+                "Timestamp": datetime.utcnow(),
+                "StatisticValues": {
+                    "Maximum": 10,
+                    "Minimum": 0,
+                    "Sum": 10,
+                    "SampleCount": 10,
+                },
+            }
+        ],
+    )
+
+    expression = f"SELECT SUM(ApiResponse) FROM \"{my_namespace}\" WHERE Path = '/my/path' GROUP BY Audience"
+    start_time = datetime.utcnow() - timedelta(hours=1)
+    end_time = datetime.utcnow() + timedelta(hours=1)
+
+    for _ in range(60):
+        result = cloudwatch.get_metric_data(
+            StartTime=start_time,
+            EndTime=end_time,
+            MetricDataQueries=[
+                {
+                    "Id": "query",
+                    "Period": 60,
+                    "Expression": expression,
+                }
+            ],
+        )["MetricDataResults"]
+        if result:
+            assert len(result) == 1
+            assert result[0]["Id"] == "query"
+            # If the Label is not supplied, AWS uses:
+            #     the group value as the query name, if the query contains a GROUP BY clause
+            #     the Id if no GROUP BY clause exists
+            # But Moto doesn't understand expressions, so we always use the Id
+            assert result[0]["Label"]
+            assert result[0]["Values"] == [10.0]
+            assert result[0]["StatusCode"] == "Complete"
+            return
+        else:
+            sleep(5)
+    assert False, "Should have found metrics within 5 minutes"


### PR DESCRIPTION
Fixes #7781 