### PR TITLE
ACM-PCA: Fix x.509 certificate generation

### DIFF
--- a/moto/acmpca/exceptions.py
+++ b/moto/acmpca/exceptions.py
@@ -16,3 +16,13 @@ class InvalidS3ObjectAclInCrlConfiguration(JsonRESTError):
             "InvalidS3ObjectAclInCrlConfiguration",
             f"Invalid value for parameter RevocationConfiguration.CrlConfiguration.S3ObjectAcl, value: {value}, valid values: ['PUBLIC_READ', 'BUCKET_OWNER_FULL_CONTROL']",
         )
+
+
+class InvalidStateException(JsonRESTError):
+    code = 400
+
+    def __init__(self, arn: str):
+        super().__init__(
+            "InvalidStateException",
+            f"The certificate authority {arn} is not in the correct state to have a certificate signing request.",
+        )

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -61,22 +61,34 @@ class CertificateAuthority(BaseModel):
         self.issued_certificates: Dict[str, bytes] = dict()
 
         subject = self.certificate_authority_configuration.get("Subject", {})
-        common_name = subject.get("CommonName", "getmoto.org")
-        country = subject.get("Country", "IN")
-        state = subject.get("State", "GA")
-        organisation = subject.get("Organization", "Moto")
-        organisation_unit = subject.get("OrganizationalUnit", "Testing")
-        self.issuer = x509.Name(
-            [
-                x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
-                x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state),
-                x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organisation),
+        name_attributes = []
+        if "Country" in subject:
+            name_attributes.append(
+                x509.NameAttribute(x509.NameOID.COUNTRY_NAME, subject["Country"])
+            )
+        if "State" in subject:
+            name_attributes.append(
                 x509.NameAttribute(
-                    x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organisation_unit
-                ),
-                x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name),
-            ]
-        )
+                    x509.NameOID.STATE_OR_PROVINCE_NAME, subject["State"]
+                )
+            )
+        if "Organization" in subject:
+            name_attributes.append(
+                x509.NameAttribute(
+                    x509.NameOID.ORGANIZATION_NAME, subject["Organization"]
+                )
+            )
+        if "OrganizationalUnit" in subject:
+            name_attributes.append(
+                x509.NameAttribute(
+                    x509.NameOID.ORGANIZATIONAL_UNIT_NAME, subject["OrganizationalUnit"]
+                )
+            )
+        if "CommonName" in subject:
+            name_attributes.append(
+                x509.NameAttribute(x509.NameOID.COMMON_NAME, subject["CommonName"])
+            )
+        self.issuer = x509.Name(name_attributes)
         self.csr = self._ca_csr(self.issuer)
 
     def generate_cert(

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -63,11 +63,13 @@ class CertificateAuthority(BaseModel):
         subject = self.certificate_authority_configuration.get("Subject", {})
         common_name = subject.get("CommonName", "getmoto.org")
         country = subject.get("Country", "IN")
+        state = subject.get("State", "GA")
         organisation = subject.get("Organization", "Moto")
-        organisation_unit = subject.get("OrganizationUnit", "Test")
+        organisation_unit = subject.get("OrganizationalUnit", "Testing")
         self.issuer = x509.Name(
             [
                 x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
+                x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state),
                 x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organisation),
                 x509.NameAttribute(
                     x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organisation_unit

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -102,7 +102,7 @@ class CertificateAuthority(BaseModel):
 
         return cert.public_bytes(serialization.Encoding.PEM)
 
-    def _ca_csr(self, issuer) -> bytes:
+    def _ca_csr(self, issuer: x509.Name) -> bytes:
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(issuer)
@@ -118,7 +118,9 @@ class CertificateAuthority(BaseModel):
         csr = x509.load_pem_x509_csr(base64.b64decode(csr_bytes))
         extensions = self._x509_extensions(csr, template_arn)
         new_cert = self.generate_cert(
-            subject=csr.subject, public_key=csr.public_key(), extensions=extensions
+            subject=csr.subject,
+            public_key=csr.public_key(),  # type: ignore[arg-type]
+            extensions=extensions,
         )
 
         cert_id = str(mock_random.uuid4()).replace("-", "")
@@ -215,7 +217,7 @@ class CertificateAuthority(BaseModel):
         if cn:
             extensions.append(
                 (
-                    x509.SubjectAlternativeName([x509.DNSName(cn[0].value)]),
+                    x509.SubjectAlternativeName([x509.DNSName(cn[0].value)]),  # type: ignore[arg-type]
                     False,
                 ),
             )

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -4,11 +4,10 @@ import base64
 import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-import cryptography.hazmat.primitives.asymmetric.rsa
-import cryptography.x509
+from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.x509 import Certificate, NameOID, load_pem_x509_certificate
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -17,7 +16,11 @@ from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 
-from .exceptions import InvalidS3ObjectAclInCrlConfiguration, ResourceNotFoundException
+from .exceptions import (
+    InvalidS3ObjectAclInCrlConfiguration,
+    InvalidStateException,
+    ResourceNotFoundException,
+)
 
 
 class CertificateAuthority(BaseModel):
@@ -46,83 +49,176 @@ class CertificateAuthority(BaseModel):
         self.usage_mode = "SHORT_LIVED_CERTIFICATE"
         self.security_standard = security_standard or "FIPS_140_2_LEVEL_3_OR_HIGHER"
 
-        self.common_name = self.certificate_authority_configuration.get(
-            "Subject", {}
-        ).get("CommonName", "Moto.org")
-        self.key = cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key(
-            public_exponent=65537, key_size=2048
-        )
+        self.key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         self.password = str(mock_random.uuid4()).encode("utf-8")
         self.private_bytes = self.key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.BestAvailableEncryption(self.password),
         )
-        self.certificate: Optional[Certificate] = None
+        self.certificate: Optional[x509.Certificate] = None
         self.certificate_chain: Optional[bytes] = None
-        self.csr = self.generate_csr(self.common_name)
-
         self.issued_certificates: Dict[str, bytes] = dict()
 
-    def generate_cert(self, common_name: str, subject: cryptography.x509.Name) -> bytes:
-        issuer = cryptography.x509.Name(
-            [  # C = US, O = Amazon, OU = Server CA 1B, CN = Amazon
-                cryptography.x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-                cryptography.x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Amazon"),
-                cryptography.x509.NameAttribute(
-                    NameOID.ORGANIZATIONAL_UNIT_NAME, "Server CA 1B"
+        subject = self.certificate_authority_configuration.get("Subject", {})
+        common_name = subject.get("CommonName", "getmoto.org")
+        country = subject.get("Country", "IN")
+        organisation = subject.get("Organization", "Moto")
+        organisation_unit = subject.get("OrganizationUnit", "Test")
+        self.issuer = x509.Name(
+            [
+                x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
+                x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organisation),
+                x509.NameAttribute(
+                    x509.NameOID.ORGANIZATIONAL_UNIT_NAME, organisation_unit
                 ),
-                cryptography.x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                x509.NameAttribute(x509.NameOID.COMMON_NAME, common_name),
             ]
         )
-        cert = (
-            cryptography.x509.CertificateBuilder()
+        self.csr = self._ca_csr(self.issuer)
+
+    def generate_cert(
+        self,
+        subject: x509.Name,
+        public_key: rsa.RSAPublicKey,
+        extensions: List[Tuple[x509.ExtensionType, bool]],
+    ) -> bytes:
+        builder = (
+            x509.CertificateBuilder()
             .subject_name(subject)
-            .issuer_name(issuer)
-            .public_key(self.key.public_key())
-            .serial_number(cryptography.x509.random_serial_number())
+            .issuer_name(self.issuer)
+            .public_key(public_key)
+            .serial_number(x509.random_serial_number())
             .not_valid_before(utcnow())
             .not_valid_after(utcnow() + datetime.timedelta(days=365))
-            .sign(self.key, hashes.SHA512(), default_backend())
         )
+
+        for extension, critical in extensions:
+            builder = builder.add_extension(extension, critical)
+
+        cert = builder.sign(self.key, hashes.SHA512(), default_backend())
 
         return cert.public_bytes(serialization.Encoding.PEM)
 
-    def generate_csr(self, common_name: str) -> bytes:
+    def _ca_csr(self, issuer) -> bytes:
         csr = (
-            cryptography.x509.CertificateSigningRequestBuilder()
-            .subject_name(
-                cryptography.x509.Name(
-                    [
-                        cryptography.x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
-                        cryptography.x509.NameAttribute(
-                            NameOID.STATE_OR_PROVINCE_NAME, "California"
-                        ),
-                        cryptography.x509.NameAttribute(
-                            NameOID.LOCALITY_NAME, "San Francisco"
-                        ),
-                        cryptography.x509.NameAttribute(
-                            NameOID.ORGANIZATION_NAME, "My Company"
-                        ),
-                        cryptography.x509.NameAttribute(
-                            NameOID.COMMON_NAME, common_name
-                        ),
-                    ]
-                )
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(issuer)
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=None),
+                critical=True,
             )
             .sign(self.key, hashes.SHA256())
         )
         return csr.public_bytes(serialization.Encoding.PEM)
 
-    def issue_certificate(self, csr_bytes: bytes) -> str:
-        cert = cryptography.x509.load_pem_x509_csr(base64.b64decode(csr_bytes))
+    def issue_certificate(self, csr_bytes: bytes, template_arn: Optional[str]) -> str:
+        csr = x509.load_pem_x509_csr(base64.b64decode(csr_bytes))
+        extensions = self._x509_extensions(csr, template_arn)
         new_cert = self.generate_cert(
-            common_name=self.common_name, subject=cert.subject
+            subject=csr.subject, public_key=csr.public_key(), extensions=extensions
         )
+
         cert_id = str(mock_random.uuid4()).replace("-", "")
         cert_arn = f"arn:{get_partition(self.region_name)}:acm-pca:{self.region_name}:{self.account_id}:certificate-authority/{self.id}/certificate/{cert_id}"
         self.issued_certificates[cert_arn] = new_cert
         return cert_arn
+
+    def _x509_extensions(
+        self, csr: x509.CertificateSigningRequest, template_arn: Optional[str]
+    ) -> List[Tuple[x509.ExtensionType, bool]]:
+        """
+        Uses a PCA certificate template ARN to return a list of X.509 extensions.
+        These extensions are part of the constructed certificate.
+
+        See https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html
+        """
+        extensions = []
+
+        if template_arn == "arn:aws:acm-pca:::template/RootCACertificate/V1":
+            extensions.extend(
+                [
+                    (
+                        x509.BasicConstraints(ca=True, path_length=None),
+                        True,
+                    ),
+                    (
+                        x509.KeyUsage(
+                            crl_sign=True,
+                            key_cert_sign=True,
+                            digital_signature=True,
+                            content_commitment=False,
+                            key_encipherment=False,
+                            data_encipherment=False,
+                            key_agreement=False,
+                            encipher_only=False,
+                            decipher_only=False,
+                        ),
+                        True,
+                    ),
+                    (
+                        x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+                        False,
+                    ),
+                ]
+            )
+
+        elif template_arn in (
+            "arn:aws:acm-pca:::template/EndEntityCertificate/V1",
+            None,
+        ):
+            extensions.extend(
+                [
+                    (
+                        x509.BasicConstraints(ca=False, path_length=None),
+                        True,
+                    ),
+                    (
+                        x509.AuthorityKeyIdentifier.from_issuer_public_key(
+                            self.key.public_key()
+                        ),
+                        False,
+                    ),
+                    (
+                        x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+                        False,
+                    ),
+                    (
+                        x509.KeyUsage(
+                            crl_sign=False,
+                            key_cert_sign=False,
+                            digital_signature=True,
+                            content_commitment=False,
+                            key_encipherment=True,
+                            data_encipherment=False,
+                            key_agreement=False,
+                            encipher_only=False,
+                            decipher_only=False,
+                        ),
+                        True,
+                    ),
+                    (
+                        x509.ExtendedKeyUsage(
+                            [
+                                x509.ExtendedKeyUsageOID.SERVER_AUTH,
+                                x509.ExtendedKeyUsageOID.CLIENT_AUTH,
+                            ]
+                        ),
+                        False,
+                    ),
+                ]
+            )
+
+        cn = csr.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+        if cn:
+            extensions.append(
+                (
+                    x509.SubjectAlternativeName([x509.DNSName(cn[0].value)]),
+                    False,
+                ),
+            )
+
+        return extensions
 
     def get_certificate(self, certificate_arn: str) -> bytes:
         return self.issued_certificates[certificate_arn]
@@ -171,7 +267,7 @@ class CertificateAuthority(BaseModel):
     def import_certificate_authority_certificate(
         self, certificate: bytes, certificate_chain: Optional[bytes]
     ) -> None:
-        self.certificate = load_pem_x509_certificate(certificate)
+        self.certificate = x509.load_pem_x509_certificate(certificate)
         self.certificate_chain = certificate_chain
         self.status = "ACTIVE"
         self.updated_at = unix_time()
@@ -243,6 +339,8 @@ class ACMPCABackend(BaseBackend):
         self, certificate_authority_arn: str
     ) -> Tuple[bytes, Optional[bytes]]:
         ca = self.describe_certificate_authority(certificate_authority_arn)
+        if ca.status != "ACTIVE":
+            raise InvalidStateException(certificate_authority_arn)
         return ca.certificate_bytes, ca.certificate_chain
 
     def get_certificate_authority_csr(self, certificate_authority_arn: str) -> bytes:
@@ -273,13 +371,15 @@ class ACMPCABackend(BaseBackend):
         ca = self.describe_certificate_authority(certificate_authority_arn)
         ca.status = "DELETED"
 
-    def issue_certificate(self, certificate_authority_arn: str, csr: bytes) -> str:
+    def issue_certificate(
+        self, certificate_authority_arn: str, csr: bytes, template_arn: Optional[str]
+    ) -> str:
         """
-        The following parameters are not yet implemented: ApiPassthrough, SigningAlgorithm, TemplateArn, Validity, ValidityNotBefore, IdempotencyToken
+        The following parameters are not yet implemented: ApiPassthrough, SigningAlgorithm, Validity, ValidityNotBefore, IdempotencyToken
         Some fields of the resulting certificate will have default values, instead of using the CSR
         """
         ca = self.describe_certificate_authority(certificate_authority_arn)
-        certificate_arn = ca.issue_certificate(csr)
+        certificate_arn = ca.issue_certificate(csr, template_arn)
         return certificate_arn
 
     def get_certificate(

--- a/moto/acmpca/responses.py
+++ b/moto/acmpca/responses.py
@@ -100,10 +100,12 @@ class ACMPCAResponse(BaseResponse):
     def issue_certificate(self) -> str:
         params = json.loads(self.body)
         certificate_authority_arn = params.get("CertificateAuthorityArn")
+        template_arn = params.get("TemplateArn")
         csr = params.get("Csr").encode("utf-8")
         certificate_arn = self.acmpca_backend.issue_certificate(
             certificate_authority_arn=certificate_authority_arn,
             csr=csr,
+            template_arn=template_arn,
         )
         return json.dumps(dict(CertificateArn=certificate_arn))
 

--- a/tests/test_acmpca/test_acmpca.py
+++ b/tests/test_acmpca/test_acmpca.py
@@ -461,12 +461,10 @@ def test_end_entity_certificate_issuance():
     )
     builder = cryptography.x509.verification.PolicyBuilder().store(store)
     verifier = builder.build_server_verifier(DNSName("bezoscorp.com"))
-    assert (
-        verifier.verify(
-            cryptography.x509.load_pem_x509_certificate(ee_cert.encode("utf-8")), []
-        )
-        == 2
+    chain = verifier.verify(
+        cryptography.x509.load_pem_x509_certificate(ee_cert.encode("utf-8")), []
     )
+    assert len(chain) == 2
 
 
 @mock_aws


### PR DESCRIPTION
This PR fixes ACM-PCA so that it generates valid set of certificates. The certificate parameters (x.509 extensions, etc.) now resemble AWS.

- `CreateCertificateAuthority` now obeys certificate subject attributes provided by the client (only country, state, organisation, organisational unit and common name)
- `GetCertificateAuthorityCsr` now produces a CSR with proper CA attributes and extensions
- `IssueCertificate` gains limited support for [certificate templates](https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html) (only [RootCACertificate/V1](https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html#RootCACertificate-V1) and [EndEntityCertificate/V1](https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html#EndEntityCertificate-V1)). Accordingly, appropriate X.509 extensions are added to the issued certificate.
- `GetCertificateAuthorityCertificate` now raises if the CA is not in correct state (as opposed to returning empty values earlier)