### PR TITLE
Fix issues for non-default partitions in elastictranscoder, sagemaker, and SSM

### DIFF
--- a/moto/elastictranscoder/responses.py
+++ b/moto/elastictranscoder/responses.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
+from moto.utilities.utils import ARN_PARTITION_REGEX
 
 from .models import ElasticTranscoderBackend, elastictranscoder_backends
 
@@ -45,7 +46,7 @@ class ElasticTranscoderResponse(BaseResponse):
         thumbnail_config = self._get_param("ThumbnailConfig")
         if not role:
             return self.err("Role cannot be blank")
-        if not re.match("^arn:aws:iam::[0-9]+:role/.+", role):
+        if not re.match(f"{ARN_PARTITION_REGEX}:iam::[0-9]+:role/.+", role):
             return self.err(f"Role ARN is invalid: {role}")
         if not output_bucket and not content_config:
             return self.err(

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -4764,7 +4764,7 @@ class SageMakerModelBackend(BaseBackend):
         return cluster.arn
 
     def describe_cluster(self, cluster_name: str) -> Dict[str, Any]:
-        if cluster_name.startswith("arn:aws:sagemaker:"):
+        if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
         if not cluster:
@@ -4772,7 +4772,7 @@ class SageMakerModelBackend(BaseBackend):
         return cluster.describe()
 
     def delete_cluster(self, cluster_name: str) -> str:
-        if cluster_name.startswith("arn:aws:sagemaker:"):
+        if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
         if not cluster:
@@ -4783,7 +4783,7 @@ class SageMakerModelBackend(BaseBackend):
         return arn
 
     def describe_cluster_node(self, cluster_name: str, node_id: str) -> Dict[str, Any]:
-        if cluster_name.startswith("arn:aws:sagemaker:"):
+        if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
         if not cluster:
@@ -4832,7 +4832,7 @@ class SageMakerModelBackend(BaseBackend):
         sort_by: Optional[str],
         sort_order: Optional[str],
     ) -> List[ClusterNode]:
-        if cluster_name.startswith("arn:aws:sagemaker:"):
+        if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
         cluster = self.clusters.get(cluster_name)
         if not cluster:
@@ -6052,9 +6052,7 @@ class FakeModelBiasJobDefinition(BaseObject):
 
     @staticmethod
     def arn_formatter(name: str, account_id: str, region: str) -> str:
-        return (
-            f"arn:aws:sagemaker:{region}:{account_id}:model-bias-job-definition/{name}"
-        )
+        return f"arn:{get_partition(region)}:sagemaker:{region}:{account_id}:model-bias-job-definition/{name}"
 
     @property
     def summary_object(self) -> Dict[str, str]:

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1187,7 +1187,9 @@ class SimpleSystemManagerBackend(BaseBackend):
 
         self.windows: Dict[str, FakeMaintenanceWindow] = dict()
         self.baselines: Dict[str, FakePatchBaseline] = dict()
-        self.ssm_prefix = f"arn:aws:ssm:{self.region_name}:{self.account_id}:parameter"
+        self.ssm_prefix = (
+            f"arn:{self.partition}:ssm:{self.region_name}:{self.account_id}:parameter"
+        )
 
     def _generate_document_information(
         self, ssm_document: Document, document_format: str


### PR DESCRIPTION
## Motivation
During extensive testing, I found some more errors when accepting / generating ARNs for partitions other than `aws` in moto.

## Changes
* Accept role ARNs from non-default partitions in elastictranscoder
* Accept cluster ARNs from non-default partitions in sagemaker
* Properly generate the SSM prefix, to strip it correctly in the `get_parameter` operation.