### PR TITLE
EC2: Terminating an instance now also terminates any NIC's

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -170,7 +170,7 @@ class InvalidNetworkInterfaceIdError(EC2ClientError):
     def __init__(self, eni_id: str):
         super().__init__(
             "InvalidNetworkInterfaceID.NotFound",
-            f"The network interface ID '{eni_id}' does not exist",
+            f"The networkInterface ID '{eni_id}' does not exist",
         )
 
 

--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -34,6 +34,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         group_ids: Optional[List[str]] = None,
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
+        delete_on_termination: Optional[bool] = False,
         **kwargs: Any,
     ):
         self.ec2_backend = ec2_backend
@@ -51,7 +52,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         self.instance: Optional[Instance] = None
         self.attachment_id: Optional[str] = None
         self.attach_time: Optional[str] = None
-        self.delete_on_termination = False
+        self.delete_on_termination = delete_on_termination
         self.description = description
         self.source_dest_check = True
 
@@ -201,6 +202,9 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         )
         return network_interface
 
+    def delete(self) -> None:
+        self.ec2_backend.delete_network_interface(eni_id=self.id)
+
     def stop(self) -> None:
         if self.public_ip_auto_assign:
             self.public_ip = None
@@ -278,6 +282,7 @@ class NetworkInterfaceBackend:
         group_ids: Optional[List[str]] = None,
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
+        delete_on_termination: Optional[bool] = False,
         **kwargs: Any,
     ) -> NetworkInterface:
         eni = NetworkInterface(
@@ -288,6 +293,7 @@ class NetworkInterfaceBackend:
             group_ids=group_ids,
             description=description,
             tags=tags,
+            delete_on_termination=delete_on_termination,
             **kwargs,
         )
         self.enis[eni.id] = eni

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -394,6 +394,8 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
         for nic in self.nics.values():
             nic.stop()
+            if nic.delete_on_termination:
+                nic.delete()
 
         self.teardown_defaults()
 
@@ -538,6 +540,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
                     device_index=device_index,
                     public_ip_auto_assign=nic.get("AssociatePublicIpAddress", False),
                     group_ids=group_ids,
+                    delete_on_termination=nic.get("DeleteOnTermination") == "true",
                 )
 
             self.attach_eni(use_nic, device_index)

--- a/moto/ec2/responses/elastic_network_interfaces.py
+++ b/moto/ec2/responses/elastic_network_interfaces.py
@@ -321,7 +321,7 @@ DESCRIBE_NETWORK_INTERFACES_RESPONSE = """<DescribeNetworkInterfacesResponse xml
             <attachment>
                 <attachTime>{{ eni.attach_time }}</attachTime>
                 <attachmentId>{{ eni.attachment_id }}</attachmentId>
-                <deleteOnTermination>{{ eni.delete_on_termination }}</deleteOnTermination>
+                <deleteOnTermination>{{ 'true' if eni.delete_on_termination else 'false' }}</deleteOnTermination>
                 <deviceIndex>{{ eni.device_index }}</deviceIndex>
                 <networkCardIndex>0</networkCardIndex>
                 <instanceId>{{ eni.instance.id }}</instanceId>
@@ -418,7 +418,7 @@ DESCRIBE_NETWORK_INTERFACE_ATTRIBUTE_RESPONSE_ATTACHMENT = """
     <attachment>
         <attachTime>{{ eni.attach_time }}</attachTime>
         <attachmentId>{{ eni.attachment_id }}</attachmentId>
-        <deleteOnTermination>{{ eni.delete_on_termination }}</deleteOnTermination>
+        <deleteOnTermination>{{ 'true' if eni.delete_on_termination else 'false' }}</deleteOnTermination>
         <deviceIndex>{{ eni.device_index }}</deviceIndex>
         <networkCardIndex>0</networkCardIndex>
         <instanceId>{{ eni.instance.id }}</instanceId>

--- a/tests/test_ec2/test_elastic_network_interfaces.py
+++ b/tests/test_ec2/test_elastic_network_interfaces.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.ec2.utils import random_private_ip
-from tests import EXAMPLE_AMI_ID
+from tests import EXAMPLE_AMI_ID, aws_verified
 
 
 @mock_aws
@@ -967,6 +967,57 @@ def test_eni_detachment():
         ex.value.response["Error"]["Message"]
         == "The network interface at device index 0 and networkCard index 0 cannot be detached."
     )
+
+
+@aws_verified
+@pytest.mark.aws_verified
+@pytest.mark.parametrize(
+    "delete_eni", [True, False], ids=["DeleteOnTermination", "KeepOnTermination"]
+)
+def test_create_instance__termination_deletes_eni(delete_eni):
+    ssm = boto3.client("ssm", "us-east-1")
+    kernel_61 = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64"
+    ami_id = ssm.get_parameter(Name=kernel_61)["Parameter"]["Value"]
+
+    ec2_client = boto3.client("ec2", "us-east-1")
+    existing_subnet_id = ec2_client.describe_subnets()["Subnets"][0]["SubnetId"]
+
+    instance = ec2_client.run_instances(
+        MaxCount=1,
+        MinCount=1,
+        ImageId=ami_id,
+        InstanceType="t3a.small",
+        NetworkInterfaces=[
+            {
+                "DeleteOnTermination": delete_eni,
+                "DeviceIndex": 0,
+                "SubnetId": existing_subnet_id,
+            }
+        ],
+    )["Instances"][0]
+    instance_id = instance["InstanceId"]
+    ec2_client.get_waiter("instance_running").wait(InstanceIds=[instance_id])
+
+    eni_id = instance["NetworkInterfaces"][0]["NetworkInterfaceId"]
+    eni = ec2_client.describe_network_interfaces(NetworkInterfaceIds=[eni_id])[
+        "NetworkInterfaces"
+    ][0]
+    assert eni["Attachment"]["DeleteOnTermination"] is delete_eni
+
+    ec2_client.terminate_instances(InstanceIds=[instance_id])
+    ec2_client.get_waiter("instance_terminated").wait(InstanceIds=[instance_id])
+
+    if delete_eni:
+        with pytest.raises(ClientError) as exc:
+            ec2_client.describe_network_interfaces(NetworkInterfaceIds=[eni_id])
+        err = exc.value.response["Error"]
+        assert err["Code"] == "InvalidNetworkInterfaceID.NotFound"
+        assert err["Message"] == f"The networkInterface ID '{eni_id}' does not exist"
+    else:
+        # Still exists - let's manually delete
+        ec2_client.describe_network_interfaces(NetworkInterfaceIds=[eni_id])
+
+        ec2_client.delete_network_interface(NetworkInterfaceId=eni_id)
 
 
 def setup_vpc(boto3):  # pylint: disable=W0621


### PR DESCRIPTION
Fixes #7896 

The `DeleteOnTermination` attribute is now also returned properly - before it would always come back as False, regardless of what was configured.