### PR TITLE
fix: make home_directory_mappings arg for Transfer's create_user() optional

### DIFF
--- a/moto/transfer/models.py
+++ b/moto/transfer/models.py
@@ -131,7 +131,7 @@ class TransferBackend(BaseBackend):
         self,
         home_directory: Optional[str],
         home_directory_type: Optional[UserHomeDirectoryType],
-        home_directory_mappings: List[Dict[str, Optional[str]]],
+        home_directory_mappings: Optional[List[Dict[str, Optional[str]]]],
         policy: Optional[str],
         posix_profile: Optional[Dict[str, Any]],
         role: str,
@@ -150,7 +150,7 @@ class TransferBackend(BaseBackend):
             tags=(tags or []),
             user_name=user_name,
         )
-        if len(home_directory_mappings) > 0:
+        if home_directory_mappings:
             for mapping in home_directory_mappings:
                 user.home_directory_mappings.append(
                     {


### PR DESCRIPTION
Related issue https://github.com/getmoto/moto/issues/7790 and PR https://github.com/getmoto/moto/pull/7891, in particular comment https://github.com/getmoto/moto/pull/7891#issuecomment-2272715013. Tagging @bblommers and @armichaud.

The `HomeDirectoryMappings` argument for the Transfer client’s `create_user()` function is _not_ marked as required, i.e. it’s optional, and should be typed & handled as such. Docs [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/transfer/client/create_user.html).

Refs: 416e30425cf9acff77adcb64c6466a4155fe1c4b