### PR TITLE
CloudFormation: create_change_set ChangeSetName more rules

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1006,17 +1006,7 @@ class CloudFormationBackend(BaseBackend):
         tags: Optional[Dict[str, str]] = None,
         role_arn: Optional[str] = None,
     ) -> Tuple[str, str]:
-        validate_create_change_set(
-            stack_name,
-            change_set_name,
-            template,
-            parameters,
-            description,
-            change_set_type,
-            notification_arns,
-            tags,
-            role_arn,
-        )
+        validate_create_change_set(stack_name)
         if change_set_type == "UPDATE":
             for stack in self.stacks.values():
                 if stack.name == stack_name:

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1006,7 +1006,7 @@ class CloudFormationBackend(BaseBackend):
         tags: Optional[Dict[str, str]] = None,
         role_arn: Optional[str] = None,
     ) -> Tuple[str, str]:
-        validate_create_change_set(stack_name)
+        validate_create_change_set(change_set_name)
         if change_set_type == "UPDATE":
             for stack in self.stacks.values():
                 if stack.name == stack_name:

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -28,6 +28,7 @@ from .utils import (
     generate_stackset_arn,
     generate_stackset_id,
     get_stack_from_s3_url,
+    validate_create_change_set,
     validate_template_cfn_lint,
     yaml_tag_constructor,
 )
@@ -1005,6 +1006,17 @@ class CloudFormationBackend(BaseBackend):
         tags: Optional[Dict[str, str]] = None,
         role_arn: Optional[str] = None,
     ) -> Tuple[str, str]:
+        validate_create_change_set(
+            stack_name,
+            change_set_name,
+            template,
+            parameters,
+            description,
+            change_set_type,
+            notification_arns,
+            tags,
+            role_arn,
+        )
         if change_set_type == "UPDATE":
             for stack in self.stacks.values():
                 if stack.name == stack_name:

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -1,6 +1,6 @@
 import os
 import string
-from typing import Any, Dict, List, Optional
+from typing import Any, List
 from urllib.parse import urlparse
 
 import yaml
@@ -138,17 +138,7 @@ def get_stack_from_s3_url(template_url: str, account_id: str, partition: str) ->
     return key.value.decode("utf-8")  # type: ignore[union-attr]
 
 
-def validate_create_change_set(
-    stack_name: str,
-    change_set_name: str,
-    template: str,
-    parameters: Dict[str, str],
-    description: str,
-    change_set_type: str,
-    notification_arns: Optional[List[str]] = None,
-    tags: Optional[Dict[str, str]] = None,
-    role_arn: Optional[str] = None,
-) -> Any:
+def validate_create_change_set(change_set_name: str) -> None:
     if not (change_set_name and change_set_name[0].isalpha()):
         raise ValidationError(f"Invalid change set name: {change_set_name}")
 

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -1,12 +1,14 @@
 import os
 import string
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 import yaml
 
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.utils import get_partition
+
+from .exceptions import ValidationError
 
 
 def generate_stack_id(stack_name: str, region: str, account: str) -> str:
@@ -134,3 +136,29 @@ def get_stack_from_s3_url(template_url: str, account_id: str, partition: str) ->
 
     key = s3_backends[account_id][partition].get_object(bucket_name, key_name)
     return key.value.decode("utf-8")  # type: ignore[union-attr]
+
+
+def validate_create_change_set(
+    stack_name: str,
+    change_set_name: str,
+    template: str,
+    parameters: Dict[str, str],
+    description: str,
+    change_set_type: str,
+    notification_arns: Optional[List[str]] = None,
+    tags: Optional[Dict[str, str]] = None,
+    role_arn: Optional[str] = None,
+) -> Any:
+    if not (change_set_name and change_set_name[0].isalpha()):
+        raise ValidationError(f"Invalid change set name: {change_set_name}")
+
+    if not all(c.isalnum() or c == "-" for c in change_set_name):
+        raise ValidationError(f"Invalid change set name: {change_set_name}")
+
+    if len(change_set_name) > 128:
+        raise ValidationError(
+            f"Change set name exceeds 128 characters: {change_set_name}"
+        )
+
+    # Additional validations can be added here later
+    return

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -2463,25 +2463,6 @@ def test_create_and_update_stack_with_unknown_resource():
 
 
 @mock_aws
-def test_valid_change_set_name():
-    cf = boto3.client("cloudformation", region_name=REGION_NAME)
-    change_set_name = "valid-change-set-name"
-    create_change_set_response = cf.create_change_set(
-        StackName=TEST_STACK_NAME,
-        ChangeSetName=change_set_name,
-        TemplateBody=json.dumps(dummy_template),
-        Description="Test Change Set",
-        ChangeSetType="CREATE",
-    )
-
-    change_set_id = create_change_set_response.get("Id")
-
-    assert change_set_id.startswith(
-        f"arn:aws:cloudformation:{REGION_NAME}:{ACCOUNT_ID}:changeSet/{change_set_name}/"
-    )
-
-
-@mock_aws
 def test_invalid_change_set_name_starting_char():
     cf = boto3.client("cloudformation", region_name=REGION_NAME)
     with pytest.raises(ClientError):

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1067,7 +1067,7 @@ def test_get_template_summary_for_stack_created_by_changeset_execution():
     conn.create_change_set(
         StackName="stack_from_changeset",
         TemplateBody=json.dumps(dummy_template3),
-        ChangeSetName="test_changeset",
+        ChangeSetName="test-changeset",
         ChangeSetType="CREATE",
     )
     with pytest.raises(
@@ -1075,7 +1075,7 @@ def test_get_template_summary_for_stack_created_by_changeset_execution():
         match="GetTemplateSummary cannot be called on REVIEW_IN_PROGRESS stacks",
     ):
         conn.get_template_summary(StackName="stack_from_changeset")
-    conn.execute_change_set(ChangeSetName="test_changeset")
+    conn.execute_change_set(ChangeSetName="test-changeset")
     result = conn.get_template_summary(StackName="stack_from_changeset")
     assert result["ResourceTypes"] == ["AWS::EC2::VPC"]
     assert result["Version"] == "2010-09-09"
@@ -2460,6 +2460,65 @@ def test_create_and_update_stack_with_unknown_resource():
             cf.update_stack(
                 StackName=TEST_STACK_NAME, TemplateBody=json.dumps(new_template)
             )
+
+
+@mock_aws
+def test_valid_change_set_name():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    change_set_name = "valid-change-set-name"
+    create_change_set_response = cf.create_change_set(
+        StackName=TEST_STACK_NAME,
+        ChangeSetName=change_set_name,
+        TemplateBody=json.dumps(dummy_template),
+        Description="Test Change Set",
+        ChangeSetType="CREATE",
+    )
+
+    change_set_id = create_change_set_response.get("Id")
+
+    assert change_set_id.startswith(
+        f"arn:aws:cloudformation:{REGION_NAME}:{ACCOUNT_ID}:changeSet/{change_set_name}/"
+    )
+
+
+@mock_aws
+def test_invalid_change_set_name_starting_char():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    with pytest.raises(ClientError):
+        cf.create_change_set(
+            StackName=TEST_STACK_NAME,
+            ChangeSetName="1invalid-change-set-name",
+            TemplateBody=json.dumps(dummy_template),
+            Description="Test Change Set",
+            ChangeSetType="CREATE",
+        )
+
+
+@mock_aws
+def test_invalid_change_set_name_length():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    long_name = "a" * 129  # Exceeds the 128 character limit
+    with pytest.raises(ClientError):
+        cf.create_change_set(
+            StackName=TEST_STACK_NAME,
+            ChangeSetName=long_name,
+            TemplateBody=json.dumps(dummy_template),
+            Description="Test Change Set",
+            ChangeSetType="CREATE",
+        )
+
+
+@mock_aws
+def test_invalid_change_set_name_special_chars():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    with pytest.raises(ClientError):
+        cf.create_change_set(
+            StackName=TEST_STACK_NAME,
+            ChangeSetName="invalid@name",
+            TemplateBody=json.dumps(dummy_template),
+            Description="Test Change Set",
+            ChangeSetType="CREATE",
+        )
 
 
 def get_role_name():


### PR DESCRIPTION
### Pull Request: Refactor Validation in `create_change_set`

**Summary:**

This PR refactors the `create_change_set` function to improve validation by centralizing it in a new `validate_create_change_set` function. This change ensures all parameters are validated consistently and makes it easier to extend validation in the future.

**Changes:**

- **Added `validate_create_change_set` Function**:
  - Centralizes validation for all parameters, currently including `change_set_name` rules (e.g., must start with a letter, be alphanumeric, and under 128 characters).

- **Updated `create_change_set`**:
  - Calls `validate_create_change_set` to validate inputs before processing.

**Testing:**

- Updated unit tests to cover validation scenarios.

[Documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation/client/create_change_set.html#:~:text=A%20change%20set%20name%20can%20contain%20only%20alphanumeric%2C%20case%20sensitive%20characters%2C%20and%20hyphens.%20It%20must%20start%20with%20an%20alphabetical%20character%20and%20can%E2%80%99t%20exceed%20128%20characters.)

![image](https://github.com/user-attachments/assets/c3890eb9-b818-4802-b45d-1c5877c3091f)