### PR TITLE
DynamoDB: update_item() now validates an empty ExpressionAttributeVal…

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -965,7 +965,11 @@ class DynamoHandler(BaseResponse):
         return dynamo_json_dump(item_dict)
 
     def _get_expr_attr_values(self) -> Dict[str, Dict[str, str]]:
-        values = self.body.get("ExpressionAttributeValues", {})
+        values = self.body.get("ExpressionAttributeValues")
+        if values is None:
+            return {}
+        if len(values) == 0:
+            raise MockValidationException("ExpressionAttributeValues must not be empty")
         for key in values.keys():
             if not key.startswith(":"):
                 raise MockValidationException(

--- a/tests/test_dynamodb/test_dynamodb_update_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_update_expressions.py
@@ -187,3 +187,22 @@ def test_update_item_add_empty_set(table_name=None):
     assert dynamodb.scan(TableName=table_name)["Items"] == [
         {"pk": {"S": "foo"}, "stringset": {"SS": ["item1"]}}
     ]
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified()
+def test_update_item_with_empty_values(table_name=None):
+    dynamodb = boto3.client("dynamodb", "us-east-1")
+
+    dynamodb.put_item(TableName=table_name, Item={"pk": {"S": "foo"}})
+    with pytest.raises(ClientError) as exc:
+        dynamodb.update_item(
+            TableName=table_name,
+            Key={"pk": {"S": "foo"}},
+            UpdateExpression="SET #d = :s",
+            ExpressionAttributeNames={"#d": "d"},
+            ExpressionAttributeValues={},
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert err["Message"] == "ExpressionAttributeValues must not be empty"


### PR DESCRIPTION
…ues-parameter

Fixes #7952 