### PR TITLE
Utility to iterate over flattened backends

### DIFF
--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -12,6 +12,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Tuple,
     TypeVar,
 )
 from uuid import uuid4
@@ -381,7 +382,7 @@ class BackendDict(Dict[str, AccountSpecificBackend[SERVICE_BACKEND]]):
                 )
                 BackendDict._instances.append(self)  # type: ignore[misc]
 
-    def iter_backends(self) -> Iterator[tuple[str, str, BaseBackend]]:
+    def iter_backends(self) -> Iterator[Tuple[str, str, BaseBackend]]:
         """
         Iterate over a flattened view of all base backends in a BackendDict.
         Each record is a tuple of account id, region name, and the base backend within that account and region.

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -380,3 +380,12 @@ class BackendDict(Dict[str, AccountSpecificBackend[SERVICE_BACKEND]]):
                     additional_regions=self._additional_regions,
                 )
                 BackendDict._instances.append(self)  # type: ignore[misc]
+
+    def iter_backends(self) -> Iterator[tuple[str, str, BaseBackend]]:
+        """
+        Iterate over a flattened view of all base backends in a BackendDict.
+        Each record is a tuple of account id, region name, and the base backend within that account and region.
+        """
+        for account_id, account_specific_backend in self.items():
+            for region_name, backend in account_specific_backend.items():
+                yield account_id, region_name, backend

--- a/tests/test_core/test_backenddict.py
+++ b/tests/test_core/test_backenddict.py
@@ -197,3 +197,16 @@ def test_global_region_defaults_to_aws() -> None:
 
     assert "aws" in s3[DEFAULT_ACCOUNT_ID]
     assert "global" in s3[DEFAULT_ACCOUNT_ID]
+
+
+def test_iterate_backend_dict() -> None:
+    ec2 = BackendDict(EC2Backend, "ec2")
+    _ = ec2[DEFAULT_ACCOUNT_ID]["us-east-1"]
+    _ = ec2[DEFAULT_ACCOUNT_ID]["us-east-2"]
+
+    regions = {"us-east-1", "us-east-2"}
+    for account, region, backend in ec2.iter_backends():
+        assert isinstance(backend, EC2Backend)
+        assert region in regions
+        regions.remove(region)
+        assert account == DEFAULT_ACCOUNT_ID


### PR DESCRIPTION
This PR adds a utility method to iterate over a flattened view of a `BackendDict`.

Each record is a tuple of account ID, region, and the corresponding `BaseBackend`.