### PR TITLE
Batch: add support for parameters in Job commands

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import logging
 import re
@@ -631,8 +632,16 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             return self.job_definition.timeout["attemptDurationSeconds"]
         return None
 
-    def _add_parameters_to_command(self, command, parameters):
-        pass
+    def _add_parameters_to_command(self, command: str | list[str], parameters: dict[str, str]) -> list[str]:
+        new_command = copy.deepcopy(command)
+        if isinstance(new_command, str):
+            new_command = [new_command]
+
+        for i, command_part in enumerate(new_command):
+            for param, value in parameters.items():
+                new_command[i] = command_part.replace(f"${param}", value)
+
+        return new_command
 
     def run(self) -> None:
         """

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -6,7 +6,7 @@ import time
 from itertools import cycle
 from sys import platform
 from time import sleep
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import dateutil.parser
 
@@ -632,7 +632,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         return None
 
     def _add_parameters_to_command(
-        self, command: str | list[str], parameters: dict[str, str]
+        self, command: Union[str, List[str]], parameters: dict[str, str]
     ) -> list[str]:
         if isinstance(command, str):
             command = [command]

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -473,6 +473,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         log_backend: LogsBackend,
         container_overrides: Optional[Dict[str, Any]],
         depends_on: Optional[List[Dict[str, str]]],
+        parameters: Optional[Dict[str, str]],
         all_jobs: Dict[str, "Job"],
         timeout: Optional[Dict[str, int]],
         array_properties: Dict[str, Any],
@@ -498,6 +499,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         self.job_stopped = False
         self.job_stopped_reason: Optional[str] = None
         self.depends_on = depends_on
+        self.parameters = parameters or {}
         self.timeout = timeout
         self.all_jobs = all_jobs
         self.array_properties: Dict[str, Any] = array_properties
@@ -546,6 +548,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         result = self.describe_short()
         result["jobQueue"] = self.job_queue.arn
         result["dependsOn"] = self.depends_on or []
+        result["parameters"] = {**self.job_definition.parameters, **self.parameters}
         if self.job_definition.type == "container":
             result["container"] = self._container_details()
         elif self.job_definition.type == "multinode":
@@ -628,6 +631,9 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             return self.job_definition.timeout["attemptDurationSeconds"]
         return None
 
+    def _add_parameters_to_command(self, command, parameters):
+        pass
+
     def run(self) -> None:
         """
         Run the container.
@@ -676,9 +682,12 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                         "privileged": self.job_definition.container_properties.get(
                             "privileged", False
                         ),
-                        "command": self._get_container_property(
-                            "command",
-                            '/bin/sh -c "for a in `seq 1 10`; do echo Hello World; sleep 1; done"',
+                        "command": self._add_parameters_to_command(
+                            self._get_container_property(
+                                "command",
+                                '/bin/sh -c "for a in `seq 1 10`; do echo Hello World; sleep 1; done"',
+                            ),
+                            {**self.job_definition.parameters, **self.parameters},
                         ),
                         "environment": {
                             e["name"]: e["value"]
@@ -1729,6 +1738,7 @@ class BatchBackend(BaseBackend):
         depends_on: Optional[List[Dict[str, str]]] = None,
         container_overrides: Optional[Dict[str, Any]] = None,
         timeout: Optional[Dict[str, int]] = None,
+        parameters: Optional[Dict[str, str]] = None,
     ) -> Tuple[str, str, str]:
         """
         Parameters RetryStrategy and Parameters are not yet implemented.
@@ -1755,6 +1765,7 @@ class BatchBackend(BaseBackend):
             all_jobs=self._jobs,
             timeout=timeout,
             array_properties=array_properties or {},
+            parameters=parameters,
         )
         self._jobs[job.job_id] = job
 
@@ -1772,6 +1783,7 @@ class BatchBackend(BaseBackend):
                     all_jobs=self._jobs,
                     timeout=timeout,
                     array_properties={"statusSummary": {}, "index": array_index},
+                    parameters=parameters,
                     provided_job_id=provided_job_id,
                 )
                 child_jobs.append(child_job)

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -635,11 +635,15 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         if isinstance(command, str):
             command = [command]
 
-        return [
+        if not self.parameters:
+            return command
+
+        new_command = [
             command_part.replace(f"${param}", value)
             for command_part in command
             for param, value in self.parameters.items()
         ]
+        return new_command
 
     def run(self) -> None:
         """

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import logging
 import re
@@ -632,16 +631,17 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             return self.job_definition.timeout["attemptDurationSeconds"]
         return None
 
-    def _add_parameters_to_command(self, command: str | list[str], parameters: dict[str, str]) -> list[str]:
-        new_command = copy.deepcopy(command)
-        if isinstance(new_command, str):
-            new_command = [new_command]
+    def _add_parameters_to_command(
+        self, command: str | list[str], parameters: dict[str, str]
+    ) -> list[str]:
+        if isinstance(command, str):
+            command = [command]
 
-        for i, command_part in enumerate(new_command):
-            for param, value in parameters.items():
-                new_command[i] = command_part.replace(f"${param}", value)
-
-        return new_command
+        return [
+            command_part.replace(f"${param}", value)
+            for command_part in command
+            for param, value in parameters.items()
+        ]
 
     def run(self) -> None:
         """

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -632,8 +632,8 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         return None
 
     def _add_parameters_to_command(
-        self, command: Union[str, List[str]], parameters: dict[str, str]
-    ) -> list[str]:
+        self, command: Union[str, List[str]], parameters: Dict[str, str]
+    ) -> List[str]:
         if isinstance(command, str):
             command = [command]
 

--- a/moto/batch/responses.py
+++ b/moto/batch/responses.py
@@ -189,6 +189,7 @@ class BatchResponse(BaseResponse):
         job_queue = self._get_param("jobQueue")
         timeout = self._get_param("timeout")
         array_properties = self._get_param("arrayProperties", {})
+        parameters = self._get_param("parameters")
 
         name, job_id, job_arn = self.batch_backend.submit_job(
             job_name,
@@ -198,6 +199,7 @@ class BatchResponse(BaseResponse):
             container_overrides=container_overrides,
             timeout=timeout,
             array_properties=array_properties,
+            parameters=parameters,
         )
 
         result = {"jobId": job_id, "jobName": name, "jobArn": job_arn}

--- a/moto/batch_simple/models.py
+++ b/moto/batch_simple/models.py
@@ -56,6 +56,7 @@ class BatchSimpleBackend(BatchBackend):
         depends_on: Optional[List[Dict[str, str]]] = None,
         container_overrides: Optional[Dict[str, Any]] = None,
         timeout: Optional[Dict[str, int]] = None,
+        parameters: Optional[Dict[str, str]] = None,
     ) -> Tuple[str, str, str]:
         # Look for job definition
         job_def = self.get_job_definition(job_def_id)
@@ -76,6 +77,7 @@ class BatchSimpleBackend(BatchBackend):
             all_jobs=self._jobs,
             timeout=timeout,
             array_properties=array_properties,
+            parameters=parameters,
         )
 
         if "size" in array_properties:
@@ -93,6 +95,7 @@ class BatchSimpleBackend(BatchBackend):
                     timeout=timeout,
                     array_properties={"statusSummary": {}, "index": array_index},
                     provided_job_id=provided_job_id,
+                    parameters=parameters,
                 )
                 self._mark_job_as_finished(include_start_attempt=True, job=child_job)
                 child_jobs.append(child_job)

--- a/tests/test_batch/__init__.py
+++ b/tests/test_batch/__init__.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Tuple
 from uuid import uuid4
 
@@ -34,8 +35,21 @@ def _setup(ec2_client: Any, iam_client: Any) -> Tuple[str, str, str, str]:
     sg_id = resp["GroupId"]
 
     role_name = f"{str(uuid4())[0:6]}"
+    assume_role_policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "batch.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    )
+
     resp = iam_client.create_role(
-        RoleName=role_name, AssumeRolePolicyDocument="some_policy"
+        RoleName=role_name, AssumeRolePolicyDocument=assume_role_policy
     )
     iam_arn = resp["Role"]["Arn"]
     iam_client.create_instance_profile(InstanceProfileName=role_name)

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -1094,7 +1094,7 @@ def test_submit_job_invalid_name():
 @mock_aws()
 def test_submit_job_with_parameters():
     """
-    Test verifies that parameters can be passed when submiting a Job
+    Test verifies that parameters will be used when submitting a Job
     """
 
     ec2_client, iam_client, _, _, batch_client = _get_clients()
@@ -1131,13 +1131,12 @@ def test_submit_job_with_parameters():
         parameters={"seconds": "5"},
     )
 
-    resp = batch_client.submit_job(
+    job_id = batch_client.submit_job(
         jobName="test1",
         jobQueue=queue_arn,
         jobDefinition=job_definition_name,
         parameters={"seconds": "10"},
-    )
+    )["jobId"]
 
-    job_id = resp["jobId"]
-
-    batch_client.describe_jobs(jobs=[job_id])
+    job = batch_client.describe_jobs(jobs=[job_id])["jobs"][0]
+    assert job["parameters"] == {"seconds": "10"}

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -1128,15 +1128,15 @@ def test_submit_job_with_parameters():
             "memory": 512,
             "command": ["sleep", "$seconds"],
         },
-        parameters={"seconds": "5"},
+        parameters={"seconds": "0"},
     )
 
     job_id = batch_client.submit_job(
         jobName="test1",
         jobQueue=queue_arn,
         jobDefinition=job_definition_name,
-        parameters={"seconds": "10"},
+        parameters={"seconds": "0.1"},
     )["jobId"]
 
     job = batch_client.describe_jobs(jobs=[job_id])["jobs"][0]
-    assert job["parameters"] == {"seconds": "10"}
+    assert job["parameters"] == {"seconds": "0.1"}

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -1119,7 +1119,7 @@ def test_submit_job_with_parameters():
 
     job_definition_name = f"sleep_{str(uuid4())[0:6]}"
 
-    resp = batch_client.register_job_definition(
+    batch_client.register_job_definition(
         jobDefinitionName=job_definition_name,
         type="container",
         containerProperties={

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -1089,3 +1089,55 @@ def test_submit_job_invalid_name():
             jobName=too_long_job_name, jobQueue="arn", jobDefinition="job_def_name"
         )
     assert exc.match("ClientException")
+
+
+@mock_aws()
+def test_submit_job_with_parameters():
+    """
+    Test verifies that parameters can be passed when submiting a Job
+    """
+
+    ec2_client, iam_client, _, _, batch_client = _get_clients()
+    _, _, _, iam_arn = _setup(ec2_client, iam_client)
+
+    compute_name = str(uuid4())
+    resp = batch_client.create_compute_environment(
+        computeEnvironmentName=compute_name,
+        type="UNMANAGED",
+        state="ENABLED",
+        serviceRole=iam_arn,
+    )
+    arn = resp["computeEnvironmentArn"]
+
+    resp = batch_client.create_job_queue(
+        jobQueueName=str(uuid4()),
+        state="ENABLED",
+        priority=123,
+        computeEnvironmentOrder=[{"order": 123, "computeEnvironment": arn}],
+    )
+    queue_arn = resp["jobQueueArn"]
+
+    job_definition_name = f"sleep_{str(uuid4())[0:6]}"
+
+    resp = batch_client.register_job_definition(
+        jobDefinitionName=job_definition_name,
+        type="container",
+        containerProperties={
+            "image": "busybox",
+            "vcpus": 1,
+            "memory": 512,
+            "command": ["sleep", "$seconds"],
+        },
+        parameters={"seconds": "5"},
+    )
+
+    resp = batch_client.submit_job(
+        jobName="test1",
+        jobQueue=queue_arn,
+        jobDefinition=job_definition_name,
+        parameters={"seconds": "10"},
+    )
+
+    job_id = resp["jobId"]
+
+    batch_client.describe_jobs(jobs=[job_id])


### PR DESCRIPTION
This PR adds support for using parameters in job commands. It also implements the ability to overwrite parameters during the submit job operation.