### PR TITLE
feat: Deal with APIGateway GetAPI with an empty string

### DIFF
--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Any, Dict, List
 from urllib.parse import unquote
 
 from moto.core.responses import TYPE_RESPONSE, BaseResponse
@@ -122,7 +122,7 @@ class APIGatewayResponse(BaseResponse):
         return 200, {}, json.dumps(rest_api.to_dict())
 
     @staticmethod
-    def get_rest_api_without_id(*args) -> TYPE_RESPONSE:
+    def get_rest_api_without_id(*args: Any) -> TYPE_RESPONSE:
         return 200, {}, "{}"
 
     def put_rest_api(self) -> TYPE_RESPONSE:

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -123,6 +123,11 @@ class APIGatewayResponse(BaseResponse):
 
     @staticmethod
     def get_rest_api_without_id(*args: Any) -> TYPE_RESPONSE:
+        """
+        AWS is returning an empty response when restApiId is an empty string. This is slightly odd and it seems an
+        outlier, therefore it was decided we could have a custom handler for this particular use case instead of
+        trying to make it work with the existing url-matcher.
+        """
         return 200, {}, "{}"
 
     def put_rest_api(self) -> TYPE_RESPONSE:

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -121,6 +121,10 @@ class APIGatewayResponse(BaseResponse):
         rest_api = self.backend.get_rest_api(function_id)
         return 200, {}, json.dumps(rest_api.to_dict())
 
+    @staticmethod
+    def get_rest_api_without_id(*args) -> TYPE_RESPONSE:
+        return 200, {}, "{}"
+
     def put_rest_api(self) -> TYPE_RESPONSE:
         function_id = self.path.replace("/restapis/", "", 1).split("/")[0]
         mode = self._get_param("mode", "merge")

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -121,8 +121,7 @@ class APIGatewayResponse(BaseResponse):
         rest_api = self.backend.get_rest_api(function_id)
         return 200, {}, json.dumps(rest_api.to_dict())
 
-    @staticmethod
-    def get_rest_api_without_id(*args: Any) -> TYPE_RESPONSE:
+    def get_rest_api_without_id(self, *args: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
         """
         AWS is returning an empty response when restApiId is an empty string. This is slightly odd and it seems an
         outlier, therefore it was decided we could have a custom handler for this particular use case instead of

--- a/moto/apigateway/urls.py
+++ b/moto/apigateway/urls.py
@@ -5,6 +5,7 @@ url_bases = [r"https?://apigateway\.(.+)\.amazonaws.com"]
 
 url_paths = {
     "{0}/restapis$": APIGatewayResponse.dispatch,
+    "{0}/restapis/$": APIGatewayResponse.get_rest_api_without_id,
     "{0}/restapis/(?P<function_id>[^/]+)/?$": APIGatewayResponse.dispatch,
     "{0}/restapis/(?P<function_id>[^/]+)/resources$": APIGatewayResponse.dispatch,
     "{0}/restapis/(?P<function_id>[^/]+)/authorizers$": APIGatewayResponse.dispatch,

--- a/moto/apigatewayv2/responses.py
+++ b/moto/apigatewayv2/responses.py
@@ -64,6 +64,11 @@ class ApiGatewayV2Response(BaseResponse):
 
     @staticmethod
     def get_api_without_id(*args: Any) -> TYPE_RESPONSE:
+        """
+        AWS is returning an empty response when apiId is an empty string. This is slightly odd and it seems an
+        outlier, therefore it was decided we could have a custom handler for this particular use case instead of
+        trying to make it work with the existing url-matcher.
+        """
         return 200, {}, "{}"
 
     def get_apis(self) -> TYPE_RESPONSE:

--- a/moto/apigatewayv2/responses.py
+++ b/moto/apigatewayv2/responses.py
@@ -63,7 +63,7 @@ class ApiGatewayV2Response(BaseResponse):
         return 200, {}, json.dumps(api.to_json())
 
     @staticmethod
-    def get_api_without_id(*args: Any) -> TYPE_RESPONSE:
+    def get_api_without_id(*args: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
         """
         AWS is returning an empty response when apiId is an empty string. This is slightly odd and it seems an
         outlier, therefore it was decided we could have a custom handler for this particular use case instead of

--- a/moto/apigatewayv2/responses.py
+++ b/moto/apigatewayv2/responses.py
@@ -1,6 +1,7 @@
 """Handles incoming apigatewayv2 requests, invokes methods, returns responses."""
 
 import json
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import TYPE_RESPONSE, BaseResponse
@@ -62,7 +63,7 @@ class ApiGatewayV2Response(BaseResponse):
         return 200, {}, json.dumps(api.to_json())
 
     @staticmethod
-    def get_api_without_id(*args) -> TYPE_RESPONSE:
+    def get_api_without_id(*args: Any) -> TYPE_RESPONSE:
         return 200, {}, "{}"
 
     def get_apis(self) -> TYPE_RESPONSE:

--- a/moto/apigatewayv2/responses.py
+++ b/moto/apigatewayv2/responses.py
@@ -61,6 +61,10 @@ class ApiGatewayV2Response(BaseResponse):
         api = self.apigatewayv2_backend.get_api(api_id=api_id)
         return 200, {}, json.dumps(api.to_json())
 
+    @staticmethod
+    def get_api_without_id(*args) -> TYPE_RESPONSE:
+        return 200, {}, "{}"
+
     def get_apis(self) -> TYPE_RESPONSE:
         apis = self.apigatewayv2_backend.get_apis()
         return 200, {}, json.dumps({"items": [a.to_json() for a in apis]})

--- a/moto/apigatewayv2/urls.py
+++ b/moto/apigatewayv2/urls.py
@@ -9,6 +9,7 @@ url_bases = [
 
 url_paths = {
     "{0}/v2/apis$": ApiGatewayV2Response.dispatch,
+    "{0}/v2/apis/$": ApiGatewayV2Response.get_api_without_id,
     "{0}/v2/apis/(?P<api_id>[^/]+)$": ApiGatewayV2Response.dispatch,
     "{0}/v2/apis/(?P<api_id>[^/]+)/authorizers$": ApiGatewayV2Response.dispatch,
     "{0}/v2/apis/(?P<api_id>[^/]+)/authorizers/(?P<authorizer_id>[^/]+)$": ApiGatewayV2Response.dispatch,

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1927,6 +1927,17 @@ def test_get_api_key_unknown_apikey():
 
 
 @mock_aws
+def test_get_rest_api_without_id():
+    client = boto3.client("apigateway", region_name="us-east-1")
+    resp = client.get_rest_api(restApiId="")
+
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    del resp["ResponseMetadata"]
+    assert resp == {}
+
+
+@mock_aws
 def test_get_domain_name_unknown_domainname():
     client = boto3.client("apigateway", region_name="us-east-1")
     with pytest.raises(ClientError) as ex:

--- a/tests/test_apigatewayv2/test_apigatewayv2.py
+++ b/tests/test_apigatewayv2/test_apigatewayv2.py
@@ -142,6 +142,17 @@ def test_get_api_unknown():
 
 
 @mock_aws
+def test_get_api_without_id():
+    client = boto3.client("apigatewayv2", region_name="ap-southeast-1")
+    resp = client.get_api(ApiId="")
+
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    del resp["ResponseMetadata"]
+    assert resp == {}
+
+
+@mock_aws
 def test_get_api():
     client = boto3.client("apigatewayv2", region_name="ap-southeast-1")
     api_id = client.create_api(Name="test-get-api", ProtocolType="WEBSOCKET")["ApiId"]


### PR DESCRIPTION
Fixes https://github.com/getmoto/moto/issues/7974

AWS returns a 200 empty response when doing a `get_api` with an empty string in `apigatewayv2`. Same behaviour is seen with `get_rest_api` in `apigateway`. `boto` is returning a 404 `not yet implemented` error. This PR tries to mock that use case.

```
import boto3
import json

# apigateway.get_rest_api
client = boto3.session.Session(profile_name="dev", region_name="us-east-1").client("apigateway")
resp = client.get_rest_api(restApiId="")

print(json.dumps(resp, default=str))

# apigatewayv2.get_api
client = boto3.session.Session(profile_name="dev", region_name="us-east-1").client("apigatewayv2")
resp = client.get_api(ApiId="")

print(json.dumps(resp, default=str))
```

Both returns:
```
{
    "ResponseMetadata": {
        "RequestId": "e156a293-3eff-4b81-be31-6712e05c843f",
        "HTTPStatusCode": 200,
        "HTTPHeaders": {
            "date": "Wed, 14 Aug 2024 14:11:18 GMT",
            "content-type": "application/json",
            "content-length": "14959",
            "connection": "keep-alive",
            "x-amzn-requestid": "e156a293-3eff-4b81-be31-6712e05c843f",
            "x-amz-apigw-id": "cgIpBINbIAMEcoA="
        },
        "RetryAttempts": 0
    }
}
```

As discussed in https://github.com/getmoto/moto/issues/7974#issuecomment-2288226432, this seems an outlier in the way AWS normally behaves, so it was decided we could have a custom handler for this use case, instead of trying to make it work with the generic dispatcher architecture used everywhere else.

Feedback is more than welcome!