### PR TITLE
Admin: Support Py 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
+        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12", "3.13.0-rc.1" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +30,11 @@ jobs:
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' }}
         run: |
           python -m pip install --upgrade pip
+      - name: Install XML dependencies
+        if: ${{ matrix.python-version == '3.13.0-rc.1' }}
+        run: |
+          echo "The libxml dependency needs these system packages to compile in Python 3.13"
+          sudo apt install -y libxml2-dev libxslt-dev
       - name: Install project dependencies
         if: ${{ steps.pip-cache.outputs.cache-hit != 'true' }}
         run: |
@@ -42,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13.0-rc.1"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests_decoratormode.yml
+++ b/.github/workflows/tests_decoratormode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13.0-rc.1"]
 
     steps:
     - uses: actions/checkout@v4

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -358,7 +358,9 @@ class SESBackend(BaseBackend):
                     f"Did not have authority to send from email {source}"
                 )
 
-        fieldvalues = [message.get(header, "") for header in ["TO", "CC", "BCC"]]
+        fieldvalues = [
+            message[header] for header in ["TO", "CC", "BCC"] if header in message
+        ]
         destinations += [
             formataddr((realname, email_address))
             for realname, email_address in getaddresses(fieldvalues)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Testing
 keywords = aws ec2 s3 boto3 mock


### PR DESCRIPTION
The SES changes are due to a logic bug that only manifests in Python3.13.

When no CC/BCC fields are set, the `fieldvalues` would be set to something like: `['to@example.com, foo@example.com', '', '']`
Sending that to the builtin `emails.utils.getaddresses`-method in Python 3.12 results in:
`[('', 'to@example.com'), ('', 'foo@example.com'), ('', '')]`

But in Python 3.13, this results in an empty list.

This PR ensures that there are no empty strings in `fieldvalues`, which in turns means that the `getaddresses`-method keeps working.