### PR TITLE
RDS Fix bug that causes second PIT restore to fail

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1881,7 +1881,8 @@ class RDSBackend(BaseBackend):
         # remove the db subnet group as it cannot be copied
         # and is not used in the restored instance
         source_dict = db_instance.__dict__
-        del source_dict["db_subnet_group"]
+        if "db_subnet_group" in source_dict:
+            del source_dict["db_subnet_group"]
 
         new_instance_props = copy.deepcopy(source_dict)
         new_instance_props.pop("backend")

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1262,7 +1262,34 @@ def test_restore_db_instance_to_point_in_time():
         )
         == 1
     )
+    # ensure another pit restore can be made
+    new_instance = conn.restore_db_instance_to_point_in_time(
+        SourceDBInstanceIdentifier="db-primary-1",
+        TargetDBInstanceIdentifier="db-restore-2",
+    )["DBInstance"]
+    assert new_instance["DBInstanceIdentifier"] == "db-restore-2"
+    assert new_instance["DBInstanceClass"] == "db.m1.small"
+    assert new_instance["StorageType"] == "gp2"
+    assert new_instance["Engine"] == "postgres"
+    assert new_instance["DBName"] == "staging-postgres"
+    assert new_instance["DBParameterGroups"][0]["DBParameterGroupName"] == (
+        "default.postgres9.3"
+    )
+    assert new_instance["DBSecurityGroups"] == [
+        {"DBSecurityGroupName": "my_sg", "Status": "active"}
+    ]
+    assert new_instance["Endpoint"]["Port"] == 5432
 
+    # Verify it exists
+    assert len(conn.describe_db_instances()["DBInstances"]) == 3
+    assert (
+        len(
+            conn.describe_db_instances(DBInstanceIdentifier="db-restore-2")[
+                "DBInstances"
+            ]
+        )
+        == 1
+    )
 
 @mock_aws
 def test_restore_db_instance_from_db_snapshot_and_override_params():

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1291,6 +1291,7 @@ def test_restore_db_instance_to_point_in_time():
         == 1
     )
 
+
 @mock_aws
 def test_restore_db_instance_from_db_snapshot_and_override_params():
     conn = boto3.client("rds", region_name=DEFAULT_REGION)


### PR DESCRIPTION
Previous code broke if you tried to create more than one PIT restore due to a KeyError on 'db_subnet_group' when trying to delete the key.  This just checks for existence before deleting the key

Added a test to the existing `test_restore_db_instance_to_point_in_time()`.  Don't know if it's wanted or if I should ass it to a separate function

