### PR TITLE
Admin: Compress JSON in binary distributions

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1,7 +1,5 @@
 import datetime
 import enum
-import json
-import os
 import re
 import time
 import typing
@@ -15,7 +13,7 @@ from moto.core.common_models import BaseModel
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random as random
 from moto.utilities.paginator import paginate
-from moto.utilities.utils import get_partition, md5_hash
+from moto.utilities.utils import get_partition, load_resource, md5_hash
 
 from ..settings import get_cognito_idp_user_pool_id_strategy
 from .exceptions import (
@@ -439,10 +437,8 @@ class CognitoIdpUserPool(BaseModel):
         self.access_tokens: Dict[str, Tuple[str, str]] = {}
         self.id_tokens: Dict[str, Tuple[str, str]] = {}
 
-        with open(
-            os.path.join(os.path.dirname(__file__), "resources/jwks-private.json")
-        ) as f:
-            self.json_web_key = jwk.RSAKey.import_key(json.loads(f.read()))
+        jwks_file = load_resource(__name__, "resources/jwks-private.json")
+        self.json_web_key = jwk.RSAKey.import_key(jwks_file)
 
     @property
     def backend(self) -> "CognitoIdpBackend":

--- a/moto/ec2/models/instance_types.py
+++ b/moto/ec2/models/instance_types.py
@@ -17,12 +17,15 @@ offerings_path = "../resources/instance_type_offerings"
 INSTANCE_TYPE_OFFERINGS: Dict[str, Any] = {}
 for _location_type in listdir(root / offerings_path):
     INSTANCE_TYPE_OFFERINGS[_location_type] = {}
-    for _region in listdir(root / offerings_path / _location_type):
-        full_path = offerings_path + "/" + _location_type + "/" + _region
+    for data_file in listdir(root / offerings_path / _location_type):
+        # data_file = {region}.{content_type}
+        # E.g.: us-east-1.json or eu-west-1.json.gz
+        full_path = offerings_path + "/" + _location_type + "/" + data_file
+        _region = data_file.split(".")[0]
         res = load_resource(__name__, full_path)
         for instance in res:
             instance["LocationType"] = _location_type
-        INSTANCE_TYPE_OFFERINGS[_location_type][_region.replace(".json", "")] = res
+        INSTANCE_TYPE_OFFERINGS[_location_type][_region] = res
 
 
 class InstanceType(Dict[str, Any]):

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -1,3 +1,4 @@
+import gzip
 import hashlib
 import json
 import pkgutil
@@ -37,10 +38,18 @@ def str2bool(v: Any) -> Optional[bool]:
 def load_resource(package: str, resource: str) -> Any:
     """
     Open a file, and return the contents as JSON.
+    Will try to load a compressed version (resources/file.json.gz) first, if it exists.
     Usage:
     load_resource(__name__, "resources/file.json")
     """
-    return json.loads(pkgutil.get_data(package, resource))  # type: ignore
+    try:
+        compressed_resource = resource
+        if not resource.endswith(".gz"):
+            compressed_resource = f"{resource}.gz"
+        data = gzip.decompress(pkgutil.get_data(package, compressed_resource))  # type: ignore
+    except FileNotFoundError:
+        data = pkgutil.get_data(package, resource)  # type: ignore
+    return json.loads(data)
 
 
 def load_resource_as_str(package: str, resource: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+import glob
+import gzip
+from contextlib import suppress
+from pathlib import Path
+
+from setuptools import Command, setup
+from setuptools.command.build import build
+
+
+class CompressJsonCommand(Command):
+    def initialize_options(self) -> None:
+        self.bdist_dir: Path = None
+
+    def finalize_options(self) -> None:
+        with suppress(Exception):
+            self.bdist_dir = Path(self.get_finalized_command("bdist_wheel").bdist_dir)
+
+    def run(self) -> None:
+        # Only run this command when creating a binary distribution
+        if self.bdist_dir:
+            build_dir = self.get_finalized_command("build_py").build_lib
+            json_files = glob.glob(f"{build_dir}/**/*.json", recursive=True)
+            for file in json_files:
+                target_filename = f"{file}.gz"
+                print(f"Compressing {file} into {target_filename}...")  # noqa
+                with open(file, "rb") as source:
+                    with open(target_filename, "wb") as target:
+                        target.write(gzip.compress(source.read()))
+                print(f"Removing {file}...")  # noqa
+                Path(file).unlink()
+
+
+class BuildAndCompressJson(build):
+    sub_commands = build.sub_commands + [("compress_json_command", None)]
+
+
+setup(
+    cmdclass={
+        "build": BuildAndCompressJson,
+        "compress_json_command": CompressJsonCommand,
+    }
+)


### PR DESCRIPTION
Fixes #7909 

Registers a new custom Command when running `python -m build` that finds all JSON files and compresses them.
This only happens during `bdist` creation, so the source distribution is left intact.

@bpandola How do you feel about this approach? 