### PR TITLE
Techdebt: S3: Untangle GET-methods

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -7101,7 +7101,7 @@
 
 ## s3
 <details>
-<summary>68% implemented</summary>
+<summary>71% implemented</summary>
 
 - [X] abort_multipart_upload
 - [X] complete_multipart_upload
@@ -7126,7 +7126,7 @@
 - [X] delete_object_tagging
 - [X] delete_objects
 - [X] delete_public_access_block
-- [ ] get_bucket_accelerate_configuration
+- [X] get_bucket_accelerate_configuration
 - [X] get_bucket_acl
 - [ ] get_bucket_analytics_configuration
 - [X] get_bucket_cors
@@ -7165,7 +7165,7 @@
 - [ ] list_bucket_metrics_configurations
 - [X] list_buckets
 - [ ] list_directory_buckets
-- [ ] list_multipart_uploads
+- [X] list_multipart_uploads
 - [X] list_object_versions
 - [X] list_objects
 - [X] list_objects_v2
@@ -7189,7 +7189,7 @@
 - [ ] put_bucket_request_payment
 - [X] put_bucket_tagging
 - [X] put_bucket_versioning
-- [ ] put_bucket_website
+- [X] put_bucket_website
 - [X] put_object
 - [X] put_object_acl
 - [X] put_object_legal_hold

--- a/docs/docs/services/s3.rst
+++ b/docs/docs/services/s3.rst
@@ -39,7 +39,7 @@ s3
 - [X] delete_object_tagging
 - [X] delete_objects
 - [X] delete_public_access_block
-- [ ] get_bucket_accelerate_configuration
+- [X] get_bucket_accelerate_configuration
 - [X] get_bucket_acl
 - [ ] get_bucket_analytics_configuration
 - [X] get_bucket_cors
@@ -82,7 +82,11 @@ s3
 - [ ] list_bucket_metrics_configurations
 - [X] list_buckets
 - [ ] list_directory_buckets
-- [ ] list_multipart_uploads
+- [X] list_multipart_uploads
+  
+        The delimiter and max-uploads parameters have not yet been implemented.
+        
+
 - [X] list_object_versions
   
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
@@ -149,7 +153,7 @@ s3
 - [ ] put_bucket_request_payment
 - [X] put_bucket_tagging
 - [X] put_bucket_versioning
-- [ ] put_bucket_website
+- [X] put_bucket_website
 - [X] put_object
 - [X] put_object_acl
 - [X] put_object_legal_hold

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1047,7 +1047,7 @@ class FakeBucket(CloudFormationModel):
         self.versioning_status: Optional[str] = None
         self.rules: List[LifecycleRule] = []
         self.policy: Optional[bytes] = None
-        self.website_configuration: Optional[Dict[str, Any]] = None
+        self.website_configuration: Optional[bytes] = None
         self.acl: Optional[FakeAcl] = get_canned_acl("private")
         self.cors: List[CorsRule] = []
         self.logging: Dict[str, Any] = {}
@@ -1883,6 +1883,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             s3_backends.bucket_accounts.pop(bucket_name, None)
             return self.buckets.pop(bucket_name)
 
+    def get_bucket_accelerate_configuration(self, bucket_name: str) -> Optional[str]:
+        bucket = self.get_bucket(bucket_name)
+        return bucket.accelerate_configuration
+
     def put_bucket_versioning(self, bucket_name: str, status: str) -> None:
         self.get_bucket(bucket_name).versioning_status = status
 
@@ -2086,15 +2090,13 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket = self.get_bucket(bucket_name)
         bucket.delete_lifecycle()
 
-    def set_bucket_website_configuration(
-        self, bucket_name: str, website_configuration: Dict[str, Any]
+    def put_bucket_website(
+        self, bucket_name: str, website_configuration: bytes
     ) -> None:
         bucket = self.get_bucket(bucket_name)
         bucket.website_configuration = website_configuration
 
-    def get_bucket_website_configuration(
-        self, bucket_name: str
-    ) -> Optional[Dict[str, Any]]:
+    def get_bucket_website_configuration(self, bucket_name: str) -> Optional[bytes]:
         bucket = self.get_bucket(bucket_name)
         return bucket.website_configuration
 
@@ -2558,7 +2560,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         )
         return key
 
-    def get_all_multiparts(self, bucket_name: str) -> Dict[str, FakeMultipart]:
+    def list_multipart_uploads(self, bucket_name: str) -> Dict[str, FakeMultipart]:
+        """
+        The delimiter and max-uploads parameters have not yet been implemented.
+        """
         bucket = self.get_bucket(bucket_name)
         return bucket.multiparts
 

--- a/tests/test_core/test_responses.py
+++ b/tests/test_core/test_responses.py
@@ -280,7 +280,7 @@ def test_compression_gzip_in_s3() -> None:
     response = S3Response()
     response.setup_class(request, request.url, request.headers)
 
-    assert body == response.body.encode("utf-8")
+    assert body == response.body
 
 
 def _gzip_compress_body(body: str) -> bytes:

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -52,7 +52,7 @@ def test_s3_server_bucket_create(key_name):
     assert res.status_code == 200
     assert "ETag" in dict(res.headers)
 
-    # ListBuckets
+    # ListObjects
     res = test_client.get(
         "/", "http://foobaz.localhost:5000/", query_string={"prefix": key_name}
     )
@@ -60,6 +60,29 @@ def test_s3_server_bucket_create(key_name):
     content = xmltodict.parse(res.data)["ListBucketResult"]["Contents"]
     # If we receive a dict, we only received one result
     # If content is of type list, our call returned multiple results - which is not correct
+    assert isinstance(content, dict)
+    assert content["Key"] == key_name
+
+    # ListObjects V2
+    res = test_client.get(
+        "/",
+        "http://foobaz.localhost:5000/",
+        query_string={"prefix": key_name, "list-type": "2"},
+    )
+    assert res.status_code == 200
+    content = xmltodict.parse(res.data)["ListBucketResult"]["Contents"]
+    assert isinstance(content, dict)
+    assert content["Key"] == key_name
+
+    # ListObjectsVersions
+    res = test_client.get(
+        "/",
+        "http://foobaz.localhost:5000/",
+        query_string={"prefix": key_name, "versions": ""},
+    )
+    assert res.status_code == 200
+    assert xmltodict.parse(res.data)["ListVersionsResult"]["Prefix"] == key_name
+    content = xmltodict.parse(res.data)["ListVersionsResult"]["Version"]
     assert isinstance(content, dict)
     assert content["Key"] == key_name
 


### PR DESCRIPTION
No logical changes - this just untangles the massive `_key_response_get`-method in S3Response.

The end-goal here is to get rid of the `if ".." in querystring..` spaghetti altogether, and let our regular `dispatch` method handle the dispatching, but there are several steps that need to be handled first:

1. untangle POST/PUT/DELETE requests
2. ensure dispatch() can handle querystrings
3. ensure dispatch() knows and can handle the difference between virtual-host and path-style URL's
4. change `s3/urls.py` to use `dispatch`
5. and then we can remove all `if ".." in querystring` sections