### PR TITLE
S3: create_bucket() now has additional LocationConstraint-validation

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -203,6 +203,26 @@ class IllegalLocationConstraintException(S3ClientError):
         )
 
 
+class IncompatibleLocationConstraintException(S3ClientError):
+    code = 400
+
+    def __init__(self, location: str) -> None:
+        super().__init__(
+            "IllegalLocationConstraintException",
+            f"The {location} location constraint is incompatible for the region specific endpoint this request was sent to.",
+        )
+
+
+class InvalidLocationConstraintException(S3ClientError):
+    code = 400
+
+    def __init__(self) -> None:
+        super().__init__(
+            "InvalidLocationConstraint",
+            "The specified location-constraint is not valid",
+        )
+
+
 class MalformedXML(S3ClientError):
     code = 400
 

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -774,10 +774,7 @@ def test_get_function_code_signing_config(key):
 def test_get_function_by_arn():
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", "us-east-1")
-    s3_conn.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": _lambda_region},
-    )
+    s3_conn.create_bucket(Bucket=bucket_name)
 
     zip_content = get_test_zip_file2()
     s3_conn.put_object(Bucket=bucket_name, Key="test.zip", Body=zip_content)
@@ -860,10 +857,7 @@ def test_delete_function():
 def test_delete_function_by_arn():
     bucket_name = str(uuid4())
     s3_conn = boto3.client("s3", "us-east-1")
-    s3_conn.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": _lambda_region},
-    )
+    s3_conn.create_bucket(Bucket=bucket_name)
 
     zip_content = get_test_zip_file2()
     s3_conn.put_object(Bucket=bucket_name, Key="test.zip", Body=zip_content)

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1045,7 +1045,7 @@ def test_stack_dynamodb_resources_integration():
 
 @mock_aws
 def test_create_log_group_using_fntransform():
-    s3_resource = boto3.resource("s3")
+    s3_resource = boto3.resource("s3", "us-west-2")
     s3_resource.create_bucket(
         Bucket="owi-common-cf",
         CreateBucketConfiguration={"LocationConstraint": "us-west-2"},

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -1527,8 +1527,8 @@ def test_cloudwatch_return_s3_metrics():
     cloudwatch = boto3.client("cloudwatch", "eu-west-3")
 
     # given
-    s3 = boto3.resource("s3")
-    s3_client = boto3.client("s3")
+    s3 = boto3.resource("s3", "eu-west-3")
+    s3_client = boto3.client("s3", "eu-west-3")
     bucket = s3.Bucket(bucket_name)
     bucket.create(CreateBucketConfiguration={"LocationConstraint": "eu-west-3"})
     bucket.put_object(Body=b"ABCD", Key="file.txt")

--- a/tests/test_firehose/test_firehose_put.py
+++ b/tests/test_firehose/test_firehose_put.py
@@ -12,8 +12,6 @@ from tests.test_firehose.test_firehose_destination_types import (
     create_redshift_delivery_stream,
 )
 
-S3_LOCATION_CONSTRAINT = "us-west-1"
-
 
 @mock_aws
 def test_put_record_redshift_destination():
@@ -113,10 +111,13 @@ def test_put_record_batch_extended_s3_destination():
     # Create a S3 bucket.
     bucket_name = "firehosetestbucket"
     s3_client = boto3.client("s3", region_name=TEST_REGION)
-    s3_client.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": S3_LOCATION_CONSTRAINT},
-    )
+    if TEST_REGION == "us-east-1":
+        s3_client.create_bucket(Bucket=bucket_name)
+    else:
+        s3_client.create_bucket(
+            Bucket=bucket_name,
+            CreateBucketConfiguration={"LocationConstraint": TEST_REGION},
+        )
 
     stream_name = f"test_put_record_{mock_random.get_random_hex(6)}"
     client.create_delivery_stream(

--- a/tests/test_logs/test_integration.py
+++ b/tests/test_logs/test_integration.py
@@ -275,10 +275,7 @@ def test_put_subscription_filter_with_firehose():
     # Create a S3 bucket.
     bucket_name = "firehosetestbucket"
     s3_client = boto3.client("s3", region_name=region_name)
-    s3_client.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": "us-west-1"},
-    )
+    s3_client.create_bucket(Bucket=bucket_name)
 
     # Create the Firehose delivery stream that uses that S3 bucket as
     # the destination.

--- a/tests/test_s3/test_s3_acl.py
+++ b/tests/test_s3/test_s3_acl.py
@@ -81,11 +81,9 @@ def test_acl_switching_nonexistent_key():
 
 @mock_aws
 def test_s3_object_in_public_bucket():
-    s3_resource = boto3.resource("s3")
+    s3_resource = boto3.resource("s3", DEFAULT_REGION_NAME)
     bucket = s3_resource.Bucket("test-bucket")
-    bucket.create(
-        ACL="public-read", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    bucket.create(ACL="public-read")
     bucket.put_object(Body=b"ABCD", Key="file.txt")
 
     s3_anonymous = boto3.resource("s3")
@@ -107,11 +105,9 @@ def test_s3_object_in_public_bucket():
 
 @mock_aws
 def test_s3_object_in_public_bucket_using_multiple_presigned_urls():
-    s3_resource = boto3.resource("s3")
+    s3_resource = boto3.resource("s3", DEFAULT_REGION_NAME)
     bucket = s3_resource.Bucket("test-bucket")
-    bucket.create(
-        ACL="public-read", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    bucket.create(ACL="public-read")
     bucket.put_object(Body=b"ABCD", Key="file.txt")
 
     params = {"Bucket": "test-bucket", "Key": "file.txt"}
@@ -128,11 +124,9 @@ def test_s3_object_in_public_bucket_using_multiple_presigned_urls():
 
 @mock_aws
 def test_s3_object_in_private_bucket():
-    s3_resource = boto3.resource("s3")
+    s3_resource = boto3.resource("s3", DEFAULT_REGION_NAME)
     bucket = s3_resource.Bucket("test-bucket")
-    bucket.create(
-        ACL="private", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    bucket.create(ACL="private")
     bucket.put_object(ACL="private", Body=b"ABCD", Key="file.txt")
 
     s3_anonymous = boto3.resource("s3")

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -392,12 +392,8 @@ def test_copy_object_with_versioning(bucket_name=None):
 def test_copy_object_from_unversioned_to_versioned_bucket():
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
 
-    client.create_bucket(
-        Bucket="src", CreateBucketConfiguration={"LocationConstraint": "eu-west-1"}
-    )
-    client.create_bucket(
-        Bucket="dest", CreateBucketConfiguration={"LocationConstraint": "eu-west-1"}
-    )
+    client.create_bucket(Bucket="src")
+    client.create_bucket(Bucket="dest")
     client.put_bucket_versioning(
         Bucket="dest", VersioningConfiguration={"Status": "Enabled"}
     )
@@ -459,9 +455,7 @@ def test_copy_object_with_kms_encryption():
     kms_client = boto3.client("kms", region_name=DEFAULT_REGION_NAME)
     kms_key = kms_client.create_key()["KeyMetadata"]["KeyId"]
 
-    client.create_bucket(
-        Bucket="blah", CreateBucketConfiguration={"LocationConstraint": "eu-west-1"}
-    )
+    client.create_bucket(Bucket="blah")
 
     client.put_object(Bucket="blah", Key="test1", Body=b"test1")
 

--- a/tests/test_s3/test_s3_lifecycle.py
+++ b/tests/test_s3/test_s3_lifecycle.py
@@ -5,14 +5,13 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from moto.s3.responses import DEFAULT_REGION_NAME
 
 
 @mock_aws
 def test_lifecycle_with_filters():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     # Create a lifecycle rule with a Filter (no tags):
     lfc = {
@@ -223,10 +222,8 @@ def test_lifecycle_with_filters():
 
 @mock_aws
 def test_lifecycle_with_eodm():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     lfc = {
         "Rules": [
@@ -273,10 +270,8 @@ def test_lifecycle_with_eodm():
 
 @mock_aws
 def test_lifecycle_with_nve():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     lfc = {
         "Rules": [
@@ -309,10 +304,8 @@ def test_lifecycle_with_nve():
 
 @mock_aws
 def test_lifecycle_with_nvt():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     lfc = {
         "Rules": [
@@ -377,10 +370,8 @@ def test_lifecycle_with_nvt():
 
 @mock_aws
 def test_lifecycle_with_multiple_nvt():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     lfc = {
         "Rules": [
@@ -412,10 +403,8 @@ def test_lifecycle_with_multiple_nvt():
 
 @mock_aws
 def test_lifecycle_with_multiple_transitions():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     lfc = {
         "Rules": [
@@ -447,10 +436,8 @@ def test_lifecycle_with_multiple_transitions():
 
 @mock_aws
 def test_lifecycle_with_aimu():
-    client = boto3.client("s3")
-    client.create_bucket(
-        Bucket="bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    client = boto3.client("s3", DEFAULT_REGION_NAME)
+    client.create_bucket(Bucket="bucket")
 
     lfc = {
         "Rules": [

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -19,13 +19,14 @@ from tests.test_s3 import empty_bucket, s3_aws_verified
 @mock_aws
 def test_put_bucket_logging():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    wrong_region_client = boto3.client("s3", region_name="us-west-2")
     bucket_name = "mybucket"
     log_bucket = "logbucket"
     wrong_region_bucket = "wrongregionlogbucket"
     s3_client.create_bucket(Bucket=bucket_name)
     # Adding the ACL for log-delivery later...
     s3_client.create_bucket(Bucket=log_bucket)
-    s3_client.create_bucket(
+    wrong_region_client.create_bucket(
         Bucket=wrong_region_bucket,
         CreateBucketConfiguration={"LocationConstraint": "us-west-2"},
     )

--- a/tests/test_s3/test_s3_storageclass.py
+++ b/tests/test_s3/test_s3_storageclass.py
@@ -3,11 +3,12 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from moto.s3.responses import DEFAULT_REGION_NAME
 
 
 @mock_aws
 def test_s3_storage_class_standard():
-    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="Bucket")
 
     # add an object to the bucket with standard storage
@@ -21,10 +22,8 @@ def test_s3_storage_class_standard():
 
 @mock_aws
 def test_s3_storage_class_infrequent_access():
-    s3_client = boto3.client("s3")
-    s3_client.create_bucket(
-        Bucket="Bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
-    )
+    s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="Bucket")
 
     # add an object to the bucket with standard storage
 
@@ -42,11 +41,9 @@ def test_s3_storage_class_infrequent_access():
 
 @mock_aws
 def test_s3_storage_class_intelligent_tiering():
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
 
-    s3_client.create_bucket(
-        Bucket="Bucket", CreateBucketConfiguration={"LocationConstraint": "us-east-2"}
-    )
+    s3_client.create_bucket(Bucket="Bucket")
     s3_client.put_object(
         Bucket="Bucket",
         Key="my_key_infrequent",
@@ -118,10 +115,8 @@ def test_s3_invalid_copied_storage_class():
 
 @mock_aws
 def test_s3_invalid_storage_class():
-    s3_client = boto3.client("s3")
-    s3_client.create_bucket(
-        Bucket="Bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="Bucket")
 
     # Try to add an object with an invalid storage class
     with pytest.raises(ClientError) as err:
@@ -138,10 +133,8 @@ def test_s3_invalid_storage_class():
 
 @mock_aws
 def test_s3_default_storage_class():
-    s3_client = boto3.client("s3")
-    s3_client.create_bucket(
-        Bucket="Bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="Bucket")
 
     s3_client.put_object(Bucket="Bucket", Key="First_Object", Body="Body")
 
@@ -153,10 +146,8 @@ def test_s3_default_storage_class():
 
 @mock_aws
 def test_s3_copy_object_error_for_glacier_storage_class_not_restored():
-    s3_client = boto3.client("s3")
-    s3_client.create_bucket(
-        Bucket="Bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="Bucket")
 
     s3_client.put_object(
         Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="GLACIER"
@@ -174,10 +165,8 @@ def test_s3_copy_object_error_for_glacier_storage_class_not_restored():
 
 @mock_aws
 def test_s3_copy_object_error_for_deep_archive_storage_class_not_restored():
-    s3_client = boto3.client("s3")
-    s3_client.create_bucket(
-        Bucket="Bucket", CreateBucketConfiguration={"LocationConstraint": "us-west-1"}
-    )
+    s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
+    s3_client.create_bucket(Bucket="Bucket")
 
     s3_client.put_object(
         Bucket="Bucket", Key="First_Object", Body="Body", StorageClass="DEEP_ARCHIVE"

--- a/tests/test_sagemaker/test_sagemaker_pipeline.py
+++ b/tests/test_sagemaker/test_sagemaker_pipeline.py
@@ -26,7 +26,7 @@ TEST_REGION_NAME = "us-west-1"
 
 @contextmanager
 def setup_s3_pipeline_definition(bucket_name, object_key, pipeline_definition):
-    client = boto3.client("s3")
+    client = boto3.client("s3", TEST_REGION_NAME)
     client.create_bucket(
         Bucket=bucket_name,
         CreateBucketConfiguration={"LocationConstraint": TEST_REGION_NAME},


### PR DESCRIPTION
Fixes #7774

The provided LocationConstraint must be equal to the region that the request was send to, same as with AWS.

Note that this may catch a lot of people out if region names are not explicitly specified, and it is taken from either a previous (cached) boto3-client, a configuration setting or from a environment variable.

For example, if `~/.aws/config` states that `region = us-east-1`, the following now (correctly) fails:
```
s3_conn = boto3.client("s3")
s3_conn.create_bucket(Bucket=bucket_name, "CreateBucketConfiguration": {"LocationConstraint": "us-west-2"})
```

Moto was (until now) quite forgiving and simply assumed that you really meant to send this request to `us-west-2`, but will now throw a `InvalidLocationConstraint`-exception.
