### PR TITLE
Match wafv2 backend service name to service

### DIFF
--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -422,6 +422,4 @@ class WAFV2Backend(BaseBackend):
         ]
 
 
-wafv2_backends = BackendDict(
-    WAFV2Backend, "waf-regional", additional_regions=PARTITION_NAMES
-)
+wafv2_backends = BackendDict(WAFV2Backend, "wafv2", additional_regions=PARTITION_NAMES)


### PR DESCRIPTION
## Motivation
Currently, the service name in the wafv2 backend dict is "waf-regional". This mismatch leads to errors when trying to load the service based on the service name in the backend dict (as in LocalStack persistence).

It would be nice to match the service name to the actual service, so this mismatch is prevented.
The `waf-regional` name is for waf classic, not wafv2: https://docs.aws.amazon.com/waf/latest/developerguide/classic-waf-chapter.html

## Changes
* Change wafv2 backend service name from `waf-regional` to `wafv2`
