### PR TITLE
Resolved issue with Configuration being a required parameter for Athena Workgroups

### DIFF
--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -62,6 +62,9 @@ class WorkGroup(TaggableResourceMixin, BaseModel):
         self.description = description
         self.configuration = configuration
 
+        if not configuration:
+             self.configuration = {}
+
         if "EnableMinimumEncryptionConfiguration" not in self.configuration:
             self.configuration["EnableMinimumEncryptionConfiguration"] = False
         if "EnforceWorkGroupConfiguration" not in self.configuration:


### PR DESCRIPTION
Bug introduced by pull request https://github.com/getmoto/moto/pull/7946 which force Configuration to become a required parameter for Athena Workgroups when it is not. This change allow for the work in the pull request mentioned to function without making Configuration required.