### PR TITLE
Techdebt: Fix flaky SNS/S3 tests

### DIFF
--- a/.github/workflows/dependency_test.yml
+++ b/.github/workflows/dependency_test.yml
@@ -20,8 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_list
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ "3.10" ]
         service: ${{ fromJson(needs.prepare_list.outputs.matrix) }}
 
     steps:

--- a/tests/test_s3/test_s3_lock.py
+++ b/tests/test_s3/test_s3_lock.py
@@ -177,7 +177,7 @@ def test_locked_object_compliance_mode(bypass_governance_retention, bucket_name=
     s3_client = boto3.client("s3", DEFAULT_REGION_NAME)
 
     key_name = "file.txt"
-    seconds_lock = 5 if allow_aws_request() else 1
+    seconds_lock = 5 if allow_aws_request() else 2
 
     enable_versioning(bucket_name, s3_client)
 
@@ -235,9 +235,7 @@ def test_locked_object_compliance_mode(bypass_governance_retention, bucket_name=
         == "Access Denied because object protected by object lock."
     )
 
-    from time import sleep
-
-    sleep(seconds_lock)
+    time.sleep(seconds_lock)
 
 
 @mock_aws


### PR DESCRIPTION
The S3 test verifies that a certain amount of time has passed - but the logic compares seconds, not milliseconds. If a test starts at `0:0:1.999`, then a `second` has passed at `0:0:2.000` - changing the outcome of the test. Changing the wait time to 2 seconds fixes the flakiness, so the test will always have the same outcome regardless of when it starts.

The dependency tests are not dependent on each other - so if one fails, the other ones can continue going. Hence: `fail-fast: False`.

The SNS test now explicitly waits until the server is ready, reducing a chance for flakiness.