### PR TITLE
Resolve a `DeprecationWarning` due to an invalid string escape

### DIFF
--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -257,7 +257,7 @@ def test_list_resource_record_set_invalid_start_record_name(invalid_char):
 
 
 @mock_aws
-@pytest.mark.parametrize("valid_char", ["*", ".", "\\t", "\ ", "国", "}", "\\ç"])
+@pytest.mark.parametrize("valid_char", ["*", ".", "\\t", "\\ ", "国", "}", "\\ç"])
 def test_list_resource_record_set_valid_characters(valid_char):
     """
     Validation that we can use odd characters as part of the domain name


### PR DESCRIPTION
CI is throwing a warning about an invalid string escape (`"\ "`) ([recent example](https://github.com/getmoto/moto/actions/runs/10570098846/job/29284013829#step:7:849)).

This PR addresses the `DeprecationWarning` by updating the test string to `"\\ "`.