### PR TITLE
Catch and verify an expected `UserWarning` in the test suite

### DIFF
--- a/tests/test_events/test_events_integration.py
+++ b/tests/test_events/test_events_integration.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 from datetime import datetime
@@ -111,7 +112,13 @@ def test_send_to_sqs_fifo_queue():
 
     # when
     event_time = datetime(2021, 1, 1, 12, 23, 34)
-    with pytest.warns(UserWarning, match="you must enable content-based deduplication"):
+    # Catch and validate a UserWarning when running locally.
+    context = (
+        pytest.warns(UserWarning, match="you must enable content-based deduplication")
+        if not settings.TEST_SERVER_MODE
+        else contextlib.nullcontext()
+    )
+    with context:
         client_events.put_events(
             Entries=[
                 {

--- a/tests/test_events/test_events_integration.py
+++ b/tests/test_events/test_events_integration.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest import SkipTest, mock
 
 import boto3
+import pytest
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -110,16 +111,17 @@ def test_send_to_sqs_fifo_queue():
 
     # when
     event_time = datetime(2021, 1, 1, 12, 23, 34)
-    client_events.put_events(
-        Entries=[
-            {
-                "Time": event_time,
-                "Source": "source",
-                "DetailType": "type",
-                "Detail": json.dumps({"key": "value"}),
-            }
-        ]
-    )
+    with pytest.warns(UserWarning, match="you must enable content-based deduplication"):
+        client_events.put_events(
+            Entries=[
+                {
+                    "Time": event_time,
+                    "Source": "source",
+                    "DetailType": "type",
+                    "Detail": json.dumps({"key": "value"}),
+                }
+            ]
+        )
 
     # then
     response = client_sqs.receive_message(


### PR DESCRIPTION
The test suite validates that an SQS FIFO queue with content-deduplication disabled does not receive messages from EventBridge, but doesn't catch and verify the `UserWarning` that gets raised in the code because of this ([recent example in CI](https://github.com/getmoto/moto/actions/runs/10570098846/job/29284013829#step:7:865)). As a result, that `UserWarning` gets reported by pytest at the end of the test run.

This PR uses `pytest.warns()` to catch and verify the expected `UserWarning`.