### PR TITLE
Batch: fix job parameters definition

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -639,7 +639,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
             return command
 
         new_command = [
-            command_part.replace(f"${param}", value)
+            command_part.replace(f"Ref::{param}", value)
             for command_part in command
             for param, value in self.parameters.items()
         ]

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -1126,7 +1126,7 @@ def test_submit_job_with_parameters():
             "image": "busybox",
             "vcpus": 1,
             "memory": 512,
-            "command": ["sleep", "$seconds"],
+            "command": ["sleep", "Ref::seconds"],
         },
         parameters={"seconds": "0"},
     )


### PR DESCRIPTION
As this [document](https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters) shows. The parameters are defined in a command like `Ref::parameter` and not `$parameter`. This was a small error introduced in my last PR.