### PR TITLE
S3: fix CreateBucket from us-east-1 in other regions, and set bucket region to LocationConstraint

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -895,7 +895,9 @@ class S3Response(BaseResponse):
             if self.body and not location_constraint:
                 raise MalformedXML()
 
-            bucket_region = location_constraint if location_constraint else DEFAULT_REGION_NAME
+            bucket_region = (
+                location_constraint if location_constraint else DEFAULT_REGION_NAME
+            )
             try:
                 new_bucket = self.backend.create_bucket(bucket_name, bucket_region)
             except BucketAlreadyExists:

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -881,9 +881,11 @@ class S3Response(BaseResponse):
             # - you should not use any location constraint
             location_constraint = self._get_location_constraint()
             if self.region == DEFAULT_REGION_NAME:
-                # REGION = us-east-1 - we should never receive a LocationConstraint
-                if location_constraint:
+                # REGION = us-east-1 - we should never receive a LocationConstraint for `us-east-1`
+                # However, you can create buckets in other regions from us-east-1
+                if location_constraint == DEFAULT_REGION_NAME:
                     raise InvalidLocationConstraintException
+
             else:
                 # Non-Standard region - the LocationConstraint must be equal to the actual region the request was send to
                 if not location_constraint:
@@ -893,8 +895,9 @@ class S3Response(BaseResponse):
             if self.body and not location_constraint:
                 raise MalformedXML()
 
+            bucket_region = location_constraint if location_constraint else DEFAULT_REGION_NAME
             try:
-                new_bucket = self.backend.create_bucket(bucket_name, self.region)
+                new_bucket = self.backend.create_bucket(bucket_name, bucket_region)
             except BucketAlreadyExists:
                 new_bucket = self.backend.get_bucket(bucket_name)
                 if new_bucket.account_id == self.get_current_account():

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -292,6 +292,24 @@ def test_create_bucket_with_wrong_location_constraint(constraint):
     )
 
 
+@aws_verified
+@pytest.mark.aws_verified
+@pytest.mark.parametrize(
+    "constraint", ["us-east-2", "eu-central-1"]
+)
+def test_create_bucket_in_regions_from_us_east_1(constraint):
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = str(uuid.uuid4())
+    client.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": constraint}
+    )
+    assert (
+        client.get_bucket_location(Bucket=bucket_name)["LocationConstraint"]
+        == constraint
+    )
+
+
 @mock_aws
 def test_create_existing_bucket_in_us_east_1():
     """Creating a bucket that already exists in us-east-1 returns the bucket.

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -294,15 +294,12 @@ def test_create_bucket_with_wrong_location_constraint(constraint):
 
 @aws_verified
 @pytest.mark.aws_verified
-@pytest.mark.parametrize(
-    "constraint", ["us-east-2", "eu-central-1"]
-)
+@pytest.mark.parametrize("constraint", ["us-east-2", "eu-central-1"])
 def test_create_bucket_in_regions_from_us_east_1(constraint):
     client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket_name = str(uuid.uuid4())
     client.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": constraint}
+        Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": constraint}
     )
     assert (
         client.get_bucket_location(Bucket=bucket_name)["LocationConstraint"]

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -305,6 +305,7 @@ def test_create_bucket_in_regions_from_us_east_1(constraint):
         client.get_bucket_location(Bucket=bucket_name)["LocationConstraint"]
         == constraint
     )
+    client.delete_bucket(Bucket=bucket_name)
 
 
 @mock_aws


### PR DESCRIPTION
Follow-up from #8007: it seems the PR was a bit too strict.

AWS S3 allows you to create buckets in other regions if your client region is set in `us-east-1` (and only from that region, as its behavior is already quite specific). 

Due to this, the bucket can also have a region different from the client region. 