### PR TITLE
ACM InUseBy with elbv2

### DIFF
--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -130,7 +130,10 @@ class AWSCertificateManagerResponse(BaseResponse):
         certs = []
         statuses = self._get_param("CertificateStatuses")
         for cert_bundle in self.acm_backend.list_certificates(statuses):
-            certs.append(cert_bundle.describe()["Certificate"])
+            _cert = cert_bundle.describe()["Certificate"]
+            _in_use_by = _cert.pop("InUseBy", [])
+            _cert["InUse"] = bool(_in_use_by)
+            certs.append(_cert)
 
         result = {"CertificateSummaryList": certs}
         return json.dumps(result)

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -14,6 +14,7 @@ from moto.ec2.models.subnets import Subnet
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 
+from ..elb.models import register_certificate
 from .exceptions import (
     ActionTargetGroupNotFoundError,
     DuplicateListenerError,
@@ -1420,6 +1421,14 @@ Member must satisfy regular expression pattern: {expression}"
             default_actions,
             alpn_policy,
         )
+        if certificate:
+            register_certificate(
+                account_id=self.account_id,
+                region=self.region_name,
+                arn_certificate=certificate,
+                arn_user=arn,
+            )
+
         balancer.listeners[listener.arn] = listener
         for action in default_actions:
             if action.type == "forward":

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -15,6 +15,7 @@ from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 
 from ..elb.models import register_certificate
+from ..utilities.utils import ARN_PARTITION_REGEX
 from .exceptions import (
     ActionTargetGroupNotFoundError,
     DuplicateListenerError,
@@ -1421,7 +1422,7 @@ Member must satisfy regular expression pattern: {expression}"
             default_actions,
             alpn_policy,
         )
-        if certificate:
+        if certificate and not re.search(f"{ARN_PARTITION_REGEX}:iam:", certificate):
             register_certificate(
                 account_id=self.account_id,
                 region=self.region_name,

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -711,7 +711,7 @@ def test_request_certificate_issued_status_with_wait_in_envvar():
 
 
 @mock_aws
-def test_request_certificate_with_mutiple_times():
+def test_request_certificate_with_multiple_times():
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("Cant manipulate time in server mode")
 
@@ -791,6 +791,12 @@ def test_elb_acm_in_use_by():
         create_load_balancer_request["DNSName"]
     ]
 
+    certificates = acm_client.list_certificates()["CertificateSummaryList"]
+    cert = [
+        _cert for _cert in certificates if _cert["CertificateArn"] == certificate_arn
+    ][0]
+    assert cert["InUse"]
+
 
 @mock_aws
 def test_elbv2_acm_in_use_by():
@@ -819,3 +825,9 @@ def test_elbv2_acm_in_use_by():
     assert response["Certificate"]["InUseBy"] == [
         create_listener_resp["Listeners"][0]["ListenerArn"]
     ]
+
+    certificates = acm_client.list_certificates()["CertificateSummaryList"]
+    cert = [
+        _cert for _cert in certificates if _cert["CertificateArn"] == certificate_arn
+    ][0]
+    assert cert["InUse"]

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from tests.test_elbv2.test_elbv2 import create_load_balancer
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")
 
@@ -788,4 +789,33 @@ def test_elb_acm_in_use_by():
 
     assert response["Certificate"]["InUseBy"] == [
         create_load_balancer_request["DNSName"]
+    ]
+
+
+@mock_aws
+def test_elbv2_acm_in_use_by():
+    acm_client = boto3.client("acm", region_name="us-east-1")
+
+    certificate_arn = acm_client.request_certificate(
+        DomainName="fake.domain.com",
+        DomainValidationOptions=[
+            {"DomainName": "fake.domain.com", "ValidationDomain": "domain.com"}
+        ],
+    )["CertificateArn"]
+
+    response, _, _, _, _, elbv2_client = create_load_balancer()
+    load_balancer_arn = response["LoadBalancers"][0]["LoadBalancerArn"]
+
+    create_listener_resp = elbv2_client.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=443,
+        DefaultActions=[],
+        Certificates=[{"CertificateArn": certificate_arn}],
+        AlpnPolicy=["pol1", "pol2"],
+    )
+
+    response = acm_client.describe_certificate(CertificateArn=certificate_arn)
+    assert response["Certificate"]["InUseBy"] == [
+        create_listener_resp["Listeners"][0]["ListenerArn"]
     ]


### PR DESCRIPTION
This PR is similar to https://github.com/getmoto/moto/pull/4414, implementing the same use case for ELBV2.
In a nutshell, it updates the `InUseBy` property of an ACM certificate when attaching it to an ELBV2 listener.

I also fixed the `ListCertificate` operation that should return a boolean `InUse` property, which gets computed from the `InUseBy` attached to the certificate description.