### PR TITLE
EventBridge: Add Name param to ListConnections response

### DIFF
--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -424,6 +424,7 @@ class EventsHandler(BaseResponse):
                     "ConnectionArn": connection.arn,
                     "ConnectionState": "AUTHORIZED",
                     "CreationTime": connection.creation_time,
+                    "Name": connection.name,
                     "LastModifiedTime": connection.creation_time,
                     "AuthorizationType": connection.authorization_type,
                 }

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -2317,6 +2317,7 @@ def test_create_and_list_connections():
         f"arn:aws:events:eu-central-1:{ACCOUNT_ID}:connection/test/"
         in response["Connections"][0]["ConnectionArn"]
     )
+    assert response["Connections"][0]["Name"] == "test"
 
 
 @mock_aws


### PR DESCRIPTION
This PR adds the missing 'Name' parameter to EventBridge [ListConnections](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListConnections.html#API_ListConnections_ResponseSyntax) operation.

This patch is from the LocalStack fork.