### PR TITLE
Fix KeyError Action

### DIFF
--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -243,7 +243,7 @@ class IAMRequestBase(object, metaclass=ABCMeta):
     def _action_from_request(self) -> str:
         if "X-Amz-Target" in self._headers:
             return self._headers["X-Amz-Target"].split(".")[-1]
-        return self._data["Action"]
+        return self._data.get("Action", "")
 
     def check_signature(self) -> None:
         original_signature = self._get_string_between(


### PR DESCRIPTION

Fixes such case
```
@set_initial_no_auth_action_count(0)
def test_lambda_request_unauthorized_user(mocker, aws_lambda):
    mocker.patch(
        "moto.awslambda.responses.LambdaResponse.invoke",
        return_value=(403, {}, '{"message": "No access"}'),
    )
    with pytest.raises(exceptions.ClientError):
        lambda_with_unauthorized_user().request(
            function_name=LAMBDA_FUNCTION,
            payload={"parameter": "value"},
        )

@pytest.fixture(scope="function")
def aws_lambda(iam_user, aws_lambda_role, aws_lambda_bucket):
    with mock_aws(config={"lambda": {"use_docker": True}}):
        lmb = boto3.client(service_name="lambda", region_name=REGION)
        lmb.create_function(
            FunctionName=LAMBDA_FUNCTION,
            Runtime=LAMBDA_PYTHON_RUNTIME,
            Role=aws_lambda_role["Role"]["Arn"],
            Handler="aws_lambda_function.aws_lambda_handler",
            Code={"S3Bucket": LAMBDA_BUCKET, "S3Key": "test.zip"},
            Description="test aws-lambda-function",
            Timeout=1,
            MemorySize=128,
            PackageType="ZIP",
            Publish=True,
            VpcConfig={"SecurityGroupIds": ["sg-123abc"], "SubnetIds": ["subnet-123abc"]},
        )

        yield lmb
