### PR TITLE
Group Dependabot Updates for Java/DotNet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,15 @@ updates:
     directory: "other_langs/tests_java"
     schedule:
       interval: "monthly"
+    groups:
+      java-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "nuget"
     directory: "other_langs/tests_dotnet"
     schedule:
       interval: "monthly"
+    groups:
+      dotnet-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Avoid the multiple PR spam by grouping all Java and DotNet dependency updates into a single PR.