### PR TITLE
Core: Support auth calls for AWSLambda

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -196,6 +196,7 @@ class ActionAuthenticatorMixin(object):
                 data=self.data,  # type: ignore[attr-defined]
                 body=self.body,  # type: ignore[attr-defined]
                 headers=self.headers,  # type: ignore[attr-defined]
+                action=self._get_action(),  # type: ignore[attr-defined]
             )
             iam_request.check_signature()
             iam_request.check_action_permitted(resource)
@@ -552,7 +553,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         return None  # type: ignore[return-value]
 
     def _get_action(self) -> str:
-        action = self.querystring.get("Action", [""])[0]
+        action = self.querystring.get("Action")
+        if action and isinstance(action, list):
+            action = action[0]
         if action:
             return action
         # Some services use a header for the action

--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -8,6 +8,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
+from moto.core import set_initial_no_auth_action_count
 
 from ..markers import requires_docker
 from .test_lambda import LooseVersion, boto3_version
@@ -418,3 +419,36 @@ def test_invoke_lambda_with_entrypoint():
     payload = result["Payload"].read().decode("utf-8")
 
     assert json.loads(payload) == in_data
+
+
+@set_initial_no_auth_action_count(4)
+@mock_aws
+def test_lambda_request_unauthorized_user():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Auth decorator does not work in server mode")
+    iam = boto3.client("iam", region_name="us-west-2")
+    user_name = "test-user"
+    iam.create_user(UserName=user_name)
+    policy_document = {
+        "Version": "2012-10-17",
+        "Statement": {
+            "Effect": "Deny",
+            "Action": ["s3:*", "secretsmanager:*", "lambda:*"],
+            "Resource": "*",
+        },
+    }
+    policy_arn = iam.create_policy(
+        PolicyName="policy2", PolicyDocument=json.dumps(policy_document)
+    )["Policy"]["Arn"]
+    iam.attach_user_policy(UserName=user_name, PolicyArn=policy_arn)
+    access_key = iam.create_access_key(UserName=user_name)["AccessKey"]
+
+    _lambda = boto3.session.Session(
+        aws_access_key_id=access_key["AccessKeyId"],
+        aws_secret_access_key=access_key["SecretAccessKey"],
+        region_name="us-west-2",
+    ).client(service_name="lambda")
+
+    with pytest.raises(ClientError) as exc:
+        _lambda.invoke(FunctionName="n/a", Payload="{}")
+    assert "not authorized to perform: lambda:Invoke" in str(exc.value)


### PR DESCRIPTION
Supercedes #8063

When determining whether the current request is allowed, we need the action that is invoked - e.g. S3:ListBucket, Lambda:Invoke.
Before it would only look at the `X-Amz-Target`-header and at the `Action=`-parameter (typically found in request bodies).

However, for a lot of other services, we need to query `botocore` to determine the action based on the request-url and method. Luckily, the `_get_action`-method combines all methods (`X-Amz-Target`, `Action=`, `botocore`), so we can just use that.