### PR TITLE
ec2: fix security groups describe rule response

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -634,13 +634,17 @@ class SecurityGroupBackend:
         results = []
 
         if sg_rule_ids:
+            rules_sources = [
+                self.sg_old_ingress_ruls.items(),
+                self.sg_old_egress_ruls.items(),
+            ]
             # go thru all the rules in the backend to find a match
             for sg_rule_id in sg_rule_ids:
-                for sg in self.sg_old_ingress_ruls:
-                    for rule in self.sg_old_ingress_ruls[sg]:
-                        if rule.id == sg_rule_id:
-                            results.append(rule)
-
+                for rules in rules_sources:
+                    for sg, rules_list in rules:
+                        for rule in rules_list:
+                            if rule.id == sg_rule_id:
+                                results.append(rule)
             return results
 
         if group_ids:

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -645,7 +645,7 @@ class SecurityGroupBackend:
                         for rule in rules_list:
                             if rule.id == sg_rule_id:
                                 results.append(rule)
-        
+
             return results
 
         if group_ids:

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -645,6 +645,7 @@ class SecurityGroupBackend:
                         for rule in rules_list:
                             if rule.id == sg_rule_id:
                                 results.append(rule)
+        
             return results
 
         if group_ids:

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -698,16 +698,17 @@ def test_create_and_describe_security_grp_rule():
         assert rule["IpProtocol"] == "-1"
         assert rule["CidrIpv4"] == "0.0.0.0/0"
         assert "GroupId" in rule
-    
+
     # Test default egress rule content
     _verify_egress_rule(rules[0])
 
-    # check that the default rule is present using security group rule ids 
+    # check that the default rule is present using security group rule ids
     response = client.describe_security_group_rules(
         SecurityGroupRuleIds=[rules[0]["SecurityGroupRuleId"]]
     )
     rules = response["SecurityGroupRules"]
     _verify_egress_rule(rules[0])
+
 
 @mock_aws
 @pytest.mark.parametrize("use_vpc", [True, False], ids=["Use VPC", "Without VPC"])

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -684,6 +684,7 @@ def test_create_and_describe_security_grp_rule():
         Description="Test SG", GroupName=sg_name, VpcId=vpc.id
     )
 
+    # check that the default rule is present using filters
     response = client.describe_security_group_rules(
         Filters=[{"Name": "group-id", "Values": [sg["GroupId"]]}]
     )
@@ -692,12 +693,21 @@ def test_create_and_describe_security_grp_rule():
     # Only the default rule is present
     assert len(rules) == 1
 
+    def _verify_egress_rule(rule):
+        assert rule["IsEgress"] is True
+        assert rule["IpProtocol"] == "-1"
+        assert rule["CidrIpv4"] == "0.0.0.0/0"
+        assert "GroupId" in rule
+    
     # Test default egress rule content
-    assert rules[0]["IsEgress"] is True
-    assert rules[0]["IpProtocol"] == "-1"
-    assert rules[0]["CidrIpv4"] == "0.0.0.0/0"
-    assert "GroupId" in rules[0]
+    _verify_egress_rule(rules[0])
 
+    # check that the default rule is present using security group rule ids 
+    response = client.describe_security_group_rules(
+        SecurityGroupRuleIds=[rules[0]["SecurityGroupRuleId"]]
+    )
+    rules = response["SecurityGroupRules"]
+    _verify_egress_rule(rules[0])
 
 @mock_aws
 @pytest.mark.parametrize("use_vpc", [True, False], ids=["Use VPC", "Without VPC"])


### PR DESCRIPTION
When using the `describe-security-group-rules` call with a security-group-id `filter`, it correctly returns the egress and ingress rules. However, if we try to use the `describe-security-group-rules` call and specify the `--security-group-rule-ids`, it does not return the rule as expected. 

This PR will now consider both egress and ingress rules while using `--security-group-rule-ids` param in the command. 

Fixes: https://github.com/localstack/localstack/issues/11445