### PR TITLE
Austoscaling: Ensure CreateDate is in isoformat

### DIFF
--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ["acm", "awslambda", "cloudfront", "codebuild", "ds", "elb", "iam", "rds", "route53", "sqs"]
+        service: ["acm", "autoscaling", "awslambda", "cloudfront", "codebuild", "ds", "elb", "iam", "rds", "route53", "sqs"]
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import os
-import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -487,7 +487,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
 
         self.metrics: List[str] = []
         self.warm_pool: Optional[FakeWarmPool] = None
-        self.created_time = created_time
+        self.created_time = created_time.isoformat()
 
     @property
     def tags(self) -> List[Dict[str, str]]:

--- a/other_langs/terraform/autoscaling/data.tf
+++ b/other_langs/terraform/autoscaling/data.tf
@@ -1,0 +1,17 @@
+data "aws_caller_identity" "this" {}
+
+data "aws_vpc" "this" {
+  default = true
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+}
+
+data "aws_subnet" "this" {
+  for_each = toset(data.aws_subnets.this.ids)
+  id       = each.value
+}

--- a/other_langs/terraform/autoscaling/main.tf
+++ b/other_langs/terraform/autoscaling/main.tf
@@ -1,0 +1,33 @@
+resource "tls_private_key" "this" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = var.app_name
+  public_key = tls_private_key.this.public_key_openssh
+}
+
+resource "aws_launch_template" "this" {
+  name                   = var.app_name
+  image_id               = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = aws_key_pair.this.key_name
+  vpc_security_group_ids = [aws_security_group.this.id]
+}
+
+resource "aws_autoscaling_group" "this" {
+  name                  = var.app_name
+  desired_capacity      = 10
+  min_size              = 1
+  max_size              = 50
+  health_check_type     = "EC2"
+  vpc_zone_identifier   = [for subnet_id in data.aws_subnet.this : subnet_id.id]
+
+  wait_for_capacity_timeout = 0
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = aws_launch_template.this.latest_version
+  }
+}

--- a/other_langs/terraform/autoscaling/provider.tf
+++ b/other_langs/terraform/autoscaling/provider.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = var.aws_region
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+   autoscaling = "http://localhost:5000"
+    ec2        = "http://localhost:5000"
+    sts        = "http://localhost:5000"
+  }
+
+  access_key = "my-access-key"
+  secret_key = "my-access-key"
+}

--- a/other_langs/terraform/autoscaling/security_groups.tf
+++ b/other_langs/terraform/autoscaling/security_groups.tf
@@ -1,0 +1,24 @@
+resource "aws_security_group" "this" {
+  name        = var.app_name
+  vpc_id      = data.aws_vpc.this.id
+
+  ingress {
+    description = "SSH ingress"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [for cidr in data.aws_subnet.this : cidr.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = var.app_name
+  }
+
+}

--- a/other_langs/terraform/autoscaling/variables.tf
+++ b/other_langs/terraform/autoscaling/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "The AWS Region to use."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "app_name" {
+  description = "The application name."
+  type        = string
+  default     = "sandwich"
+}
+
+variable "ami_id" {
+  description = "The AMI to use."
+  type        = string
+  default     = "ami-12c6146b"
+}
+
+variable "instance_type" {
+  description = "The instance type to use."
+  type        = string
+  default     = "t2.nano"
+}

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from uuid import uuid4
+from freezegun import freeze_time
 
 import boto3
 import pytest
@@ -1343,7 +1344,7 @@ def test_create_template_with_block_device():
     assert volumes[1]["VolumeType"] == "gp3"
     assert volumes[1]["Size"] == 20
 
-
+@freezegun.freeze_time("2024-09-05 12:34:56")
 @mock_aws
 def test_sets_created_time():
     mocked_networking = setup_networking()
@@ -1364,6 +1365,4 @@ def test_sets_created_time():
 
     asgs = conn.describe_auto_scaling_groups()["AutoScalingGroups"]
     assert len(asgs) == 1
-    assert asgs[0]["CreatedTime"] != datetime.strptime(
-        "2013-05-06T17:47:15.107Z", "%Y-%m-%dT%H:%M:%S.%f%z"
-    )
+    assert asgs[0]["CreatedTime"] == "2024-09-05T12:34:56"

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1344,7 +1344,7 @@ def test_create_template_with_block_device():
     assert volumes[1]["VolumeType"] == "gp3"
     assert volumes[1]["Size"] == 20
 
-@freezegun.freeze_time("2024-09-05 12:34:56")
+@freeze_time("2024-09-05 12:34:56")
 @mock_aws
 def test_sets_created_time():
     mocked_networking = setup_networking()

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1,9 +1,9 @@
+from datetime import datetime
 from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from freezegun import freeze_time
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -1344,7 +1344,6 @@ def test_create_template_with_block_device():
     assert volumes[1]["Size"] == 20
 
 
-@freeze_time("2024-09-05 12:34:56")
 @mock_aws
 def test_sets_created_time():
     mocked_networking = setup_networking()
@@ -1365,4 +1364,6 @@ def test_sets_created_time():
 
     asgs = conn.describe_auto_scaling_groups()["AutoScalingGroups"]
     assert len(asgs) == 1
-    assert asgs[0]["CreatedTime"] == "2024-09-05T12:34:56"
+    assert asgs[0]["CreatedTime"].strftime("%Y %m %d") == datetime.now().strftime(
+        "%Y %m %d"
+    )

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -1,10 +1,9 @@
-from datetime import datetime
 from uuid import uuid4
-from freezegun import freeze_time
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from freezegun import freeze_time
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
@@ -1343,6 +1342,7 @@ def test_create_template_with_block_device():
     # Our Ebs-volume
     assert volumes[1]["VolumeType"] == "gp3"
     assert volumes[1]["Size"] == 20
+
 
 @freeze_time("2024-09-05 12:34:56")
 @mock_aws

--- a/update_version_from_git.py
+++ b/update_version_from_git.py
@@ -26,6 +26,7 @@ import os
 import re
 import subprocess
 import sys
+
 from packaging.version import Version
 
 


### PR DESCRIPTION
Howdy,

When creating an AutoScaling Group the  `CreatedTime` should be in ISO format. At the moment the returned value is causing a deserialization error.

```
│ Error: reading Auto Scaling Group (sandwich): operation error Auto Scaling: DescribeAutoScalingGroups, https response error StatusCode: 200, RequestID: ucKD1cbqn2lqSIvuMlxcMYuaWEyT6kImWKuyBdbUHE7Gr4YZ0VdO, deserialization failed, failed to decode response body, unable to parse time string, parse errors:
│  * "2006-01-02T15:04:05.999999999Z": parsing time "2024-09-06 02:13:02.824378" as "2006-01-02T15:04:05.999999999Z": cannot parse " 02:13:02.824378" as "T"
│  * "2006-01-02T15:04:05.999999999": parsing time "2024-09-06 02:13:02.824378" as "2006-01-02T15:04:05.999999999": cannot parse " 02:13:02.824378" as "T"
│  * "2006-01-02T15:04:05.999999999Z07:00": parsing time "2024-09-06 02:13:02.824378" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse " 02:13:02.824378" as "T"
│  * "2006-01-02T15:04:05Z07:00": parsing time "2024-09-06 02:13:02.824378" as "2006-01-02T15:04:05Z07:00": cannot parse " 02:13:02.824378" as "T"
```

As part of the PR, I included the terraform tests to reproduce the above error with the current version of moto `5.0.13`

```
terraform --version
Terraform v1.9.5
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v5.65.0
```