### PR TITLE
Firehose: Add Snowflake Destination

### DIFF
--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -47,6 +47,7 @@ DESTINATION_TYPES_TO_NAMES = {
     "http_endpoint": "HttpEndpoint",
     "elasticsearch": "Elasticsearch",
     "redshift": "Redshift",
+    "snowflake": "Snowflake",
     "splunk": "Splunk",  # Unimplemented
 }
 
@@ -200,6 +201,7 @@ class FirehoseBackend(BaseBackend):
         elasticsearch_destination_configuration: Dict[str, Any],
         splunk_destination_configuration: Dict[str, Any],
         http_endpoint_destination_configuration: Dict[str, Any],
+        snowflake_destination_configuration: Dict[str, Any],
         tags: List[Dict[str, str]],
     ) -> str:
         """Create a Kinesis Data Firehose delivery stream."""
@@ -600,6 +602,7 @@ class FirehoseBackend(BaseBackend):
         elasticsearch_destination_update: Dict[str, Any],
         splunk_destination_update: Dict[str, Any],
         http_endpoint_destination_update: Dict[str, Any],
+        snowflake_destination_configuration: Dict[str, Any]
     ) -> None:
         (dest_name, dest_config) = find_destination_config_in_args(locals())
 

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -602,7 +602,7 @@ class FirehoseBackend(BaseBackend):
         elasticsearch_destination_update: Dict[str, Any],
         splunk_destination_update: Dict[str, Any],
         http_endpoint_destination_update: Dict[str, Any],
-        snowflake_destination_configuration: Dict[str, Any]
+        snowflake_destination_configuration: Dict[str, Any],
     ) -> None:
         (dest_name, dest_config) = find_destination_config_in_args(locals())
 

--- a/moto/firehose/responses.py
+++ b/moto/firehose/responses.py
@@ -32,6 +32,7 @@ class FirehoseResponse(BaseResponse):
             self._get_param("ElasticsearchDestinationConfiguration"),
             self._get_param("SplunkDestinationConfiguration"),
             self._get_param("HttpEndpointDestinationConfiguration"),
+            self._get_param("SnowflakeDestinationConfiguration"),
             self._get_param("Tags"),
         )
         return json.dumps({"DeliveryStreamARN": delivery_stream_arn})
@@ -109,6 +110,7 @@ class FirehoseResponse(BaseResponse):
             self._get_param("ElasticsearchDestinationUpdate"),
             self._get_param("SplunkDestinationUpdate"),
             self._get_param("HttpEndpointDestinationUpdate"),
+            self._get_param("SnowflakeDestinationConfiguration")
         )
         return json.dumps({})
 

--- a/moto/firehose/responses.py
+++ b/moto/firehose/responses.py
@@ -110,7 +110,7 @@ class FirehoseResponse(BaseResponse):
             self._get_param("ElasticsearchDestinationUpdate"),
             self._get_param("SplunkDestinationUpdate"),
             self._get_param("HttpEndpointDestinationUpdate"),
-            self._get_param("SnowflakeDestinationConfiguration")
+            self._get_param("SnowflakeDestinationConfiguration"),
         )
         return json.dumps({})
 


### PR DESCRIPTION
So far we cannot use moto to test Firehose Service with the Snowflake destination

Example:
```python
@pytest.fixture(autouse=True, scope="class")
    def firehose_client_inst(self):
        with mock_aws():
            firehose_client = boto3.client("firehose", region_name="eu-west-1")

            for firehose_stream_name in FIREHOSE_STREAM_NAMES:
                firehose_client.create_delivery_stream(
                    DeliveryStreamName=firehose_stream_name,
                    SnowflakeDestinationConfiguration={
                        "RoleARN": f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:role/firehose_delivery_role",
                        "AccountUrl": "fake-account.eu-west-1.snowflakecomputing.com",
                        "Database": "myDatabase",
                        "Schema": "mySchema",
                        "Table": "myTable",
                        "S3BackupMode": "FailedDataOnly",
                        "S3Configuration": {
                            "RoleARN": f"arn:aws:iam::{DEFAULT_ACCOUNT_ID}:role/firehose_delivery_role",
                            "BucketARN": "arn:aws:s3:::kinesis-test"
                        }
                    }
                )

            yield firehose_client
```

Output error:
```
botocore.errorfactory.InvalidArgumentException: An error occurred (InvalidArgumentException) when calling the CreateDeliveryStream operation: Exactly one destination configuration is supported for a Firehose
```

Tests OK on my project if I modify Moto lib locally.