### PR TITLE
[BUG Fix] route53 - list_tags_for_resources: Resolve when a single ID is provided

### DIFF
--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -380,6 +380,9 @@ class Route53(BaseResponse):
         resource_ids = xmltodict.parse(self.body)["ListTagsForResourcesRequest"][
             "ResourceIds"
         ]["ResourceId"]
+        # If only one resource id is passed, it is a string, not a list
+        if not isinstance(resource_ids, list):
+            resource_ids = [resource_ids]
         tag_sets = self.backend.list_tags_for_resources(resource_ids=resource_ids)
         template = Template(LIST_TAGS_FOR_RESOURCES_RESPONSE)
         return template.render(tag_sets=tag_sets, resource_type=resource_type)

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -373,7 +373,7 @@ class Route53(BaseResponse):
             return 200, headers, template.render()
 
     def list_tags_for_resources(self) -> str:
-        if id_matcher := re.search(r"/tags/[-a-z]+/(.+)", self.parsed_url.path):
+        if id_matcher := re.search(r"/tags/(.+)", self.parsed_url.path):
             resource_type = unquote(id_matcher.group(1))
         else:
             resource_type = ""

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -634,6 +634,7 @@ def test_list_tags_for_resources():
     assert len(response["ResourceTagSets"]) == 2
     for set in response["ResourceTagSets"]:
         assert set["ResourceId"] in (zone1_id, zone2_id)
+        assert set["ResourceType"] == "hostedzone"
         if set["ResourceId"] == zone1_id:
             assert tag1 in set["Tags"]
             assert tag2 in set["Tags"]
@@ -652,6 +653,7 @@ def test_list_tags_for_resources():
     assert len(response["ResourceTagSets"]) == 1
     for set in response["ResourceTagSets"]:
         assert set["ResourceId"] == zone1_id
+        assert set["ResourceType"] == "hostedzone"
         assert tag1 in set["Tags"]
         assert tag2 in set["Tags"]
         assert tag3 not in set["Tags"]
@@ -664,6 +666,7 @@ def test_list_tags_for_resources():
     assert len(response["ResourceTagSets"]) == 2
     for set in response["ResourceTagSets"]:
         assert set["ResourceId"] in (healthcheck1_id, healthcheck2_id)
+        assert set["ResourceType"] == "healthcheck"
         if set["ResourceId"] == healthcheck1_id:
             assert tag1 in set["Tags"]
             assert tag2 in set["Tags"]

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -644,6 +644,18 @@ def test_list_tags_for_resources():
             assert tag2 not in set["Tags"]
             assert tag3 in set["Tags"]
             assert tag4 in set["Tags"]
+    
+    # Test hostedzone with single resource
+    response = conn.list_tags_for_resources(
+        ResourceIds=[zone1_id], ResourceType="hostedzone"
+    )
+    assert len(response["ResourceTagSets"]) == 1
+    for set in response["ResourceTagSets"]:
+        assert set["ResourceId"] == zone1_id
+        assert tag1 in set["Tags"]
+        assert tag2 in set["Tags"]
+        assert tag3 not in set["Tags"]
+        assert tag4 not in set["Tags"]
 
     # Test healthcheck
     response = conn.list_tags_for_resources(

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -645,7 +645,7 @@ def test_list_tags_for_resources():
             assert tag2 not in set["Tags"]
             assert tag3 in set["Tags"]
             assert tag4 in set["Tags"]
-    
+
     # Test hostedzone with single resource
     response = conn.list_tags_for_resources(
         ResourceIds=[zone1_id], ResourceType="hostedzone"


### PR DESCRIPTION
Fixes two bugs.

1. When list_tags_for_resource is passed only a single ID, the request is a string and not a list
2. The regex for deriving resource_type was always None