### PR TITLE
[BUG FIX] EC2: Exclude existing tags to be overwritten from the TagLimitExceeded validation

### DIFF
--- a/moto/ec2/models/tags.py
+++ b/moto/ec2/models/tags.py
@@ -26,7 +26,14 @@ class TagBackend:
             if resource_id in self.tags:
                 if (
                     len(self.tags[resource_id])
-                    + len([tag for tag in tags if not tag.startswith("aws:")])
+                    + len(
+                        [
+                            tag
+                            for tag in tags
+                            if not tag.startswith("aws:")
+                            and tag not in self.tags[resource_id]
+                        ]
+                    )
                     > 50
                 ):
                     raise TagLimitExceeded()


### PR DESCRIPTION
Although EC2 API does not provide a method to update existing tags, [CreateTags](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateTags.html) will overwrite existing tag keys with the new given value. Therefore, existing tags passed as argument to `create_tags()` method should not be taken into consideration to validate `TagLimitExceeded` exception when the resource underneath exists.

It has been tested in AWS that, updating one or more tag values of a resource which tag count is already on the limit (50), works well using AWS CLI, boto3 and Terraform.