### PR TITLE
IAM: Urlencode IAM policies in responses to match AWS

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -101,6 +101,12 @@ def mark_account_as_visited(
         pass
 
 
+def _serialize_version_datetime(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d")
+    raise TypeError("Unable to serialize value.")
+
+
 LIMIT_KEYS_PER_USER = 2
 
 
@@ -747,13 +753,8 @@ class Role(CloudFormationModel):
 
         assume_role_policy_document = properties["AssumeRolePolicyDocument"]
         if not isinstance(assume_role_policy_document, str):
-
-            def _serialize_datetime(value):
-                if isinstance(value, datetime):
-                    return value.strftime("%Y-%m-%d")
-
             assume_role_policy_document = json.dumps(
-                assume_role_policy_document, default=_serialize_datetime
+                assume_role_policy_document, default=_serialize_version_datetime
             )
 
         iam_backend = iam_backends[account_id][get_partition(region_name)]

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import string
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 from urllib import parse
 
@@ -102,7 +102,7 @@ def mark_account_as_visited(
 
 
 def _serialize_version_datetime(value: Any) -> str:
-    if isinstance(value, datetime):
+    if isinstance(value, date):
         return value.strftime("%Y-%m-%d")
     raise TypeError("Unable to serialize value.")
 

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -898,7 +898,7 @@ class Role(CloudFormationModel):
       <Path>{{ role.path }}</Path>
       <Arn>{{ role.arn }}</Arn>
       <RoleName>{{ role.name }}</RoleName>
-      <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+      <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
       {% if role.description is not none %}
       <Description>{{ role.description_escaped }}</Description>
       {% endif %}

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -745,10 +745,21 @@ class Role(CloudFormationModel):
         properties = cloudformation_json["Properties"]
         role_name = properties.get("RoleName", resource_name)
 
+        assume_role_policy_document = properties["AssumeRolePolicyDocument"]
+        if not isinstance(assume_role_policy_document, str):
+
+            def _serialize_datetime(value):
+                if isinstance(value, datetime):
+                    return value.strftime("%Y-%m-%d")
+
+            assume_role_policy_document = json.dumps(
+                assume_role_policy_document, default=_serialize_datetime
+            )
+
         iam_backend = iam_backends[account_id][get_partition(region_name)]
         role = iam_backend.create_role(
             role_name=role_name,
-            assume_role_policy_document=properties["AssumeRolePolicyDocument"],
+            assume_role_policy_document=assume_role_policy_document,
             path=properties.get("Path", "/"),
             permissions_boundary=properties.get("PermissionsBoundary", ""),
             description=properties.get("Description", ""),

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1403,7 +1403,7 @@ CREATE_INSTANCE_PROFILE_TEMPLATE = """<CreateInstanceProfileResponse xmlns="http
           <Path>{{ role.path }}</Path>
           <Arn>{{ role.arn }}</Arn>
           <RoleName>{{ role.name }}</RoleName>
-          <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+          <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
           <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
           <RoleId>{{ role.id }}</RoleId>
         </member>
@@ -1444,7 +1444,7 @@ GET_INSTANCE_PROFILE_TEMPLATE = """<GetInstanceProfileResponse xmlns="https://ia
           <Path>{{ role.path }}</Path>
           <Arn>{{ role.arn }}</Arn>
           <RoleName>{{ role.name }}</RoleName>
-          <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+          <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
           <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
           <RoleId>{{ role.id }}</RoleId>
         </member>
@@ -1482,7 +1482,7 @@ GET_ROLE_POLICY_TEMPLATE = """<GetRolePolicyResponse xmlns="https://iam.amazonaw
 <GetRolePolicyResult>
   <PolicyName>{{ policy_name }}</PolicyName>
   <RoleName>{{ role_name }}</RoleName>
-  <PolicyDocument>{{ policy_document }}</PolicyDocument>
+  <PolicyDocument>{{ policy_document | urlencode }}</PolicyDocument>
 </GetRolePolicyResult>
 <ResponseMetadata>
   <RequestId>7e7cd8bc-99ef-11e1-a4c3-27EXAMPLE804</RequestId>
@@ -1566,7 +1566,7 @@ LIST_ROLES_TEMPLATE = """<ListRolesResponse xmlns="https://iam.amazonaws.com/doc
         <Path>{{ role.path }}</Path>
         <Arn>{{ role.arn }}</Arn>
         <RoleName>{{ role.name }}</RoleName>
-        <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+        <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
         <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
         <RoleId>{{ role.id }}</RoleId>
         <MaxSessionDuration>{{ role.max_session_duration }}</MaxSessionDuration>
@@ -1662,7 +1662,7 @@ LIST_INSTANCE_PROFILES_TEMPLATE = """<ListInstanceProfilesResponse xmlns="https:
             <Path>{{ role.path }}</Path>
             <Arn>{{ role.arn }}</Arn>
             <RoleName>{{ role.name }}</RoleName>
-            <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+            <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
             <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
             <RoleId>{{ role.id }}</RoleId>
           </member>
@@ -1831,7 +1831,7 @@ GET_GROUP_POLICY_TEMPLATE = """<GetGroupPolicyResponse xmlns="https://iam.amazon
 <GetGroupPolicyResult>
   <PolicyName>{{ policy_name }}</PolicyName>
   <GroupName>{{ group_name }}</GroupName>
-  <PolicyDocument>{{ policy_document }}</PolicyDocument>
+  <PolicyDocument>{{ policy_document | urlencode }}</PolicyDocument>
 </GetGroupPolicyResult>
 <ResponseMetadata>
   <RequestId>7e7cd8bc-99ef-11e1-a4c3-27EXAMPLE804</RequestId>
@@ -1927,7 +1927,7 @@ GET_USER_POLICY_TEMPLATE = """<GetUserPolicyResponse>
       <UserName>{{ user_name }}</UserName>
       <PolicyName>{{ policy_name }}</PolicyName>
       <PolicyDocument>
-      {{ policy_document }}
+      {{ policy_document | urlencode }}
       </PolicyDocument>
    </GetUserPolicyResult>
    <ResponseMetadata>
@@ -2134,7 +2134,7 @@ LIST_INSTANCE_PROFILES_FOR_ROLE_TEMPLATE = """<ListInstanceProfilesForRoleRespon
         <Path>{{ role.path }}</Path>
         <Arn>{{ role.arn }}</Arn>
         <RoleName>{{ role.name }}</RoleName>
-        <AssumeRolePolicyDocument>{{ role.assume_policy_document }}</AssumeRolePolicyDocument>
+        <AssumeRolePolicyDocument>{{ role.assume_policy_document | urlencode }}</AssumeRolePolicyDocument>
         <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
         <RoleId>{{ role.id }}</RoleId>
       </member>
@@ -2319,7 +2319,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         {% for policy in user.policies %}
             <member>
                 <PolicyName>{{ policy }}</PolicyName>
-                <PolicyDocument>{{ user.policies[policy] }}</PolicyDocument>
+                <PolicyDocument>{{ user.policies[policy] | urlencode }}</PolicyDocument>
             </member>
         {% endfor %}
         </UserPolicyList>
@@ -2355,7 +2355,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         {% for policy in group.policies %}
             <member>
                 <PolicyName>{{ policy }}</PolicyName>
-                <PolicyDocument>{{ group.policies[policy] }}</PolicyDocument>
+                <PolicyDocument>{{ group.policies[policy] | urlencode }}</PolicyDocument>
             </member>
         {% endfor %}
         </GroupPolicyList>
@@ -2369,7 +2369,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         {% for inline_policy in role.policies %}
             <member>
                 <PolicyName>{{ inline_policy }}</PolicyName>
-                <PolicyDocument>{{ role.policies[inline_policy] }}</PolicyDocument>
+                <PolicyDocument>{{ role.policies[inline_policy] | urlencode }}</PolicyDocument>
             </member>
         {% endfor %}
         </RolePolicyList>
@@ -2399,7 +2399,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
                 <Path>{{ role.path }}</Path>
                 <Arn>{{ role.arn }}</Arn>
                 <RoleName>{{ role.name }}</RoleName>
-                <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+                <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
                 {% if role.description is not none %}
                 <Description>{{ role.description_escaped }}</Description>
                 {% endif %}
@@ -2424,7 +2424,7 @@ GET_ACCOUNT_AUTHORIZATION_DETAILS_TEMPLATE = """<GetAccountAuthorizationDetailsR
         <Path>{{ role.path }}</Path>
         <Arn>{{ role.arn }}</Arn>
         <RoleName>{{ role.name }}</RoleName>
-        <AssumeRolePolicyDocument>{{ role.assume_role_policy_document }}</AssumeRolePolicyDocument>
+        <AssumeRolePolicyDocument>{{ role.assume_role_policy_document | urlencode }}</AssumeRolePolicyDocument>
         <CreateDate>{{ role.created_iso_8601 }}</CreateDate>
         <RoleId>{{ role.id }}</RoleId>
       </member>

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -209,8 +209,11 @@ def test_get_instance_profile__should_throw__when_instance_profile_does_not_exis
 def test_create_role_and_instance_profile():
     conn = boto3.client("iam", region_name="us-east-1")
     conn.create_instance_profile(InstanceProfileName="my-profile", Path="my-path")
+    assume_role_policy_document = {"value": "some policy"}
     conn.create_role(
-        RoleName="my-role", AssumeRolePolicyDocument="some policy", Path="/my-path/"
+        RoleName="my-role",
+        AssumeRolePolicyDocument=json.dumps(assume_role_policy_document),
+        Path="/my-path/",
     )
 
     conn.add_role_to_instance_profile(
@@ -219,7 +222,7 @@ def test_create_role_and_instance_profile():
 
     role = conn.get_role(RoleName="my-role")["Role"]
     assert role["Path"] == "/my-path/"
-    assert role["AssumeRolePolicyDocument"] == "some policy"
+    assert role["AssumeRolePolicyDocument"] == assume_role_policy_document
 
     profile = conn.get_instance_profile(InstanceProfileName="my-profile")[
         "InstanceProfile"


### PR DESCRIPTION
## Motivation

Currently, moto does not urlencode (or quote) IAM policy strings in its return values.

While this seemingly matches the AWS behavior, as described here: https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetRolePolicy.html , more investigation shows AWS actually quoting the IAM policies, as shown in responses (printed by boto3 in debug mode):

```
<GetUserPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">\n  <GetUserPolicyResult>\n    <PolicyDocument>%7B%22Version%22%3A%20%222012-10-17%22%2C%20%22Statement%22%3A%20%5B%7B%22Effect%22%3A%20%22Allow%22%2C%20%22Action%22%3A%20%5B%22apigatway%3APUT%22%5D%2C%20%22Resource%22%3A%20%5B%22arn%3Aaws%3Aapigateway%3Aeu-central-1%3A%3A%2Ftags%2Farn%253Aaws%253Aapigateway%253Aeu-central-1%253A%253A%252Frestapis%252Faaeeieije%22%5D%7D%5D%7D</PolicyDocument>\n    <PolicyName>test-policy-e6e63d20</PolicyName>\n    <UserName>test-user-f7e28e2a</UserName>\n  </GetUserPolicyResult>\n  <ResponseMetadata>\n    <RequestId>f3802db8-a14c-464e-a771-ff7fe32b6258</RequestId>\n  </ResponseMetadata>\n</GetUserPolicyResponse>\n

<GetRolePolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">\n  <GetRolePolicyResult>\n    <PolicyDocument>%7B%22Version%22%3A%20%222012-10-17%22%2C%20%22Statement%22%3A%20%5B%7B%22Effect%22%3A%20%22Allow%22%2C%20%22Action%22%3A%20%5B%22apigatway%3APUT%22%5D%2C%20%22Resource%22%3A%20%5B%22arn%3Aaws%3Aapigateway%3Aeu-central-1%3A%3A%2Ftags%2Farn%253Aaws%253Aapigateway%253Aeu-central-1%253A%253A%252Frestapis%252Faaeeieije%22%5D%7D%5D%7D</PolicyDocument>\n    <PolicyName>test-policy-deb509f4</PolicyName>\n    <RoleName>test-role-c91b9d39</RoleName>\n  </GetRolePolicyResult>\n  <ResponseMetadata>\n    <RequestId>39d72c56-b704-4f5b-b877-faed38d66107</RequestId>\n  </ResponseMetadata>\n</GetRolePolicyResponse>\n

<GetGroupPolicyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">\n  <GetGroupPolicyResult>\n    <PolicyDocument>%7B%22Version%22%3A%20%222012-10-17%22%2C%20%22Statement%22%3A%20%5B%7B%22Effect%22%3A%20%22Allow%22%2C%20%22Action%22%3A%20%5B%22apigatway%3APUT%22%5D%2C%20%22Resource%22%3A%20%5B%22arn%3Aaws%3Aapigateway%3Aeu-central-1%3A%3A%2Ftags%2Farn%253Aaws%253Aapigateway%253Aeu-central-1%253A%253A%252Frestapis%252Faaeeieije%22%5D%7D%5D%7D</PolicyDocument>\n    <GroupName>test-group-aef07898</GroupName>\n    <PolicyName>test-policy-ce391a0a</PolicyName>\n  </GetGroupPolicyResult>\n  <ResponseMetadata>\n    <RequestId>43faabdb-8ec0-4268-b0c1-8fc4f8d5c9ce</RequestId>\n  </ResponseMetadata>\n</GetGroupPolicyResponse>\n

<GetRoleResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">\n  <GetRoleResult>\n    <Role>\n      <Path>/</Path>\n      <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22aws%3ASourceArn%22%3A%22arn%253Aaws%253Aapigateway%253Aeu-central-1%253A%253A%252Frestapis%252Faaeeieije%22%7D%7D%7D%5D%7D</AssumeRolePolicyDocument>\n      <MaxSessionDuration>3600</MaxSessionDuration>\n      <RoleId>AROA4U6S5KWRHJDLN2CH2</RoleId>\n      <RoleLastUsed/>\n      <RoleName>test-role-607dbc4b</RoleName>\n      <Arn>arn:aws:iam::869636330914:role/test-role-607dbc4b</Arn>\n      <CreateDate>2024-09-25T15:10:45Z</CreateDate>\n    </Role>\n  </GetRoleResult>\n  <ResponseMetadata>\n    <RequestId>48170cd2-4fe2-456b-8132-abd1d739e77b</RequestId>\n  </ResponseMetadata>\n</GetRoleResponse>\n
```

While this does not impact many users, the disparity shows when you try to set a field in the IAM policies to a urlencoded value, like necessary for matching the resource for the `apigateway.TagResource` operation: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonapigatewaymanagement.html#amazonapigatewaymanagement-Tags

Since boto3 will unquote the string, it does not matches the input anymore.

## Changes
* Urlencode returned policy documents, so a single decode will still keep the already-urlencoded parts of the policy correct.
* Add tests testing this behavior by adding policy documents with urlencoded parts, and asserting that the response matches the input.

