### PR TITLE
batch: fix bug in add_parameters_to_command

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -638,12 +638,17 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         if not self.parameters:
             return command
 
-        new_command = [
-            command_part.replace(f"Ref::{param}", value)
+        return [
+            next(
+                (
+                    command_part.replace(f"Ref::{param}", value)
+                    for param, value in self.parameters.items()
+                    if f"Ref::{param}" in command_part
+                ),
+                command_part,
+            )
             for command_part in command
-            for param, value in self.parameters.items()
         ]
-        return new_command
 
     def run(self) -> None:
         """

--- a/tests/test_batch/test_utils.py
+++ b/tests/test_batch/test_utils.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 import pytest
 
 from moto.batch.exceptions import ValidationError
+from moto.batch.models import Job
 from moto.batch.utils import JobStatus
 
 
@@ -67,3 +70,14 @@ def test_JobStatus_status_transitions():
         else:
             assert before_status == JobStatus.STARTING
             assert after_status == JobStatus.RUNNING
+
+
+@patch.object(Job, "__init__", lambda self, *args, **kwargs: None)
+def test_add_parameters_to_command():
+    _parameters = {"dossier_md5": "abc", "study_id": "T123BC00001"}
+    _command = ["--dossier_md5", "Ref::dossier_md5", "--study_id", "Ref::study_id"]
+
+    job = Job()  # noqa
+    job.parameters = _parameters
+    output = job._add_parameters_to_command(command=_command)
+    assert output == ["--dossier_md5", "abc", "--study_id", "T123BC00001"]


### PR DESCRIPTION
https://github.com/getmoto/moto/pull/7973 introduced support for parameters in job commands.
However, the `_add_parameters_to_command` function had a bug that resulted in duplicated arguments, when the number of arguments was greater than one.

This was due to the nested list comprehension logic adopted.

For instance, the  given the following job parameters `{'dossier_md5': 'abc', 'event_id': 'E12340060311'}` and the following command `['--dossier_md5', 'Ref::dossier_md5', '--event_id', 'Ref::event_id']` we were given the following output:
```
['--dossier_md5', '--dossier_md5', 'abc', 'Ref::dossier_md5', '--event_id', '--event_id', 'Ref::event_id', 'E12340060311']
```

This PR adjusts the logic accordingly and adds a simple unit test to verify the fix.

