### PR TITLE
QuickSight support users with special characters

### DIFF
--- a/moto/quicksight/responses.py
+++ b/moto/quicksight/responses.py
@@ -1,6 +1,7 @@
 """Handles incoming quicksight requests, invokes methods, returns responses."""
 
 import json
+from urllib.parse import unquote
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
@@ -42,7 +43,7 @@ class QuickSightResponse(BaseResponse):
         aws_account_id = self.path.split("/")[-7]
         namespace = self.path.split("/")[-5]
         group_name = self.path.split("/")[-3]
-        user_name = self.path.split("/")[-1]
+        user_name = unquote(self.path.split("/")[-1])
         member = self.quicksight_backend.create_group_membership(
             aws_account_id, namespace, group_name, user_name
         )
@@ -58,7 +59,7 @@ class QuickSightResponse(BaseResponse):
         aws_account_id = self.path.split("/")[-7]
         namespace = self.path.split("/")[-5]
         group_name = self.path.split("/")[-3]
-        user_name = self.path.split("/")[-1]
+        user_name = unquote(self.path.split("/")[-1])
         member = self.quicksight_backend.describe_group_membership(
             aws_account_id, namespace, group_name, user_name
         )
@@ -116,7 +117,7 @@ class QuickSightResponse(BaseResponse):
     def describe_user(self) -> str:
         aws_account_id = self.path.split("/")[-5]
         namespace = self.path.split("/")[-3]
-        user_name = self.path.split("/")[-1]
+        user_name = unquote(self.path.split("/")[-1])
 
         user = self.quicksight_backend.describe_user(
             aws_account_id, namespace, user_name
@@ -134,7 +135,7 @@ class QuickSightResponse(BaseResponse):
     def delete_user(self) -> TYPE_RESPONSE:
         aws_account_id = self.path.split("/")[-5]
         namespace = self.path.split("/")[-3]
-        user_name = self.path.split("/")[-1]
+        user_name = unquote(self.path.split("/")[-1])
 
         self.quicksight_backend.delete_user(aws_account_id, namespace, user_name)
         return 204, {"status": 204}, json.dumps({"Status": 204})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,9 @@ prompt_toolkit
 
 # type stubs that mypy doesn't install automatically
 botocore-stubs
+types-requests
+types-python-dateutil
+types-PyYAML
 
 
 # typing_extensions is currently used for:

--- a/tests/test_quicksight/test_quicksight_users.py
+++ b/tests/test_quicksight/test_quicksight_users.py
@@ -11,78 +11,135 @@ from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 # http://docs.getmoto.org/en/latest/docs/contributing/development_tips/tests.html
 
 
+@pytest.mark.parametrize(
+    "request_params",
+    [
+        {
+            "Email": "fakeemail@example.com",
+            "UserName": "tfacctestm9hpsr970z",
+            "UserRole": "READER",
+            "IdentityType": "QUICKSIGHT",
+        },
+        {
+            "Email": "authoremail@example.com",
+            "UserName": "QuickSightAuthor/authoremail@example.com",
+            "UserRole": "AUTHOR",
+            "IdentityType": "IAM",
+        },
+    ],
+)
 @mock_aws
-def test_register_user__quicksight():
+def test_register_user__quicksight(request_params):
     client = boto3.client("quicksight", region_name="us-east-2")
     resp = client.register_user(
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
-        Email="fakeemail@example.com",
-        IdentityType="QUICKSIGHT",
-        UserName="tfacctestm9hpsr970z",
-        UserRole="READER",
+        Email=request_params["Email"],
+        IdentityType=request_params["IdentityType"],
+        UserName=request_params["UserName"],
+        UserRole=request_params["UserRole"],
     )
 
     assert "UserInvitationUrl" in resp
     assert "User" in resp
 
     assert resp["User"]["Arn"] == (
-        f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:user/default/tfacctestm9hpsr970z"
+        f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:user/default/{request_params['UserName']}"
     )
-    assert resp["User"]["UserName"] == "tfacctestm9hpsr970z"
-    assert resp["User"]["Email"] == "fakeemail@example.com"
-    assert resp["User"]["Role"] == "READER"
-    assert resp["User"]["IdentityType"] == "QUICKSIGHT"
+    assert resp["User"]["UserName"] == request_params["UserName"]
+    assert resp["User"]["Email"] == request_params["Email"]
+    assert resp["User"]["Role"] == request_params["UserRole"]
+    assert resp["User"]["IdentityType"] == request_params["IdentityType"]
     assert resp["User"]["Active"] is False
 
 
+@pytest.mark.parametrize(
+    "request_params",
+    [
+        {
+            "Email": "fakeemail@example.com",
+            "UserName": "tfacctestm9hpsr970z",
+            "UserRole": "READER",
+            "IdentityType": "QUICKSIGHT",
+        },
+        {
+            "Email": "authoremail@example.com",
+            "UserName": "QuickSightAuthor/authoremail@example.com",
+            "UserRole": "AUTHOR",
+            "IdentityType": "IAM",
+        },
+    ],
+)
 @mock_aws
-def test_describe_user__quicksight():
+def test_describe_user__quicksight(request_params):
     client = boto3.client("quicksight", region_name="us-east-1")
     client.register_user(
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
-        Email="fakeemail@example.com",
-        IdentityType="QUICKSIGHT",
-        UserName="tfacctestm9hpsr970z",
-        UserRole="READER",
+        Email=request_params["Email"],
+        IdentityType=request_params["IdentityType"],
+        UserName=request_params["UserName"],
+        UserRole=request_params["UserRole"],
     )
 
     resp = client.describe_user(
-        UserName="tfacctestm9hpsr970z", AwsAccountId=ACCOUNT_ID, Namespace="default"
+        UserName=request_params["UserName"],
+        AwsAccountId=ACCOUNT_ID,
+        Namespace="default",
     )
 
     assert "User" in resp
 
     assert resp["User"]["Arn"] == (
-        f"arn:aws:quicksight:us-east-1:{ACCOUNT_ID}:user/default/tfacctestm9hpsr970z"
+        f"arn:aws:quicksight:us-east-1:{ACCOUNT_ID}:user/default/{request_params['UserName']}"
     )
-    assert resp["User"]["UserName"] == "tfacctestm9hpsr970z"
-    assert resp["User"]["Email"] == "fakeemail@example.com"
-    assert resp["User"]["Role"] == "READER"
-    assert resp["User"]["IdentityType"] == "QUICKSIGHT"
+    assert resp["User"]["UserName"] == request_params["UserName"]
+    assert resp["User"]["Email"] == request_params["Email"]
+    assert resp["User"]["Role"] == request_params["UserRole"]
+    assert resp["User"]["IdentityType"] == request_params["IdentityType"]
     assert resp["User"]["Active"] is False
 
 
+@pytest.mark.parametrize(
+    "request_params",
+    [
+        {
+            "Email": "fakeemail@example.com",
+            "UserName": "tfacctestm9hpsr970z",
+            "UserRole": "READER",
+            "IdentityType": "QUICKSIGHT",
+        },
+        {
+            "Email": "authoremail@example.com",
+            "UserName": "QuickSightAuthor/authoremail@example.com",
+            "UserRole": "AUTHOR",
+            "IdentityType": "IAM",
+        },
+    ],
+)
 @mock_aws
-def test_delete_user__quicksight():
+def test_delete_user__quicksight(request_params):
     client = boto3.client("quicksight", region_name="us-east-2")
     client.register_user(
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
-        Email="fakeemail@example.com",
-        IdentityType="QUICKSIGHT",
-        UserName="tfacctestm9hpsr970z",
-        UserRole="READER",
+        Email=request_params["Email"],
+        IdentityType=request_params["IdentityType"],
+        UserName=request_params["UserName"],
+        UserRole=request_params["UserRole"],
     )
 
     client.delete_user(
-        UserName="tfacctestm9hpsr970z", AwsAccountId=ACCOUNT_ID, Namespace="default"
+        UserName=request_params["UserName"],
+        AwsAccountId=ACCOUNT_ID,
+        Namespace="default",
     )
 
     with pytest.raises(ClientError) as exc:
         client.describe_user(
-            UserName="tfacctestm9hpsr970z", AwsAccountId=ACCOUNT_ID, Namespace="default"
+            UserName=request_params["UserName"],
+            AwsAccountId=ACCOUNT_ID,
+            Namespace="default",
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "ResourceNotFoundException"
@@ -100,7 +157,7 @@ def test_list_users__initial():
 @mock_aws
 def test_list_users():
     client = boto3.client("quicksight", region_name="us-east-2")
-    for i in range(4):
+    for i in range(2):
         client.register_user(
             AwsAccountId=ACCOUNT_ID,
             Namespace="default",
@@ -108,6 +165,15 @@ def test_list_users():
             IdentityType="QUICKSIGHT",
             UserName=f"fake{i}",
             UserRole="READER",
+        )
+    for i in range(2, 4):
+        client.register_user(
+            AwsAccountId=ACCOUNT_ID,
+            Namespace="default",
+            Email=f"fakeemail{i}@example.com",
+            IdentityType="IAM",
+            UserName=f"QuickSightAuthor/fakeemail{i}@example.com",
+            UserRole="AUTHOR",
         )
 
     resp = client.list_users(AwsAccountId=ACCOUNT_ID, Namespace="default")
@@ -127,76 +193,118 @@ def test_list_users():
     } in resp["UserList"]
 
     assert {
-        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:user/default/fake3",
-        "UserName": "fake3",
+        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:user/default/QuickSightAuthor/fakeemail3@example.com",
+        "UserName": "QuickSightAuthor/fakeemail3@example.com",
         "Email": "fakeemail3@example.com",
-        "Role": "READER",
-        "IdentityType": "QUICKSIGHT",
+        "Role": "AUTHOR",
+        "IdentityType": "IAM",
         "Active": False,
     } in resp["UserList"]
 
 
+@pytest.mark.parametrize(
+    "request_params",
+    [
+        {
+            "Email": "fakeemail@example.com",
+            "UserName": "user.1",
+            "UserRole": "READER",
+            "IdentityType": "QUICKSIGHT",
+            "GroupName": "group1",
+        },
+        {
+            "Email": "authoremail@example.com",
+            "UserName": "QuickSightAuthor/authoremail@example.com",
+            "UserRole": "AUTHOR",
+            "IdentityType": "IAM",
+            "GroupName": "group.2",
+        },
+    ],
+)
 @mock_aws
-def test_create_group_membership():
+def test_create_group_membership(request_params):
     client = boto3.client("quicksight", region_name="us-east-2")
     client.register_user(
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
-        Email="fakeemail@example.com",
-        IdentityType="QUICKSIGHT",
-        UserName="user.1",
-        UserRole="READER",
+        Email=request_params["Email"],
+        IdentityType=request_params["IdentityType"],
+        UserName=request_params["UserName"],
+        UserRole=request_params["UserRole"],
     )
     client.create_group(
-        AwsAccountId=ACCOUNT_ID, Namespace="default", GroupName="group1"
+        AwsAccountId=ACCOUNT_ID,
+        Namespace="default",
+        GroupName=request_params["GroupName"],
     )
 
     resp = client.create_group_membership(
-        MemberName="user.1",
-        GroupName="group1",
+        MemberName=request_params["UserName"],
+        GroupName=request_params["GroupName"],
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
     )
 
     assert resp["GroupMember"] == {
-        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group1/user.1",
-        "MemberName": "user.1",
+        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/{request_params["GroupName"]}/{request_params["UserName"]}",
+        "MemberName": request_params["UserName"],
     }
     assert resp["Status"] == 200
 
 
+@pytest.mark.parametrize(
+    "request_params",
+    [
+        {
+            "Email": "fakeemail@example.com",
+            "UserName": "user.1",
+            "UserRole": "READER",
+            "IdentityType": "QUICKSIGHT",
+            "GroupName": "group1",
+        },
+        {
+            "Email": "authoremail@example.com",
+            "UserName": "QuickSightAuthor/authoremail@example.com",
+            "UserRole": "AUTHOR",
+            "IdentityType": "IAM",
+            "GroupName": "group.2",
+        },
+    ],
+)
 @mock_aws
-def test_describe_group_membership():
+def test_describe_group_membership(request_params):
     client = boto3.client("quicksight", region_name="us-east-2")
     client.register_user(
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
-        Email="fakeemail@example.com",
-        IdentityType="QUICKSIGHT",
-        UserName="user1",
-        UserRole="READER",
+        Email=request_params["Email"],
+        IdentityType=request_params["IdentityType"],
+        UserName=request_params["UserName"],
+        UserRole=request_params["UserRole"],
     )
     client.create_group(
-        AwsAccountId=ACCOUNT_ID, Namespace="default", GroupName="group1"
+        AwsAccountId=ACCOUNT_ID,
+        Namespace="default",
+        GroupName=request_params["GroupName"],
     )
 
     client.create_group_membership(
-        MemberName="user1",
-        GroupName="group1",
+        MemberName=request_params["UserName"],
+        GroupName=request_params["GroupName"],
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
     )
 
     resp = client.describe_group_membership(
-        MemberName="user1",
-        GroupName="group1",
+        MemberName=request_params["UserName"],
+        GroupName=request_params["GroupName"],
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
     )
 
     assert resp["GroupMember"] == {
-        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group1/user1",
-        "MemberName": "user1",
+        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/{request_params["GroupName"]}/{request_params["UserName"]}",
+        "MemberName": request_params["UserName"],
     }
     assert resp["Status"] == 200
 
@@ -204,15 +312,25 @@ def test_describe_group_membership():
 @mock_aws
 def test_list_group_memberships():
     client = boto3.client("quicksight", region_name="us-east-2")
-    for i in range(3):
+    for i in range(2):
         client.register_user(
             AwsAccountId=ACCOUNT_ID,
             Namespace="default",
-            Email="fakeemail@example.com",
+            Email=f"fakeemail{i}@example.com",
             IdentityType="QUICKSIGHT",
             UserName=f"user{i}",
             UserRole="READER",
         )
+    for i in range(2, 4):
+        client.register_user(
+            AwsAccountId=ACCOUNT_ID,
+            Namespace="default",
+            Email=f"fakeemail{i}@example.com",
+            IdentityType="IAM",
+            UserName=f"QuickSightAuthor/fakeemail{i}@example.com",
+            UserRole="AUTHOR",
+        )
+
     client.create_group(
         AwsAccountId=ACCOUNT_ID, Namespace="default", GroupName="group1"
     )
@@ -227,13 +345,13 @@ def test_list_group_memberships():
         Namespace="default",
     )
     client.create_group_membership(
-        MemberName="user1",
+        MemberName="QuickSightAuthor/fakeemail2@example.com",
         GroupName="group1",
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
     )
     client.create_group_membership(
-        MemberName="user2",
+        MemberName="user1",
         GroupName="group2",
         AwsAccountId=ACCOUNT_ID,
         Namespace="default",
@@ -251,7 +369,19 @@ def test_list_group_memberships():
         "MemberName": "user0",
     } in resp["GroupMemberList"]
     assert {
-        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group1/user1",
+        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group1/QuickSightAuthor/fakeemail2@example.com",
+        "MemberName": "QuickSightAuthor/fakeemail2@example.com",
+    } in resp["GroupMemberList"]
+
+    resp = client.list_group_memberships(
+        GroupName="group2", AwsAccountId=ACCOUNT_ID, Namespace="default"
+    )
+
+    assert len(resp["GroupMemberList"]) == 1
+    assert resp["Status"] == 200
+
+    assert {
+        "Arn": f"arn:aws:quicksight:us-east-2:{ACCOUNT_ID}:group/default/group2/user1",
         "MemberName": "user1",
     } in resp["GroupMemberList"]
 
@@ -262,11 +392,11 @@ def test_list_group_memberships__after_deleting_user():
     client.create_group(
         AwsAccountId=ACCOUNT_ID, Namespace="default", GroupName="group1"
     )
-    for i in range(3):
+    for i in range(2):
         client.register_user(
             AwsAccountId=ACCOUNT_ID,
             Namespace="default",
-            Email="fakeemail@example.com",
+            Email=f"fakeemail{i}@example.com",
             IdentityType="QUICKSIGHT",
             UserName=f"user{i}",
             UserRole="READER",
@@ -277,13 +407,33 @@ def test_list_group_memberships__after_deleting_user():
             AwsAccountId=ACCOUNT_ID,
             Namespace="default",
         )
+    for i in range(2, 4):
+        client.register_user(
+            AwsAccountId=ACCOUNT_ID,
+            Namespace="default",
+            Email=f"fakeemail{i}@example.com",
+            IdentityType="IAM",
+            UserName=f"QuickSightAuthor/fakeemail{i}@example.com",
+            UserRole="AUTHOR",
+        )
+        client.create_group_membership(
+            MemberName=f"QuickSightAuthor/fakeemail{i}@example.com",
+            GroupName="group1",
+            AwsAccountId=ACCOUNT_ID,
+            Namespace="default",
+        )
 
     resp = client.list_group_memberships(
         GroupName="group1", AwsAccountId=ACCOUNT_ID, Namespace="default"
     )
-    assert len(resp["GroupMemberList"]) == 3
+    assert len(resp["GroupMemberList"]) == 4
 
     client.delete_user(UserName="user1", AwsAccountId=ACCOUNT_ID, Namespace="default")
+    client.delete_user(
+        UserName="QuickSightAuthor/fakeemail2@example.com",
+        AwsAccountId=ACCOUNT_ID,
+        Namespace="default",
+    )
 
     resp = client.list_group_memberships(
         GroupName="group1", AwsAccountId=ACCOUNT_ID, Namespace="default"


### PR DESCRIPTION
In our production environment there are federated users which ontain a / in their name, e.g.: _QuickSightAuthor/my.name@mycompany.com_

This change was created to support users with special charaters in their name.

No new features ware added.