### PR TITLE
Scheduler: start_date parameter validation (create_schedule)

### DIFF
--- a/moto/scheduler/exceptions.py
+++ b/moto/scheduler/exceptions.py
@@ -18,3 +18,10 @@ class ScheduleNotFound(JsonRESTError):
 class ScheduleGroupNotFound(JsonRESTError):
     def __init__(self) -> None:
         super().__init__("ResourceNotFoundException", "ScheduleGroup not found")
+
+
+class ValidationException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message: str):
+        super().__init__(error_type="ValidationException", message=message)

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -1,7 +1,7 @@
 """EventBridgeSchedulerBackend class with methods for supported APIs."""
 
 import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -59,11 +59,11 @@ class Schedule(BaseModel):
             }
         return target
 
-    def _validate_start_date(self, start_date: Optional[int]) -> Optional[int]:
+    def _validate_start_date(self, start_date: Optional[str]) -> Optional[str]:
         # `.count("*")` means a recurrence expression
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler/client/create_schedule.html (StartDate parameter)
         if self.schedule_expression.count("*") and start_date is not None:
-            start_date_as_dt = utcfromtimestamp(start_date)
+            start_date_as_dt = utcfromtimestamp(cast(int, start_date))
             now = utcnow()
             if start_date_as_dt.date() == now.date():
                 diff = abs(now - start_date_as_dt)

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -59,11 +59,12 @@ class Schedule(BaseModel):
         if self.schedule_expression.count("*") and start_date is not None:
             start_date_as_dt = utcfromtimestamp(start_date)
             now = utcnow()
-            diff = abs(now - start_date_as_dt)
-            rule = datetime.timedelta(minutes=5)
-            within_rule = diff <= rule
-            if not within_rule:
-                raise ValidationException(message="The StartDate you specify cannot be earlier than 5 minutes ago.")
+            if start_date_as_dt.date() == now.date():
+                diff = abs(now - start_date_as_dt)
+                rule = datetime.timedelta(minutes=5)
+                within_rule = diff <= rule
+                if not within_rule:
+                    raise ValidationException(message="The StartDate you specify cannot be earlier than 5 minutes ago.")
         return start_date
 
     def to_dict(self, short: bool = False) -> Dict[str, Any]:

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -1,14 +1,14 @@
 """EventBridgeSchedulerBackend class with methods for supported APIs."""
-
+import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.core.utils import unix_time
+from moto.core.utils import unix_time, utcfromtimestamp, utcnow
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 
-from .exceptions import ScheduleExists, ScheduleGroupNotFound, ScheduleNotFound
+from .exceptions import ScheduleExists, ScheduleGroupNotFound, ScheduleNotFound, ValidationException
 
 
 class Schedule(BaseModel):
@@ -39,7 +39,7 @@ class Schedule(BaseModel):
         self.target = Schedule.validate_target(target)
         self.state = state or "ENABLED"
         self.kms_key_arn = kms_key_arn
-        self.start_date = start_date
+        self.start_date = self._validate_start_date(start_date)
         self.end_date = end_date
         self.action_after_completion = action_after_completion
         self.creation_date = self.last_modified_date = unix_time()
@@ -52,6 +52,19 @@ class Schedule(BaseModel):
                 "MaximumRetryAttempts": 185,
             }
         return target
+
+    def _validate_start_date(self, start_date: Optional[int]) -> Optional[int]:
+        # `.count("*")` means a recurrence expression
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler/client/create_schedule.html (StartDate parameter)
+        if self.schedule_expression.count("*") and start_date is not None:
+            start_date_as_dt = utcfromtimestamp(start_date)
+            now = utcnow()
+            diff = abs(now - start_date_as_dt)
+            rule = datetime.timedelta(minutes=5)
+            within_rule = diff <= rule
+            if not within_rule:
+                raise ValidationException(message="The StartDate you specify cannot be earlier than 5 minutes ago.")
+        return start_date
 
     def to_dict(self, short: bool = False) -> Dict[str, Any]:
         dct: Dict[str, Any] = {

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -1,4 +1,5 @@
 """EventBridgeSchedulerBackend class with methods for supported APIs."""
+
 import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -8,7 +9,12 @@ from moto.core.utils import unix_time, utcfromtimestamp, utcnow
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 
-from .exceptions import ScheduleExists, ScheduleGroupNotFound, ScheduleNotFound, ValidationException
+from .exceptions import (
+    ScheduleExists,
+    ScheduleGroupNotFound,
+    ScheduleNotFound,
+    ValidationException,
+)
 
 
 class Schedule(BaseModel):
@@ -64,7 +70,9 @@ class Schedule(BaseModel):
                 rule = datetime.timedelta(minutes=5)
                 within_rule = diff <= rule
                 if not within_rule:
-                    raise ValidationException(message="The StartDate you specify cannot be earlier than 5 minutes ago.")
+                    raise ValidationException(
+                        message="The StartDate you specify cannot be earlier than 5 minutes ago."
+                    )
         return start_date
 
     def to_dict(self, short: bool = False) -> Dict[str, Any]:

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 import boto3
 import pytest
@@ -6,6 +6,7 @@ from botocore.client import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID
+
 
 # See our Development Tips on writing tests for hints on how to write good tests:
 # http://docs.getmoto.org/en/latest/docs/contributing/development_tips/tests.html
@@ -229,3 +230,59 @@ def test_delete_schedule_for_none_existing_schedule():
     err = exc.value.response["Error"]
     assert err["Code"] == "ResourceNotFoundException"
     assert err["Message"] == "Schedule my-schedule does not exist."
+
+
+@mock_aws
+def test_create_get_schedule__with_start_date():
+    # Arrange
+    expected_start_date = start_date = datetime.now(UTC).replace(microsecond=0)
+
+    # Act
+    client = boto3.client("scheduler", region_name="eu-west-1")
+    client.create_schedule(
+        StartDate=start_date,
+        Name="my-schedule",
+        ScheduleExpression="some cron *",
+        FlexibleTimeWindow={
+            "MaximumWindowInMinutes": 4,
+            "Mode": "OFF",
+        },
+        Target={
+            "Arn": "not supported yet",
+            "RoleArn": "n/a",
+        },
+    )
+
+    # Assert
+    resp = client.get_schedule(Name="my-schedule")
+    start_date_as_utc = datetime.astimezone(resp["StartDate"], UTC)
+    assert start_date_as_utc == expected_start_date
+
+
+@mock_aws
+def test_create_schedule__exception_with_start_date():
+    # Arrange
+    expected_error = "ValidationException"
+    expected_error_message = "The StartDate you specify cannot be earlier than 5 minutes ago."
+
+    # Act
+    with pytest.raises(ClientError) as exc:
+        client = boto3.client("scheduler", region_name="eu-west-1")
+        client.create_schedule(
+            Name="my-schedule",
+            StartDate=datetime.now().strftime("%Y-%m-%d"),
+            ScheduleExpression="some cron *",
+            FlexibleTimeWindow={
+                "MaximumWindowInMinutes": 4,
+                "Mode": "OFF",
+            },
+            Target={
+                "Arn": "not supported yet",
+                "RoleArn": "n/a",
+            },
+        )
+
+    # Assert
+    err = exc.value.response["Error"]
+    assert err["Code"] == expected_error
+    assert err["Message"] == expected_error_message

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 
 import boto3
 import pytest
@@ -6,7 +6,6 @@ from botocore.client import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID
-
 
 # See our Development Tips on writing tests for hints on how to write good tests:
 # http://docs.getmoto.org/en/latest/docs/contributing/development_tips/tests.html
@@ -263,7 +262,9 @@ def test_create_get_schedule__with_start_date():
 def test_create_schedule__exception_with_start_date():
     # Arrange
     expected_error = "ValidationException"
-    expected_error_message = "The StartDate you specify cannot be earlier than 5 minutes ago."
+    expected_error_message = (
+        "The StartDate you specify cannot be earlier than 5 minutes ago."
+    )
     start_date = datetime.now(UTC) - timedelta(minutes=6)
 
     # Act

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 
 import boto3
 import pytest
@@ -264,13 +264,14 @@ def test_create_schedule__exception_with_start_date():
     # Arrange
     expected_error = "ValidationException"
     expected_error_message = "The StartDate you specify cannot be earlier than 5 minutes ago."
+    start_date = datetime.now(UTC) - timedelta(minutes=6)
 
     # Act
     with pytest.raises(ClientError) as exc:
         client = boto3.client("scheduler", region_name="eu-west-1")
         client.create_schedule(
             Name="my-schedule",
-            StartDate=datetime.now().strftime("%Y-%m-%d"),
+            StartDate=start_date,
             ScheduleExpression="some cron *",
             FlexibleTimeWindow={
                 "MaximumWindowInMinutes": 4,


### PR DESCRIPTION
There is a missing validation on the `start_date` parameter in `create_schedule` action if the `schedule_expression` is recurrence and `start_date` is today's date, so there might be a `ValidationException` with the message: _**The StartDate you specify cannot be earlier than 5 minutes ago.**_
