### PR TITLE
Update Shield exception for no subscription on describe_subscriptions

### DIFF
--- a/moto/shield/exceptions.py
+++ b/moto/shield/exceptions.py
@@ -36,13 +36,3 @@ class ValidationException(JsonRESTError):
 
     def __init__(self, message: str):
         super().__init__("ValidationException", message)
-
-
-class SubscriptionNotFoundError(JsonRESTError):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            "SubscriptionNotFoundException",
-            "No Shield subscription has been created for this account",
-        )

--- a/moto/shield/models.py
+++ b/moto/shield/models.py
@@ -14,7 +14,6 @@ from moto.shield.exceptions import (
     InvalidResourceException,
     ResourceAlreadyExistsException,
     ResourceNotFoundException,
-    SubscriptionNotFoundError,
     ValidationException,
 )
 from moto.utilities.tagging_service import TaggingService
@@ -329,7 +328,7 @@ class ShieldBackend(BaseBackend):
 
     def describe_subscription(self) -> Subscription:
         if self.subscription is None:
-            raise SubscriptionNotFoundError()
+            raise ResourceNotFoundException("The subscription does not exist.")
         return self.subscription
 
 

--- a/tests/test_shield/test_shield.py
+++ b/tests/test_shield/test_shield.py
@@ -375,6 +375,14 @@ def test_untag_resource():
 @mock_aws
 def test_create_and_describe_subscription():
     client = boto3.client("shield", region_name="eu-west-1")
+
+    # Check exception when subscription does not exist
+    with pytest.raises(ClientError) as exc:
+        connection = client.describe_subscription()
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
+    assert err["Message"] == "The subscription does not exist."
+
     client.create_subscription()
     connection = client.describe_subscription()
     subscription = connection["Subscription"]


### PR DESCRIPTION
Resolves: #8180 & added test to validate

Code should be "ResourceNotFound"
Message should be "The subscription does not exist."

Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/shield/client/describe_subscription.html