### PR TITLE
Fix BaseResponse.uri_to_regexp

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -521,16 +521,16 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 return elem.replace("$", r"\$")
 
             # When the element ends with +} the parameter can contain a / otherwise not.
-            no_slash_allowed = False if "+" == elem[-2:-1] else True
+            slash_allowed = True if "+}" == elem[-2:] else False
             name = (
                 elem.replace("{", "")
                 .replace("}", "")
                 .replace("+", "")
                 .replace("-", "_")
             )
-            if no_slash_allowed:
-                return f"(?P<{name}>[^/]+)"
-            return f"(?P<{name}>.+)"
+            if slash_allowed:
+                return f"(?P<{name}>.+)"
+            return f"(?P<{name}>[^/]+)"
 
         elems = uri.split("/")
         regexp = "/".join([_convert(elem) for elem in elems])

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -521,7 +521,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 return elem.replace("$", r"\$")
 
             # When the element ends with +} the parameter can contain a / otherwise not.
-            slash_allowed = True if "+}" == elem[-2:] else False
+            slash_allowed = elem.endswith("+}")
             name = (
                 elem.replace("{", "")
                 .replace("}", "")

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -505,35 +505,35 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     @staticmethod
     def uri_to_regexp(uri: str) -> str:
         """converts uri w/ placeholder to regexp
-          '/cars/{carName}/drivers/{DriverName}'
-        -> '^/cars/.*/drivers/[^/]*$'
+          '/accounts/{AwsAccountId}/namespaces/{Namespace}/groups'
+        -> '^/accounts/(?P<AwsAccountId>[^/]+)/namespaces/(?P<Namespace>[^/]+)/groups$'
 
-          '/cars/{carName}/drivers/{DriverName}/drive'
-        -> '^/cars/.*/drivers/.*/drive$'
+          '/trustStores/{trustStoreArn+}'
+        -> '^/trustStores/(?P<trustStoreArn>.+)$'
 
         """
 
-        def _convert(elem: str, is_last: bool) -> str:
+        def _convert(elem: str) -> str:
             if not re.match("^{.*}$", elem):
                 # URL-parts sometimes contain a $
                 # Like Greengrass: /../deployments/$reset
                 # We don't want to our regex to think this marks an end-of-line, so let's escape it
                 return elem.replace("$", r"\$")
+
+            # When the element ends with +} the parameter can contain a / otherwise not.
+            no_slash_allowed = False if "+" == elem[-2:-1] else True
             name = (
                 elem.replace("{", "")
                 .replace("}", "")
                 .replace("+", "")
                 .replace("-", "_")
             )
-            if is_last:
+            if no_slash_allowed:
                 return f"(?P<{name}>[^/]+)"
-            return f"(?P<{name}>.*)"
+            return f"(?P<{name}>.+)"
 
         elems = uri.split("/")
-        num_elems = len(elems)
-        regexp = "/".join(
-            [_convert(elem, (i == num_elems - 1)) for i, elem in enumerate(elems)]
-        )
+        regexp = "/".join([_convert(elem) for elem in elems])
         return f"^{regexp}$"
 
     def _get_action_from_method_and_request_uri(


### PR DESCRIPTION
Found an issue on how the URIs send by the boto3 client converted into function names.

I have 2 URI:
1. `/accounts/{AwsAccountId}/namespaces/{Namespace}/groups`
2. `/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}/groups`

These URIs were converted into these regular expressions:
1. `/accounts/(?P<AwsAccountId>.*)/namespaces/(?P<Namespace>.*)/groups`
2. `/accounts/(?P<AwsAccountId>.*)/namespaces/(?P<Namespace>.*)/users/(?P<UserName>.*)/groups`

Unfortunately both request URIs match regular expression 1:
1. `/accounts/1235/namespaces/default/groups`
2. `/accounts/123456789012/namespaces/default/users/authoremail%40example.com/groups`

Investigating on how AWS defines the requestUri in the service.json files I found that there are 2 types of parameters.
1. e.g. quicksight: `/accounts/{AwsAccountId}/namespaces/{Namespace}/users/{UserName}/groups`
2. e.g. workspaceweb: `/portals/{portalArn+}/trustStores`

As you can see in the requestUri from workspaceweb there is a + at the end of the parameter. Checking the code this means, that the parameter can contain a / as it is a Arn. The same I found in the S3 API.

To fix this issue I changed the function BaseResponse.uri_to_regexp to replace the parameter without the + at the end with `(?P<{name}>[^/]+)` to allow any text but no /.  For the parameter with a + I used `(?P<{name}>.+)` to allow any character with minimum length of 1.
I found the usage of .* is not recommended as this causes issues with URIs form the mediastoredata API where `^/$` is ListItems and `^/{Path+}$` is GetObject.

On my development machine most of the test ran successfully. In local mode 2 tests fail and in server mode 3 tests fail. Checking this failuers, I think they are unrelated to this change and therefore I created this pull request.