### PR TITLE
Support custom ids

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1312,9 +1312,11 @@ class RestAPI(CloudFormationModel):
     ) -> Deployment:
         if stage_variables is None:
             stage_variables = {}
+        # Since there are no unique values to a deployment, we will use the stage name for the deployment.
+        # We are also passing a list of deployment ids to generate to prevent overwriting deployments.
         deployment_id = ApigwDeploymentIdentifier(
-            self.account_id, self.region_name, name
-        ).generate()
+            self.account_id, self.region_name, stage_name=name
+        ).generate(list(self.deployments.keys()))
         deployment = Deployment(deployment_id, name, description)
         self.deployments[deployment_id] = deployment
         if name:
@@ -2177,7 +2179,7 @@ class APIGatewayBackend(BaseBackend):
             self.account_id,
             self.region_name,
             # The value of an api key must be unique on aws
-            payload.get("value"),
+            payload.get("value", ""),
         ).generate()
         key = ApiKey(api_key_id=api_key_id, **payload)
         self.keys[key.id] = key

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1166,7 +1166,10 @@ class RestAPI(CloudFormationModel):
 
     def add_child(self, path: str, parent_id: Optional[str] = None) -> Resource:
         child_id = create_apigw_id(
-            self.account_id, self.region_name, "resource", parent_id + "." + path
+            self.account_id,
+            self.region_name,
+            "resource",
+            (parent_id or "") + "." + path,
         )
         child = Resource(
             resource_id=child_id,
@@ -2158,7 +2161,7 @@ class APIGatewayBackend(BaseBackend):
                 if api_key.value == payload["value"]:
                     raise ApiKeyAlreadyExists()
         api_key_id = create_apigw_id(
-            self.account_id, self.region_name, "api_key", payload.get("name")
+            self.account_id, self.region_name, "api_key", payload["name"]
         )
         key = ApiKey(api_key_id=api_key_id, **payload)
         self.keys[key.id] = key

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -75,7 +75,7 @@ from .utils import (
     ApigwModelIdentifier,
     ApigwRequestValidatorIdentifier,
     ApigwResourceIdentifier,
-    ApigwRestApiValidatorIdentifier,
+    ApigwRestApiIdentifier,
     ApigwUsagePlanIdentifier,
     ApigwVpcLinkIdentifier,
     create_id,
@@ -1656,7 +1656,7 @@ class APIGatewayBackend(BaseBackend):
         minimum_compression_size: Optional[int] = None,
         disable_execute_api_endpoint: Optional[bool] = None,
     ) -> RestAPI:
-        api_id = ApigwRestApiValidatorIdentifier(
+        api_id = ApigwRestApiIdentifier(
             self.account_id, self.region_name, name
         ).generate()
         rest_api = RestAPI(

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -2177,7 +2177,7 @@ class APIGatewayBackend(BaseBackend):
             self.account_id,
             self.region_name,
             # The value of an api key must be unique on aws
-            payload["value"],
+            payload.get("value"),
         ).generate()
         key = ApiKey(api_key_id=api_key_id, **payload)
         self.keys[key.id] = key

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -5,20 +5,70 @@ from typing import Any, Dict
 import yaml
 
 from moto.moto_api._internal import mock_random as random
-from moto.utilities.id_generator import generate_str_id
+from moto.utilities.id_generator import ResourceIdentifier, generate_str_id
 
 
-def create_apigw_id(account_id: str, region: str, resource: str, name: str) -> str:
-    return generate_str_id(
-        account_id,
-        region,
-        "apigateway",
-        resource,
-        name,
-        length=10,
-        include_digits=True,
-        lower_case=True,
-    )
+class ApigwIdentifier(ResourceIdentifier):
+    service = "apigateway"
+
+    def __init__(self, account_id: str, region: str, name: str):
+        super().__init__(account_id, region, name)
+
+    def generate(self) -> str:
+        return generate_str_id(
+            self,
+            length=10,
+            include_digits=True,
+            lower_case=True,
+        )
+
+
+class ApigwApiKeyIdentifier(ApigwIdentifier):
+    resource = "api_key"
+
+    def __init__(self, account_id: str, region: str, value: str):
+        super().__init__(account_id, region, value)
+
+
+class ApigwAuthorizerIdentifier(ApigwIdentifier):
+    resource = "authorizer"
+
+
+class ApigwDeploymentIdentifier(ApigwIdentifier):
+    resource = "deployment"
+
+
+class ApigwModelIdentifier(ApigwIdentifier):
+    resource = "model"
+
+
+class ApigwRequestValidatorIdentifier(ApigwIdentifier):
+    resource = "request_validator"
+
+
+class ApigwResourceIdentifier(ApigwIdentifier):
+    resource = "resource"
+
+    def __init__(
+        self, account_id: str, region: str, parent_id: str = "", path_name: str = "/"
+    ):
+        super().__init__(
+            account_id,
+            region,
+            ".".join((parent_id, path_name)),
+        )
+
+
+class ApigwRestApiValidatorIdentifier(ApigwIdentifier):
+    resource = "rest_api"
+
+
+class ApigwUsagePlanIdentifier(ApigwIdentifier):
+    resource = "usage_plan"
+
+
+class ApigwVpcLinkIdentifier(ApigwIdentifier):
+    resource = "vpc_link"
 
 
 def create_id() -> str:

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Union
 import yaml
 
 from moto.moto_api._internal import mock_random as random
-from moto.utilities.id_generator import ResourceIdentifier, generate_str_id
+from moto.utilities.id_generator import ResourceIdentifier, Tags, generate_str_id
 
 
 class ApigwIdentifier(ResourceIdentifier):
@@ -14,10 +14,13 @@ class ApigwIdentifier(ResourceIdentifier):
     def __init__(self, account_id: str, region: str, name: str):
         super().__init__(account_id, region, name)
 
-    def generate(self, existing_ids: Union[List[str], None] = None) -> str:
+    def generate(
+        self, existing_ids: Union[List[str], None] = None, tags: Tags = None
+    ) -> str:
         return generate_str_id(
-            self,
-            existing_ids,
+            resource_identifier=self,
+            existing_ids=existing_ids,
+            tags=tags,
             length=10,
             include_digits=True,
             lower_case=True,

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -63,7 +63,7 @@ class ApigwResourceIdentifier(ApigwIdentifier):
         )
 
 
-class ApigwRestApiValidatorIdentifier(ApigwIdentifier):
+class ApigwRestApiIdentifier(ApigwIdentifier):
     resource = "rest_api"
 
 

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -8,7 +8,7 @@ from moto.moto_api._internal import mock_random as random
 from moto.utilities.id_generator import generate_str_id
 
 
-def create_apigw_id(account_id, region, resource, name) -> str:
+def create_apigw_id(account_id: str, region: str, resource: str, name: str) -> str:
     return generate_str_id(
         account_id,
         region,

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -5,6 +5,20 @@ from typing import Any, Dict
 import yaml
 
 from moto.moto_api._internal import mock_random as random
+from moto.utilities.id_generator import generate_str_id
+
+
+def create_apigw_id(account_id, region, resource, name) -> str:
+    return generate_str_id(
+        account_id,
+        region,
+        "apigateway",
+        resource,
+        name,
+        length=10,
+        include_digits=True,
+        lower_case=True,
+    )
 
 
 def create_id() -> str:

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -1,6 +1,6 @@
 import json
 import string
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 import yaml
 
@@ -14,9 +14,10 @@ class ApigwIdentifier(ResourceIdentifier):
     def __init__(self, account_id: str, region: str, name: str):
         super().__init__(account_id, region, name)
 
-    def generate(self) -> str:
+    def generate(self, existing_ids: Union[List[str], None] = None) -> str:
         return generate_str_id(
             self,
+            existing_ids,
             length=10,
             include_digits=True,
             lower_case=True,
@@ -36,6 +37,9 @@ class ApigwAuthorizerIdentifier(ApigwIdentifier):
 
 class ApigwDeploymentIdentifier(ApigwIdentifier):
     resource = "deployment"
+
+    def __init__(self, account_id: str, region: str, stage_name: str):
+        super().__init__(account_id, region, stage_name)
 
 
 class ApigwModelIdentifier(ApigwIdentifier):

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -26,7 +26,11 @@ from .list_secrets.filters import (
     tag_key,
     tag_value,
 )
-from .utils import get_secret_name_from_partial_arn, random_password, secret_arn
+from .utils import (
+    SecretsManagerSecretIdentifier,
+    get_secret_name_from_partial_arn,
+    random_password,
+)
 
 MAX_RESULTS_DEFAULT = 100
 
@@ -94,7 +98,9 @@ class FakeSecret:
     ):
         self.secret_id = secret_id
         self.name = secret_id
-        self.arn = secret_arn(account_id, region_name, secret_id)
+        self.arn = SecretsManagerSecretIdentifier(
+            account_id, region_name, secret_id
+        ).generate()
         self.account_id = account_id
         self.region = region_name
         self.secret_string = secret_string
@@ -935,7 +941,9 @@ class SecretsManagerBackend(BaseBackend):
             if not force_delete_without_recovery:
                 raise SecretNotFoundException()
             else:
-                arn = secret_arn(self.account_id, self.region_name, secret_id=secret_id)
+                arn = SecretsManagerSecretIdentifier(
+                    self.account_id, self.region_name, secret_id=secret_id
+                ).generate()
                 name = secret_id
                 deletion_date = utcnow()
                 return arn, name, self._unix_time_secs(deletion_date)

--- a/moto/secretsmanager/utils.py
+++ b/moto/secretsmanager/utils.py
@@ -2,7 +2,7 @@ import re
 import string
 
 from moto.moto_api._internal import mock_random as random
-from moto.utilities.id_generator import ResourceIdentifier, generate_str_id
+from moto.utilities.id_generator import ExistingIds, ResourceIdentifier, generate_str_id
 from moto.utilities.utils import ARN_PARTITION_REGEX, get_partition
 
 
@@ -104,9 +104,12 @@ class SecretsManagerSecretIdentifier(ResourceIdentifier):
     def __init__(self, account_id: str, region: str, secret_id: str):
         super().__init__(account_id, region, name=secret_id)
 
-    def generate(self) -> str:
+    def generate(self, existing_ids: ExistingIds = None) -> str:
         id_string = generate_str_id(
-            resource_identifier=self, length=6, include_digits=False
+            existing_ids=existing_ids,
+            resource_identifier=self,
+            length=6,
+            include_digits=False,
         )
         return (
             f"arn:{get_partition(self.region)}:secretsmanager:{self.region}:"

--- a/moto/secretsmanager/utils.py
+++ b/moto/secretsmanager/utils.py
@@ -2,6 +2,7 @@ import re
 import string
 
 from moto.moto_api._internal import mock_random as random
+from moto.utilities.id_generator import generate_str_id
 from moto.utilities.utils import ARN_PARTITION_REGEX, get_partition
 
 
@@ -63,7 +64,15 @@ def random_password(
 
 
 def secret_arn(account_id: str, region: str, secret_id: str) -> str:
-    id_string = "".join(random.choice(string.ascii_letters) for _ in range(6))
+    id_string = generate_str_id(
+        account_id,
+        region,
+        "secretsmanager",
+        "secret",
+        secret_id,
+        length=6,
+        include_digits=False,
+    )
     return f"arn:{get_partition(region)}:secretsmanager:{region}:{account_id}:secret:{secret_id}-{id_string}"
 
 

--- a/moto/secretsmanager/utils.py
+++ b/moto/secretsmanager/utils.py
@@ -2,7 +2,12 @@ import re
 import string
 
 from moto.moto_api._internal import mock_random as random
-from moto.utilities.id_generator import ExistingIds, ResourceIdentifier, generate_str_id
+from moto.utilities.id_generator import (
+    ExistingIds,
+    ResourceIdentifier,
+    Tags,
+    generate_str_id,
+)
 from moto.utilities.utils import ARN_PARTITION_REGEX, get_partition
 
 
@@ -104,10 +109,11 @@ class SecretsManagerSecretIdentifier(ResourceIdentifier):
     def __init__(self, account_id: str, region: str, secret_id: str):
         super().__init__(account_id, region, name=secret_id)
 
-    def generate(self, existing_ids: ExistingIds = None) -> str:
+    def generate(self, existing_ids: ExistingIds = None, tags: Tags = None) -> str:
         id_string = generate_str_id(
-            existing_ids=existing_ids,
             resource_identifier=self,
+            existing_ids=existing_ids,
+            tags=tags,
             length=6,
             include_digits=False,
         )

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -3,15 +3,13 @@ from typing import Any, Callable, Dict, List, Union
 
 from moto.moto_api._internal import mock_random
 
-IdSource = Callable[[str, str, str, str, str], str | None]
-
 
 class MotoIdManager:
     """class to manage custom ids. Do not create instance and instead
     use the `id_manager` instance created below."""
 
-    _custom_ids: dict[str, str]
-    _id_sources: List[IdSource]
+    _custom_ids: Dict[str, str]
+    _id_sources: List[Callable[[str, str, str, str, str], Union[str, None]]]
 
     _lock: threading.RLock
 
@@ -54,7 +52,9 @@ class MotoIdManager:
                 ".".join([account_id, region, service, resource, name]), None
             )
 
-    def add_id_source(self, id_source: IdSource) -> None:
+    def add_id_source(
+        self, id_source: Callable[[str, str, str, str, str], Union[str, None]]
+    ) -> None:
         self._id_sources.append(id_source)
 
     def find_id_from_sources(

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -47,7 +47,7 @@ class ResourceIdentifier(abc.ABC):
             [self.account_id, self.region, self.service, self.resource, self.name]
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.unique_identifier
 
 

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -1,10 +1,23 @@
 import abc
+import logging
 import threading
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, TypedDict, Union
 
 from moto.moto_api._internal import mock_random
 
+log = logging.getLogger(__name__)
+
 ExistingIds = Union[List[str], None]
+Tags = Union[Dict[str, str], None]
+
+# Custom resource tag to override the generated resource ID.
+TAG_KEY_CUSTOM_ID = "_custom_id_"
+
+
+class IdSourceContext(TypedDict, total=False):
+    resource_identifier: "ResourceIdentifier"
+    tags: Tags
+    existing_ids: ExistingIds
 
 
 class ResourceIdentifier(abc.ABC):
@@ -25,9 +38,8 @@ class ResourceIdentifier(abc.ABC):
         self.name = name or ""
 
     @abc.abstractmethod
-    def generate(self, existing_ids: ExistingIds = None) -> str: ...
-
-    """ If `existing_ids` is provided, we will not return a custom id if it is already on the list"""
+    def generate(self, existing_ids: ExistingIds = None, tags: Tags = None) -> str:
+        """Method to generate a resource id"""
 
     @property
     def unique_identifier(self) -> str:
@@ -35,13 +47,16 @@ class ResourceIdentifier(abc.ABC):
             [self.account_id, self.region, self.service, self.resource, self.name]
         )
 
+    def __str__(self):
+        return self.unique_identifier
+
 
 class MotoIdManager:
     """class to manage custom ids. Do not create instance and instead
     use the `id_manager` instance created below."""
 
     _custom_ids: Dict[str, str]
-    _id_sources: List[Callable[[ResourceIdentifier], Union[str, None]]]
+    _id_sources: List[Callable[[IdSourceContext], Union[str, None]]]
 
     _lock: threading.RLock
 
@@ -50,13 +65,14 @@ class MotoIdManager:
         self._lock = threading.RLock()
         self._id_sources = []
 
+        self.add_id_source(self.get_id_from_tags)
         self.add_id_source(self.get_custom_id)
 
-    def get_custom_id(
-        self, resource_identifier: ResourceIdentifier
-    ) -> Union[str, None]:
+    def get_custom_id(self, id_source_context: IdSourceContext) -> Union[str, None]:
         # retrieves a custom_id for a resource. Returns None
-        return self._custom_ids.get(resource_identifier.unique_identifier)
+        if resource_identifier := id_source_context.get("resource_identifier"):
+            return self._custom_ids.get(resource_identifier.unique_identifier)
+        return None
 
     def set_custom_id(
         self, resource_identifier: ResourceIdentifier, custom_id: str
@@ -73,18 +89,29 @@ class MotoIdManager:
             self._custom_ids.pop(resource_identifier.unique_identifier, None)
 
     def add_id_source(
-        self, id_source: Callable[[ResourceIdentifier], Union[str, None]]
+        self, id_source: Callable[[IdSourceContext], Union[str, None]]
     ) -> None:
         self._id_sources.append(id_source)
 
-    def find_id_from_sources(
-        self, resource_identifier: ResourceIdentifier, existing_ids: List[str]
-    ) -> Union[str, None]:
+    @staticmethod
+    def get_id_from_tags(id_source_context: IdSourceContext) -> Union[str, None]:
+        if tags := id_source_context.get("tags"):
+            return tags.get(TAG_KEY_CUSTOM_ID)
+
+        return None
+
+    def find_id_from_sources(self, id_source_context: IdSourceContext) -> Union[str, None]:
+        existing_ids = id_source_context.get("existing_ids") or []
         for id_source in self._id_sources:
-            if (
-                found_id := id_source(resource_identifier)
-            ) and found_id not in existing_ids:
-                return found_id
+            if found_id := id_source(id_source_context):
+                if found_id in existing_ids:
+                    log.debug(
+                        f"Found id {found_id} for resource {id_source_context.get('resource_identifier')}, "
+                        "but a resource already exists with this id."
+                    )
+                else:
+                    return found_id
+
         return None
 
 
@@ -92,17 +119,41 @@ moto_id_manager = MotoIdManager()
 
 
 def moto_id(fn: Callable[..., str]) -> Callable[..., str]:
-    # Decorator for helping in creation of static ids within Moto.
+    """
+    Decorator for helping in creation of static ids.
+
+    The decorated function should accept the following parameters
+
+    :param resource_identifier
+    :param existing_ids
+        If provided, we will omit returning a custom id if it is already on the list
+    :param tags
+        If provided will look for a tag named `_custom_id_`. This will take precedence over registered custom ids
+    """
+
     def _wrapper(
         resource_identifier: ResourceIdentifier,
-        existing_ids: ExistingIds,
+        existing_ids: ExistingIds = None,
+        tags: Tags = None,
         **kwargs: Dict[str, Any],
     ) -> str:
-        if found_id := moto_id_manager.find_id_from_sources(
-            resource_identifier, existing_ids or []
+        if resource_identifier and (
+            found_id := moto_id_manager.find_id_from_sources(
+                IdSourceContext(
+                    resource_identifier=resource_identifier,
+                    existing_ids=existing_ids,
+                    tags=tags,
+                )
+            )
         ):
             return found_id
-        return fn(resource_identifier, existing_ids, **kwargs)
+
+        return fn(
+            resource_identifier=resource_identifier,
+            existing_ids=existing_ids,
+            tags=tags,
+            **kwargs,
+        )
 
     return _wrapper
 
@@ -110,7 +161,8 @@ def moto_id(fn: Callable[..., str]) -> Callable[..., str]:
 @moto_id
 def generate_str_id(  # type: ignore
     resource_identifier: ResourceIdentifier,
-    existing_ids: ExistingIds,
+    existing_ids: ExistingIds = None,
+    tags: Tags = None,
     length: int = 20,
     include_digits: bool = True,
     lower_case: bool = False,

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -1,0 +1,92 @@
+import threading
+from typing import Callable
+
+from moto.moto_api._internal import mock_random
+
+IdSource = Callable[[str, str, str, str, str], str | None]
+
+
+class MotoIdManager:
+    """class to manage custom ids. Do not create instance and instead
+    use the `id_manager` instance created below."""
+
+    _custom_ids: dict[str, str]
+    _id_sources: [IdSource]
+
+    _lock: threading.RLock
+
+    def __init__(self):
+        self._custom_ids = {}
+        self._lock = threading.RLock()
+        self._id_sources = []
+
+        self.add_id_source(self.get_custom_id)
+
+    def get_custom_id(self, account_id, region, service, resource, name) -> str | None:
+        # retrieves a custom_id for a resource. Returns None
+        return self._custom_ids.get(
+            ".".join([account_id, region, service, resource, name])
+        )
+
+    def set_custom_id(self, account_id, region, service, resource, name, custom_id):
+        # sets a custom_id for a resource
+        with self._lock:
+            self._custom_ids[
+                ".".join([account_id, region, service, resource, name])
+            ] = custom_id
+
+    def unset_custom_id(self, account_id, region, service, resource, name):
+        # removes a set custom_id for a resource
+        with self._lock:
+            self._custom_ids.pop(
+                ".".join([account_id, region, service, resource, name]), None
+            )
+
+    def add_id_source(self, id_source: IdSource):
+        self._id_sources.append(id_source)
+
+    def find_id_from_sources(
+        self, account_id: str, region: str, service: str, resource: str, name: str
+    ) -> str | None:
+        for id_source in self._id_sources:
+            if found_id := id_source(account_id, region, service, resource, name):
+                return found_id
+
+
+id_manager = MotoIdManager()
+
+
+def moto_id(fn):
+    # Decorator for helping in creation of static ids within Moto.
+    def _wrapper(account_id, region, service, resource, name, **kwargs):
+        if found_id := id_manager.find_id_from_sources(
+            account_id, region, service, resource, name
+        ):
+            return found_id
+        return fn(account_id, region, service, resource, name, **kwargs)
+
+    return _wrapper
+
+
+@moto_id
+def generate_uid(account_id, region, service, resource, name, length=32):
+    return mock_random.get_random_hex(length)
+
+
+@moto_id
+def generate_short_uid(account_id, region, service, resource, name):
+    return mock_random.get_random_hex(8)
+
+
+@moto_id
+def generate_str_id(
+    account_id,
+    region,
+    service,
+    resource,
+    name,
+    length: int = 20,
+    include_digits: bool = True,
+    lower_case: bool = False,
+):
+    return mock_random.get_random_string(length, include_digits, lower_case)

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Callable
+from typing import Any, Callable
 
 from moto.moto_api._internal import mock_random
 
@@ -11,38 +11,50 @@ class MotoIdManager:
     use the `id_manager` instance created below."""
 
     _custom_ids: dict[str, str]
-    _id_sources: [IdSource]
+    _id_sources: list[IdSource]
 
     _lock: threading.RLock
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._custom_ids = {}
         self._lock = threading.RLock()
         self._id_sources = []
 
         self.add_id_source(self.get_custom_id)
 
-    def get_custom_id(self, account_id, region, service, resource, name) -> str | None:
+    def get_custom_id(
+        self, account_id: str, region: str, service: str, resource: str, name: str
+    ) -> str | None:
         # retrieves a custom_id for a resource. Returns None
         return self._custom_ids.get(
             ".".join([account_id, region, service, resource, name])
         )
 
-    def set_custom_id(self, account_id, region, service, resource, name, custom_id):
+    def set_custom_id(
+        self,
+        account_id: str,
+        region: str,
+        service: str,
+        resource: str,
+        name: str,
+        custom_id: str,
+    ) -> None:
         # sets a custom_id for a resource
         with self._lock:
             self._custom_ids[
                 ".".join([account_id, region, service, resource, name])
             ] = custom_id
 
-    def unset_custom_id(self, account_id, region, service, resource, name):
+    def unset_custom_id(
+        self, account_id: str, region: str, service: str, resource: str, name: str
+    ) -> None:
         # removes a set custom_id for a resource
         with self._lock:
             self._custom_ids.pop(
                 ".".join([account_id, region, service, resource, name]), None
             )
 
-    def add_id_source(self, id_source: IdSource):
+    def add_id_source(self, id_source: IdSource) -> None:
         self._id_sources.append(id_source)
 
     def find_id_from_sources(
@@ -51,14 +63,22 @@ class MotoIdManager:
         for id_source in self._id_sources:
             if found_id := id_source(account_id, region, service, resource, name):
                 return found_id
+        return None
 
 
 id_manager = MotoIdManager()
 
 
-def moto_id(fn):
+def moto_id(fn: Callable[..., str]) -> Callable[..., str]:
     # Decorator for helping in creation of static ids within Moto.
-    def _wrapper(account_id, region, service, resource, name, **kwargs):
+    def _wrapper(
+        account_id: str,
+        region: str,
+        service: str,
+        resource: str,
+        name: str,
+        **kwargs: dict[str, Any],
+    ) -> str:
         if found_id := id_manager.find_id_from_sources(
             account_id, region, service, resource, name
         ):
@@ -69,14 +89,14 @@ def moto_id(fn):
 
 
 @moto_id
-def generate_str_id(
-    account_id,
-    region,
-    service,
-    resource,
-    name,
+def generate_str_id(  # type: ignore
+    account_id: str,
+    region: str,
+    service: str,
+    resource: str,
+    name: str,
     length: int = 20,
     include_digits: bool = True,
     lower_case: bool = False,
-):
+) -> str:
     return mock_random.get_random_string(length, include_digits, lower_case)

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -20,7 +20,7 @@ class ResourceIdentifier(abc.ABC):
     def __init__(self, account_id: str, region: str, name: str):
         self.account_id = account_id
         self.region = region
-        self.name = name
+        self.name = name or ""
 
     @abc.abstractmethod
     def generate(self) -> str: ...
@@ -57,7 +57,9 @@ class MotoIdManager:
     def set_custom_id(
         self, resource_identifier: ResourceIdentifier, custom_id: str
     ) -> None:
-        # sets a custom_id for a resource
+        # Do not set a custom_id for a resource no value was found for the name
+        if not resource_identifier.name:
+            return
         with self._lock:
             self._custom_ids[resource_identifier.unique_identifier] = custom_id
 

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -69,16 +69,6 @@ def moto_id(fn):
 
 
 @moto_id
-def generate_uid(account_id, region, service, resource, name, length=32):
-    return mock_random.get_random_hex(length)
-
-
-@moto_id
-def generate_short_uid(account_id, region, service, resource, name):
-    return mock_random.get_random_hex(8)
-
-
-@moto_id
 def generate_str_id(
     account_id,
     region,

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -100,7 +100,9 @@ class MotoIdManager:
 
         return None
 
-    def find_id_from_sources(self, id_source_context: IdSourceContext) -> Union[str, None]:
+    def find_id_from_sources(
+        self, id_source_context: IdSourceContext
+    ) -> Union[str, None]:
         existing_ids = id_source_context.get("existing_ids") or []
         for id_source in self._id_sources:
             if found_id := id_source(id_source_context):

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Any, Callable
+from typing import Any, Callable, Dict, List, Union
 
 from moto.moto_api._internal import mock_random
 
@@ -11,7 +11,7 @@ class MotoIdManager:
     use the `id_manager` instance created below."""
 
     _custom_ids: dict[str, str]
-    _id_sources: list[IdSource]
+    _id_sources: List[IdSource]
 
     _lock: threading.RLock
 
@@ -24,7 +24,7 @@ class MotoIdManager:
 
     def get_custom_id(
         self, account_id: str, region: str, service: str, resource: str, name: str
-    ) -> str | None:
+    ) -> Union[str, None]:
         # retrieves a custom_id for a resource. Returns None
         return self._custom_ids.get(
             ".".join([account_id, region, service, resource, name])
@@ -59,7 +59,7 @@ class MotoIdManager:
 
     def find_id_from_sources(
         self, account_id: str, region: str, service: str, resource: str, name: str
-    ) -> str | None:
+    ) -> Union[str, None]:
         for id_source in self._id_sources:
             if found_id := id_source(account_id, region, service, resource, name):
                 return found_id
@@ -77,7 +77,7 @@ def moto_id(fn: Callable[..., str]) -> Callable[..., str]:
         service: str,
         resource: str,
         name: str,
-        **kwargs: dict[str, Any],
+        **kwargs: Dict[str, Any],
     ) -> str:
         if found_id := id_manager.find_id_from_sources(
             account_id, region, service, resource, name

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -66,13 +66,13 @@ class MotoIdManager:
         self._id_sources = []
 
         self.add_id_source(self.get_id_from_tags)
-        self.add_id_source(self.get_custom_id)
+        self.add_id_source(self.get_custom_id_from_context)
 
-    def get_custom_id(self, id_source_context: IdSourceContext) -> Union[str, None]:
+    def get_custom_id(
+        self, resource_identifier: ResourceIdentifier
+    ) -> Union[str, None]:
         # retrieves a custom_id for a resource. Returns None
-        if resource_identifier := id_source_context.get("resource_identifier"):
-            return self._custom_ids.get(resource_identifier.unique_identifier)
-        return None
+        return self._custom_ids.get(resource_identifier.unique_identifier)
 
     def set_custom_id(
         self, resource_identifier: ResourceIdentifier, custom_id: str
@@ -98,6 +98,14 @@ class MotoIdManager:
         if tags := id_source_context.get("tags"):
             return tags.get(TAG_KEY_CUSTOM_ID)
 
+        return None
+
+    def get_custom_id_from_context(
+        self, id_source_context: IdSourceContext
+    ) -> Union[str, None]:
+        # retrieves a custom_id for a resource. Returns None
+        if resource_identifier := id_source_context.get("resource_identifier"):
+            return self.get_custom_id(resource_identifier)
         return None
 
     def find_id_from_sources(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import boto3
 import pytest
 
 from moto import mock_aws
+from moto.utilities.id_generator import ResourceIdentifier, moto_id_manager
 
 
 @pytest.fixture(scope="function")
@@ -16,3 +17,19 @@ def account_id():
         with mock_aws():
             identity = boto3.client("sts", "us-east-1").get_caller_identity()
             yield identity["Account"]
+
+
+@pytest.fixture
+def set_custom_id():
+    set_ids = []
+
+    def _set_custom_id(resource_identifier: ResourceIdentifier, custom_id):
+        moto_id_manager.set_custom_id(
+            resource_identifier=resource_identifier, custom_id=custom_id
+        )
+        set_ids.append(resource_identifier)
+
+    yield _set_custom_id
+
+    for resource_identifier in set_ids:
+        moto_id_manager.unset_custom_id(resource_identifier)

--- a/tests/test_apigateway/test_apigateway_custom_ids.py
+++ b/tests/test_apigateway/test_apigateway_custom_ids.py
@@ -1,0 +1,133 @@
+import boto3
+
+from moto import mock_aws
+from moto.apigateway.utils import (
+    ApigwApiKeyIdentifier,
+    ApigwDeploymentIdentifier,
+    ApigwModelIdentifier,
+    ApigwRequestValidatorIdentifier,
+    ApigwResourceIdentifier,
+    ApigwRestApiValidatorIdentifier,
+    ApigwUsagePlanIdentifier,
+)
+
+API_ID = "ApiId"
+API_KEY_ID = "ApiKeyId"
+DEPLOYMENT_ID = "DeployId"
+MODEL_ID = "ModelId"
+PET_1_RESOURCE_ID = "Pet1Id"
+PET_2_RESOURCE_ID = "Pet2Id"
+REQUEST_VALIDATOR_ID = "ReqValId"
+ROOT_RESOURCE_ID = "RootId"
+USAGE_PLAN_ID = "UPlanId"
+
+
+@mock_aws
+def test_custom_id_rest_api(set_custom_id, account_id):
+    region_name = "us-west-2"
+    rest_api_name = "my-api"
+    model_name = "modelName"
+    request_validator_name = "request-validator-name"
+    stage_name = "stage-name"
+
+    client = boto3.client("apigateway", region_name=region_name)
+
+    set_custom_id(
+        ApigwRestApiValidatorIdentifier(account_id, region_name, rest_api_name), API_ID
+    )
+    set_custom_id(
+        ApigwResourceIdentifier(account_id, region_name, path_name="/"),
+        ROOT_RESOURCE_ID,
+    )
+    set_custom_id(
+        ApigwResourceIdentifier(
+            account_id, region_name, parent_id=ROOT_RESOURCE_ID, path_name="pet"
+        ),
+        PET_1_RESOURCE_ID,
+    )
+    set_custom_id(
+        ApigwResourceIdentifier(
+            account_id, region_name, parent_id=PET_1_RESOURCE_ID, path_name="pet"
+        ),
+        PET_2_RESOURCE_ID,
+    )
+    set_custom_id(ApigwModelIdentifier(account_id, region_name, model_name), MODEL_ID)
+    set_custom_id(
+        ApigwRequestValidatorIdentifier(
+            account_id, region_name, request_validator_name
+        ),
+        REQUEST_VALIDATOR_ID,
+    )
+    set_custom_id(
+        ApigwDeploymentIdentifier(account_id, region_name, stage_name=stage_name),
+        DEPLOYMENT_ID,
+    )
+
+    rest_api = client.create_rest_api(name=rest_api_name)
+    assert rest_api["id"] == API_ID
+    assert rest_api["rootResourceId"] == ROOT_RESOURCE_ID
+
+    pet_resource_1 = client.create_resource(
+        restApiId=API_ID, parentId=ROOT_RESOURCE_ID, pathPart="pet"
+    )
+    assert pet_resource_1["id"] == PET_1_RESOURCE_ID
+
+    # we create a second resource with the same path part to ensure we can pass different ids
+    pet_resource_2 = client.create_resource(
+        restApiId=API_ID, parentId=PET_1_RESOURCE_ID, pathPart="pet"
+    )
+    assert pet_resource_2["id"] == PET_2_RESOURCE_ID
+
+    model = client.create_model(
+        restApiId=API_ID,
+        name=model_name,
+        schema="EMPTY",
+        contentType="application/json",
+    )
+    assert model["id"] == MODEL_ID
+
+    request_validator = client.create_request_validator(
+        restApiId=API_ID, name=request_validator_name
+    )
+    assert request_validator["id"] == REQUEST_VALIDATOR_ID
+
+    # Creating the resource to make a deployment
+    client.put_method(
+        restApiId=API_ID,
+        httpMethod="ANY",
+        resourceId=PET_2_RESOURCE_ID,
+        authorizationType="NONE",
+    )
+    client.put_integration(
+        restApiId=API_ID, resourceId=PET_2_RESOURCE_ID, httpMethod="ANY", type="MOCK"
+    )
+    deployment = client.create_deployment(restApiId=API_ID, stageName=stage_name)
+    assert deployment["id"] == DEPLOYMENT_ID
+
+
+@mock_aws
+def test_custom_id_api_key(account_id, set_custom_id):
+    region_name = "us-west-2"
+    api_key_value = "01234567890123456789"
+    usage_plan_name = "usage-plan"
+
+    client = boto3.client("apigateway", region_name=region_name)
+
+    set_custom_id(
+        ApigwApiKeyIdentifier(account_id, region_name, value=api_key_value), API_KEY_ID
+    )
+    set_custom_id(
+        ApigwUsagePlanIdentifier(account_id, region_name, usage_plan_name),
+        USAGE_PLAN_ID,
+    )
+
+    api_key = client.create_api_key(name="api-key", value=api_key_value)
+    usage_plan = client.create_usage_plan(name=usage_plan_name)
+
+    # verify that we can create a usage plan key using the custom ids
+    client.create_usage_plan_key(
+        usagePlanId=USAGE_PLAN_ID, keyId=API_KEY_ID, keyType="API_KEY"
+    )
+
+    assert api_key["id"] == API_KEY_ID
+    assert usage_plan["id"] == USAGE_PLAN_ID

--- a/tests/test_apigateway/test_apigateway_custom_ids.py
+++ b/tests/test_apigateway/test_apigateway_custom_ids.py
@@ -8,7 +8,7 @@ from moto.apigateway.utils import (
     ApigwModelIdentifier,
     ApigwRequestValidatorIdentifier,
     ApigwResourceIdentifier,
-    ApigwRestApiValidatorIdentifier,
+    ApigwRestApiIdentifier,
     ApigwUsagePlanIdentifier,
 )
 
@@ -37,7 +37,7 @@ def test_custom_id_rest_api(set_custom_id, account_id):
     client = boto3.client("apigateway", region_name=region_name)
 
     set_custom_id(
-        ApigwRestApiValidatorIdentifier(account_id, region_name, rest_api_name), API_ID
+        ApigwRestApiIdentifier(account_id, region_name, rest_api_name), API_ID
     )
     set_custom_id(
         ApigwResourceIdentifier(account_id, region_name, path_name="/"),

--- a/tests/test_apigateway/test_apigateway_custom_ids.py
+++ b/tests/test_apigateway/test_apigateway_custom_ids.py
@@ -24,7 +24,9 @@ USAGE_PLAN_ID = "UPlanId"
 
 
 @mock_aws
-@pytest.mark.skipif(not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode")
+@pytest.mark.skipif(
+    not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode"
+)
 def test_custom_id_rest_api(set_custom_id, account_id):
     region_name = "us-west-2"
     rest_api_name = "my-api"
@@ -108,7 +110,9 @@ def test_custom_id_rest_api(set_custom_id, account_id):
 
 
 @mock_aws
-@pytest.mark.skipif(not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode")
+@pytest.mark.skipif(
+    not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode"
+)
 def test_custom_id_api_key(account_id, set_custom_id):
     region_name = "us-west-2"
     api_key_value = "01234567890123456789"

--- a/tests/test_apigateway/test_apigateway_custom_ids.py
+++ b/tests/test_apigateway/test_apigateway_custom_ids.py
@@ -1,6 +1,7 @@
 import boto3
+import pytest
 
-from moto import mock_aws
+from moto import mock_aws, settings
 from moto.apigateway.utils import (
     ApigwApiKeyIdentifier,
     ApigwDeploymentIdentifier,
@@ -23,6 +24,7 @@ USAGE_PLAN_ID = "UPlanId"
 
 
 @mock_aws
+@pytest.mark.skipif(not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode")
 def test_custom_id_rest_api(set_custom_id, account_id):
     region_name = "us-west-2"
     rest_api_name = "my-api"
@@ -106,6 +108,7 @@ def test_custom_id_rest_api(set_custom_id, account_id):
 
 
 @mock_aws
+@pytest.mark.skipif(not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode")
 def test_custom_id_api_key(account_id, set_custom_id):
     region_name = "us-west-2"
     api_key_value = "01234567890123456789"

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1954,6 +1954,7 @@ def test_update_secret_version_stage_dont_specify_current_stage(secret_arn=None)
 
 
 @mock_aws
+@pytest.mark.skipif(not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode")
 def test_create_secret_custom_id(account_id, set_custom_id):
     secret_suffix = "randomSuffix"
     secret_name = "secret-name"

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -13,6 +13,7 @@ from freezegun import freeze_time
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.secretsmanager.utils import SecretsManagerSecretIdentifier
 
 from . import secretsmanager_aws_verified
 
@@ -1950,3 +1951,20 @@ def test_update_secret_version_stage_dont_specify_current_stage(secret_arn=None)
         err["Message"]
         == f"The parameter RemoveFromVersionId can't be empty. Staging label AWSCURRENT is currently attached to version {current_version}, so you must explicitly reference that version in RemoveFromVersionId."
     )
+
+
+@mock_aws
+def test_create_secret_custom_id(account_id, set_custom_id):
+    secret_suffix = "randomSuffix"
+    secret_name = "secret-name"
+    region_name = "us-east-1"
+
+    client = boto3.client("secretsmanager", region_name=region_name)
+
+    set_custom_id(
+        SecretsManagerSecretIdentifier(account_id, region_name, secret_name),
+        secret_suffix,
+    )
+    secret = client.create_secret(Name=secret_name, SecretString="my secret")
+
+    assert secret["ARN"].split(":")[-1] == f"{secret_name}-{secret_suffix}"

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1954,7 +1954,9 @@ def test_update_secret_version_stage_dont_specify_current_stage(secret_arn=None)
 
 
 @mock_aws
-@pytest.mark.skipif(not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode")
+@pytest.mark.skipif(
+    not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode"
+)
 def test_create_secret_custom_id(account_id, set_custom_id):
     secret_suffix = "randomSuffix"
     secret_name = "secret-name"

--- a/tests/test_utilities/test_id_generator.py
+++ b/tests/test_utilities/test_id_generator.py
@@ -4,6 +4,7 @@ from moto.utilities.id_generator import (
     ResourceIdentifier,
     Tags,
     moto_id,
+    moto_id_manager,
 )
 
 ACCOUNT = "account"
@@ -110,3 +111,24 @@ def test_generate_with_tags_fallback(set_custom_id):
         tags={TAG_KEY_CUSTOM_ID: TAG_ID},
     )
     assert generated_id == CUSTOM_ID
+
+
+def test_set_custom_id_lifecycle():
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    moto_id_manager.set_custom_id(resource_identifier, CUSTOM_ID)
+
+    found_id = moto_id_manager.get_custom_id(resource_identifier)
+    assert found_id == CUSTOM_ID
+
+    moto_id_manager.unset_custom_id(resource_identifier)
+
+    found_id = moto_id_manager.get_custom_id(resource_identifier)
+    assert found_id is None
+
+
+def test_set_custom_id_name_is_not_set():
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, None)
+    moto_id_manager.set_custom_id(resource_identifier, CUSTOM_ID)
+
+    assert moto_id_manager._custom_ids == {}

--- a/tests/test_utilities/test_id_generator.py
+++ b/tests/test_utilities/test_id_generator.py
@@ -1,0 +1,112 @@
+from moto.utilities.id_generator import (
+    TAG_KEY_CUSTOM_ID,
+    ExistingIds,
+    ResourceIdentifier,
+    Tags,
+    moto_id,
+)
+
+ACCOUNT = "account"
+REGION = "us-east-1"
+RESOURCE_NAME = "my-resource"
+
+CUSTOM_ID = "custom"
+GENERATED_ID = "generated"
+TAG_ID = "fromTag"
+SERVICE = "test-service"
+RESOURCE = "test-resource"
+
+
+@moto_id
+def generate_test_id(
+    resource_identifier: ResourceIdentifier,
+    existing_ids: ExistingIds = None,
+    tags: Tags = None,
+):
+    return GENERATED_ID
+
+
+class TestResourceIdentifier(ResourceIdentifier):
+    service = SERVICE
+    resource = RESOURCE
+
+    def generate(self, existing_ids: ExistingIds = None, tags: Tags = None) -> str:
+        return generate_test_id(
+            resource_identifier=self, existing_ids=existing_ids, tags=tags
+        )
+
+
+def test_generate_with_no_resource_identifier():
+    generated_id = generate_test_id(None)
+    assert generated_id == GENERATED_ID
+
+
+def test_generate_with_matching_resource_identifier(set_custom_id):
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    set_custom_id(resource_identifier, CUSTOM_ID)
+
+    generated_id = generate_test_id(resource_identifier=resource_identifier)
+    assert generated_id == CUSTOM_ID
+
+
+def test_generate_with_non_matching_resource_identifier(set_custom_id):
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+    resource_identifier_2 = TestResourceIdentifier(ACCOUNT, REGION, "non-matching")
+
+    set_custom_id(resource_identifier, CUSTOM_ID)
+
+    generated_id = generate_test_id(resource_identifier=resource_identifier_2)
+    assert generated_id == GENERATED_ID
+
+
+def test_generate_with_custom_id_tag():
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    generated_id = generate_test_id(
+        resource_identifier=resource_identifier, tags={TAG_KEY_CUSTOM_ID: TAG_ID}
+    )
+    assert generated_id == TAG_ID
+
+
+def test_generate_with_custom_id_tag_has_priority(set_custom_id):
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    set_custom_id(resource_identifier, CUSTOM_ID)
+    generated_id = generate_test_id(
+        resource_identifier=resource_identifier, tags={TAG_KEY_CUSTOM_ID: TAG_ID}
+    )
+    assert generated_id == TAG_ID
+
+
+def test_generate_with_existing_id(set_custom_id):
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    set_custom_id(resource_identifier, CUSTOM_ID)
+    generated_id = generate_test_id(
+        resource_identifier=resource_identifier, existing_ids=[CUSTOM_ID]
+    )
+    assert generated_id == GENERATED_ID
+
+
+def test_generate_with_tags_and_existing_id(set_custom_id):
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    generated_id = generate_test_id(
+        resource_identifier=resource_identifier,
+        existing_ids=[TAG_ID],
+        tags={TAG_KEY_CUSTOM_ID: TAG_ID},
+    )
+    assert generated_id == GENERATED_ID
+
+
+def test_generate_with_tags_fallback(set_custom_id):
+    resource_identifier = TestResourceIdentifier(ACCOUNT, REGION, RESOURCE_NAME)
+
+    set_custom_id(resource_identifier, CUSTOM_ID)
+    generated_id = generate_test_id(
+        resource_identifier=resource_identifier,
+        existing_ids=[TAG_ID],
+        tags={TAG_KEY_CUSTOM_ID: TAG_ID},
+    )
+    assert generated_id == CUSTOM_ID


### PR DESCRIPTION
# Motivation

This pr aims to introduce a mechanism by which we can define custom ids in order to be able to create a resource with deterministic ids.

A `ResourceIdentifier` base class will allow us to quickly create objects to manage ids. Each resource can implement their own `generate` method giving us much flexibility when it comes to the type of id created.

The `MotoIdManager` implements an interface over the registered custom ids. It also contains a method `add_id_source` that will allow us the possibility to further expand the behaviour of the id manager.

# Changes

- Implementation of the id manager
- Integration of the `ResourceIdentifier` in `apigateway` and `secretsmanager` as to provide examples of how it can be used.
- Added tests for implemented services.

# Not in scope

Many services can benefit from this upgrade, but only 2 are implemented here to provide a sample of how to use. Follow PRs will spread the functionality to more services. This should help the review process over smaller PRs!