### PR TITLE
Make .json.gz files deterministic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class CompressJsonCommand(Command):
                 print(f"Compressing {file} into {target_filename}...")  # noqa
                 with open(file, "rb") as source:
                     with open(target_filename, "wb") as target:
-                        target.write(gzip.compress(source.read()))
+                        target.write(gzip.compress(source.read(), mtime=0))
                 print(f"Removing {file}...")  # noqa
                 Path(file).unlink()
 


### PR DESCRIPTION
Make `.json.gz` files deterministic to fix reproducible builds.

See https://reproducible-builds.org/ for why this is good.