### PR TITLE
APIGateway: fix strict filtering for API keys

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -2152,7 +2152,9 @@ class APIGatewayBackend(BaseBackend):
 
     def get_api_keys(self, name: Optional[str] = None) -> List[ApiKey]:
         return [
-            key for key in self.keys.values() if not name or key.name.startswith(name)
+            key
+            for key in self.keys.values()
+            if not name or (key.name and key.name.startswith(name))
         ]
 
     def get_api_key(self, api_key_id: str) -> ApiKey:
@@ -2232,7 +2234,11 @@ class APIGatewayBackend(BaseBackend):
 
         plan_keys = self.usage_plan_keys[usage_plan_id].values()
         if name:
-            return [key for key in plan_keys if not name or key.name.startswith(name)]
+            return [
+                key
+                for key in plan_keys
+                if not name or (key.name and key.name.startswith(name))
+            ]
         return list(plan_keys)
 
     def get_usage_plan_key(self, usage_plan_id: str, key_id: str) -> UsagePlanKey:

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -2232,7 +2232,7 @@ class APIGatewayBackend(BaseBackend):
 
         plan_keys = self.usage_plan_keys[usage_plan_id].values()
         if name:
-            return [key for key in plan_keys if not name or key.name == name]
+            return [key for key in plan_keys if not name or key.name.startswith(name)]
         return list(plan_keys)
 
     def get_usage_plan_key(self, usage_plan_id: str, key_id: str) -> UsagePlanKey:

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -2151,7 +2151,9 @@ class APIGatewayBackend(BaseBackend):
         return key
 
     def get_api_keys(self, name: Optional[str] = None) -> List[ApiKey]:
-        return [key for key in self.keys.values() if not name or name == key.name]
+        return [
+            key for key in self.keys.values() if not name or key.name.startswith(name)
+        ]
 
     def get_api_key(self, api_key_id: str) -> ApiKey:
         if api_key_id not in self.keys:

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1555,7 +1555,15 @@ def test_get_api_keys():
     keys = client.get_api_keys(nameQuery="TESTKEY2")["items"]
     assert [key["name"] for key in keys] == ["TESTKEY2"]
 
+    # assert that passing only a prefix works
+    keys = client.get_api_keys(nameQuery="TESTKEY")["items"]
+    assert [key["name"] for key in keys] == ["TESTKEY1", "TESTKEY2"]
+
     keys = client.get_api_keys(nameQuery="TESTKEY3")["items"]
+    assert keys == []
+
+    # assert that suffix of a name does not work
+    keys = client.get_api_keys(nameQuery="KEY2")["items"]
     assert keys == []
 
 

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1799,6 +1799,9 @@ def test_usage_plan_keys():
     # Query By Name
     plans = client.get_usage_plan_keys(usagePlanId=usage_plan_id, nameQuery=key_name)
     assert len(plans["items"]) == 1
+    # test using only a prefix
+    plans = client.get_usage_plan_keys(usagePlanId=usage_plan_id, nameQuery="test-")
+    assert len(plans["items"]) == 1
     plans = client.get_usage_plan_keys(usagePlanId=usage_plan_id, nameQuery="unknown")
     assert len(plans["items"]) == 0
 


### PR DESCRIPTION
Following #8202, the behavior was not fully compliant with AWS, as even if not documented at all by AWS, the `nameQuery` parameter also accepts prefixes. This was validated on AWS for both `GetApiKeys` and `GetUsagePlanKeys`. 