### PR TITLE
ELBv2: remove_tags() now throws a ResourceNotFound Exception

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1990,6 +1990,7 @@ Member must satisfy regular expression pattern: {expression}"
 
     def remove_tags(self, resource_arns: List[str], tag_keys: List[str]) -> None:
         for arn in resource_arns:
+            self._get_resource_by_arn(arn)
             self.tagging_service.untag_resource_using_names(arn, tag_keys)
 
     def describe_tags(self, resource_arns: List[str]) -> Dict[str, Dict[str, str]]:

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -198,6 +198,13 @@ def test_add_remove_tags():
 
     conn.remove_tags(ResourceArns=[lb["LoadBalancerArn"]], TagKeys=["a"])
 
+    with pytest.raises(ClientError) as exc:
+        # add a random string in the ARN to make the resource non-existent
+        BAD_LB_ARN = lb["LoadBalancerArn"] + "randomstring"
+        conn.remove_tags(ResourceArns=[BAD_LB_ARN], TagKeys=["a"])
+    err = exc.value.response["Error"]
+    assert err["Code"] == "LoadBalancerNotFound"
+
     tags = {
         d["Key"]: d["Value"]
         for d in conn.describe_tags(ResourceArns=[lb["LoadBalancerArn"]])[

--- a/tests/test_elbv2/test_elbv2_listener_tags.py
+++ b/tests/test_elbv2/test_elbv2_listener_tags.py
@@ -1,3 +1,6 @@
+import pytest
+from botocore.exceptions import ClientError
+
 from moto import mock_aws
 
 from .test_elbv2 import create_load_balancer
@@ -73,3 +76,29 @@ def test_listener_add_remove_tags():
         {"Key": "b", "Value": "b"},
         {"Key": "c", "Value": "b"},
     ]
+
+
+@mock_aws
+def test_remove_tags_to_invalid_listener():
+    response, _, _, _, _, elbv2 = create_load_balancer()
+    load_balancer_arn = response.get("LoadBalancers")[0].get("LoadBalancerArn")
+
+    listener_arn = elbv2.create_listener(
+        LoadBalancerArn=load_balancer_arn,
+        Protocol="HTTP",
+        Port=80,
+        DefaultActions=[],
+    )["Listeners"][0]["ListenerArn"]
+
+    # add a random string in the ARN to make the resource non-existent
+    BAD_ARN = listener_arn + "randomstring"
+
+    # test for exceptions on remove tags
+    with pytest.raises(ClientError) as err:
+        elbv2.remove_tags(ResourceArns=[BAD_ARN], TagKeys=["a"])
+
+    assert err.value.response["Error"]["Code"] == "ListenerNotFound"
+    assert (
+        err.value.response["Error"]["Message"]
+        == "The specified listener does not exist."
+    )


### PR DESCRIPTION
## Motivation
This pr aims to add parity with `remove_tags` API of `elbv2` that throws exception in certain scenarios. Currently, no exceptions were being thrown from `remove_tags`.

##  Changes
Include logic to throw exceptions similar to `add_tags` by using the method `_get_resource_by_arn` that can check for various NotFound scenarios.
Added test cases for loadbalancer, listener, listener rule and target group to reflect the new behavior. 

## Not in scope
It doesn't currently cover the singular nature of the API. Even though the parameter `ResourceArns` expects a list but only one ARN can be passed. This use case is not covered yet.