### PR TITLE
Custom id tag support

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -1658,7 +1658,7 @@ class APIGatewayBackend(BaseBackend):
     ) -> RestAPI:
         api_id = ApigwRestApiIdentifier(
             self.account_id, self.region_name, name
-        ).generate()
+        ).generate(tags=tags)
         rest_api = RestAPI(
             api_id,
             self.account_id,

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -100,7 +100,7 @@ class FakeSecret:
         self.name = secret_id
         self.arn = SecretsManagerSecretIdentifier(
             account_id, region_name, secret_id
-        ).generate()
+        ).generate(tags=tags)
         self.account_id = account_id
         self.region = region_name
         self.secret_string = secret_string

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -8,7 +8,7 @@ from moto.moto_api._internal import mock_random
 log = logging.getLogger(__name__)
 
 ExistingIds = Union[List[str], None]
-Tags = Union[Dict[str, str], None]
+Tags = Union[Dict[str, str], List[Dict[str, str]], None]
 
 # Custom resource tag to override the generated resource ID.
 TAG_KEY_CUSTOM_ID = "_custom_id_"
@@ -95,10 +95,21 @@ class MotoIdManager:
 
     @staticmethod
     def get_id_from_tags(id_source_context: IdSourceContext) -> Union[str, None]:
-        if tags := id_source_context.get("tags"):
+        if not (tags := id_source_context.get("tags")):
+            return None
+
+        if isinstance(tags, dict):
             return tags.get(TAG_KEY_CUSTOM_ID)
 
-        return None
+        if isinstance(tags, list):
+            return next(
+                (
+                    tag.get("Value")
+                    for tag in tags
+                    if tag.get("Key") == TAG_KEY_CUSTOM_ID
+                ),
+                None,
+            )
 
     def get_custom_id_from_context(
         self, id_source_context: IdSourceContext

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -71,7 +71,8 @@ class MotoIdManager:
     def get_custom_id(
         self, resource_identifier: ResourceIdentifier
     ) -> Union[str, None]:
-        # retrieves a custom_id for a resource. Returns None
+        # retrieves a custom_id for a resource. Returns None if no id were registered
+        # that matches the `resource_identifier`
         return self._custom_ids.get(resource_identifier.unique_identifier)
 
     def set_custom_id(

--- a/tests/test_apigateway/test_apigateway_custom_ids.py
+++ b/tests/test_apigateway/test_apigateway_custom_ids.py
@@ -11,6 +11,8 @@ from moto.apigateway.utils import (
     ApigwRestApiIdentifier,
     ApigwUsagePlanIdentifier,
 )
+from moto.utilities.id_generator import TAG_KEY_CUSTOM_ID
+from tests import DEFAULT_ACCOUNT_ID
 
 API_ID = "ApiId"
 API_KEY_ID = "ApiKeyId"
@@ -27,7 +29,7 @@ USAGE_PLAN_ID = "UPlanId"
 @pytest.mark.skipif(
     not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode"
 )
-def test_custom_id_rest_api(set_custom_id, account_id):
+def test_custom_id_rest_api(set_custom_id):
     region_name = "us-west-2"
     rest_api_name = "my-api"
     model_name = "modelName"
@@ -37,33 +39,40 @@ def test_custom_id_rest_api(set_custom_id, account_id):
     client = boto3.client("apigateway", region_name=region_name)
 
     set_custom_id(
-        ApigwRestApiIdentifier(account_id, region_name, rest_api_name), API_ID
+        ApigwRestApiIdentifier(DEFAULT_ACCOUNT_ID, region_name, rest_api_name), API_ID
     )
     set_custom_id(
-        ApigwResourceIdentifier(account_id, region_name, path_name="/"),
+        ApigwResourceIdentifier(DEFAULT_ACCOUNT_ID, region_name, path_name="/"),
         ROOT_RESOURCE_ID,
     )
     set_custom_id(
         ApigwResourceIdentifier(
-            account_id, region_name, parent_id=ROOT_RESOURCE_ID, path_name="pet"
+            DEFAULT_ACCOUNT_ID, region_name, parent_id=ROOT_RESOURCE_ID, path_name="pet"
         ),
         PET_1_RESOURCE_ID,
     )
     set_custom_id(
         ApigwResourceIdentifier(
-            account_id, region_name, parent_id=PET_1_RESOURCE_ID, path_name="pet"
+            DEFAULT_ACCOUNT_ID,
+            region_name,
+            parent_id=PET_1_RESOURCE_ID,
+            path_name="pet",
         ),
         PET_2_RESOURCE_ID,
     )
-    set_custom_id(ApigwModelIdentifier(account_id, region_name, model_name), MODEL_ID)
+    set_custom_id(
+        ApigwModelIdentifier(DEFAULT_ACCOUNT_ID, region_name, model_name), MODEL_ID
+    )
     set_custom_id(
         ApigwRequestValidatorIdentifier(
-            account_id, region_name, request_validator_name
+            DEFAULT_ACCOUNT_ID, region_name, request_validator_name
         ),
         REQUEST_VALIDATOR_ID,
     )
     set_custom_id(
-        ApigwDeploymentIdentifier(account_id, region_name, stage_name=stage_name),
+        ApigwDeploymentIdentifier(
+            DEFAULT_ACCOUNT_ID, region_name, stage_name=stage_name
+        ),
         DEPLOYMENT_ID,
     )
 
@@ -113,7 +122,7 @@ def test_custom_id_rest_api(set_custom_id, account_id):
 @pytest.mark.skipif(
     not settings.TEST_DECORATOR_MODE, reason="Can't access the id manager in proxy mode"
 )
-def test_custom_id_api_key(account_id, set_custom_id):
+def test_custom_id_api_key(set_custom_id):
     region_name = "us-west-2"
     api_key_value = "01234567890123456789"
     usage_plan_name = "usage-plan"
@@ -121,10 +130,11 @@ def test_custom_id_api_key(account_id, set_custom_id):
     client = boto3.client("apigateway", region_name=region_name)
 
     set_custom_id(
-        ApigwApiKeyIdentifier(account_id, region_name, value=api_key_value), API_KEY_ID
+        ApigwApiKeyIdentifier(DEFAULT_ACCOUNT_ID, region_name, value=api_key_value),
+        API_KEY_ID,
     )
     set_custom_id(
-        ApigwUsagePlanIdentifier(account_id, region_name, usage_plan_name),
+        ApigwUsagePlanIdentifier(DEFAULT_ACCOUNT_ID, region_name, usage_plan_name),
         USAGE_PLAN_ID,
     )
 
@@ -138,3 +148,15 @@ def test_custom_id_api_key(account_id, set_custom_id):
 
     assert api_key["id"] == API_KEY_ID
     assert usage_plan["id"] == USAGE_PLAN_ID
+
+
+@mock_aws
+def test_create_rest_api_with_custom_id_tag():
+    rest_api_name = "rest_api"
+    api_id = "testTagId"
+    client = boto3.client("apigateway")
+    rest_api = client.create_rest_api(
+        name=rest_api_name, tags={TAG_KEY_CUSTOM_ID: api_id}
+    )
+
+    assert rest_api["id"] == api_id

--- a/tests/test_apigateway/test_apigateway_custom_ids.py
+++ b/tests/test_apigateway/test_apigateway_custom_ids.py
@@ -154,7 +154,7 @@ def test_custom_id_api_key(set_custom_id):
 def test_create_rest_api_with_custom_id_tag():
     rest_api_name = "rest_api"
     api_id = "testTagId"
-    client = boto3.client("apigateway")
+    client = boto3.client("apigateway", region_name="us-west-2")
     rest_api = client.create_rest_api(
         name=rest_api_name, tags={TAG_KEY_CUSTOM_ID: api_id}
     )

--- a/tests/test_utilities/test_id_generator.py
+++ b/tests/test_utilities/test_id_generator.py
@@ -12,7 +12,7 @@ REGION = "us-east-1"
 RESOURCE_NAME = "my-resource"
 
 CUSTOM_ID = "custom"
-GENERATED_ID = "generated"
+GENERIC_ID = "generated"
 TAG_ID = "fromTag"
 SERVICE = "test-service"
 RESOURCE = "test-resource"
@@ -24,7 +24,7 @@ def generate_test_id(
     existing_ids: ExistingIds = None,
     tags: Tags = None,
 ):
-    return GENERATED_ID
+    return GENERIC_ID
 
 
 class TestResourceIdentifier(ResourceIdentifier):
@@ -39,7 +39,7 @@ class TestResourceIdentifier(ResourceIdentifier):
 
 def test_generate_with_no_resource_identifier():
     generated_id = generate_test_id(None)
-    assert generated_id == GENERATED_ID
+    assert generated_id == GENERIC_ID
 
 
 def test_generate_with_matching_resource_identifier(set_custom_id):
@@ -58,7 +58,7 @@ def test_generate_with_non_matching_resource_identifier(set_custom_id):
     set_custom_id(resource_identifier, CUSTOM_ID)
 
     generated_id = generate_test_id(resource_identifier=resource_identifier_2)
-    assert generated_id == GENERATED_ID
+    assert generated_id == GENERIC_ID
 
 
 def test_generate_with_custom_id_tag():
@@ -87,7 +87,7 @@ def test_generate_with_existing_id(set_custom_id):
     generated_id = generate_test_id(
         resource_identifier=resource_identifier, existing_ids=[CUSTOM_ID]
     )
-    assert generated_id == GENERATED_ID
+    assert generated_id == GENERIC_ID
 
 
 def test_generate_with_tags_and_existing_id(set_custom_id):
@@ -98,7 +98,7 @@ def test_generate_with_tags_and_existing_id(set_custom_id):
         existing_ids=[TAG_ID],
         tags={TAG_KEY_CUSTOM_ID: TAG_ID},
     )
-    assert generated_id == GENERATED_ID
+    assert generated_id == GENERIC_ID
 
 
 def test_generate_with_tags_fallback(set_custom_id):


### PR DESCRIPTION
# Motivation

As a follow up to #8216, This pr aims at expanding support of custom ids to resources that can be created with tags. Providing a tag named `_custom_ids` at creation can be used to create a custom id for the created resource.

# Changes

- Fixed `get_id_from_tags` method to by able to accept tags created as dict (e.g `{"_custom_id_": "myCustomId"}`) or as a list (e.g. `[ {"Key": "_custom_id_", "Value": "myCustomId"} ]`)
- Added tests for apigw and secrets manager to showcase an example of each type

# TODO

- [ ] Rebase on master, currently based on #8231 to allow for ci to run
