### PR TITLE
Core: fixed typing for conditional expression

### DIFF
--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -62,7 +62,7 @@ class IamInstanceProfileAssociationBackend:
         iam_instance_profile_association = IamInstanceProfileAssociation(
             self,
             iam_association_id,
-            self.get_instance(instance_id) if instance_id else None,  # type: ignore[attr-defined]
+            self.get_instance(instance_id) if instance_id else None,  # type: ignore[attr-defined, arg-type]
             instance_profile,
         )
         # Regarding to AWS there can be only one association with ec2.

--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -1,6 +1,9 @@
+from typing import List
+
 from moto.core.utils import camelcase_to_underscores
 from moto.ec2.utils import add_tag_specification
 
+from ..models.managed_prefixes import ManagedPrefixList
 from ._base_response import EC2BaseResponse
 
 
@@ -294,7 +297,7 @@ class VPCs(EC2BaseResponse):
         managed_prefix_list = self.ec2_backend.get_managed_prefix_list_entries(
             prefix_list_id=prefix_list_id
         )
-        entries = []
+        entries: List[ManagedPrefixList] = []
         if managed_prefix_list:
             entries = (
                 list(managed_prefix_list.entries.values())[-1]

--- a/moto/packages/boto/ec2/instance.py
+++ b/moto/packages/boto/ec2/instance.py
@@ -25,7 +25,7 @@
 Represents an EC2 Instance
 """
 
-from typing import Any
+from typing import Any, Optional
 
 from moto.packages.boto.ec2.ec2object import EC2Object, TaggedEC2Object
 from moto.packages.boto.ec2.image import ProductCodes
@@ -159,8 +159,8 @@ class Instance(TaggedEC2Object):
         self.platform = None
         self.interfaces: Any = []
         self.hypervisor = None
-        self.virtualization_type = None
-        self.architecture = None
+        self.virtualization_type: Optional[str] = None
+        self.architecture: Optional[str] = None
         self.instance_profile = None
         self._previous_state = None
         self._placement = InstancePlacement()

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -658,6 +658,9 @@ def get_canned_acl(acl: str) -> FakeAcl:
 
 
 class LifecycleFilter(BaseModel):
+    tag_key: Optional[str]
+    tag_value: Optional[str]
+
     def __init__(
         self,
         prefix: Optional[str] = None,


### PR DESCRIPTION
# Motivation

With it's latest release, `mypy` has improved it's capabilities to [Inferring Unions for Conditional Expressions](https://github.com/python/mypy/blob/master/CHANGELOG.md#inferring-unions-for-conditional-expressions). This created a new issues with `mypy` and [tests failing](https://github.com/getmoto/moto/actions/runs/11337740019) at the linting step.

# Changes

- Added type annotation to prevent inference at declaration (`var = None`) conflict with inference in conditional expression (`var = "string" if cond() else None`) resulting in `expression has type "Union[Any, str]", variable has type "None"` error.