### PR TITLE
Prep release 5.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 Moto Changelog
 ==============
 
+5.0.18
+-----
+Docker Digest for 5.0.18: <autopopulateddigest>
+
+    New Methods:
+        * RDS:
+            * delete_db_proxy()
+            * deregister_db_proxy_targets()
+            * describe_db_proxy_target_groups()
+            * describe_db_proxy_targets()
+            * modify_db_proxy_target_group()
+            * register_db_proxy_targets()
+
+    Miscellaneous:
+        * CloudFormation: create_change_set() now supports the UsePreviousTemplate-parameter
+        * CognitoIDP: MFA-related features (like AssociateSoftwareToken) now also work with non-Python SDK's
+        * ECS: update_service() now correctly sets the createdAt/updatedAt values when forceNewDeployment=True
+        * ELBv2: remove_tags() now throws a ResourceNotFound Exception
+
+
 5.0.17
 -----
 Docker Digest for 5.0.17: _sha256:39372432cb24ab46211ca45648ca787e104589070b0d0a13ea0d73c6eb550079_

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6379,6 +6379,7 @@
 - [ ] start_asset_bundle_export_job
 - [ ] start_asset_bundle_import_job
 - [ ] start_dashboard_snapshot_job
+- [ ] start_dashboard_snapshot_job_schedule
 - [ ] tag_resource
 - [ ] untag_resource
 - [ ] update_account_customization
@@ -6640,7 +6641,7 @@
 
 ## redshift
 <details>
-<summary>22% implemented</summary>
+<summary>21% implemented</summary>
 
 - [ ] accept_reserved_node_exchange
 - [ ] add_partner
@@ -6664,6 +6665,7 @@
 - [ ] create_event_subscription
 - [ ] create_hsm_client_certificate
 - [ ] create_hsm_configuration
+- [ ] create_integration
 - [ ] create_redshift_idc_application
 - [ ] create_scheduled_action
 - [X] create_snapshot_copy_grant
@@ -6682,6 +6684,7 @@
 - [ ] delete_event_subscription
 - [ ] delete_hsm_client_certificate
 - [ ] delete_hsm_configuration
+- [ ] delete_integration
 - [ ] delete_partner
 - [ ] delete_redshift_idc_application
 - [ ] delete_resource_policy
@@ -6714,6 +6717,7 @@
 - [ ] describe_hsm_client_certificates
 - [ ] describe_hsm_configurations
 - [ ] describe_inbound_integrations
+- [ ] describe_integrations
 - [ ] describe_logging_status
 - [ ] describe_node_configuration_options
 - [ ] describe_orderable_cluster_options
@@ -6755,6 +6759,7 @@
 - [ ] modify_custom_domain_association
 - [ ] modify_endpoint_access
 - [ ] modify_event_subscription
+- [ ] modify_integration
 - [ ] modify_redshift_idc_application
 - [ ] modify_scheduled_action
 - [X] modify_snapshot_copy_retention_period
@@ -8755,6 +8760,7 @@
 - [ ] list_certificates
 - [ ] list_connectors
 - [ ] list_executions
+- [ ] list_file_transfer_results
 - [ ] list_host_keys
 - [ ] list_profiles
 - [ ] list_security_policies

--- a/docs/docs/services/quicksight.rst
+++ b/docs/docs/services/quicksight.rst
@@ -164,6 +164,7 @@ quicksight
 - [ ] start_asset_bundle_export_job
 - [ ] start_asset_bundle_import_job
 - [ ] start_dashboard_snapshot_job
+- [ ] start_dashboard_snapshot_job_schedule
 - [ ] tag_resource
 - [ ] untag_resource
 - [ ] update_account_customization

--- a/docs/docs/services/redshift.rst
+++ b/docs/docs/services/redshift.rst
@@ -36,6 +36,7 @@ redshift
 - [ ] create_event_subscription
 - [ ] create_hsm_client_certificate
 - [ ] create_hsm_configuration
+- [ ] create_integration
 - [ ] create_redshift_idc_application
 - [ ] create_scheduled_action
 - [X] create_snapshot_copy_grant
@@ -54,6 +55,7 @@ redshift
 - [ ] delete_event_subscription
 - [ ] delete_hsm_client_certificate
 - [ ] delete_hsm_configuration
+- [ ] delete_integration
 - [ ] delete_partner
 - [ ] delete_redshift_idc_application
 - [ ] delete_resource_policy
@@ -86,6 +88,7 @@ redshift
 - [ ] describe_hsm_client_certificates
 - [ ] describe_hsm_configurations
 - [ ] describe_inbound_integrations
+- [ ] describe_integrations
 - [ ] describe_logging_status
 - [ ] describe_node_configuration_options
 - [ ] describe_orderable_cluster_options
@@ -127,6 +130,7 @@ redshift
 - [ ] modify_custom_domain_association
 - [ ] modify_endpoint_access
 - [ ] modify_event_subscription
+- [ ] modify_integration
 - [ ] modify_redshift_idc_application
 - [ ] modify_scheduled_action
 - [X] modify_snapshot_copy_retention_period

--- a/docs/docs/services/transfer.rst
+++ b/docs/docs/services/transfer.rst
@@ -52,6 +52,7 @@ transfer
 - [ ] list_certificates
 - [ ] list_connectors
 - [ ] list_executions
+- [ ] list_file_transfer_results
 - [ ] list_host_keys
 - [ ] list_profiles
 - [ ] list_security_policies

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -8,9 +8,7 @@ backend_url_patterns = [
     ("apigateway", re.compile("https?://apigateway\\.(.+)\\.amazonaws.com")),
     (
         "apigatewaymanagementapi",
-        re.compile(
-            "https?://([^.]+\\.)*execute-api\\.[a-z]{2}-[-a-z]+-\\d+\\.amazonaws\\.com"
-        ),
+        re.compile("https?://([^.]+\\.)*execute-api\\.[^.]+\\.amazonaws\\.com"),
     ),
     ("appconfig", re.compile("https?://appconfig\\.(.+)\\.amazonaws\\.com")),
     (
@@ -121,10 +119,13 @@ backend_url_patterns = [
     ("memorydb", re.compile("https?://memory-db\\.(.+)\\.amazonaws\\.com")),
     (
         "meteringmarketplace",
-        re.compile("https?://metering.marketplace.(.+).amazonaws.com"),
+        re.compile("https?://metering\\.marketplace\\.(.+)\\.amazonaws\\.com"),
     ),
-    ("meteringmarketplace", re.compile("https?://aws-marketplace.(.+).amazonaws.com")),
-    ("moto_api._internal", re.compile("https?://motoapi.amazonaws.com")),
+    (
+        "meteringmarketplace",
+        re.compile("https?://aws-marketplace\\.(.+)\\.amazonaws\\.com"),
+    ),
+    ("moto_api._internal", re.compile("https?://motoapi\\.amazonaws\\.com")),
     ("mq", re.compile("https?://mq\\.(.+)\\.amazonaws\\.com")),
     ("networkmanager", re.compile("https?://networkmanager\\.(.+)\\.amazonaws\\.com")),
     ("opensearchserverless", re.compile("https?://aoss\\.(.+)\\.amazonaws\\.com")),
@@ -171,7 +172,7 @@ backend_url_patterns = [
     ("sagemaker", re.compile("https?://api\\.sagemaker\\.(.+)\\.amazonaws.com")),
     (
         "sagemakermetrics",
-        re.compile("https?://metrics.sagemaker\\.(.+)\\.amazonaws\\.com"),
+        re.compile("https?://metrics\\.sagemaker\\.(.+)\\.amazonaws\\.com"),
     ),
     (
         "sagemakerruntime",
@@ -202,7 +203,7 @@ backend_url_patterns = [
     ("textract", re.compile("https?://textract\\.(.+)\\.amazonaws\\.com")),
     (
         "timestreamquery",
-        re.compile("https?://query.timestream\\.(.+)\\.amazonaws\\.com"),
+        re.compile("https?://query\\.timestream\\.(.+)\\.amazonaws\\.com"),
     ),
     (
         "timestreamwrite",

--- a/moto/meteringmarketplace/urls.py
+++ b/moto/meteringmarketplace/urls.py
@@ -1,8 +1,8 @@
 from .responses import MarketplaceMeteringResponse
 
 url_bases = [
-    "https?://metering.marketplace.(.+).amazonaws.com",
-    "https?://aws-marketplace.(.+).amazonaws.com",
+    r"https?://metering\.marketplace\.(.+)\.amazonaws\.com",
+    r"https?://aws-marketplace\.(.+)\.amazonaws\.com",
 ]
 
 url_paths = {"{0}/$": MarketplaceMeteringResponse.dispatch}

--- a/moto/moto_api/_internal/urls.py
+++ b/moto/moto_api/_internal/urls.py
@@ -1,7 +1,7 @@
 from .recorder.responses import RecorderResponse
 from .responses import MotoAPIResponse
 
-url_bases = ["https?://motoapi.amazonaws.com"]
+url_bases = [r"https?://motoapi\.amazonaws\.com"]
 
 response_instance = MotoAPIResponse()
 recorder_response = RecorderResponse()

--- a/moto/sagemakermetrics/urls.py
+++ b/moto/sagemakermetrics/urls.py
@@ -3,7 +3,7 @@
 from .responses import SageMakerMetricsResponse
 
 url_bases = [
-    r"https?://metrics.sagemaker\.(.+)\.amazonaws\.com",
+    r"https?://metrics\.sagemaker\.(.+)\.amazonaws\.com",
 ]
 
 url_paths = {

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -385,7 +385,7 @@ Notification
 
     @lru_cache()
     def private_key(self) -> rsa.RSAPrivateKey:
-        return rsa.generate_private_key(public_exponent=65537, key_size=2028)
+        return rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     def _parse_message_structure(self, message: str, protocol: str) -> str:
         try:

--- a/moto/timestreamquery/urls.py
+++ b/moto/timestreamquery/urls.py
@@ -3,7 +3,7 @@
 from moto.timestreamwrite.responses import TimestreamWriteResponse
 
 url_bases = [
-    r"https?://query.timestream\.(.+)\.amazonaws\.com",
+    r"https?://query\.timestream\.(.+)\.amazonaws\.com",
 ]
 
 url_paths = {

--- a/tests/test_iam/test_iam_signing_certificates.py
+++ b/tests/test_iam/test_iam_signing_certificates.py
@@ -191,7 +191,7 @@ def test_update_unknown_certificate(user_name=None):
 
 
 def create_certificate():
-    key = rsa.generate_private_key(public_exponent=65537, key_size=2028)
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     cert_subject = [NameAttribute(NameOID.COMMON_NAME, "iam.amazonaws.com")]
     issuer = [
         NameAttribute(NameOID.COUNTRY_NAME, "US"),

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1991,7 +1991,7 @@ def test_create_secret_with_tag_custom_id(set_custom_id):
     secret_suffix = "randomSuffix"
     secret_name = "secret-name"
 
-    client = boto3.client("secretsmanager")
+    client = boto3.client("secretsmanager", "us-east-1")
 
     secret = client.create_secret(
         Name=secret_name,


### PR DESCRIPTION
Includes:
 - A bunch of regex fixes, where we want to match on the dot-character (`\.`) instead of any characters
 - Some test fixes, like a missing region
 - Explicit deletion of a KMS key in an AWS parity test, to avoid having to delete resources manually from our AWS account
 - Fix a StepFunction test as we were using a unsupported value in `create_state_machine(encryption_config.type)`, and AWS apparently only added validation for that field recently
 - Improve the key size for some RSA keys, as the GitHub vulnarability scanner complains about key sizes < 2048