### PR TITLE
Update `botocore` version specifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 python_requires = >=3.8
 install_requires =
     boto3>=1.9.201
-    botocore>=1.14.0,<1.35.45
+    botocore>=1.14.0
     cryptography>=3.3.1
     requests>=2.5
     xmltodict

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 python_requires = >=3.8
 install_requires =
     boto3>=1.9.201
-    botocore>=1.14.0
+    botocore>=1.14.0,!=1.35.45,!=1.35.46
     cryptography>=3.3.1
     requests>=2.5
     xmltodict


### PR DESCRIPTION
Reverts #8248 
Should work again now that botocore 1.35.46 is out (see https://github.com/boto/botocore/issues/3284)