### PR TITLE
Introducing Moto Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dw/moto.svg)](https://pypistats.org/packages/moto)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Financial Contributors](https://opencollective.com/moto/tiers/badge.svg)](https://opencollective.com/moto)
-
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Moto%20Guru-006BFF)](https://gurubase.io/g/moto)
 
 ## Install
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Moto Guru](https://gurubase.io/g/moto) to Gurubase. Moto Guru uses the data from this repo and data from the [docs](https://docs.getmoto.org/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Moto Guru", which highlights that Moto now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Moto Guru in Gurubase, just let me know that's totally fine.
