### PR TITLE
Organizations: Allow cross-account access

### DIFF
--- a/moto/organizations/exceptions.py
+++ b/moto/organizations/exceptions.py
@@ -11,6 +11,16 @@ class AccountAlreadyRegisteredException(JsonRESTError):
         )
 
 
+class AccountAlreadyClosedException(JsonRESTError):
+    code = 400
+
+    def __init__(self) -> None:
+        super().__init__(
+            "AccountAlreadyClosedException",
+            "The provided account is already closed.",
+        )
+
+
 class AccountNotRegisteredException(JsonRESTError):
     code = 400
 

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -455,9 +455,11 @@ class OrganizationsBackend(BaseBackend):
 
     def describe_organization(self) -> Dict[str, Any]:
         if self.org:
+            # This is a master account
             return self.org.describe()
 
         if self.account_id in organizations_backends.master_accounts:
+            # This is a member account
             master_account_id, partition = organizations_backends.master_accounts[
                 self.account_id
             ]
@@ -995,8 +997,8 @@ class OrganizationsBackend(BaseBackend):
         account_id = kwargs["AccountId"]
         if account_id not in organizations_backends.master_accounts:
             raise AWSOrganizationsNotInUseException
-        organizations_backends.master_accounts.pop(kwargs["AccountId"], None)
-        account = self.get_account_by_id(kwargs["AccountId"])
+        organizations_backends.master_accounts.pop(account_id, None)
+        account = self.get_account_by_id(account_id)
         for policy in account.attached_policies:
             policy.attachments.remove(account)
         self.accounts.remove(account)

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -1,7 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, Iterator
-import weakref
+from typing import Any, Dict, List, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -456,7 +455,9 @@ class OrganizationsBackend(BaseBackend):
             return self.org.describe()
 
         if self.account_id in organizations_backends.master_accounts:
-            master_account_id, partition = organizations_backends.master_accounts[self.account_id]
+            master_account_id, partition = organizations_backends.master_accounts[
+                self.account_id
+            ]
             return organizations_backends[master_account_id][partition].org.describe()
 
         raise AWSOrganizationsNotInUseException
@@ -529,7 +530,10 @@ class OrganizationsBackend(BaseBackend):
         new_account = FakeAccount(self.org, **kwargs)  # type: ignore
         self.accounts.append(new_account)
         self.attach_policy(PolicyId=utils.DEFAULT_POLICY_ID, TargetId=new_account.id)
-        organizations_backends.master_accounts[new_account.id] = (self.account_id, self.partition)
+        organizations_backends.master_accounts[new_account.id] = (
+            self.account_id,
+            self.partition,
+        )
         return new_account.create_account_status
 
     def close_account(self, **kwargs: Any) -> None:
@@ -537,7 +541,7 @@ class OrganizationsBackend(BaseBackend):
             if account.id == kwargs["AccountId"]:
                 account.close()
                 return
-        organizations_backends.master_accounts.pop(kwargs['AccountID'], None)
+        organizations_backends.master_accounts.pop(kwargs["AccountID"], None)
         raise AccountNotFoundException
 
     def get_account_by_id(self, account_id: str) -> FakeAccount:
@@ -985,10 +989,10 @@ class OrganizationsBackend(BaseBackend):
             raise InvalidInputException("You specified an invalid value.")
 
     def remove_account_from_organization(self, **kwargs: str) -> None:
-        account_id = kwargs['AccountId']
+        account_id = kwargs["AccountId"]
         if account_id not in organizations_backends:
             raise AWSOrganizationsNotInUseException
-        organizations_backends.master_accounts.pop(kwargs['AccountId'], None)
+        organizations_backends.master_accounts.pop(kwargs["AccountId"], None)
         account = self.get_account_by_id(kwargs["AccountId"])
         for policy in account.attached_policies:
             policy.attachments.remove(account)
@@ -999,6 +1003,7 @@ class OrganizationsBackendDict(BackendDict):
     """
     Specialised to keep track of master accounts.
     """
+
     def __init__(
         self,
         backend: Any,

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -1019,7 +1019,7 @@ class OrganizationsBackendDict(BackendDict[OrganizationsBackend]):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 
         # Maps account IDs to the (partition, master account ID) which owns the organisation
-        self.master_accounts: dict[str, tuple[str, str]] = {}
+        self.master_accounts: Dict[str, Tuple[str, str]] = {}
 
 
 organizations_backends = OrganizationsBackendDict(

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -463,7 +463,7 @@ class OrganizationsBackend(BaseBackend):
             master_account_id, partition = organizations_backends.master_accounts[
                 self.account_id
             ]
-            return organizations_backends[master_account_id][partition].org.describe()
+            return organizations_backends[master_account_id][partition].org.describe()  # type: ignore[union-attr]
 
         raise AWSOrganizationsNotInUseException
 
@@ -1004,7 +1004,7 @@ class OrganizationsBackend(BaseBackend):
         self.accounts.remove(account)
 
 
-class OrganizationsBackendDict(BackendDict):
+class OrganizationsBackendDict(BackendDict[OrganizationsBackend]):
     """
     Specialised to keep track of master accounts.
     """
@@ -1019,7 +1019,7 @@ class OrganizationsBackendDict(BackendDict):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 
         # Maps account IDs to the (partition, master account ID) which owns the organisation
-        self.master_accounts: dict[str, [str, str]] = {}
+        self.master_accounts: dict[str, tuple[str, str]] = {}
 
 
 organizations_backends = OrganizationsBackendDict(

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -1018,7 +1018,7 @@ class OrganizationsBackendDict(BackendDict[OrganizationsBackend]):
     ):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 
-        # Maps account IDs to the (partition, master account ID) which owns the organisation
+        # Maps member account IDs to the (master account ID, partition) which owns the organisation
         self.master_accounts: Dict[str, Tuple[str, str]] = {}
 
 

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -400,12 +400,9 @@ class FakeDelegatedAdministrator(BaseModel):
 
 
 class OrganizationsBackend(BaseBackend):
-    _organizations_backend_refs = set()
-
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self._reset()
-        self._organizations_backend_refs.add(weakref.ref(self))  # type: set[weakref.ReferenceType["OrganizationsBackend"]]
 
     def _reset(self) -> None:
         self.org: Optional[FakeOrganization] = None
@@ -421,13 +418,6 @@ class OrganizationsBackend(BaseBackend):
             raise RootNotFoundException
 
         return root  # type: ignore[return-value]
-
-    @classmethod
-    def _get_organizations_backend_refs(cls) -> Iterator["OrganizationsBackend"]:
-        for backend_ref in cls._organizations_backend_refs:
-            backend = backend_ref()
-            if backend is not None:
-                yield backend
 
     def create_organization(self, region: str, **kwargs: Any) -> Dict[str, Any]:
         self.org = FakeOrganization(

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -645,6 +645,13 @@ def test_remove_account_from_organization():
     assert len(accounts) == 1
     assert not created_account_exists(accounts)
 
+    # After the account is removed from an organisation, calling DescribeOrganization from the removed account should raise
+    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account_id}):
+        with pytest.raises(ClientError) as exc:
+            client.describe_organization()
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert "AWSOrganizationsNotInUse" in exc.value.response["Error"]["Code"]
+
     # Attempting to remove invalid account must raise
     bad_account_id = "010101010101"
     with pytest.raises(ClientError) as exc:

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -122,14 +122,17 @@ def test_describe_organization():
     response = client.describe_organization()
     validate_organization(response)
 
-    # Ensure member accounts can also describe the organisation
+    # Ensure member accounts can also describe the organisation from any region
     account_id = client.create_account(AccountName=mockname, Email=mockemail)[
         "CreateAccountStatus"
     ]["AccountId"]
 
-    with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account_id}):
-        response = client.describe_organization()
-        validate_organization(response)
+    for region_name in ["ap-south-1", "eu-west-1"]:
+        with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": account_id}):
+            response = boto3.client(
+                "organizations", region_name=region_name
+            ).describe_organization()
+            validate_organization(response)
 
 
 @mock_aws

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -117,6 +117,9 @@ def test_create_account_creates_custom_role():
 
 @mock_aws
 def test_describe_organization():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Involves changing account using env variable")
+
     client = boto3.client("organizations", region_name="us-east-1")
     client.create_organization(FeatureSet="ALL")
     response = client.describe_organization()
@@ -626,6 +629,9 @@ def test_get_paginated_list_create_account_status():
 
 @mock_aws
 def test_remove_account_from_organization():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("Involves changing account using env variable")
+
     client = boto3.client("organizations", region_name="us-east-1")
     _ = client.create_organization(FeatureSet="ALL")["Organization"]
     create_account_status = client.create_account(


### PR DESCRIPTION
This PR unlocks cross-account support for AWS Organizations.

After creating an organization and adding a member account to it, it is now possible to retrieve the details of the parent organization using `DescribeOrganization` from the member account.

Plus:
- Calling `CloseAccount` on an already closed account raises
- Calling `RemoveAccountFromOrganization` on an account which does not belong to any raises

A similar pattern was employed for S3 in https://github.com/getmoto/moto/pull/6333