### PR TITLE
InstanceMetadata: Fix compatibility with werkzeug 3.1.x

### DIFF
--- a/moto/instance_metadata/responses.py
+++ b/moto/instance_metadata/responses.py
@@ -55,4 +55,12 @@ class InstanceMetadataResponse(BaseResponse):
             raise NotImplementedError(
                 f"The {path} metadata path has not been implemented"
             )
+        try:
+            from werkzeug.datastructures.headers import EnvironHeaders
+
+            if isinstance(headers, EnvironHeaders):
+                # We should be returning a generic dict here, not werkzeug-specific classes
+                headers = {key: value for key, value in headers}
+        except ImportError:
+            pass
         return 200, headers, result


### PR DESCRIPTION
Werkzeug 3.1.x has changed the `EnvironHeaders`-class, and the `update`-method no longer accepts another `EnvironHeaders`-class as an argument.

This PR changes the `InstanceMetadata`-class to return the headers as a dictionary. That is a more standardized way to handle headers, and also ensures that `EnvironHeaders.update(headers_as_dict)` works.