### PR TITLE
IOT RoleAlias support - API and CloudFormation object, enhancements to search_index() response

### DIFF
--- a/CLOUDFORMATION_COVERAGE.md
+++ b/CLOUDFORMATION_COVERAGE.md
@@ -277,6 +277,11 @@ Please let us know if you'd like support for a resource not yet listed here.
    - [x] update implemented
    - [x] delete implemented
    - [x] Fn::GetAtt implemented
+- AWS::IoT::RoleAlias:
+   - [x] create implemented
+   - [x] update implemented
+   - [x] delete implemented
+   - [x] Fn::GetAtt implemented
 - AWS::KMS::Key:
    - [x] create implemented
    - [ ] update implemented

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -4539,7 +4539,7 @@
 - [ ] create_provisioning_claim
 - [ ] create_provisioning_template
 - [ ] create_provisioning_template_version
-- [ ] create_role_alias
+- [X] create_role_alias
 - [ ] create_scheduled_audit
 - [ ] create_security_profile
 - [ ] create_stream
@@ -4572,7 +4572,7 @@
 - [ ] delete_provisioning_template
 - [ ] delete_provisioning_template_version
 - [ ] delete_registration_code
-- [ ] delete_role_alias
+- [X] delete_role_alias
 - [ ] delete_scheduled_audit
 - [ ] delete_security_profile
 - [ ] delete_stream
@@ -4609,7 +4609,7 @@
 - [ ] describe_mitigation_action
 - [ ] describe_provisioning_template
 - [ ] describe_provisioning_template_version
-- [ ] describe_role_alias
+- [X] describe_role_alias
 - [ ] describe_scheduled_audit
 - [ ] describe_security_profile
 - [ ] describe_stream
@@ -4682,7 +4682,7 @@
 - [ ] list_provisioning_template_versions
 - [ ] list_provisioning_templates
 - [ ] list_related_resources_for_audit_finding
-- [ ] list_role_aliases
+- [X] list_role_aliases
 - [ ] list_sbom_validation_results
 - [ ] list_scheduled_audits
 - [ ] list_security_profiles
@@ -4749,7 +4749,7 @@
 - [ ] update_package_configuration
 - [ ] update_package_version
 - [ ] update_provisioning_template
-- [ ] update_role_alias
+- [X] update_role_alias
 - [ ] update_scheduled_audit
 - [ ] update_security_profile
 - [ ] update_stream

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -769,3 +769,60 @@ class IoTResponse(BaseResponse):
         query = self._get_param("queryString")
         things = self.iot_backend.search_index(query)
         return json.dumps({"things": things, "thingGroups": []})
+
+    def create_role_alias(self) -> str:
+        role_alias_name = self._get_param("roleAlias")
+        role_arn = self._get_param("roleArn")
+        credential_duration_seconds = self._get_int_param(
+            "credentialDurationSeconds", 3600
+        )
+        created_role_alias = self.iot_backend.create_role_alias(
+            role_alias_name=role_alias_name,
+            role_arn=role_arn,
+            credential_duration_seconds=credential_duration_seconds,
+        )
+        return json.dumps(
+            dict(
+                roleAlias=created_role_alias.role_alias,
+                roleAliasArn=created_role_alias.arn,
+            )
+        )
+
+    def list_role_aliases(self) -> str:
+        # page_size = self._get_int_param("pageSize")
+        # marker = self._get_param("marker")
+        # ascending_order = self._get_param("ascendingOrder")
+        return json.dumps(
+            dict(
+                roleAliases=[_.role_alias for _ in self.iot_backend.list_role_aliases()]
+            )
+        )
+
+    def describe_role_alias(self) -> str:
+        role_alias_name = self._get_param("roleAlias")
+        role_alias = self.iot_backend.describe_role_alias(
+            role_alias_name=role_alias_name
+        )
+        return json.dumps({"roleAliasDescription": role_alias.to_dict()})
+
+    def update_role_alias(self) -> str:
+        role_alias_name = self._get_param("roleAlias")
+        role_arn = self._get_param("roleArn", None)
+        credential_duration_seconds = self._get_int_param(
+            "credentialDurationSeconds", 0
+        )
+
+        role_alias = self.iot_backend.update_role_alias(
+            role_alias_name=role_alias_name,
+            role_arn=role_arn,
+            credential_duration_seconds=credential_duration_seconds,
+        )
+
+        return json.dumps(
+            dict(roleAlias=role_alias.role_alias, roleAliasArn=role_alias.arn)
+        )
+
+    def delete_role_alias(self) -> str:
+        role_alias_name = self._get_param("roleAlias")
+        self.iot_backend.delete_role_alias(role_alias_name=role_alias_name)
+        return json.dumps({})

--- a/tests/test_iot/test_iot_rolealias.py
+++ b/tests/test_iot/test_iot_rolealias.py
@@ -1,0 +1,128 @@
+import boto3
+import pytest
+
+from moto import mock_aws
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    with mock_aws():
+        yield boto3.client("iot", region_name="eu-west-1")
+
+
+def test_create_role_alias(client):
+    role_alias_name = "test-role-alias"
+    create_response = client.create_role_alias(
+        roleAlias=role_alias_name,
+        roleArn="arn:aws:iam::123456789012:role/my-role",
+        credentialDurationSeconds=1234,
+    )
+
+    assert create_response["roleAlias"] == role_alias_name
+    assert (
+        create_response["roleAliasArn"]
+        == f"arn:aws:iot:eu-west-1:123456789012:rolealias/{role_alias_name}"
+    )
+
+    assert len(client.list_role_aliases()["roleAliases"]) == 1
+
+
+def test_create_role_alias_twice(client):
+    role_alias_name = "test-role-alias"
+    create_response = client.create_role_alias(
+        roleAlias=role_alias_name,
+        roleArn="arn:aws:iam::123456789012:role/my-role",
+        credentialDurationSeconds=1234,
+    )
+
+    assert create_response["roleAlias"] == role_alias_name
+    assert (
+        create_response["roleAliasArn"]
+        == f"arn:aws:iot:eu-west-1:123456789012:rolealias/{role_alias_name}"
+    )
+
+    with pytest.raises(client.exceptions.ResourceAlreadyExistsException):
+        client.create_role_alias(
+            roleAlias=role_alias_name,
+            roleArn="arn:aws:iam::123456789012:role/my-role",
+            credentialDurationSeconds=1234,
+        )
+
+
+def test_list_role_aliases(client):
+    client.create_role_alias(
+        roleAlias="test-role-alias", roleArn="arn:aws:iam::123456789012:role/my-role"
+    )
+    client.create_role_alias(
+        roleAlias="another_role_alias",
+        roleArn="arn:aws:iam::123456789012:role/my-role",
+    )
+
+    response = client.list_role_aliases()
+
+    assert response["roleAliases"] == ["test-role-alias", "another_role_alias"]
+
+
+def test_delete_role_alias(client):
+    role_alias_name = "test-role-alias"
+
+    client.create_role_alias(
+        roleAlias=role_alias_name, roleArn="arn:aws:iam::123456789012:role/my-role"
+    )
+    assert len(client.list_role_aliases()["roleAliases"]) == 1
+
+    client.delete_role_alias(roleAlias=role_alias_name)
+    assert len(client.list_role_aliases()["roleAliases"]) == 0
+
+
+def test_delete_nonexistent_role_alias(client):
+    with pytest.raises(client.exceptions.ResourceNotFoundException):
+        client.delete_role_alias(roleAlias="test_role_alias")
+
+
+def test_describe_role_alias(client):
+    role_alias_name = "test-role-alias"
+    client.create_role_alias(
+        roleAlias=role_alias_name, roleArn="arn:aws:iam::123456789012:role/my-role"
+    )
+
+    response = client.describe_role_alias(roleAlias=role_alias_name)
+    assert response["roleAliasDescription"]["roleAlias"] == role_alias_name
+    assert (
+        response["roleAliasDescription"]["roleAliasArn"]
+        == f"arn:aws:iot:eu-west-1:123456789012:rolealias/{role_alias_name}"
+    )
+    assert (
+        response["roleAliasDescription"]["roleArn"]
+        == "arn:aws:iam::123456789012:role/my-role"
+    )
+    assert response["roleAliasDescription"]["credentialDurationSeconds"] == 3600
+    assert "owner" in response["roleAliasDescription"]
+    assert "creationDate" in response["roleAliasDescription"]
+    assert "lastModifiedDate" in response["roleAliasDescription"]
+
+
+def test_update_role_alias(client):
+    role_alias_name = "test-role-alias"
+    client.create_role_alias(
+        roleAlias=role_alias_name,
+        roleArn="arn:aws:iam::123456789012:role/my-role",
+        credentialDurationSeconds=1234,
+    )
+    client.update_role_alias(
+        roleAlias=role_alias_name,
+        roleArn="arn:aws:iam::123456789012:role/other-role",
+        credentialDurationSeconds=2345,
+    )
+    response = client.describe_role_alias(roleAlias=role_alias_name)
+
+    assert response["roleAliasDescription"]["roleAlias"] == role_alias_name
+    assert (
+        response["roleAliasDescription"]["roleAliasArn"]
+        == f"arn:aws:iot:eu-west-1:123456789012:rolealias/{role_alias_name}"
+    )
+    assert (
+        response["roleAliasDescription"]["roleArn"]
+        == "arn:aws:iam::123456789012:role/other-role"
+    )
+    assert response["roleAliasDescription"]["credentialDurationSeconds"] == 2345

--- a/tests/test_iot/test_iot_search.py
+++ b/tests/test_iot/test_iot_search.py
@@ -1,3 +1,5 @@
+import json
+
 import boto3
 import pytest
 
@@ -31,6 +33,48 @@ def test_search_things(query_string, results):
     for thing in resp["things"]:
         del thing["connectivity"]["timestamp"]
         assert thing["connectivity"] == {"connected": True}
+        assert "thingId" in thing
+
+
+@mock_aws
+def test_search_things_include_group_names():
+    client = boto3.client("iot", region_name="ap-northeast-1")
+
+    thing_name = "test-thing-name"
+    client.create_thing(thingName=thing_name)
+
+    client.create_thing_group(thingGroupName="TestGroup1")
+    client.create_thing_group(thingGroupName="AnotherGroup")
+    client.create_thing_group(thingGroupName="GroupWithoutMembers")
+
+    client.add_thing_to_thing_group(thingName=thing_name, thingGroupName="TestGroup1")
+    client.add_thing_to_thing_group(thingName=thing_name, thingGroupName="AnotherGroup")
+
+    resp = client.search_index(queryString=f"thingName:{thing_name}")
+    assert len(resp["things"]) == 1
+    assert resp["things"][0]["thingGroupNames"] == ["TestGroup1", "AnotherGroup"]
+
+
+@mock_aws
+def test_search_things_include_named_shadow():
+    iot_client = boto3.client("iot", region_name="ap-northeast-1")
+    iotdata_client = boto3.client("iot-data", region_name="ap-northeast-1")
+    raw_payload = b'{"state": {"desired": {"led": "on"}, "reported": {"led": "off"}}}'
+
+    thing_name = "test-thing-name"
+    iot_client.create_thing(thingName=thing_name)
+    iotdata_client.update_thing_shadow(
+        thingName=thing_name, shadowName="test_shadow", payload=raw_payload
+    )
+
+    resp = iot_client.search_index(queryString=f"thingName:{thing_name}")
+
+    assert len(resp["things"]) == 1
+    shadow = json.loads(resp["things"][0]["shadow"])
+
+    assert shadow["name"]["test_shadow"]["desired"] == {"led": "on"}
+    assert shadow["name"]["test_shadow"]["reported"] == {"led": "off"}
+    assert shadow["name"]["test_shadow"]["hasDelta"]
 
 
 @mock_aws


### PR DESCRIPTION
In this PR I'd like to contribute:
* IoT RoleAlias API: `create_role_alias()`, `list_role_aliases()`, `describe_role_alias()`, `update_role_alias()`, `delete_role_alias()`
* `AWS::IoT::RoleAlias` CloudFormation object

Enhance search() index response - add missing `thingGroupNames` and `shadow` fields