### PR TITLE
ECR: list_images() should list images with multiple tags separately

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -338,15 +338,6 @@ class Image(BaseObject):
         }
 
     @property
-    def response_list_object(self) -> Dict[str, Any]:  # type: ignore[misc]
-        response_object = self.gen_response_object()
-        response_object["imageTag"] = self.image_tag
-        response_object["imageDigest"] = self.get_image_digest()
-        return {
-            k: v for k, v in response_object.items() if v is not None and v != [None]
-        }
-
-    @property
     def response_describe_object(self) -> Dict[str, Any]:  # type: ignore[misc]
         response_object = self.gen_response_object()
         response_object["imageTags"] = self.image_tags

--- a/moto/ecr/responses.py
+++ b/moto/ecr/responses.py
@@ -69,9 +69,11 @@ class ECRResponse(BaseResponse):
         repository_str = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         images = self.ecr_backend.list_images(repository_str, registry_id)
-        return json.dumps(
-            {"imageIds": [image.response_list_object for image in images]}
-        )
+        resp = []
+        for image in images:
+            for tag in image.image_tags or [None]:  # type: ignore
+                resp.append({"imageDigest": image.image_digest, "imageTag": tag})
+        return json.dumps({"imageIds": resp})
 
     def describe_images(self) -> str:
         repository_str = self._get_param("repositoryName")


### PR DESCRIPTION
Fixes #8269 

The `list_images()`-method returns a `dict(imageDigest=..., imageTag=...)`, which means that we images may be listed multiple times if they have multiple tags.

The original implementation ([added 7 years ago!](https://github.com/getmoto/moto/pull/961)) didn't account for that, and would only return every image with it's latest tag and ignore other tags.