### PR TITLE
DynamoDB: Validate duplicate path in projection expression

### DIFF
--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -305,6 +305,17 @@ class DuplicateUpdateExpression(InvalidUpdateExpression):
         )
 
 
+class InvalidProjectionExpression(MockValidationException):
+    msg = (
+        "Invalid ProjectionExpression: "
+        "Two document paths overlap with each other; must remove or rewrite one of these paths; "
+        "path one: [{paths[0]}], path two: [{paths[1]}]"
+    )
+
+    def __init__(self, paths: List[str]):
+        super().__init__(self.msg.format(paths=paths))
+
+
 class TooManyClauses(InvalidUpdateExpression):
     def __init__(self, _type: str) -> None:
         super().__init__(

--- a/moto/dynamodb/parsing/ast_nodes.py
+++ b/moto/dynamodb/parsing/ast_nodes.py
@@ -10,6 +10,7 @@ from ..exceptions import (
     MockValidationException,
     TooManyClauses,
 )
+from ..utils import extract_duplicates
 
 
 class Node(metaclass=abc.ABCMeta):
@@ -38,8 +39,11 @@ class Node(metaclass=abc.ABCMeta):
             set_attributes = [s.children[0].to_str() for s in set_actions]
             # We currently only check for duplicates
             # We should also check for partial duplicates, i.e. [attr, attr.sub] is also invalid
-            if len(set_attributes) != len(set(set_attributes)):
-                raise DuplicateUpdateExpression(set_attributes)
+            duplicates = extract_duplicates(set_attributes)
+            if duplicates:
+                # There might be more than one attribute duplicated:
+                # they may get mixed up in the Error Message which is inline with actual boto3 Error Messages
+                raise DuplicateUpdateExpression(duplicates)
 
             set_clauses = self.find_clauses([UpdateExpressionSetClause])
             if limit_set_actions and len(set_clauses) > 1:

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -14,12 +14,14 @@ from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
 from moto.utilities.aws_headers import amz_crc32
 
 from .exceptions import (
+    InvalidProjectionExpression,
     KeyIsEmptyStringException,
     MockValidationException,
     ProvidedKeyDoesNotExist,
     ResourceNotFoundException,
     UnknownKeyType,
 )
+from .utils import extract_duplicates
 
 TRANSACTION_MAX_ITEMS = 25
 
@@ -794,6 +796,9 @@ class DynamoHandler(BaseResponse):
 
         if projection_expression:
             expressions = [x.strip() for x in projection_expression.split(",")]
+            duplicates = extract_duplicates(expressions)
+            if duplicates:
+                raise InvalidProjectionExpression(duplicates)
             for expression in expressions:
                 check_projection_expression(expression)
             return [

--- a/moto/dynamodb/utils.py
+++ b/moto/dynamodb/utils.py
@@ -1,0 +1,5 @@
+from typing import List
+
+
+def extract_duplicates(input_list: List[str]) -> List[str]:
+    return [item for item in input_list if input_list.count(item) > 1]


### PR DESCRIPTION
Hi, this is a proposed fix for issue #8297 

In case of duplicate paths in PorjectionExpression AWS raises an error below. Moto - does not.

botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the Query operation: Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [body], path two: [body]

Appreciate your feedback a lot!