### PR TITLE
Admin: Remove univeral wheel option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -255,9 +255,6 @@ console_scripts =
     moto_server = moto.server:main
     moto_proxy = moto.proxy:main
 
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 markers =
     network: requires network connection


### PR DESCRIPTION
Universal wheels were a great way to indicate that a project supported both Python 2 _and_ 3.. but it's probably time to get rid of that.

That should also get rid of a deprecation warning when building the project:
```
2024-11-08T19:59:54.2032474Z /tmp/.../setuptools/_distutils/cmd.py:111: SetuptoolsDeprecationWarning: bdist_wheel.universal is deprecated
2024-11-08T19:59:54.2034257Z !!
2024-11-08T19:59:54.2034534Z 
2024-11-08T19:59:54.2037019Z         ********************************************************************************
2024-11-08T19:59:54.2038500Z         With Python 2.7 end-of-life, support for building universal wheels
2024-11-08T19:59:54.2039705Z         (i.e., wheels that support both Python 2 and Python 3)
2024-11-08T19:59:54.2040740Z         is being obviated.
2024-11-08T19:59:54.2041664Z         Please discontinue using this option, or if you still need it,
2024-11-08T19:59:54.2042873Z         file an issue with pypa/setuptools describing your use case.
2024-11-08T19:59:54.2043571Z 
2024-11-08T19:59:54.2044461Z         By 2025-Aug-30, you need to update your project and remove deprecated calls
2024-11-08T19:59:54.2045657Z         or your builds will no longer be supported.
2024-11-08T19:59:54.2046985Z         ********************************************************************************
2024-11-08T19:59:54.2047609Z 
2024-11-08T19:59:54.2048023Z !!
```