### PR TITLE
Admin: Fix various tests to keep parity with AWS

### DIFF
--- a/moto/stepfunctions/parser/api.py
+++ b/moto/stepfunctions/parser/api.py
@@ -268,10 +268,10 @@ class InvalidOutput(ServiceException):
 
 class InvalidToken(ServiceException):
     code: str = "InvalidToken"
-    exception_type: str = "UnrecognizedClientException"
+    exception_type: str = "InvalidToken"
     sender_fault: bool = False
     status_code: int = 400
-    message: str = "The security token included in the request is invalid."
+    message: str = "Invalid Token: 'Invalid token'"
 
     def __init__(self):
         super().__init__(self.message, self.exception_type, self.status_code)

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -2130,6 +2130,7 @@ def test_authorize_security_group_rules_with_different_ipranges_or_prefixes(is_i
         for rule in created_rules:
             rule.pop("GroupOwnerId", None)
             rule.pop("Tags", None)
+            rule.pop("SecurityGroupRuleArn", None)
             rule.pop("SecurityGroupRuleId", None)
             del rule["GroupId"]
 

--- a/tests/test_iot/test_iot_integration.py
+++ b/tests/test_iot/test_iot_integration.py
@@ -1,0 +1,27 @@
+import json
+
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_search_things_include_named_shadow():
+    iot_client = boto3.client("iot", region_name="ap-northeast-1")
+    iotdata_client = boto3.client("iot-data", region_name="ap-northeast-1")
+    raw_payload = b'{"state": {"desired": {"led": "on"}, "reported": {"led": "off"}}}'
+
+    thing_name = "test-thing-name"
+    iot_client.create_thing(thingName=thing_name)
+    iotdata_client.update_thing_shadow(
+        thingName=thing_name, shadowName="test_shadow", payload=raw_payload
+    )
+
+    resp = iot_client.search_index(queryString=f"thingName:{thing_name}")
+
+    assert len(resp["things"]) == 1
+    shadow = json.loads(resp["things"][0]["shadow"])
+
+    assert shadow["name"]["test_shadow"]["desired"] == {"led": "on"}
+    assert shadow["name"]["test_shadow"]["reported"] == {"led": "off"}
+    assert shadow["name"]["test_shadow"]["hasDelta"]

--- a/tests/test_iot/test_iot_search.py
+++ b/tests/test_iot/test_iot_search.py
@@ -1,5 +1,3 @@
-import json
-
 import boto3
 import pytest
 
@@ -53,28 +51,6 @@ def test_search_things_include_group_names():
     resp = client.search_index(queryString=f"thingName:{thing_name}")
     assert len(resp["things"]) == 1
     assert resp["things"][0]["thingGroupNames"] == ["TestGroup1", "AnotherGroup"]
-
-
-@mock_aws
-def test_search_things_include_named_shadow():
-    iot_client = boto3.client("iot", region_name="ap-northeast-1")
-    iotdata_client = boto3.client("iot-data", region_name="ap-northeast-1")
-    raw_payload = b'{"state": {"desired": {"led": "on"}, "reported": {"led": "off"}}}'
-
-    thing_name = "test-thing-name"
-    iot_client.create_thing(thingName=thing_name)
-    iotdata_client.update_thing_shadow(
-        thingName=thing_name, shadowName="test_shadow", payload=raw_payload
-    )
-
-    resp = iot_client.search_index(queryString=f"thingName:{thing_name}")
-
-    assert len(resp["things"]) == 1
-    shadow = json.loads(resp["things"][0]["shadow"])
-
-    assert shadow["name"]["test_shadow"]["desired"] == {"led": "on"}
-    assert shadow["name"]["test_shadow"]["reported"] == {"led": "off"}
-    assert shadow["name"]["test_shadow"]["hasDelta"]
 
 
 @mock_aws

--- a/tests/test_stepfunctions/parser/test_stepfunctions.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions.py
@@ -157,7 +157,6 @@ def test_version_is_only_available_when_published():
             publish=True,
             tracingConfiguration={"enabled": True},
             loggingConfiguration={"level": "OFF"},
-            encryptionConfiguration=encryption_config,
         )
         assert resp["stateMachineVersionArn"] == f"{arn2}:2"
     finally:

--- a/tests/test_stepfunctions/parser/test_stepfunctions_dynamodb_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_dynamodb_integration.py
@@ -269,29 +269,21 @@ def test_send_task_failure_invalid_token(table_name=None, sleep_time=0):
                     client.send_task_failure(taskToken="bad_token", error="test error")
 
                 # Verify
-                assert (
-                    exc.value.response["Error"]["Code"] == "UnrecognizedClientException"
-                )
+                assert exc.value.response["Error"]["Code"] == "InvalidToken"
                 assert (
                     exc.value.response["Error"]["Message"]
-                    == "The security token included "
-                    "in the request is invalid."
+                    == "Invalid Token: 'Invalid token'"
                 )
 
                 # Execute
                 with pytest.raises(ClientError) as exc:
-                    client.send_task_success(
-                        taskToken="bad_token", output="test output"
-                    )
+                    client.send_task_success(taskToken="bad_token", output="output")
 
                 # Verify
-                assert (
-                    exc.value.response["Error"]["Code"] == "UnrecognizedClientException"
-                )
+                assert exc.value.response["Error"]["Code"] == "InvalidToken"
                 assert (
                     exc.value.response["Error"]["Message"]
-                    == "The security token included "
-                    "in the request is invalid."
+                    == "Invalid Token: 'Invalid token'"
                 )
 
     verify_execution_result(


### PR DESCRIPTION
 - EC2 security group changes were a result of AWS returning additional attributes that we don't yet support
 - StepFunction changes were a result of AWS changing the error details
 - The IOT test was moved to an `_integration.py`-file as it integrates with `iotdata`, because our ServiceDependencies workflow expects every tests that integrates a different service to be in a dedicated file.