### PR TITLE
IoT: Add get_indexing_configuration(), update_indexing_configuration()

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -4628,7 +4628,7 @@
 - [ ] get_buckets_aggregation
 - [ ] get_cardinality
 - [ ] get_effective_policies
-- [ ] get_indexing_configuration
+- [X] get_indexing_configuration
 - [X] get_job_document
 - [ ] get_logging_options
 - [ ] get_ota_update
@@ -4742,7 +4742,7 @@
 - [ ] update_dynamic_thing_group
 - [ ] update_event_configurations
 - [ ] update_fleet_metric
-- [ ] update_indexing_configuration
+- [X] update_indexing_configuration
 - [ ] update_job
 - [ ] update_mitigation_action
 - [ ] update_package

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -826,3 +826,13 @@ class IoTResponse(BaseResponse):
         role_alias_name = self._get_param("roleAlias")
         self.iot_backend.delete_role_alias(role_alias_name=role_alias_name)
         return json.dumps({})
+
+    def get_indexing_configuration(self) -> str:
+        return json.dumps(self.iot_backend.get_index_configuration())
+
+    def update_indexing_configuration(self) -> str:
+        self.iot_backend.update_indexing_configuration(
+            self._get_param("thingIndexingConfiguration", {}),
+            self._get_param("thingGroupIndexingConfiguration", {}),
+        )
+        return json.dumps({})

--- a/tests/test_iot/test_iot_indexing_configuration.py
+++ b/tests/test_iot/test_iot_indexing_configuration.py
@@ -1,0 +1,63 @@
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_validate_default_indexing_configuration():
+    client = boto3.client("iot", region_name="us-east-1")
+    indexing_config = client.get_indexing_configuration()
+
+    thingIndexingConfiguration = indexing_config["thingIndexingConfiguration"]
+    assert thingIndexingConfiguration["thingIndexingMode"] in [
+        "OFF",
+        "REGISTRY",
+        "REGISTRY_AND_SHADOW",
+    ]
+
+    thingGroupIndexingConfiguration = indexing_config["thingGroupIndexingConfiguration"]
+    assert thingGroupIndexingConfiguration["thingGroupIndexingMode"] in ["ON", "OFF"]
+
+
+@mock_aws
+def test_update_indexing_mode():
+    client = boto3.client("iot", region_name="us-east-1")
+    client.update_indexing_configuration(
+        thingIndexingConfiguration={
+            "thingIndexingMode": "REGISTRY",
+            "thingConnectivityIndexingMode": "STATUS",
+            "deviceDefenderIndexingMode": "VIOLATIONS",
+            "namedShadowIndexingMode": "ON",
+            "managedFields": [{"name": "field1", "type": "String"}],
+            "customFields": [{"name": "custom_field1", "type": "Boolean"}],
+            "filter": {"namedShadowNames": ["shadow_1", "shadow_2"]},
+        },
+        thingGroupIndexingConfiguration={
+            "thingGroupIndexingMode": "ON",
+            "managedFields": [{"name": "thing_field_1", "type": "String"}],
+            "customFields": [{"name": "thing_custom_field", "type": "Number"}],
+        },
+    )
+
+    indexing_config = client.get_indexing_configuration()
+
+    thingIndexingConfiguration = indexing_config["thingIndexingConfiguration"]
+    assert thingIndexingConfiguration["thingIndexingMode"] == "REGISTRY"
+    assert thingIndexingConfiguration["thingConnectivityIndexingMode"] == "STATUS"
+    assert thingIndexingConfiguration["deviceDefenderIndexingMode"] == "VIOLATIONS"
+    assert thingIndexingConfiguration["namedShadowIndexingMode"] == "ON"
+    assert thingIndexingConfiguration["managedFields"] == [
+        {"name": "field1", "type": "String"}
+    ]
+    assert thingIndexingConfiguration["customFields"] == [
+        {"name": "custom_field1", "type": "Boolean"}
+    ]
+
+    thingGroupIndexingConfiguration = indexing_config["thingGroupIndexingConfiguration"]
+    assert thingGroupIndexingConfiguration["thingGroupIndexingMode"] == "ON"
+    assert thingGroupIndexingConfiguration["managedFields"] == [
+        {"name": "thing_field_1", "type": "String"}
+    ]
+    assert thingGroupIndexingConfiguration["customFields"] == [
+        {"name": "thing_custom_field", "type": "Number"}
+    ]


### PR DESCRIPTION
I'd like to contribute two IoT calls with a very simple implementation: `get_indexing_configuration()` and `update_indexing_configuration()`