### PR TITLE
Prep release 5.0.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
         description: 'Version'
         required: true
       current_release:
-        description: 'True to release Docker and update version info in moto/__init__.py'
+        description: 'Release Docker and update version info in moto/__init__.py'
+        default: true
         required: true
         type: boolean
 
@@ -106,7 +107,9 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
+          motoserver/moto:latest
           motoserver/moto:${{ env.VERSION }}
+          ghcr.io/getmoto/motoserver:latest
           ghcr.io/getmoto/motoserver:${{ env.VERSION }}
     - name: Increase patch version number
       if: ${{ inputs.current_release }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 Moto Changelog
 ==============
 
+5.0.21
+-----
+Docker Digest for 5.0.21: <autopopulateddigest>
+
+    New Methods:
+        * IOT:
+            * create_job_template()
+            * create_role_alias()
+            * delete_job_template()
+            * delete_role_alias()
+            * describe_job_template()
+            * describe_role_alias()
+            * get_indexing_configuration()
+            * list_job_templates()
+            * list_role_aliases()
+            * update_indexing_configuration()
+            * update_role_alias()
+
+    Miscellaneous:
+        * Batch: list_jobs() now supports the arrayJobId-parameter
+        * CloudFormation now supports the types AWS::IoT::JobTemplate, AWS::IoT::RoleAlias
+        * DynamoDB: ProjectionExpressions are now validated for duplicate values
+        * DynamoDB: scan() now supports parallelization using the Segment/TotalSegments parameters
+        * DynamoDB: update_item() now validates when an ADD/DELETE occurs on the same set
+        * EC2: create_fleet() now correctly handles Overrides with a single value
+        * ECR: list_images() now lists images with multiple tags separately
+        * IOT: create_job() now supports the parameters abortConfig, jobExecutionsRetryConfig, schedulingConfig, timeoutConfig
+        * S3: get_object_attributes() no longer throws an error for Glacier objects
+
+
 5.0.20
 -----
 Docker Digest for 5.0.20: _sha256:a1041f318c56ed341c70541647b256d40dae776ce654ca4db9d27d94600542a1_

--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -882,6 +882,7 @@
 - [ ] update_flow_alias
 - [ ] update_knowledge_base
 - [ ] update_prompt
+- [ ] validate_flow_definition
 </details>
 
 ## budgets
@@ -1186,6 +1187,7 @@
 - [X] describe_trails
 - [ ] disable_federation
 - [ ] enable_federation
+- [ ] generate_query
 - [ ] get_channel
 - [ ] get_event_data_store
 - [X] get_event_selectors
@@ -4243,7 +4245,7 @@
 
 ## iam
 <details>
-<summary>74% implemented</summary>
+<summary>72% implemented</summary>
 
 - [ ] add_client_id_to_open_id_connect_provider
 - [X] add_role_to_instance_profile
@@ -4293,7 +4295,11 @@
 - [X] detach_group_policy
 - [X] detach_role_policy
 - [X] detach_user_policy
+- [ ] disable_organizations_root_credentials_management
+- [ ] disable_organizations_root_sessions
 - [X] enable_mfa_device
+- [ ] enable_organizations_root_credentials_management
+- [ ] enable_organizations_root_sessions
 - [ ] generate_credential_report
 - [ ] generate_organizations_access_report
 - [ ] generate_service_last_accessed_details
@@ -4339,6 +4345,7 @@
 - [X] list_mfa_devices
 - [X] list_open_id_connect_provider_tags
 - [X] list_open_id_connect_providers
+- [ ] list_organizations_features
 - [X] list_policies
 - [ ] list_policies_granting_service_access
 - [X] list_policy_tags
@@ -4498,7 +4505,7 @@
 
 ## iot
 <details>
-<summary>31% implemented</summary>
+<summary>33% implemented</summary>
 
 - [ ] accept_certificate_transfer
 - [ ] add_thing_to_billing_group
@@ -4679,6 +4686,7 @@
 - [X] list_policy_versions
 - [X] list_principal_policies
 - [X] list_principal_things
+- [ ] list_principal_things_v2
 - [ ] list_provisioning_template_versions
 - [ ] list_provisioning_templates
 - [ ] list_related_resources_for_audit_finding
@@ -4694,6 +4702,7 @@
 - [X] list_thing_groups
 - [X] list_thing_groups_for_thing
 - [X] list_thing_principals
+- [ ] list_thing_principals_v2
 - [ ] list_thing_registration_task_reports
 - [ ] list_thing_registration_tasks
 - [X] list_thing_types
@@ -4756,6 +4765,7 @@
 - [X] update_thing
 - [X] update_thing_group
 - [X] update_thing_groups_for_thing
+- [ ] update_thing_type
 - [ ] update_topic_rule_destination
 - [ ] validate_security_profile_behaviors
 </details>
@@ -4961,7 +4971,7 @@
 
 ## lakeformation
 <details>
-<summary>36% implemented</summary>
+<summary>33% implemented</summary>
 
 - [X] add_lf_tags_to_resource
 - [ ] assume_decorated_role_with_saml
@@ -4973,10 +4983,12 @@
 - [ ] create_lake_formation_identity_center_configuration
 - [ ] create_lake_formation_opt_in
 - [X] create_lf_tag
+- [ ] create_lf_tag_expression
 - [ ] delete_data_cells_filter
 - [ ] delete_lake_formation_identity_center_configuration
 - [ ] delete_lake_formation_opt_in
 - [X] delete_lf_tag
+- [ ] delete_lf_tag_expression
 - [ ] delete_objects_on_cancel
 - [X] deregister_resource
 - [ ] describe_lake_formation_identity_center_configuration
@@ -4988,6 +5000,7 @@
 - [X] get_data_lake_settings
 - [ ] get_effective_permissions_for_path
 - [X] get_lf_tag
+- [ ] get_lf_tag_expression
 - [ ] get_query_state
 - [ ] get_query_statistics
 - [X] get_resource_lf_tags
@@ -4999,6 +5012,7 @@
 - [X] grant_permissions
 - [X] list_data_cells_filter
 - [ ] list_lake_formation_opt_ins
+- [ ] list_lf_tag_expressions
 - [X] list_lf_tags
 - [X] list_permissions
 - [X] list_resources
@@ -5015,6 +5029,7 @@
 - [ ] update_data_cells_filter
 - [ ] update_lake_formation_identity_center_configuration
 - [X] update_lf_tag
+- [ ] update_lf_tag_expression
 - [ ] update_resource
 - [ ] update_table_objects
 - [ ] update_table_storage_optimizer
@@ -5707,6 +5722,7 @@
 - [ ] add_data_source
 - [X] add_tags
 - [ ] associate_package
+- [ ] associate_packages
 - [ ] authorize_vpc_endpoint_access
 - [ ] cancel_domain_config_change
 - [ ] cancel_service_software_update
@@ -5738,6 +5754,7 @@
 - [ ] describe_reserved_instances
 - [ ] describe_vpc_endpoints
 - [ ] dissociate_package
+- [ ] dissociate_packages
 - [ ] get_application
 - [X] get_compatible_versions
 - [ ] get_data_source
@@ -5768,6 +5785,7 @@
 - [ ] update_data_source
 - [X] update_domain_config
 - [ ] update_package
+- [ ] update_package_scope
 - [ ] update_scheduled_action
 - [ ] update_vpc_endpoint
 - [ ] upgrade_domain
@@ -6265,7 +6283,7 @@
 
 ## quicksight
 <details>
-<summary>9% implemented</summary>
+<summary>8% implemented</summary>
 
 - [ ] batch_create_topic_reviewed_answer
 - [ ] batch_delete_topic_reviewed_answer
@@ -6273,6 +6291,8 @@
 - [ ] create_account_customization
 - [ ] create_account_subscription
 - [ ] create_analysis
+- [ ] create_brand
+- [ ] create_custom_permissions
 - [ ] create_dashboard
 - [X] create_data_set
 - [ ] create_data_source
@@ -6295,6 +6315,9 @@
 - [ ] delete_account_customization
 - [ ] delete_account_subscription
 - [ ] delete_analysis
+- [ ] delete_brand
+- [ ] delete_brand_assignment
+- [ ] delete_custom_permissions
 - [ ] delete_dashboard
 - [ ] delete_data_set
 - [ ] delete_data_set_refresh_properties
@@ -6317,6 +6340,7 @@
 - [ ] delete_topic_refresh_schedule
 - [X] delete_user
 - [ ] delete_user_by_principal_id
+- [ ] delete_user_custom_permission
 - [ ] delete_vpc_connection
 - [ ] describe_account_customization
 - [ ] describe_account_settings
@@ -6326,6 +6350,10 @@
 - [ ] describe_analysis_permissions
 - [ ] describe_asset_bundle_export_job
 - [ ] describe_asset_bundle_import_job
+- [ ] describe_brand
+- [ ] describe_brand_assignment
+- [ ] describe_brand_published_version
+- [ ] describe_custom_permissions
 - [ ] describe_dashboard
 - [ ] describe_dashboard_definition
 - [ ] describe_dashboard_permissions
@@ -6369,6 +6397,8 @@
 - [ ] list_analyses
 - [ ] list_asset_bundle_export_jobs
 - [ ] list_asset_bundle_import_jobs
+- [ ] list_brands
+- [ ] list_custom_permissions
 - [ ] list_dashboard_versions
 - [ ] list_dashboards
 - [ ] list_data_sets
@@ -6417,6 +6447,10 @@
 - [ ] update_account_settings
 - [ ] update_analysis
 - [ ] update_analysis_permissions
+- [ ] update_brand
+- [ ] update_brand_assignment
+- [ ] update_brand_published_version
+- [ ] update_custom_permissions
 - [ ] update_dashboard
 - [ ] update_dashboard_links
 - [ ] update_dashboard_permissions
@@ -6447,6 +6481,7 @@
 - [ ] update_topic_permissions
 - [ ] update_topic_refresh_schedule
 - [X] update_user
+- [ ] update_user_custom_permission
 - [ ] update_vpc_connection
 </details>
 
@@ -8548,11 +8583,12 @@
 
 ## sts
 <details>
-<summary>75% implemented</summary>
+<summary>66% implemented</summary>
 
 - [X] assume_role
 - [X] assume_role_with_saml
 - [X] assume_role_with_web_identity
+- [ ] assume_root
 - [ ] decode_authorization_message
 - [ ] get_access_key_info
 - [X] get_caller_identity
@@ -9068,6 +9104,7 @@
 - bcm-data-exports
 - bedrock-agent-runtime
 - bedrock-runtime
+- billing
 - billingconductor
 - braket
 - chatbot
@@ -9103,6 +9140,7 @@
 - connect
 - connect-contact-lens
 - connectcampaigns
+- connectcampaignsv2
 - connectcases
 - connectparticipant
 - controlcatalog
@@ -9220,6 +9258,7 @@
 - omics
 - opsworkscm
 - outposts
+- partnercentral-selling
 - payment-cryptography
 - payment-cryptography-data
 - pca-connector-ad

--- a/docs/docs/services/bedrock-agent.rst
+++ b/docs/docs/services/bedrock-agent.rst
@@ -78,4 +78,5 @@ bedrock-agent
 - [ ] update_flow_alias
 - [ ] update_knowledge_base
 - [ ] update_prompt
+- [ ] validate_flow_definition
 

--- a/docs/docs/services/cloudtrail.rst
+++ b/docs/docs/services/cloudtrail.rst
@@ -30,6 +30,7 @@ cloudtrail
 - [X] describe_trails
 - [ ] disable_federation
 - [ ] enable_federation
+- [ ] generate_query
 - [ ] get_channel
 - [ ] get_event_data_store
 - [X] get_event_selectors

--- a/docs/docs/services/iam.rst
+++ b/docs/docs/services/iam.rst
@@ -64,9 +64,13 @@ iam
 - [X] detach_group_policy
 - [X] detach_role_policy
 - [X] detach_user_policy
+- [ ] disable_organizations_root_credentials_management
+- [ ] disable_organizations_root_sessions
 - [X] enable_mfa_device
   Enable MFA Device for user.
 
+- [ ] enable_organizations_root_credentials_management
+- [ ] enable_organizations_root_sessions
 - [ ] generate_credential_report
 - [ ] generate_organizations_access_report
 - [ ] generate_service_last_accessed_details
@@ -128,6 +132,7 @@ iam
 - [X] list_mfa_devices
 - [X] list_open_id_connect_provider_tags
 - [X] list_open_id_connect_providers
+- [ ] list_organizations_features
 - [X] list_policies
 - [ ] list_policies_granting_service_access
 - [X] list_policy_tags

--- a/docs/docs/services/iot.rst
+++ b/docs/docs/services/iot.rst
@@ -61,7 +61,7 @@ iot
 - [ ] create_provisioning_claim
 - [ ] create_provisioning_template
 - [ ] create_provisioning_template_version
-- [ ] create_role_alias
+- [X] create_role_alias
 - [ ] create_scheduled_audit
 - [ ] create_security_profile
 - [ ] create_stream
@@ -94,7 +94,7 @@ iot
 - [ ] delete_provisioning_template
 - [ ] delete_provisioning_template_version
 - [ ] delete_registration_code
-- [ ] delete_role_alias
+- [X] delete_role_alias
 - [ ] delete_scheduled_audit
 - [ ] delete_security_profile
 - [ ] delete_stream
@@ -139,7 +139,7 @@ iot
 - [ ] describe_mitigation_action
 - [ ] describe_provisioning_template
 - [ ] describe_provisioning_template_version
-- [ ] describe_role_alias
+- [X] describe_role_alias
 - [ ] describe_scheduled_audit
 - [ ] describe_security_profile
 - [ ] describe_stream
@@ -158,7 +158,7 @@ iot
 - [ ] get_buckets_aggregation
 - [ ] get_cardinality
 - [ ] get_effective_policies
-- [ ] get_indexing_configuration
+- [X] get_indexing_configuration
 - [X] get_job_document
 - [ ] get_logging_options
 - [ ] get_ota_update
@@ -237,10 +237,11 @@ iot
         
 
 - [X] list_principal_things
+- [ ] list_principal_things_v2
 - [ ] list_provisioning_template_versions
 - [ ] list_provisioning_templates
 - [ ] list_related_resources_for_audit_finding
-- [ ] list_role_aliases
+- [X] list_role_aliases
 - [ ] list_sbom_validation_results
 - [ ] list_scheduled_audits
 - [ ] list_security_profiles
@@ -260,6 +261,7 @@ iot
         
 
 - [X] list_thing_principals
+- [ ] list_thing_principals_v2
 - [ ] list_thing_registration_task_reports
 - [ ] list_thing_registration_tasks
 - [X] list_thing_types
@@ -324,14 +326,14 @@ iot
 - [ ] update_dynamic_thing_group
 - [ ] update_event_configurations
 - [ ] update_fleet_metric
-- [ ] update_indexing_configuration
+- [X] update_indexing_configuration
 - [ ] update_job
 - [ ] update_mitigation_action
 - [ ] update_package
 - [ ] update_package_configuration
 - [ ] update_package_version
 - [ ] update_provisioning_template
-- [ ] update_role_alias
+- [X] update_role_alias
 - [ ] update_scheduled_audit
 - [ ] update_security_profile
 - [ ] update_stream
@@ -342,6 +344,7 @@ iot
 
 - [X] update_thing_group
 - [X] update_thing_groups_for_thing
+- [ ] update_thing_type
 - [ ] update_topic_rule_destination
 - [ ] validate_security_profile_behaviors
 

--- a/docs/docs/services/lakeformation.rst
+++ b/docs/docs/services/lakeformation.rst
@@ -24,10 +24,12 @@ lakeformation
 - [ ] create_lake_formation_identity_center_configuration
 - [ ] create_lake_formation_opt_in
 - [X] create_lf_tag
+- [ ] create_lf_tag_expression
 - [ ] delete_data_cells_filter
 - [ ] delete_lake_formation_identity_center_configuration
 - [ ] delete_lake_formation_opt_in
 - [X] delete_lf_tag
+- [ ] delete_lf_tag_expression
 - [ ] delete_objects_on_cancel
 - [X] deregister_resource
 - [ ] describe_lake_formation_identity_center_configuration
@@ -39,6 +41,7 @@ lakeformation
 - [X] get_data_lake_settings
 - [ ] get_effective_permissions_for_path
 - [X] get_lf_tag
+- [ ] get_lf_tag_expression
 - [ ] get_query_state
 - [ ] get_query_statistics
 - [X] get_resource_lf_tags
@@ -54,6 +57,7 @@ lakeformation
         
 
 - [ ] list_lake_formation_opt_ins
+- [ ] list_lf_tag_expressions
 - [X] list_lf_tags
 - [X] list_permissions
   
@@ -74,6 +78,7 @@ lakeformation
 - [ ] update_data_cells_filter
 - [ ] update_lake_formation_identity_center_configuration
 - [X] update_lf_tag
+- [ ] update_lf_tag_expression
 - [ ] update_resource
 - [ ] update_table_objects
 - [ ] update_table_storage_optimizer

--- a/docs/docs/services/opensearch.rst
+++ b/docs/docs/services/opensearch.rst
@@ -20,6 +20,7 @@ opensearch
 - [ ] add_data_source
 - [X] add_tags
 - [ ] associate_package
+- [ ] associate_packages
 - [ ] authorize_vpc_endpoint_access
 - [ ] cancel_domain_config_change
 - [ ] cancel_service_software_update
@@ -51,6 +52,7 @@ opensearch
 - [ ] describe_reserved_instances
 - [ ] describe_vpc_endpoints
 - [ ] dissociate_package
+- [ ] dissociate_packages
 - [ ] get_application
 - [X] get_compatible_versions
 - [ ] get_data_source
@@ -81,6 +83,7 @@ opensearch
 - [ ] update_data_source
 - [X] update_domain_config
 - [ ] update_package
+- [ ] update_package_scope
 - [ ] update_scheduled_action
 - [ ] update_vpc_endpoint
 - [ ] upgrade_domain

--- a/docs/docs/services/quicksight.rst
+++ b/docs/docs/services/quicksight.rst
@@ -22,6 +22,8 @@ quicksight
 - [ ] create_account_customization
 - [ ] create_account_subscription
 - [ ] create_analysis
+- [ ] create_brand
+- [ ] create_custom_permissions
 - [ ] create_dashboard
 - [X] create_data_set
 - [ ] create_data_source
@@ -44,6 +46,9 @@ quicksight
 - [ ] delete_account_customization
 - [ ] delete_account_subscription
 - [ ] delete_analysis
+- [ ] delete_brand
+- [ ] delete_brand_assignment
+- [ ] delete_custom_permissions
 - [ ] delete_dashboard
 - [ ] delete_data_set
 - [ ] delete_data_set_refresh_properties
@@ -66,6 +71,7 @@ quicksight
 - [ ] delete_topic_refresh_schedule
 - [X] delete_user
 - [ ] delete_user_by_principal_id
+- [ ] delete_user_custom_permission
 - [ ] delete_vpc_connection
 - [ ] describe_account_customization
 - [ ] describe_account_settings
@@ -75,6 +81,10 @@ quicksight
 - [ ] describe_analysis_permissions
 - [ ] describe_asset_bundle_export_job
 - [ ] describe_asset_bundle_import_job
+- [ ] describe_brand
+- [ ] describe_brand_assignment
+- [ ] describe_brand_published_version
+- [ ] describe_custom_permissions
 - [ ] describe_dashboard
 - [ ] describe_dashboard_definition
 - [ ] describe_dashboard_permissions
@@ -118,6 +128,8 @@ quicksight
 - [ ] list_analyses
 - [ ] list_asset_bundle_export_jobs
 - [ ] list_asset_bundle_import_jobs
+- [ ] list_brands
+- [ ] list_custom_permissions
 - [ ] list_dashboard_versions
 - [ ] list_dashboards
 - [ ] list_data_sets
@@ -171,6 +183,10 @@ quicksight
 - [ ] update_account_settings
 - [ ] update_analysis
 - [ ] update_analysis_permissions
+- [ ] update_brand
+- [ ] update_brand_assignment
+- [ ] update_brand_published_version
+- [ ] update_custom_permissions
 - [ ] update_dashboard
 - [ ] update_dashboard_links
 - [ ] update_dashboard_permissions
@@ -201,5 +217,6 @@ quicksight
 - [ ] update_topic_permissions
 - [ ] update_topic_refresh_schedule
 - [X] update_user
+- [ ] update_user_custom_permission
 - [ ] update_vpc_connection
 

--- a/docs/docs/services/sts.rst
+++ b/docs/docs/services/sts.rst
@@ -21,6 +21,7 @@ sts
 
 - [X] assume_role_with_saml
 - [X] assume_role_with_web_identity
+- [ ] assume_root
 - [ ] decode_authorization_message
 - [ ] get_access_key_info
 - [X] get_caller_identity

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -2598,7 +2598,7 @@ class IoTBackend(BaseBackend):
         self.describe_role_alias(role_alias_name=role_alias_name)
         del self.role_aliases[role_alias_name]
 
-    def get_index_configuration(self) -> Dict[str, Any]:
+    def get_indexing_configuration(self) -> Dict[str, Any]:
         return self.indexing_configuration.to_dict()
 
     def update_indexing_configuration(

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -836,7 +836,7 @@ class IoTResponse(BaseResponse):
         return json.dumps({})
 
     def get_indexing_configuration(self) -> str:
-        return json.dumps(self.iot_backend.get_index_configuration())
+        return json.dumps(self.iot_backend.get_indexing_configuration())
 
     def update_indexing_configuration(self) -> str:
         self.iot_backend.update_indexing_configuration(


### PR DESCRIPTION
Fixes our release process to always update the `latest` docker tag, in addition to making a separate `<version>` tag