### PR TITLE
Docs: managed policies are not loaded by default

### DIFF
--- a/docs/docs/releases.rst
+++ b/docs/docs/releases.rst
@@ -58,4 +58,5 @@ For Moto 5.x:
  - All decorators have been replaced with `mock_aws`
  - The `batch_simple` decorator has been replaced with: `@mock_aws(config={"batch": {"use_docker": False}})`
  - The `awslambda_simple` decorator has been replaced with: `@mock_aws(config={"lambda": {"use_docker": False}})`
+ - AWS IAM managed Policies are no longer loaded by default. To load them set `@mock_aws(config={"iam": {"load_aws_managed_policies": True}})` or set environment variable `MOTO_IAM_LOAD_MANAGED_POLICIES=true`
  - When starting the MotoServer, the `service`-argument (i.e.: `motoserver s3`) is no longer supported. A single MotoServer-instance can be used for all AWS-services.


### PR DESCRIPTION
Hello folks!
I have spent some time in trying to figure out that when using Moto with OpenTofu and I was able to find only an entry in the 5.0.0-alpha3 release note. I think we should list that change as a breaking change so possible other folks hitting that can hopefully find it more easily!

Thanks!

---

Since Moto 5.0.0 for performance reasons the AWS IAM managed policies are no longer automatically loaded anymore by default.

This can break usages relying on AWS IAM managed policies.

Document how to preserve the pre-5.0.0 behavior.
