### PR TITLE
Fix typo in Lambda docstring

### DIFF
--- a/docs/docs/services/lambda.rst
+++ b/docs/docs/services/lambda.rst
@@ -71,7 +71,7 @@ lambda
   
         Invoking a Function with PackageType=Image is not yet supported.
 
-        Invoking a Funcation against Lambda without docker now supports customised responses, the default being `Simple Lambda happy path OK`.
+        Invoking a Function against Lambda without docker now supports customised responses, the default being `Simple Lambda happy path OK`.
         You can use a dedicated API to override this, by configuring a queue of expected results.
 
         A request to `invoke` will take the first result from that queue.

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2389,7 +2389,7 @@ class LambdaBackend(BaseBackend):
         """
         Invoking a Function with PackageType=Image is not yet supported.
 
-        Invoking a Funcation against Lambda without docker now supports customised responses, the default being `Simple Lambda happy path OK`.
+        Invoking a Function against Lambda without docker now supports customised responses, the default being `Simple Lambda happy path OK`.
         You can use a dedicated API to override this, by configuring a queue of expected results.
 
         A request to `invoke` will take the first result from that queue.


### PR DESCRIPTION
A small typo I encountered when going through the source code.