### PR TITLE
Fix required permission for HeadObject, which requires GetObject

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -124,7 +124,7 @@ ACTION_MAP = {
         },
     },
     "KEY": {
-        "HEAD": {"DEFAULT": "HeadObject"},
+        "HEAD": {"DEFAULT": "GetObject"},
         "GET": {
             "uploadId": "ListMultipartUploadParts",
             "acl": "GetObjectAcl",


### PR DESCRIPTION
HeadObject is not part of S3 actions for use in IAM permission policies.
https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html

The reference for HeadObject states that the required permission is GetObject

> General purpose bucket permissions - To use HEAD, you must have the s3:GetObject permission. 

https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html

Indeed, `s3:HeadObject` is not a valid action for a bucket policy (screenshot from AWS Bucket Policy Editor).
<img width="403" alt="Screenshot 2024-11-18 at 6 38 56 PM" src="https://github.com/user-attachments/assets/fbc9a38a-3b00-4a28-842d-00a23ed6320d">
