### PR TITLE
SecretsManager: Improve list-secrets to exclude deleted secrets

### DIFF
--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -907,9 +907,13 @@ class SecretsManagerBackend(BaseBackend):
         filters: List[Dict[str, Any]],
         max_results: int = MAX_RESULTS_DEFAULT,
         next_token: Optional[str] = None,
+        include_planned_deletion: bool = False,
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         secret_list: List[Dict[str, Any]] = []
         for secret in self.secrets.values():
+            if hasattr(secret, "deleted_date"):
+                if secret.deleted_date and not include_planned_deletion:
+                    continue
             if _matches(secret, filters):
                 secret_list.append(secret.to_dict())
 

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -175,8 +175,14 @@ class SecretsManagerResponse(BaseResponse):
         _validate_filters(filters)
         max_results = self._get_int_param("MaxResults")
         next_token = self._get_param("NextToken")
+        include_planned_deletion = self._get_param(
+            "IncludePlannedDeletion", if_none=False
+        )
         secret_list, next_token = self.backend.list_secrets(
-            filters=filters, max_results=max_results, next_token=next_token
+            filters=filters,
+            max_results=max_results,
+            next_token=next_token,
+            include_planned_deletion=include_planned_deletion,
         )
         return json.dumps(dict(SecretList=secret_list, NextToken=next_token))
 


### PR DESCRIPTION
Original Issue: https://github.com/localstack/localstack/issues/11635

Description:
This PR addresses an issue where deleted secrets were still being displayed in the list-secrets API response.

Changes:
Modified list-secrets API: The list-secrets API has been modified to filter out deleted secrets by default.

Updated Unit Tests: Unit tests have been updated to verify the correct behavior of the list-secrets API.