### PR TITLE
Athena: list_query_execution() not filtering by workgroup name

### DIFF
--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -107,7 +107,7 @@ class Execution(BaseModel):
         query: str,
         context: str,
         config: Dict[str, Any],
-        workgroup: WorkGroup,
+        workgroup: Optional[WorkGroup],
         execution_parameters: Optional[List[str]],
     ):
         self.id = str(mock_random.uuid4())
@@ -246,14 +246,14 @@ class AthenaBackend(BaseBackend):
         query: str,
         context: str,
         config: Dict[str, Any],
-        workgroup: WorkGroup,
+        workgroup: str,
         execution_parameters: Optional[List[str]],
     ) -> str:
         execution = Execution(
             query=query,
             context=context,
             config=config,
-            workgroup=workgroup,
+            workgroup=self.work_groups.get(workgroup),
             execution_parameters=execution_parameters,
         )
         self.executions[execution.id] = execution
@@ -271,16 +271,12 @@ class AthenaBackend(BaseBackend):
     def get_query_execution(self, exec_id: str) -> Execution:
         return self.executions[exec_id]
 
-    def list_query_executions(self, workgroup: str | None) -> Dict[str, Execution]:
+    def list_query_executions(self, workgroup: Optional[str]) -> Dict[str, Execution]:
         if workgroup is not None:
             return {
                 exec_id: execution
                 for exec_id, execution in self.executions.items()
-                if (
-                    execution.workgroup.name == workgroup
-                    if isinstance(execution.workgroup, WorkGroup)
-                    else execution.workgroup == workgroup
-                )
+                if execution.workgroup and execution.workgroup.name == workgroup
             }
         return self.executions
 

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -271,7 +271,17 @@ class AthenaBackend(BaseBackend):
     def get_query_execution(self, exec_id: str) -> Execution:
         return self.executions[exec_id]
 
-    def list_query_executions(self) -> Dict[str, Execution]:
+    def list_query_executions(self, workgroup: str | None) -> Dict[str, Execution]:
+        if workgroup is not None:
+            return {
+                exec_id: execution
+                for exec_id, execution in self.executions.items()
+                if (
+                    execution.workgroup.name == workgroup
+                    if isinstance(execution.workgroup, WorkGroup)
+                    else execution.workgroup == workgroup
+                )
+            }
         return self.executions
 
     def get_query_results(self, exec_id: str) -> QueryResults:

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -104,7 +104,8 @@ class AthenaResponse(BaseResponse):
         return json.dumps(result.to_dict())
 
     def list_query_executions(self) -> str:
-        executions = self.athena_backend.list_query_executions()
+        workgroup = self._get_param("WorkGroup")
+        executions = self.athena_backend.list_query_executions(workgroup)
         return json.dumps({"QueryExecutionIds": [i for i in executions.keys()]})
 
     def stop_query_execution(self) -> str:

--- a/tests/test_athena/test_athena.py
+++ b/tests/test_athena/test_athena.py
@@ -439,6 +439,50 @@ def test_list_query_executions():
 
 
 @mock_aws
+def test_list_query_executions_by_workgroup():
+    client = boto3.client("athena", region_name="us-east-1")
+
+    create_basic_workgroup(client=client, name="athena_workgroup")
+    create_basic_workgroup(client=client, name="athena_workgroup_1")
+
+    client.start_query_execution(
+        QueryString="query1",
+        QueryExecutionContext={"Database": "string"},
+        ResultConfiguration={"OutputLocation": "string"},
+        WorkGroup="athena_workgroup",
+    )
+    exec_result = client.start_query_execution(
+        QueryString="query1",
+        QueryExecutionContext={"Database": "string"},
+        ResultConfiguration={"OutputLocation": "string"},
+        WorkGroup="athena_workgroup_1",
+    )
+    exec_id = exec_result["QueryExecutionId"]
+
+    executions = client.list_query_executions(WorkGroup="athena_workgroup_1")
+    assert len(executions["QueryExecutionIds"]) == 1
+    assert executions["QueryExecutionIds"][0] == exec_id
+
+
+@mock_aws
+def test_list_query_executions_by_workgroup_when_none_match():
+    client = boto3.client("athena", region_name="us-east-1")
+
+    create_basic_workgroup(client=client, name="athena_workgroup")
+    create_basic_workgroup(client=client, name="athena_workgroup_1")
+
+    client.start_query_execution(
+        QueryString="query1",
+        QueryExecutionContext={"Database": "string"},
+        ResultConfiguration={"OutputLocation": "string"},
+        WorkGroup="athena_workgroup",
+    )
+
+    executions = client.list_query_executions(WorkGroup="athena_workgroup_1")
+    assert len(executions["QueryExecutionIds"]) == 0
+
+
+@mock_aws
 def test_list_named_queries():
     client = boto3.client("athena", region_name="us-east-1")
     create_basic_workgroup(client=client, name="athena_workgroup")


### PR DESCRIPTION
Added filtering ability to list_query_execution() using the `WorkGroup` param to better align the function to the documentation.

Changed the types for workgroup in `start_query_execution` as they did not reflect what was being passed in during the tests. 