### PR TITLE
fix(kms): get_public_key now works with alias (name and arn)

### DIFF
--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -707,7 +707,6 @@ class KmsResponse(BaseResponse):
         key_id = self._get_param("KeyId")
 
         self._validate_key_id(key_id)
-        self._validate_cmk_id(key_id)
         key, public_key = self.kms_backend.get_public_key(key_id)
         return json.dumps(
             {

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1713,7 +1713,7 @@ def test_get_public_key_with_alias():
         == key["KeyMetadata"]["SigningAlgorithms"]
     )
     assert (
-        public_key_response_with_name["SigningAlgorithms"]
+        public_key_response_with_arn["SigningAlgorithms"]
         == key["KeyMetadata"]["SigningAlgorithms"]
     )
     assert "EncryptionAlgorithms" not in public_key_response_with_name

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1692,6 +1692,36 @@ def test_get_public_key():
     assert "EncryptionAlgorithms" not in public_key_response
 
 
+@mock_aws
+def test_get_public_key_with_alias():
+    client = boto3.client("kms", region_name="eu-west-1")
+    key = client.create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_2048")
+    key_id = key["KeyMetadata"]["KeyId"]
+    client.create_alias(
+        AliasName="alias/foo",
+        TargetKeyId=key_id,
+    )
+    alias_arn = client.list_aliases()["Aliases"][0]["AliasArn"]
+
+    public_key_response_with_name = client.get_public_key(KeyId="alias/foo")
+    public_key_response_with_arn = client.get_public_key(KeyId=alias_arn)
+
+    assert "PublicKey" in public_key_response_with_name, (
+        "PublicKey" in public_key_response_with_arn
+    )
+    assert (
+        public_key_response_with_name["SigningAlgorithms"]
+        == key["KeyMetadata"]["SigningAlgorithms"]
+    ), (
+        public_key_response_with_name["SigningAlgorithms"]
+        == key["KeyMetadata"]["SigningAlgorithms"]
+    )
+
+    assert "EncryptionAlgorithms" not in public_key_response_with_name, (
+        "EncryptionAlgorithms" not in public_key_response_with_arn
+    )
+
+
 def create_simple_key(client, id_or_arn="KeyId", description=None, policy=None):
     with mock.patch.object(rsa, "generate_private_key", return_value=""):
         params = {}

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1706,20 +1706,19 @@ def test_get_public_key_with_alias():
     public_key_response_with_name = client.get_public_key(KeyId="alias/foo")
     public_key_response_with_arn = client.get_public_key(KeyId=alias_arn)
 
-    assert "PublicKey" in public_key_response_with_name, (
-        "PublicKey" in public_key_response_with_arn
+    assert "PublicKey" in public_key_response_with_name
+    assert "PublicKey" in public_key_response_with_arn
+    assert (
+        public_key_response_with_name["SigningAlgorithms"]
+        == key["KeyMetadata"]["SigningAlgorithms"]
     )
     assert (
         public_key_response_with_name["SigningAlgorithms"]
         == key["KeyMetadata"]["SigningAlgorithms"]
-    ), (
-        public_key_response_with_name["SigningAlgorithms"]
-        == key["KeyMetadata"]["SigningAlgorithms"]
     )
+    assert "EncryptionAlgorithms" not in public_key_response_with_name
+    assert "EncryptionAlgorithms" not in public_key_response_with_arn
 
-    assert "EncryptionAlgorithms" not in public_key_response_with_name, (
-        "EncryptionAlgorithms" not in public_key_response_with_arn
-    )
 
 
 def create_simple_key(client, id_or_arn="KeyId", description=None, policy=None):

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -1720,7 +1720,6 @@ def test_get_public_key_with_alias():
     assert "EncryptionAlgorithms" not in public_key_response_with_arn
 
 
-
 def create_simple_key(client, id_or_arn="KeyId", description=None, policy=None):
     with mock.patch.object(rsa, "generate_private_key", return_value=""):
         params = {}


### PR DESCRIPTION
Fixes #8364 

The error provided was coming from the function `_validate_cmk_id()` which obviously raises an error when used with an alias, and if I understood correctly especially since `describe_key()` is using ` any_id_to_key_id()`.

Tests are passing and none seem to be broken.