### PR TITLE
ds: Fix describe_trusts with no directory_id provided

### DIFF
--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -641,16 +641,23 @@ class DirectoryServiceBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_trusts(
-        self, directory_id: str, trust_ids: Optional[List[str]]
+        self, directory_id: Optional[str], trust_ids: Optional[List[str]]
     ) -> List[Trust]:
-        self._validate_directory_id(directory_id)
-        directory = self.directories[directory_id]
-        trusts = directory.trusts
-        if trust_ids:
-            trusts = [t for t in directory.trusts if t.trust_id in trust_ids]
-        else:
+        if directory_id:
+            self._validate_directory_id(directory_id)
+            directory = self.directories[directory_id]
             trusts = directory.trusts
-        return trusts
+        else:
+            trusts = [
+                trust
+                for directory in self.directories.values()
+                for trust in directory.trusts
+            ]
+        if trust_ids:
+            queried_trusts = [t for t in trusts if t.trust_id in trust_ids]
+        else:
+            queried_trusts = trusts
+        return queried_trusts
 
     def delete_trust(
         self, trust_id: str, delete_associated_conditional_forwarder: Optional[bool]

--- a/tests/test_ds/test_ds.py
+++ b/tests/test_ds/test_ds.py
@@ -390,6 +390,10 @@ def test_describe_trusts():
     assert trusts[0]["TrustId"] == trust_ids[1]
     assert trusts[1]["TrustId"] == trust_ids[2]
 
+    # Describe all the trusts in the account
+    trusts = client.describe_trusts()["Trusts"]
+    assert len(trusts) == 5
+
 
 @mock_aws
 def test_delete_trust():


### PR DESCRIPTION
Fixes bug where no directory_id is provided, type error.

Per docs: _"If no input parameters are provided, such as DirectoryId or TrustIds, this request describes all the trust relationships belonging to the account."_

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ds/client/describe_trusts.html