### PR TITLE
RDS: Implement Managed Master Password Handling

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -499,7 +499,7 @@ class DBCluster(RDSBaseModel):
                 ]:
                     self._enable_http_endpoint = val
 
-    def master_user_secret(self):
+    def master_user_secret(self) -> Dict[str, Any]:
         return {
             "secret_arn": f"arn:{self.partition}:secretsmanager:{self.region}:{self.account_id}:secret:rds!{self.name}",
             "secret_status": self.master_user_secret_status,
@@ -951,7 +951,7 @@ class DBInstance(CloudFormationModel, RDSBaseModel):
 
         return db_family, f"default.{db_family}"
 
-    def master_user_secret(self):
+    def master_user_secret(self) -> Dict[str, Any]:
         return {
             "secret_arn": f"arn:{self.partition}:secretsmanager:{self.region}:{self.account_id}:secret:rds!{self.name}",
             "secret_status": self.master_user_secret_status,

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -51,6 +51,9 @@ class RDSResponse(BaseResponse):
             "manage_master_user_password": self._get_bool_param(
                 "ManageMasterUserPassword"
             ),
+            "master_user_secret_kms_key_id": self._get_param(
+                "MasterUserSecretKmsKeyId"
+            ),
             "multi_az": self._get_bool_param("MultiAZ"),
             "option_group_name": self._get_param("OptionGroupName"),
             "port": self._get_param("Port"),
@@ -110,6 +113,9 @@ class RDSResponse(BaseResponse):
             "master_username": self._get_param("MasterUsername"),
             "manage_master_user_password": self._get_bool_param(
                 "ManageMasterUserPassword"
+            ),
+            "master_user_secret_kms_key_id": self._get_param(
+                "MasterUserSecretKmsKeyId"
             ),
             "multi_az": self._get_bool_param("MultiAZ"),
             "option_group_name": self._get_param("OptionGroupName"),
@@ -194,6 +200,9 @@ class RDSResponse(BaseResponse):
             "master_username": self._get_param("MasterUsername"),
             "manage_master_user_password": self._get_bool_param(
                 "ManageMasterUserPassword"
+            ),
+            "master_user_secret_kms_key_id": self._get_param(
+                "MasterUserSecretKmsKeyId"
             ),
             "master_user_password": self._get_param("MasterUserPassword"),
             "network_type": self._get_param("NetworkType"),

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -54,6 +54,7 @@ class RDSResponse(BaseResponse):
             "master_user_secret_kms_key_id": self._get_param(
                 "MasterUserSecretKmsKeyId"
             ),
+            "rotate_master_user_password": self._get_param("RotateMasterUserPassword"),
             "multi_az": self._get_bool_param("MultiAZ"),
             "option_group_name": self._get_param("OptionGroupName"),
             "port": self._get_param("Port"),
@@ -74,6 +75,7 @@ class RDSResponse(BaseResponse):
             ),
             "tags": list(),
             "deletion_protection": self._get_bool_param("DeletionProtection"),
+            "apply_immediately": self._get_bool_param("ApplyImmediately"),
         }
         args["tags"] = self.unpack_list_params("Tags", "Tag")
         return args
@@ -117,6 +119,7 @@ class RDSResponse(BaseResponse):
             "master_user_secret_kms_key_id": self._get_param(
                 "MasterUserSecretKmsKeyId"
             ),
+            "rotate_master_user_password": self._get_param("RotateMasterUserPassword"),
             "multi_az": self._get_bool_param("MultiAZ"),
             "option_group_name": self._get_param("OptionGroupName"),
             "port": self._get_param("Port"),
@@ -135,6 +138,7 @@ class RDSResponse(BaseResponse):
             ),
             "tags": list(),
             "deletion_protection": self._get_bool_param("DeletionProtection"),
+            "apply_immediately": self._get_bool_param("ApplyImmediately"),
         }
         args["tags"] = self.unpack_list_params("Tags", "Tag")
         return args

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -48,6 +48,9 @@ class RDSResponse(BaseResponse):
             "kms_key_id": self._get_param("KmsKeyId"),
             "master_user_password": self._get_param("MasterUserPassword"),
             "master_username": self._get_param("MasterUsername"),
+            "manage_master_user_password": self._get_bool_param(
+                "ManageMasterUserPassword"
+            ),
             "multi_az": self._get_bool_param("MultiAZ"),
             "option_group_name": self._get_param("OptionGroupName"),
             "port": self._get_param("Port"),

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -105,6 +105,9 @@ class RDSResponse(BaseResponse):
             "kms_key_id": self._get_param("KmsKeyId"),
             "master_user_password": self._get_param("MasterUserPassword"),
             "master_username": self._get_param("MasterUsername"),
+            "manage_master_user_password": self._get_bool_param(
+                "ManageMasterUserPassword"
+            ),
             "multi_az": self._get_bool_param("MultiAZ"),
             "option_group_name": self._get_param("OptionGroupName"),
             "port": self._get_param("Port"),
@@ -186,6 +189,9 @@ class RDSResponse(BaseResponse):
             "storage_type": self._get_param("StorageType"),
             "kms_key_id": self._get_param("KmsKeyId"),
             "master_username": self._get_param("MasterUsername"),
+            "manage_master_user_password": self._get_bool_param(
+                "ManageMasterUserPassword"
+            ),
             "master_user_password": self._get_param("MasterUserPassword"),
             "network_type": self._get_param("NetworkType"),
             "port": self._get_param("Port"),


### PR DESCRIPTION
Hi everyone,

this is my first pull request in this repo, so if something is missing or unclear, let me know.

As requested in this issue https://github.com/getmoto/moto/issues/8294, this MR adds the implementation of the Managed Master Password handling for db_instance and db_cluster resources. This contains the following actions:

- Enabling/Disabling Managed Master User Password has an impact on the db_instance or db_cluster resource response and contains mocked data
- Providing a custom kms key with `MasterUserSecretKmsKeyId`will be respected in moto's response
- Setting `RotateMasterUserPassword` in a `modify_db_instance` or `modify_db_cluster`-call will set the status of the Master User Secret to `rotating`.

To keep things simple, I do not actually create a secret in moto's mocked secretsmanager when enabling Manage Master User Password. If this does not comply to the how moto works, I can update the behavior.

Closes #8294 