### PR TITLE
efs - add file system policy support

### DIFF
--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -758,5 +758,17 @@ class EFSBackend(BaseBackend):
     def untag_resource(self, resource_id: str, tag_keys: List[str]) -> None:
         self.tagging_service.untag_resource_using_names(resource_id, tag_keys)
 
+    def describe_file_system_policy(self, file_system_id: str):
+        policy = self.file_systems_by_id[file_system_id].file_system_policy
+        if not policy:
+            raise PolicyNotFound("None")
+        return policy
+
+    def put_file_system_policy(
+        self, file_system_id: str, policy: str, bypass_policy_lockout_safety_check
+    ) -> None:
+        file_system = self.file_systems_by_id[file_system_id]
+        file_system.file_system_policy = policy
+
 
 efs_backends = BackendDict(EFSBackend, "efs")

--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -758,14 +758,14 @@ class EFSBackend(BaseBackend):
     def untag_resource(self, resource_id: str, tag_keys: List[str]) -> None:
         self.tagging_service.untag_resource_using_names(resource_id, tag_keys)
 
-    def describe_file_system_policy(self, file_system_id: str):
+    def describe_file_system_policy(self, file_system_id: str) -> str:
         policy = self.file_systems_by_id[file_system_id].file_system_policy
         if not policy:
             raise PolicyNotFound("None")
         return policy
 
     def put_file_system_policy(
-        self, file_system_id: str, policy: str, bypass_policy_lockout_safety_check
+        self, file_system_id: str, policy: str, bypass_policy_lockout_safety_check: bool
     ) -> None:
         file_system = self.file_systems_by_id[file_system_id]
         file_system.file_system_policy = policy

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -198,18 +198,18 @@ class EFSResponse(BaseResponse):
         self.efs_backend.untag_resource(resource_id, tag_keys)
         return "{}", {"Content-Type": "application/json"}
 
-    def describe_file_system_policy(self):
+    def describe_file_system_policy(self) -> TYPE_RESPONSE:
         file_system_id = self._get_param("FileSystemId")
         policy = self.efs_backend.describe_file_system_policy(
             file_system_id=file_system_id,
         )
         return json.dumps(dict(FileSystemId=file_system_id, Policy=policy))
 
-    def put_file_system_policy(self):
+    def put_file_system_policy(self) -> TYPE_RESPONSE:
         file_system_id = self._get_param("FileSystemId")
         policy = self._get_param("Policy")
-        bypass_policy_lockout_safety_check = self._get_param(
-            "BypassPolicyLockoutSafetyCheck"
+        bypass_policy_lockout_safety_check = (
+            self._get_param("BypassPolicyLockoutSafetyCheck") | False
         )
         self.efs_backend.put_file_system_policy(
             file_system_id=file_system_id,

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -203,7 +203,10 @@ class EFSResponse(BaseResponse):
         policy = self.efs_backend.describe_file_system_policy(
             file_system_id=file_system_id,
         )
-        return json.dumps(dict(FileSystemId=file_system_id, Policy=policy))
+        return (
+            json.dumps(dict(FileSystemId=file_system_id, Policy=policy)),
+            {"Content-Type": "application/json"},
+        )
 
     def put_file_system_policy(self) -> TYPE_RESPONSE:
         file_system_id = self._get_param("FileSystemId")
@@ -216,4 +219,7 @@ class EFSResponse(BaseResponse):
             policy=policy,
             bypass_policy_lockout_safety_check=bypass_policy_lockout_safety_check,
         )
-        return json.dumps(dict(FileSystemId=file_system_id, Policy=policy))
+        return (
+            json.dumps(dict(FileSystemId=file_system_id, Policy=policy)),
+            {"Content-Type": "application/json"},
+        )

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -212,7 +212,7 @@ class EFSResponse(BaseResponse):
         file_system_id = self._get_param("FileSystemId")
         policy = self._get_param("Policy")
         bypass_policy_lockout_safety_check = (
-            self._get_param("BypassPolicyLockoutSafetyCheck") | False
+            self._get_param("BypassPolicyLockoutSafetyCheck") or False
         )
         self.efs_backend.put_file_system_policy(
             file_system_id=file_system_id,

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -197,3 +197,23 @@ class EFSResponse(BaseResponse):
         tag_keys = self.querystring.get("tagKeys", [])
         self.efs_backend.untag_resource(resource_id, tag_keys)
         return "{}", {"Content-Type": "application/json"}
+
+    def describe_file_system_policy(self):
+        file_system_id = self._get_param("FileSystemId")
+        policy = self.efs_backend.describe_file_system_policy(
+            file_system_id=file_system_id,
+        )
+        return json.dumps(dict(FileSystemId=file_system_id, Policy=policy))
+
+    def put_file_system_policy(self):
+        file_system_id = self._get_param("FileSystemId")
+        policy = self._get_param("Policy")
+        bypass_policy_lockout_safety_check = self._get_param(
+            "BypassPolicyLockoutSafetyCheck"
+        )
+        self.efs_backend.put_file_system_policy(
+            file_system_id=file_system_id,
+            policy=policy,
+            bypass_policy_lockout_safety_check=bypass_policy_lockout_safety_check,
+        )
+        return json.dumps(dict(FileSystemId=file_system_id, Policy=policy))

--- a/moto/efs/urls.py
+++ b/moto/efs/urls.py
@@ -17,6 +17,7 @@ url_paths = {
     "/2015-02-01/file-systems/<file_system_id>": response.dispatch,
     "/2015-02-01/file-systems/<file_system_id>/backup-policy": response.dispatch,
     "/2015-02-01/file-systems/<file_system_id>/lifecycle-configuration": response.dispatch,
+    "/2015-02-01/file-systems/<file_system_id>/policy": response.dispatch,
     "/2015-02-01/mount-targets": response.dispatch,
     "/2015-02-01/mount-targets/<mount_target_id>": response.dispatch,
     "/2015-02-01/mount-targets/<mount_target_id>/security-groups": response.dispatch,

--- a/tests/test_efs/test_filesystem_policy.py
+++ b/tests/test_efs/test_filesystem_policy.py
@@ -1,0 +1,32 @@
+import pytest
+from botocore.exceptions import ClientError
+
+from . import fixture_efs  # noqa # pylint: disable=unused-import
+
+
+def test_describe_file_system_policy__initial(efs):
+    create_fs_resp = efs.create_file_system(CreationToken="foobar")
+    fs_id = create_fs_resp["FileSystemId"]
+
+    with pytest.raises(ClientError) as exc_info:
+        efs.describe_file_system_policy(FileSystemId=fs_id)
+    err = exc_info.value.response["Error"]
+    assert err["Code"] == "PolicyNotFound"
+
+
+def test_put_file_system_policy(efs):
+    # Create the file system.
+    create_fs_resp = efs.create_file_system(CreationToken="foobar")
+    create_fs_resp.pop("ResponseMetadata")
+    fs_id = create_fs_resp["FileSystemId"]
+
+    # Create the filesystem policy
+    policy = '{\n  "Version" : "2012-10-17",\n  "Id" : "efs-policy-1234",\n  "Statement" : [ {\n    "Sid" : "efs-statement-1234",\n    "Effect" : "Allow",\n    "Principal" : {\n      "AWS" : "*"\n    },\n    "Action" : [ "elasticfilesystem:ClientRootAccess", "elasticfilesystem:ClientWrite" ],\n    "Resource" : "arn:aws:elasticfilesystem:us-east-1:1234:file-system/fs-1234",\n    "Condition" : {\n      "Bool" : {\n        "elasticfilesystem:AccessedViaMountTarget" : "true"\n      }\n    }\n  } ]\n}'
+    resp = efs.put_file_system_policy(FileSystemId=fs_id, Policy=policy)
+    assert len(resp["Policy"]) > 1
+    assert "ClientRootAccess" in resp["Policy"]
+
+    # Describe the filesystem policy
+    resp = efs.describe_file_system_policy(FileSystemId=fs_id)
+    assert len(resp["Policy"]) > 1
+    assert "ClientRootAccess" in resp["Policy"]


### PR DESCRIPTION
Adds support for file system policies for EFS.

[efs.PutFileSystemPolicy](https://docs.aws.amazon.com/efs/latest/ug/API_PutFileSystemPolicy.html)
[efs.DescribeFileSystemPolicy](https://docs.aws.amazon.com/efs/latest/ug/API_DescribeFileSystemPolicy.html)