### PR TITLE
bump cryptography version from 3.3.1 to 35.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.8
 install_requires =
     boto3>=1.9.201
     botocore>=1.14.0,!=1.35.45,!=1.35.46
-    cryptography>=3.3.1
+    cryptography>=35.0.0
     requests>=2.5
     xmltodict
     werkzeug>=0.5,!=2.2.0,!=2.2.1


### PR DESCRIPTION
The current min. cryptography version (`3.3.1`) isn't sufficient for moto's IoT submodule - versions of cryptography between `3.3.1` and `3.4.8` (inclusive) didn't support importing from `cryptography.hazmat._oid`:

```
.pyenv/versions/3.11.6/lib/python3.11/site-packages/moto/iot/models.py:9: in <module>
    from cryptography.hazmat._oid import NameOID
E   ImportError: cannot import name 'NameOID' from 'cryptography.hazmat._oid' (/home/vlas-sokolov/.pyenv/versions/3.11.6/lib/python3.11/site-packages/cryptography/hazmat/_oid.py)
```

This can be easily verified by installing any cryptography version prior to `35.0.0` and running moto's test suit from `tests/test_iot` - they will all fail. The import structure moto relies on was introduced in this [commit](https://github.com/pyca/cryptography/commit/7b5634911c892fbc64b363523b8af74a4b772f7b), which first appears in tag `35.0.0`, which is the version this PR bumps the dependent package to.