### PR TITLE
RDS: Fix config copy

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -510,7 +510,7 @@ class DBCluster(RDSBaseModel):
         }
 
     def get_cfg(self) -> Dict[str, Any]:
-        cfg = self.__dict__
+        cfg = self.__dict__.copy()
         cfg.pop("backend")
         cfg["master_user_password"] = cfg.pop("_master_user_password")
         cfg["enable_http_endpoint"] = cfg.pop("_enable_http_endpoint")


### PR DESCRIPTION
Original code was popping the `backend` attribute off of the existing cluster instance.