### PR TITLE
es & opensearch - add describe_elasticsearch_domains & describe_domains support

### DIFF
--- a/moto/es/models.py
+++ b/moto/es/models.py
@@ -147,7 +147,8 @@ class ElasticsearchServiceBackend(BaseBackend):
     ) -> List[Dict[str, Any]]:
         queried_domains = []
         for domain_name in domain_names:
-            queried_domains.append(self.domains[domain_name].to_json())
+            if domain_name in self.domains:
+                queried_domains.append(self.domains[domain_name].to_json())
         return queried_domains
 
 

--- a/moto/es/models.py
+++ b/moto/es/models.py
@@ -142,5 +142,13 @@ class ElasticsearchServiceBackend(BaseBackend):
         """
         return [{"DomainName": domain.domain_name} for domain in self.domains.values()]
 
+    def describe_elasticsearch_domains(
+        self, domain_names: List[str]
+    ) -> List[Dict[str, Any]]:
+        queried_domains = []
+        for domain_name in domain_names:
+            queried_domains.append(self.domains[domain_name].to_json())
+        return queried_domains
+
 
 es_backends = BackendDict(ElasticsearchServiceBackend, "es")

--- a/moto/es/responses.py
+++ b/moto/es/responses.py
@@ -13,7 +13,7 @@ class ElasticsearchServiceResponse(BaseResponse):
     """Handler for ElasticsearchService requests and responses."""
 
     def __init__(self) -> None:
-        super().__init__(service_name="elasticsearch")
+        super().__init__(service_name="es")
 
     @property
     def es_backend(self) -> ElasticsearchServiceBackend:
@@ -98,3 +98,10 @@ class ElasticsearchServiceResponse(BaseResponse):
     def list_domain_names(self) -> TYPE_RESPONSE:
         domain_names = self.es_backend.list_domain_names()
         return 200, {}, json.dumps({"DomainNames": domain_names})
+
+    def describe_elasticsearch_domains(self) -> TYPE_RESPONSE:
+        domain_names = self._get_param("DomainNames")
+        domain_list = self.es_backend.describe_elasticsearch_domains(
+            domain_names=domain_names,
+        )
+        return 200, {}, json.dumps({"DomainStatusList": domain_list})

--- a/moto/es/urls.py
+++ b/moto/es/urls.py
@@ -11,6 +11,7 @@ url_paths = {
     "{0}/2015-01-01/domain$": ElasticsearchServiceResponse.list_domains,
     "{0}/2015-01-01/es/domain$": ElasticsearchServiceResponse.domains,
     "{0}/2015-01-01/es/domain/(?P<domainname>[^/]+)": ElasticsearchServiceResponse.domain,
+    "{0}/2015-01-01/es/domain-info$": ElasticsearchServiceResponse.dispatch,
     "{0}/2021-01-01/domain$": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/compatibleVersions": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/domain": OpenSearchServiceResponse.dispatch,

--- a/moto/es/urls.py
+++ b/moto/es/urls.py
@@ -17,6 +17,7 @@ url_paths = {
     "{0}/2021-01-01/opensearch/domain": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/domain/(?P<domainname>[^/]+)": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/opensearch/domain/(?P<domainname>[^/]+)/config": OpenSearchServiceResponse.dispatch,
+    "{0}/2021-01-01/opensearch/domain-info$": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/tags/?": OpenSearchServiceResponse.dispatch,
     "{0}/2021-01-01/tags-removal/": OpenSearchServiceResponse.dispatch,
 }

--- a/moto/opensearch/models.py
+++ b/moto/opensearch/models.py
@@ -375,5 +375,11 @@ class OpenSearchServiceBackend(BaseBackend):
                 )
         return domains
 
+    def describe_domains(self, domain_names: List[str]) -> List[OpenSearchDomain]:
+        queried_domains = []
+        for domain_name in domain_names:
+            queried_domains.append(self.domains[domain_name])
+        return queried_domains
+
 
 opensearch_backends = BackendDict(OpenSearchServiceBackend, "opensearch")

--- a/moto/opensearch/models.py
+++ b/moto/opensearch/models.py
@@ -378,7 +378,8 @@ class OpenSearchServiceBackend(BaseBackend):
     def describe_domains(self, domain_names: List[str]) -> List[OpenSearchDomain]:
         queried_domains = []
         for domain_name in domain_names:
-            queried_domains.append(self.domains[domain_name])
+            if domain_name in self.domains:
+                queried_domains.append(self.domains[domain_name])
         return queried_domains
 
 

--- a/moto/opensearch/responses.py
+++ b/moto/opensearch/responses.py
@@ -147,3 +147,11 @@ class OpenSearchServiceResponse(BaseResponse):
             engine_type=engine_type,
         )
         return json.dumps(dict(DomainNames=domain_names))
+
+    def describe_domains(self) -> str:
+        domain_names = self._get_param("DomainNames")
+        domains = self.opensearch_backend.describe_domains(
+            domain_names=domain_names,
+        )
+        domain_list = [domain.to_dict() for domain in domains]
+        return json.dumps({"DomainStatusList": domain_list})

--- a/moto/opensearch/urls.py
+++ b/moto/opensearch/urls.py
@@ -10,5 +10,4 @@ response = OpenSearchServiceResponse()
 
 url_paths = {
     "{0}/.*$": response.dispatch,
-    "{0}/2021-01-01/opensearch/domain-info$": response.dispatch,
 }

--- a/moto/opensearch/urls.py
+++ b/moto/opensearch/urls.py
@@ -8,4 +8,7 @@ url_bases = [r"https?://es\.(.+)\.amazonaws\.com"]
 response = OpenSearchServiceResponse()
 
 
-url_paths = {"{0}/.*$": response.dispatch}
+url_paths = {
+    "{0}/.*$": response.dispatch,
+    "{0}/2021-01-01/opensearch/domain-info$": response.dispatch,
+}

--- a/tests/test_es/test_es.py
+++ b/tests/test_es/test_es.py
@@ -215,3 +215,24 @@ def test_list_domain_names_with_multiple_domains():
     assert len(resp["DomainNames"]) == 4
     for name in domain_names:
         assert {"DomainName": name} in resp["DomainNames"]
+
+
+@mock_aws
+def test_describe_elasticsearch_domains():
+    client = boto3.client("es", region_name="us-east-1")
+    domain_names = [f"env{i}" for i in range(1, 5)]
+    for name in domain_names:
+        client.create_elasticsearch_domain(
+            DomainName=name,
+            ElasticsearchVersion="7.10",
+            AdvancedOptions={"option": "value"},
+            AdvancedSecurityOptions={"Enabled": False},
+        )
+    resp = client.describe_elasticsearch_domains(DomainNames=domain_names)
+
+    assert len(resp["DomainStatusList"]) == 4
+    for domain in resp["DomainStatusList"]:
+        assert domain["DomainName"] in domain_names
+        assert domain["ElasticsearchVersion"] == "7.10"
+        assert "AdvancedSecurityOptions" in domain.keys()
+        assert "AdvancedOptions" in domain.keys()

--- a/tests/test_es/test_es.py
+++ b/tests/test_es/test_es.py
@@ -236,3 +236,7 @@ def test_describe_elasticsearch_domains():
         assert domain["ElasticsearchVersion"] == "7.10"
         assert "AdvancedSecurityOptions" in domain.keys()
         assert "AdvancedOptions" in domain.keys()
+
+    # Test for invalid domain name
+    resp = client.describe_elasticsearch_domains(DomainNames=["invalid"])
+    assert len(resp["DomainStatusList"]) == 0

--- a/tests/test_opensearch/test_opensearch.py
+++ b/tests/test_opensearch/test_opensearch.py
@@ -233,3 +233,7 @@ def test_describe_domains():
         assert domain["DomainName"] in domain_names
         assert "AdvancedSecurityOptions" in domain.keys()
         assert "AdvancedOptions" in domain.keys()
+
+    # Test for invalid domain name
+    resp = client.describe_domains(DomainNames=["invalid"])
+    assert len(resp["DomainStatusList"]) == 0

--- a/tests/test_opensearch/test_opensearch.py
+++ b/tests/test_opensearch/test_opensearch.py
@@ -203,7 +203,7 @@ def test_list_filtered_domain_names():
 
 
 @mock_aws
-def test_list_unknown_domain_names_engine_type():
+def test_list_unknown_domain_names_engine_type(): 
     client = boto3.client("opensearch", region_name="ap-southeast-1")
 
     opensearch_domain_name = "testdn"
@@ -217,3 +217,19 @@ def test_list_unknown_domain_names_engine_type():
     err = exc.value.response["Error"]
     assert err["Code"] == "EngineTypeNotFoundException"
     assert err["Message"] == "Engine Type not found: testdn"
+
+
+@mock_aws
+def test_describe_domains():
+    client = boto3.client("opensearch", region_name="us-east-1")
+    domain_names = [f"env{i}" for i in range(1, 5)]
+    opensearch_engine_version = "OpenSearch_1.0"
+    for name in domain_names:
+        client.create_domain(DomainName=name, EngineVersion=opensearch_engine_version)
+    resp = client.describe_domains(DomainNames=domain_names)
+
+    assert len(resp["DomainStatusList"]) == 4
+    for domain in resp["DomainStatusList"]:
+        assert domain["DomainName"] in domain_names
+        assert "AdvancedSecurityOptions" in domain.keys()
+        assert "AdvancedOptions" in domain.keys()

--- a/tests/test_opensearch/test_opensearch.py
+++ b/tests/test_opensearch/test_opensearch.py
@@ -203,7 +203,7 @@ def test_list_filtered_domain_names():
 
 
 @mock_aws
-def test_list_unknown_domain_names_engine_type(): 
+def test_list_unknown_domain_names_engine_type():
     client = boto3.client("opensearch", region_name="ap-southeast-1")
 
     opensearch_domain_name = "testdn"


### PR DESCRIPTION
Adds support for [describe_elasticsearch_domains](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/es/client/describe_elasticsearch_domains.html) for  ES.

Adds support for [describe_domains](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/opensearch/client/describe_domains.html) for opensearch.

Also changed ElasticSearch service_name from "elasticsearch" to "es". I had the ["unknown service" issue like this prior example](https://github.com/getmoto/moto/pull/6969#discussion_r1376735532). Didn't seem to break anything existing