### PR TITLE
DynamoDB: Make it possible to disable delete protection on a table

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -87,7 +87,7 @@ class DynamoDBBackend(BaseBackend):
         billing_mode: str,
         sse_specification: Optional[Dict[str, Any]],
         tags: List[Dict[str, str]],
-        deletion_protection_enabled: bool,
+        deletion_protection_enabled: Optional[bool],
     ) -> Table:
         if name in self.tables:
             raise ResourceInUseException(f"Table already exists: {name}")
@@ -182,7 +182,7 @@ class DynamoDBBackend(BaseBackend):
         throughput: Dict[str, Any],
         billing_mode: str,
         stream_spec: Dict[str, Any],
-        deletion_protection_enabled: bool,
+        deletion_protection_enabled: Optional[bool],
     ) -> Table:
         table = self.get_table(name)
         if attr_definitions:
@@ -195,7 +195,7 @@ class DynamoDBBackend(BaseBackend):
             table.billing_mode = billing_mode
         if stream_spec:
             self.update_table_streams(table, stream_spec)
-        if deletion_protection_enabled:
+        if deletion_protection_enabled in {True, False}:
             table.deletion_protection_enabled = deletion_protection_enabled
         return table
 

--- a/tests/test_dynamodb/test_dynamodb_update_table.py
+++ b/tests/test_dynamodb/test_dynamodb_update_table.py
@@ -71,6 +71,23 @@ def test_update_table_deletion_protection_enabled():
 
 
 @mock_aws
+def test_update_table_deletion_protection_disabled():
+    conn = boto3.resource("dynamodb", region_name="us-west-2")
+    table = conn.create_table(
+        TableName="messages",
+        KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+        DeletionProtectionEnabled=True,
+    )
+    assert table.deletion_protection_enabled
+
+    table.update(DeletionProtectionEnabled=False)
+
+    assert not table.deletion_protection_enabled
+
+
+@mock_aws
 def test_update_table__enable_stream():
     conn = boto3.client("dynamodb", region_name="us-east-1")
 


### PR DESCRIPTION
This was previously impossible due to the conditional that required the argument `deletion_protection_enabled` to be truthy for any update to be applied. 