### PR TITLE
EC2: add SecurityGroupArn to security groups

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -155,6 +155,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         self.owner_id = ec2_backend.account_id
         self.add_tags(tags or {})
         self.is_default = is_default or False
+        self.arn = f"arn:aws:ec2:{ec2_backend.account_id}:{ec2_backend.region_name}:security-group/{group_id}"
 
         # Append default IPv6 egress rule for VPCs with IPv6 support
         if vpc_id:

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -261,6 +261,7 @@ CREATE_SECURITY_GROUP_RESPONSE = """<CreateSecurityGroupResponse xmlns="http://e
    <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
    <return>true</return>
    <groupId>{{ group.id }}</groupId>
+   <securityGroupArn>{{ group.arn }}</securityGroupArn>
    <tagSet>
     {% for tag in group.get_tags() %}
         <item>
@@ -346,6 +347,7 @@ DESCRIBE_SECURITY_GROUPS_RESPONSE = """<DescribeSecurityGroupsResponse xmlns="ht
              <groupId>{{ group.id }}</groupId>
              <groupName>{{ group.name }}</groupName>
              <groupDescription>{{ group.description }}</groupDescription>
+             <securityGroupArn>{{ group.arn }}</securityGroupArn>
              {% if group.vpc_id %}
              <vpcId>{{ group.vpc_id }}</vpcId>
              {% endif %}

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -85,6 +85,7 @@ def test_create_and_describe_vpc_security_group():
 
     assert group_with.group_name == name
     assert group_with.description == "test"
+    assert group_with.security_group_arn
 
     # Trying to create another group with the same name in the same VPC should
     # throw an error


### PR DESCRIPTION
## Motiviation 
As stated in the [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/create_security_group.html) the methods for creating and describing a Security Group resource should include the attribute SecurityGroupArn.

## Changes
- ARN generation in the SecurityGroup model
- Addition of the attribute in the response templates.

## Testing 
- Extension of an existing test to assert the presence of the attribute