### PR TITLE
EC2: update_route() now correctly handles DestinationPrefixListId

### DIFF
--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -467,9 +467,7 @@ class RouteBackend:
         if destination_prefix_list_id:
             cidr = destination_prefix_list_id
         route_table = self.get_route_table(route_table_id)
-        route_id = generate_route_id(
-            route_table.id, destination_cidr_block, destination_ipv6_cidr_block
-        )
+        route_id = generate_route_id(route_table.id, cidr, destination_ipv6_cidr_block)
         try:
             route = route_table.routes[route_id]
         except KeyError:


### PR DESCRIPTION
Updated EC2 update_route to correctly use the decided destination type instead of `destination_cidr_block`.

Also added additional test cases to verify this logic.

This references issue #8394 .