### PR TITLE
[codespaces] Launch Configurations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "moto",
-  "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
-  "remoteUser": "root",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,8 @@
       "requireLocalPort": false
     }
   },
+  "postCreateCommand": "python -m venv .venv",
+  "postStartCommand": ". .venv/bin/activate && make init",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -37,7 +39,21 @@
               "args": [
                 "-c",
                 "until gh codespace ports visibility 5000:public --codespace ${CODESPACE_NAME} 2>/dev/null; do sleep 1; done"
-              ]
+              ],
+              "presentation": {
+                "reveal": "silent",
+                "focus": false
+              }
+            },
+            {
+              "label": "Kill MotoServer",
+              "type": "shell",
+              "command": "pkill -f '${workspaceFolder}/moto/server.py'",
+              "problemMatcher": [],
+              "presentation": {
+                "reveal": "silent",
+                "focus": false
+              }
             }
           ]
         },
@@ -45,49 +61,60 @@
           "version": "0.2.0",
           "configurations": [
             {
-              "name": "Debug Moto Server",
+              "name": "Run MotoServer",
               "type": "debugpy",
               "request": "launch",
               "program": "${workspaceFolder}/moto/server.py",
               "args": [
                 "--reload"
               ],
-              "console": "integratedTerminal",
+              "console": "internalConsole",
               "presentation": {
-                "hidden": true
+                "order": 11
               }
             },
             {
-              "name": "Debug Moto Server Tests",
+              "name": "Run MotoServer Tests",
               "type": "debugpy",
               "request": "launch",
               "module": "pytest",
               "console": "integratedTerminal",
               "preLaunchTask": "Open Port 5000",
+              "postDebugTask": "Kill MotoServer",
               "env": {
                 "TEST_SERVER_MODE": "true",
                 "TEST_SERVER_MODE_ENDPOINT": "https://${env:CODESPACE_NAME}-5000.${env:GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
               },
               "presentation": {
-                "hidden": true
+                "order": 12
               },
               "args": [
                 "-sv",
                 "--cov=moto",
                 "--cov-report=xml",
-                "${workspaceFolder}/tests/"
+                "${workspaceFolder}/tests/",
+                "-k",
+                "${input:pytestFilter}"
               ]
+            }
+          ],
+          "inputs": [
+            {
+              "id": "pytestFilter",
+              "type": "promptString",
+              "description": "pytest -k filter (leave empty to run all tests)",
+              "default": ""
             }
           ],
           "compounds": [
             {
-              "name": "Run Server Tests",
+              "name": "MotoServer Tests",
               "configurations": [
-                "Debug Moto Server",
-                "Debug Moto Server Tests"
+                "Run MotoServer Tests",
+                "Run MotoServer"
               ],
               "presentation": {
-                "group": "Moto Server"
+                "order": 1
               },
               "stopAll": true
             }
@@ -95,7 +122,5 @@
         }
       }
     }
-  },
-  "postCreateCommand": "python -m venv .venv",
-  "postStartCommand": ". .venv/bin/activate && make init"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,7 +77,7 @@
                 "--cov-report=xml",
                 "${workspaceFolder}/tests/"
               ]
-            },
+            }
           ],
           "compounds": [
             {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,16 +2,96 @@
   "name": "moto",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "portsAttributes": {
+    "5000": {
+      "onAutoForward": "silent",
+      "elevateIfNeeded": true,
+      "protocol": "http",
+      "requireLocalPort": false
+    }
   },
   "customizations": {
     "vscode": {
-      "extensions": ["ms-vscode.makefile-tools", "ms-python.python", "ms-python.black-formatter"],
+      "extensions": [
+        "ms-vscode.makefile-tools",
+        "ms-python.python",
+        "ms-python.black-formatter"
+      ],
       "settings": {
+        "editor.formatOnSave": true,
         "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
         "python.formatting.provider": "none",
         "[python]": {
           "editor.defaultFormatter": "ms-python.black-formatter"
+        },
+        "tasks": {
+          "version": "2.0.0",
+          "tasks": [
+            {
+              "label": "Open Port 5000",
+              "type": "shell",
+              "command": "bash",
+              "args": [
+                "-c",
+                "until gh codespace ports visibility 5000:public --codespace ${CODESPACE_NAME} 2>/dev/null; do sleep 1; done"
+              ]
+            }
+          ]
+        },
+        "launch": {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "name": "Debug Moto Server",
+              "type": "debugpy",
+              "request": "launch",
+              "program": "${workspaceFolder}/moto/server.py",
+              "args": [
+                "--reload"
+              ],
+              "console": "integratedTerminal",
+              "presentation": {
+                "hidden": true
+              }
+            },
+            {
+              "name": "Debug Moto Server Tests",
+              "type": "debugpy",
+              "request": "launch",
+              "module": "pytest",
+              "console": "integratedTerminal",
+              "preLaunchTask": "Open Port 5000",
+              "env": {
+                "TEST_SERVER_MODE": "true",
+                "TEST_SERVER_MODE_ENDPOINT": "https://${env:CODESPACE_NAME}-5000.${env:GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+              },
+              "presentation": {
+                "hidden": true
+              },
+              "args": [
+                "-sv",
+                "--cov=moto",
+                "--cov-report=xml",
+                "${workspaceFolder}/tests/"
+              ]
+            },
+          ],
+          "compounds": [
+            {
+              "name": "Run Server Tests",
+              "configurations": [
+                "Debug Moto Server",
+                "Debug Moto Server Tests"
+              ],
+              "presentation": {
+                "group": "Moto Server"
+              },
+              "stopAll": true
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Adds a Launch Configuration to run Moto Server Tests

Features:
 - A single click to start up MotoServer and MotoServer Tests
 - A prompt for an optional "pytest -k" filter to filter for specific test
 - Runs on the GitHub Codespaces "Public Port"