### PR TITLE
EC2: Remove internal Network Interface traces from the Subnet after deletion

### DIFF
--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -204,6 +204,8 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
 
     def delete(self) -> None:
         self.ec2_backend.delete_network_interface(eni_id=self.id)
+        for priv_ip in self.private_ip_addresses:
+            self.subnet.del_subnet_ip(priv_ip["PrivateIpAddress"])
 
     def stop(self) -> None:
         if self.public_ip_auto_assign:


### PR DESCRIPTION
Hello! Issue #7896 was not completely fixed, the test code in the bug report did not run completely through. The fixed IP address of the deleted instance was still kept in an internal field of the Subnet, so that another instance with the same IP address could not get created.
I tried fixing this, and added a test. All EC2 tests pass, except two that seem unrelated and also fail for me on current master (one in test_availability_zones_and_regions.py and one in test_security_groups.py).
Thanks!