### PR TITLE
IOTData: Simplify delta calculation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ all =
     jsonschema
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
-    jsondiff>=1.1.2
     py-partiql-parser==0.5.6
     aws-xray-sdk!=0.96,>=0.93
     setuptools
@@ -70,7 +69,6 @@ proxy =
     cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
-    jsondiff>=1.1.2
     py-partiql-parser==0.5.6
     aws-xray-sdk!=0.96,>=0.93
     setuptools
@@ -85,7 +83,6 @@ server =
     cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
-    jsondiff>=1.1.2
     py-partiql-parser==0.5.6
     aws-xray-sdk!=0.96,>=0.93
     setuptools
@@ -120,7 +117,6 @@ cloudformation =
     cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
-    jsondiff>=1.1.2
     py-partiql-parser==0.5.6
     aws-xray-sdk!=0.96,>=0.93
     setuptools
@@ -173,7 +169,7 @@ guardduty =
 iam =
 inspector2 =
 iot =
-iotdata = jsondiff>=1.1.2
+iotdata =
 ivs =
 kinesis =
 kinesisvideo =
@@ -209,7 +205,6 @@ resourcegroupstaggingapi =
     cfn-lint>=0.40.0
     openapi-spec-validator>=0.5.0
     pyparsing>=3.0.7
-    jsondiff>=1.1.2
     py-partiql-parser==0.5.6
 route53 =
 route53resolver =

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -196,6 +196,7 @@ def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
 @pytest.mark.parametrize(
     "desired,initial_delta,reported,delta_after_report",
     [
+        # Boolean flip
         (
             {"desired": {"online": True}},
             {"desired": {"online": True}, "delta": {"online": True}},
@@ -215,13 +216,33 @@ def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
                 "reported": {"online": False, "enabled": True},
             },
         ),
+        # No data
         ({}, {}, {"reported": {"online": False}}, {"reported": {"online": False}}),
+        # Missing data
         ({}, {}, {"reported": {"online": None}}, {}),
         (
             {"desired": {}},
             {},
             {"reported": {"online": False}},
             {"reported": {"online": False}},
+        ),
+        # Missing key
+        (
+            {"desired": {"enabled": True}},
+            {"desired": {"enabled": True}, "delta": {"enabled": True}},
+            {"reported": {}},
+            {"desired": {"enabled": True}, "delta": {"enabled": True}},
+        ),
+        # Changed key
+        (
+            {"desired": {"enabled": True}},
+            {"desired": {"enabled": True}, "delta": {"enabled": True}},
+            {"reported": {"online": True}},
+            {
+                "desired": {"enabled": True},
+                "reported": {"online": True},
+                "delta": {"enabled": True},
+            },
         ),
         # Remove from list
         (
@@ -276,6 +297,26 @@ def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
                 "delta": {"a": {"b": {"c": "d2"}}},
                 "desired": {"a": {"b": {"c": "d2"}}},
                 "reported": {"a": {"b": {"c": "d", "e": "f"}}},
+            },
+        ),
+        (
+            {"reported": {"a1": {"b1": {"c": "d"}}}},
+            {"reported": {"a1": {"b1": {"c": "d"}}}},
+            {"desired": {"a1": {"b1": {"c": "d"}}, "a2": {"b2": "sth"}}},
+            {
+                "delta": {"a2": {"b2": "sth"}},
+                "desired": {"a1": {"b1": {"c": "d"}}, "a2": {"b2": "sth"}},
+                "reported": {"a1": {"b1": {"c": "d"}}},
+            },
+        ),
+        (
+            {"reported": {"a": {"b1": {"c": "d"}}}},
+            {"reported": {"a": {"b1": {"c": "d"}}}},
+            {"desired": {"a": {"b1": {"c": "d"}, "b2": "sth"}}},
+            {
+                "delta": {"a": {"b2": "sth"}},
+                "desired": {"a": {"b1": {"c": "d"}, "b2": "sth"}},
+                "reported": {"a": {"b1": {"c": "d"}}},
             },
         ),
     ],


### PR DESCRIPTION
Fixes #8408 

Computing the delta using `jsondiff` was introduced in the very beginning: https://github.com/getmoto/moto/pull/1303, and further 'improved' with #7814 and #8342

Trying to mangle `jsondiff` into making it behave the way we wanted introduced more problems then it solved though, so this PR simplifies the implementation to compute the delta manually (which turns out to be fairly straightforward). 