### PR TITLE
chore: Fixed workflow to prevent terraform tests from failing

### DIFF
--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -23,7 +23,7 @@ jobs:
           echo "folders=$folders" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: find-jobs
     strategy:
       fail-fast: false
@@ -44,6 +44,8 @@ jobs:
         python -m build
         docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
         python scripts/ci_wait_for_server.py
+    - name: Set up Terraform
+      uses: hashicorp/setup-terraform@v3
     - name: Run tests
       if: ${{ matrix.service != 'rds' }}
       run: |

--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -23,7 +23,7 @@ jobs:
           echo "folders=$folders" >> $GITHUB_OUTPUT
 
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: find-jobs
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently, ubuntu-latest is specified as the Runner in Git Hub Actions, but ubuntu-latest will soon be changed to point to ubuntu-24.04.

The ubuntu-24.04 Runner does not have a built-in Terraform command, so terraform tests will suddenly fail one day.



- https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/
- https://github.com/actions/runner-images/issues/10636



I used a forked repository to perform the following tests.

- I explicitly specified ubuntu-24.04 at the `runs-on` and confirmed that the test failed.
    - https://github.com/cm-iwata/moto/actions/runs/12453251643/job/34763159915
- I then added a step to setup Terraform and confirmed that the test was successful.
    - https://github.com/cm-iwata/moto/actions/runs/12453304689/job/34763283277