### PR TITLE
Add short project description in package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = moto
 version = 5.0.25.dev
+description = A library that allows you to easily mock out tests based on AWS infrastructure
 long_description = file:README.md
 long_description_content_type = text/markdown
 author = Steve Pulec


### PR DESCRIPTION
Just a minuscule addition to package metadata, which is shown in places like the PyPI project page (https://pypi.org/project/moto/) or in the output of some tools, such as `poetry show`.
