### PR TITLE
RDS: Allow more db-instance operations in custom subnets

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2065,14 +2065,14 @@ class RDSBackend(BaseBackend):
             db_instance_identifier=source_db_identifier
         )[0]
 
-        # remove the db subnet group as it cannot be copied
-        # and is not used in the restored instance
-        source_dict = db_instance.__dict__
-        if "db_subnet_group" in source_dict:
-            del source_dict["db_subnet_group"]
+        new_instance_props = {}
+        for key, value in db_instance.__dict__.items():
+            # Remove backend / db subnet group as they cannot be copied
+            # and are not used in the restored instance.
+            if key in ("backend", "db_subnet_group"):
+                continue
+            new_instance_props[key] = copy.deepcopy(value)
 
-        new_instance_props = copy.deepcopy(source_dict)
-        new_instance_props.pop("backend")
         if not db_instance.option_group_supplied:
             # If the option group is not supplied originally, the 'option_group_name' will receive a default value
             # Force this reconstruction, and prevent any validation on the default value

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2005,7 +2005,7 @@ class RDSBackend(BaseBackend):
                 "You must specify apply immediately when rotating the master user password.",
             )
         database.update(db_kwargs)
-        initial_state = copy.deepcopy(database)
+        initial_state = copy.copy(database)
         database.master_user_secret_status = (
             "active"  # already set the final state in the background
         )

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1424,9 +1424,18 @@ def test_restore_db_instance_from_db_snapshot(
     )
 
 
+@pytest.mark.parametrize(
+    "custom_db_subnet_group", [True, False], ids=("custom_subnet", "default_subnet")
+)
 @mock_aws
-def test_restore_db_instance_to_point_in_time():
+def test_restore_db_instance_to_point_in_time(custom_db_subnet_group: bool):
     conn = boto3.client("rds", region_name=DEFAULT_REGION)
+
+    if custom_db_subnet_group:
+        extra_kwargs = {"DBSubnetGroupName": create_db_subnet_group()}
+    else:
+        extra_kwargs = {}
+
     conn.create_db_instance(
         DBInstanceIdentifier="db-primary-1",
         AllocatedStorage=10,
@@ -1436,6 +1445,7 @@ def test_restore_db_instance_to_point_in_time():
         MasterUsername="root",
         MasterUserPassword="hunter2",
         DBSecurityGroups=["my_sg"],
+        **extra_kwargs,
     )
     assert len(conn.describe_db_instances()["DBInstances"]) == 1
 

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -551,9 +551,18 @@ def test_describe_non_existent_database():
         conn.describe_db_instances(DBInstanceIdentifier="not-a-db")
 
 
+@pytest.mark.parametrize(
+    "custom_db_subnet_group", [True, False], ids=("custom_subnet", "default_subnet")
+)
 @mock_aws
-def test_modify_db_instance():
+def test_modify_db_instance(custom_db_subnet_group: bool):
     conn = boto3.client("rds", region_name=DEFAULT_REGION)
+
+    if custom_db_subnet_group:
+        extra_kwargs = {"DBSubnetGroupName": create_db_subnet_group()}
+    else:
+        extra_kwargs = {}
+
     conn.create_db_instance(
         DBInstanceIdentifier="db-id",
         AllocatedStorage=10,
@@ -563,6 +572,7 @@ def test_modify_db_instance():
         MasterUserPassword="hunter2",
         Port=1234,
         DBSecurityGroups=["my_sg"],
+        **extra_kwargs,
     )
     inst = conn.describe_db_instances(DBInstanceIdentifier="db-id")["DBInstances"][0]
     assert inst["AllocatedStorage"] == 10


### PR DESCRIPTION
Follow up to #8374 that fixes a new `deepcopy` call from #8373 in `modify_db_instance` and another one in `restore_db_instance_to_point_in_time`. Previously, this failed with

`TypeError: cannot pickle 'generator' object`
