### PR TITLE
DynamoDB: transact_write_items() now validates empty ExpressionAttrib…

### DIFF
--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -121,6 +121,11 @@ class ExpressionAttributeValueNotDefined(InvalidUpdateExpression):
         )
 
 
+class ExpressionAttributeValuesEmpty(MockValidationException):
+    def __init__(self) -> None:
+        super().__init__("ExpressionAttributeValues must not be empty")
+
+
 class UpdateExprSyntaxError(InvalidUpdateExpression):
     update_expr_syntax_error_msg = "Syntax error; {error_detail}"
 


### PR DESCRIPTION
…uteValues

Fixes #8405 