### PR TITLE
DynamoDB: KeyConditionExpression can have additional parentheses

### DIFF
--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -164,6 +164,10 @@ def parse_expression(
             # (hash_key = :id) and (sortkey = :sk)
             #                     ^
             if current_stage in [EXPRESSION_STAGES.INITIAL_STAGE]:
+                if not current_phrase:
+                    # hashkey = :id and (begins_with(sortkey, :sk))
+                    #                   ^
+                    continue
                 if current_phrase not in ["begins_with", ""]:
                     raise MockValidationException(
                         f"Invalid KeyConditionExpression: Invalid function name; function: {current_phrase}"


### PR DESCRIPTION
Fixes #8414 