### PR TITLE
Admin: Ruff formatting

### DIFF
--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -116,7 +116,7 @@ class StepFunctionResponse(BaseResponse):
         )
         response = {"updateDate": state_machine.update_date}
         if publish:
-            response["stateMachineVersionArn"] = state_machine.latest_version.arn # type: ignore
+            response["stateMachineVersionArn"] = state_machine.latest_version.arn  # type: ignore
         return 200, {}, json.dumps(response)
 
     def list_tags_for_resource(self) -> TYPE_RESPONSE:


### PR DESCRIPTION
Ruff complains about the formatting of a `type: ignore` all of a sudden.

I've tried upgrading ruff, which would improve the formatting - but the new formatting is not compatible with Python 3.8. So we can't do that yet.