### PR TITLE
EC2: Fix SecurityGroup ARN

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -155,7 +155,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         self.owner_id = ec2_backend.account_id
         self.add_tags(tags or {})
         self.is_default = is_default or False
-        self.arn = f"arn:aws:ec2:{ec2_backend.account_id}:{ec2_backend.region_name}:security-group/{group_id}"
+        self.arn = f"arn:aws:ec2:{ec2_backend.region_name}:{ec2_backend.account_id}:security-group/{group_id}"
 
         # Append default IPv6 egress rule for VPCs with IPv6 support
         if vpc_id:

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -85,7 +85,9 @@ def test_create_and_describe_vpc_security_group():
 
     assert group_with.group_name == name
     assert group_with.description == "test"
-    assert group_with.security_group_arn
+    assert group_with.security_group_arn.startswith(
+        f"arn:aws:ec2:{REGION}:{DEFAULT_ACCOUNT_ID}:security-group/sg-"
+    )
 
     # Trying to create another group with the same name in the same VPC should
     # throw an error


### PR DESCRIPTION
https://github.com/getmoto/moto/pull/8393 introduced the SecurityGroupArn field to supported operations, however the format of the ARN was incorrect. The correct format is:

```
arn:${Partition}:ec2:${Region}:${Account}:security-group/${SecurityGroupId}
```

https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-resources-for-iam-policies

cc: @pinzon 