### PR TITLE
RDS: Check if new instance ID already exists

### DIFF
--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -27,6 +27,11 @@ class DBInstanceNotFoundError(RDSClientError):
         )
 
 
+class DBInstanceAlreadyExists(RDSClientError):
+    def __init__(self) -> None:
+        super().__init__("DBInstanceAlreadyExists", "DB instance already exists")
+
+
 class DBSnapshotNotFoundError(RDSClientError):
     def __init__(self, snapshot_identifier: str):
         super().__init__(

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -994,9 +994,6 @@ def test_restore_db_instance_from_db_snapshot(
         db_subnet_group_name = create_db_subnet_group()
 
     # restore
-    new_instance = client.restore_db_instance_from_db_snapshot(
-        DBInstanceIdentifier="db-restore-1", DBSnapshotIdentifier=db_snapshot_identifier
-    )["DBInstance"]
     kwargs = {
         "DBInstanceIdentifier": "db-restore-1",
         "DBSnapshotIdentifier": db_snapshot_identifier,


### PR DESCRIPTION
When creating a new RDS instance, check if an instance with the same instance identifier already exists and raise an error in that case, just like real AWS does.