### PR TITLE
Scheduler: Fix Exception code/format and default timezone

### DIFF
--- a/moto/scheduler/exceptions.py
+++ b/moto/scheduler/exceptions.py
@@ -9,6 +9,8 @@ class ScheduleExists(JsonRESTError):
 
 
 class ScheduleNotFound(JsonRESTError):
+    code = 404
+
     def __init__(self, name: str) -> None:
         super().__init__(
             "ResourceNotFoundException", f"Schedule {name} does not exist."
@@ -16,6 +18,8 @@ class ScheduleNotFound(JsonRESTError):
 
 
 class ScheduleGroupNotFound(JsonRESTError):
+    code = 404
+
     def __init__(self) -> None:
         super().__init__("ResourceNotFoundException", "ScheduleGroup not found")
 

--- a/moto/scheduler/exceptions.py
+++ b/moto/scheduler/exceptions.py
@@ -20,8 +20,10 @@ class ScheduleNotFound(JsonRESTError):
 class ScheduleGroupNotFound(JsonRESTError):
     code = 404
 
-    def __init__(self) -> None:
-        super().__init__("ResourceNotFoundException", "ScheduleGroup not found")
+    def __init__(self, name: str) -> None:
+        super().__init__(
+            "ResourceNotFoundException", f"Schedule group {name} does not exist."
+        )
 
 
 class ValidationException(JsonRESTError):

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -273,7 +273,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
 
     def get_schedule_group(self, group_name: Optional[str]) -> ScheduleGroup:
         if (group_name or "default") not in self.schedule_groups:
-            raise ScheduleGroupNotFound
+            raise ScheduleGroupNotFound(group_name or "default")
         return self.schedule_groups[group_name or "default"]
 
     def list_schedule_groups(self) -> Iterable[ScheduleGroup]:

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -40,7 +40,7 @@ class Schedule(BaseModel):
         self.description = description
         self.arn = f"arn:{get_partition(region)}:scheduler:{region}:{account_id}:schedule/{group_name}/{name}"
         self.schedule_expression = schedule_expression
-        self.schedule_expression_timezone = schedule_expression_timezone
+        self.schedule_expression_timezone = schedule_expression_timezone or "UTC"
         self.flexible_time_window = flexible_time_window
         self.target = Schedule.validate_target(target)
         self.state = state or "ENABLED"
@@ -110,7 +110,7 @@ class Schedule(BaseModel):
         target: Dict[str, Any],
     ) -> None:
         self.schedule_expression = schedule_expression
-        self.schedule_expression_timezone = schedule_expression_timezone
+        self.schedule_expression_timezone = schedule_expression_timezone or "UTC"
         self.flexible_time_window = flexible_time_window
         self.target = Schedule.validate_target(target)
         self.description = description

--- a/tests/test_scheduler/test_schedule_groups.py
+++ b/tests/test_scheduler/test_schedule_groups.py
@@ -46,3 +46,15 @@ def test_list_schedule_groups():
     groups = client.list_schedule_groups()["ScheduleGroups"]
     assert len(groups) == 2
     assert groups[1]["Arn"] == arn1
+
+
+@mock_aws
+def test_get_schedule_groupe_not_found():
+    client = boto3.client("scheduler", region_name="eu-west-1")
+
+    with pytest.raises(ClientError) as exc:
+        client.get_schedule_group(Name="sg")
+    err = exc.value.response["Error"]
+    assert err["Message"] == "Schedule group sg does not exist."
+    assert err["Code"] == "ResourceNotFoundException"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -189,6 +189,7 @@ def test_get_schedule_for_none_existing_schedule():
     err = exc.value.response["Error"]
     assert err["Code"] == "ResourceNotFoundException"
     assert err["Message"] == "Schedule my-schedule does not exist."
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
 
 
 @mock_aws


### PR DESCRIPTION

Service: Event Bridge Scheduler

During extending our test coverage (in this PR: https://github.com/localstack/localstack/pull/12114) we noticed, that there is a slight discrepancy between AWS responses and MOTO responses.
This PR introduces the fixes for the response status code, as well as the response message for scheduler groups.
In addition, it also adds tests in moto for these new changes. 