### PR TITLE
RDS: Allow copy_db_cluster_snapshot() for deleted cluster

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2537,6 +2537,25 @@ class RDSBackend(BaseBackend):
             db_cluster_identifier, db_snapshot_identifier, snapshot_type="automated"
         )
 
+    def _create_db_cluster_snapshot(
+        self,
+        cluster: DBCluster,
+        db_snapshot_identifier: str,
+        snapshot_type: str,
+        tags: List[Dict[str, str]],
+    ) -> DBClusterSnapshot:
+        if db_snapshot_identifier in self.cluster_snapshots:
+            raise DBClusterSnapshotAlreadyExistsError(db_snapshot_identifier)
+        if len(self.cluster_snapshots) >= int(
+            os.environ.get("MOTO_RDS_SNAPSHOT_LIMIT", "100")
+        ):
+            raise SnapshotQuotaExceededError()
+        snapshot = DBClusterSnapshot(
+            self, cluster, db_snapshot_identifier, snapshot_type, tags
+        )
+        self.cluster_snapshots[db_snapshot_identifier] = snapshot
+        return snapshot
+
     def create_db_cluster_snapshot(
         self,
         db_cluster_identifier: str,
@@ -2547,21 +2566,14 @@ class RDSBackend(BaseBackend):
         cluster = self.clusters.get(db_cluster_identifier)
         if cluster is None:
             raise DBClusterNotFoundError(db_cluster_identifier)
-        if db_snapshot_identifier in self.cluster_snapshots:
-            raise DBClusterSnapshotAlreadyExistsError(db_snapshot_identifier)
-        if len(self.cluster_snapshots) >= int(
-            os.environ.get("MOTO_RDS_SNAPSHOT_LIMIT", "100")
-        ):
-            raise SnapshotQuotaExceededError()
         if tags is None:
             tags = list()
         if cluster.copy_tags_to_snapshot:
             tags += cluster.get_tags()
-        snapshot = DBClusterSnapshot(
-            self, cluster, db_snapshot_identifier, snapshot_type, tags
+
+        return self._create_db_cluster_snapshot(
+            cluster, db_snapshot_identifier, snapshot_type, tags
         )
-        self.cluster_snapshots[db_snapshot_identifier] = snapshot
-        return snapshot
 
     def copy_db_cluster_snapshot(
         self,
@@ -2577,10 +2589,9 @@ class RDSBackend(BaseBackend):
             tags = source_snapshot.tags
         else:
             tags = self._merge_tags(source_snapshot.tags, tags)
-        return self.create_db_cluster_snapshot(
-            db_cluster_identifier=source_snapshot.cluster.db_cluster_identifier,  # type: ignore
-            db_snapshot_identifier=target_snapshot_identifier,
-            tags=tags,
+
+        return self._create_db_cluster_snapshot(
+            source_snapshot.cluster, target_snapshot_identifier, "manual", tags
         )
 
     def delete_db_cluster_snapshot(

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -850,6 +850,25 @@ def test_copy_db_snapshots(
 
 
 @mock_aws
+def test_copy_db_snapshots_snapshot_type_is_always_manual(client):
+    # Even when copying a snapshot with SnapshotType=="automated", the
+    # SnapshotType of the copy is "manual".
+    db_instance_identifier = create_db_instance()["DBInstanceIdentifier"]
+    client.delete_db_instance(
+        DBInstanceIdentifier=db_instance_identifier,
+        FinalDBSnapshotIdentifier="final-snapshot",
+    )
+    snapshot1 = client.describe_db_snapshots()["DBSnapshots"][0]
+    assert snapshot1["SnapshotType"] == "automated"
+
+    snapshot2 = client.copy_db_snapshot(
+        SourceDBSnapshotIdentifier="final-snapshot",
+        TargetDBSnapshotIdentifier="snapshot-2",
+    )["DBSnapshot"]
+    assert snapshot2["SnapshotType"] == "manual"
+
+
+@mock_aws
 def test_copy_db_snapshot_invalid_arns(client):
     invalid_arn = (
         f"arn:aws:rds:{DEFAULT_REGION}:123456789012:this-is-not-a-snapshot:snapshot-1"

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -594,6 +594,25 @@ def test_copy_db_cluster_snapshot(delete_cluster: bool, client):
 
 
 @mock_aws
+def test_copy_db_cluster_snapshot_type_is_always_manual(client):
+    # Even when copying a snapshot with SnapshotType=="automated", the
+    # SnapshotType of the copy is "manual".
+    db_cluster_identifier = create_db_cluster()
+    client.delete_db_cluster(
+        DBClusterIdentifier=db_cluster_identifier,
+        FinalDBSnapshotIdentifier="final-snapshot",
+    )
+    snapshot1 = client.describe_db_cluster_snapshots()["DBClusterSnapshots"][0]
+    assert snapshot1["SnapshotType"] == "automated"
+
+    snapshot2 = client.copy_db_cluster_snapshot(
+        SourceDBClusterSnapshotIdentifier="final-snapshot",
+        TargetDBClusterSnapshotIdentifier="snapshot-2",
+    )["DBClusterSnapshot"]
+    assert snapshot2["SnapshotType"] == "manual"
+
+
+@mock_aws
 def test_copy_db_cluster_snapshot_fails_for_existed_target_snapshot(client):
     db_cluster_identifier = create_db_cluster()
     client.create_db_cluster_snapshot(

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -567,13 +567,17 @@ def test_copy_db_cluster_snapshot_fails_for_unknown_snapshot(client):
     assert err["Message"] == "DBClusterSnapshot snapshot-1 not found."
 
 
+@pytest.mark.parametrize("delete_cluster", [True, False])
 @mock_aws
-def test_copy_db_cluster_snapshot(client):
+def test_copy_db_cluster_snapshot(delete_cluster: bool, client):
     db_cluster_identifier = create_db_cluster()
     client.create_db_cluster_snapshot(
         DBClusterIdentifier=db_cluster_identifier,
         DBClusterSnapshotIdentifier="snapshot-1",
     ).get("DBClusterSnapshot")
+
+    if delete_cluster:
+        client.delete_db_cluster(DBClusterIdentifier=db_cluster_identifier)
 
     target_snapshot = client.copy_db_cluster_snapshot(
         SourceDBClusterSnapshotIdentifier="snapshot-1",


### PR DESCRIPTION
Make it possible to call `copy_db_cluster_snapshot()` even when the original cluster was already deleted. A similar bug was fixed in #7392, but for normal RDS instances. This also fixes it for RDS clusters.

While implementing the new code, I wondered what happens when a snapshot with `SnapshotType=="automated"` gets copied. Does the copy have the same property (because it was copied) or does it have `SnapshotType=="manual"` because the snapshot was manually created? Turns out the latter is true, and this is correctly implemented by moto. But there weren't any test cases for this, so the second commit adds them.