### PR TITLE
Ensure compatibility with latest `botocore` S3 client customizations

### DIFF
--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -7,7 +7,11 @@ from urllib.parse import urlparse
 
 import requests
 from botocore.awsrequest import AWSPreparedRequest
-from botocore.httpchecksum import AwsChunkedWrapper
+
+try:
+    from botocore.httpchecksum import AwsChunkedWrapper
+except ImportError:
+    AwsChunkedWrapper = None
 
 
 class Recorder:

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -34,7 +34,7 @@ class Recorder:
 
         if body is None:
             if isinstance(request, AWSPreparedRequest):
-                body = request.body
+                body = request.body  # type: ignore
                 if isinstance(request.body, AwsChunkedWrapper):
                     body = request.body.read()
                 body_str, body_encoded = self._encode_body(body)

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -33,9 +33,10 @@ class Recorder:
 
         if body is None:
             if isinstance(request, AWSPreparedRequest):
-                body = request.body  # type: ignore
                 if hasattr(request.body, "read"):
-                    body = request.body.read()
+                    body = request.body.read()  # type: ignore
+                else:
+                    body = request.body  # type: ignore
                 body_str, body_encoded = self._encode_body(body)
             else:
                 try:

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -8,11 +8,6 @@ from urllib.parse import urlparse
 import requests
 from botocore.awsrequest import AWSPreparedRequest
 
-try:
-    from botocore.httpchecksum import AwsChunkedWrapper
-except ModuleNotFoundError:
-    AwsChunkedWrapper = None
-
 
 class Recorder:
     def __init__(self) -> None:
@@ -39,7 +34,7 @@ class Recorder:
         if body is None:
             if isinstance(request, AWSPreparedRequest):
                 body = request.body  # type: ignore
-                if isinstance(request.body, AwsChunkedWrapper):
+                if hasattr(request.body, "read"):
                     body = request.body.read()
                 body_str, body_encoded = self._encode_body(body)
             else:

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 import requests
 from botocore.awsrequest import AWSPreparedRequest
+from botocore.httpchecksum import AwsChunkedWrapper
 
 
 class Recorder:
@@ -33,7 +34,10 @@ class Recorder:
 
         if body is None:
             if isinstance(request, AWSPreparedRequest):
-                body_str, body_encoded = self._encode_body(body=request.body)
+                body = request.body
+                if isinstance(request.body, AwsChunkedWrapper):
+                    body = request.body.read()
+                body_str, body_encoded = self._encode_body(body)
             else:
                 try:
                     request_body = None

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -10,7 +10,7 @@ from botocore.awsrequest import AWSPreparedRequest
 
 try:
     from botocore.httpchecksum import AwsChunkedWrapper
-except ImportError:
+except ModuleNotFoundError:
     AwsChunkedWrapper = None
 
 

--- a/moto/moto_proxy/proxy3.py
+++ b/moto/moto_proxy/proxy3.py
@@ -155,12 +155,12 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
             return
 
         req_body = b""
-        if "Content-Length" in req.headers:
-            content_length = int(req.headers["Content-Length"])
-            req_body = self.rfile.read(content_length)
-        elif "chunked" in self.headers.get("Transfer-Encoding", ""):
+        if "chunked" in self.headers.get("Transfer-Encoding", ""):
             # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
             req_body = self.read_chunked_body(self.rfile)
+        elif "Content-Length" in req.headers:
+            content_length = int(req.headers["Content-Length"])
+            req_body = self.rfile.read(content_length)
         if self.headers.get("Content-Type", "").startswith("multipart/form-data"):
             boundary = self.headers["Content-Type"].split("boundary=")[-1]
             req_body, form_data = get_body_from_form_data(req_body, boundary)  # type: ignore

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -184,6 +184,12 @@ class S3Response(BaseResponse):
         self.bucket_name = self.parse_bucket_name_from_url(request, full_url)
         self.request = request
         if (
+            not self.body
+            and request.headers.get("Content-Encoding", "") == "aws-chunked"
+            and hasattr(request, "input_stream")
+        ):
+            self.body = request.input_stream.getvalue()
+        if (
             self.request.headers.get("x-amz-content-sha256")
             == "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
         ):

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1347,6 +1347,8 @@ class S3Response(BaseResponse):
 
     def _handle_encoded_body(self, body: bytes) -> bytes:
         decoded_body = b""
+        if not body:
+            return decoded_body
         body_io = io.BytesIO(body)
         # first line should equal '{content_length}\r\n' while the content_length is a hex number
         content_length = int(body_io.readline().strip(), 16)

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1771,6 +1771,8 @@ class S3Response(BaseResponse):
             checksum_value = compute_checksum(
                 self.raw_body, algorithm=checksum_algorithm
             )
+            if isinstance(checksum_value, bytes):
+                checksum_value = checksum_value.decode("utf-8")
             response_headers.update({checksum_header: checksum_value})
         return checksum_algorithm, checksum_value
 

--- a/tests/test_s3/__init__.py
+++ b/tests/test_s3/__init__.py
@@ -81,3 +81,12 @@ def empty_bucket(client, bucket_name):
         client.delete_object(
             Bucket=bucket_name, Key=key["Key"], VersionId=key.get("VersionId"), **kwargs
         )
+
+
+def generate_content_md5(content: bytes) -> str:
+    import base64
+    import hashlib
+
+    md = hashlib.md5(content).digest()
+    content_md5 = base64.b64encode(md).decode("utf-8")
+    return content_md5

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1076,7 +1076,7 @@ def test_setting_content_encoding():
     bucket.put_object(Body=b"abcdef", ContentEncoding="gzip", Key="keyname")
 
     key = s3_resource.Object("mybucket", "keyname")
-    assert key.content_encoding == "gzip"
+    assert "gzip" in key.content_encoding
 
 
 @mock_aws
@@ -1626,8 +1626,8 @@ def test_list_objects_v2_checksum_algo():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     s3_client.create_bucket(Bucket="mybucket")
     resp = s3_client.put_object(Bucket="mybucket", Key="0", Body="a")
-    assert "ChecksumCRC32" not in resp
-    assert "x-amz-sdk-checksum-algorithm" not in resp["ResponseMetadata"]["HTTPHeaders"]
+    # Default checksum behavior varies by boto3 version and will not be asserted here.
+    assert resp
     resp = s3_client.put_object(
         Bucket="mybucket", Key="1", Body="a", ChecksumAlgorithm="CRC32"
     )
@@ -1646,7 +1646,7 @@ def test_list_objects_v2_checksum_algo():
     )
 
     resp = s3_client.list_objects_v2(Bucket="mybucket")["Contents"]
-    assert "ChecksumAlgorithm" not in resp[0]
+    assert "ChecksumAlgorithm" in resp[0]
     assert resp[1]["ChecksumAlgorithm"] == ["CRC32"]
     assert resp[2]["ChecksumAlgorithm"] == ["SHA256"]
 

--- a/tests/test_s3/test_s3_copyobject.py
+++ b/tests/test_s3/test_s3_copyobject.py
@@ -7,6 +7,7 @@ from botocore.client import ClientError
 
 from moto import mock_aws
 from moto.s3.responses import DEFAULT_REGION_NAME
+from tests.test_s3 import generate_content_md5
 from tests.test_s3.test_s3 import enable_versioning
 
 from . import s3_aws_verified
@@ -656,6 +657,7 @@ def test_copy_objet_legal_hold():
         Key=source_key,
         Body=b"somedata",
         ObjectLockLegalHoldStatus="ON",
+        ContentMD5=generate_content_md5(b"somedata"),
     )
 
     head_object = client.head_object(Bucket=bucket_name, Key=source_key)
@@ -692,9 +694,10 @@ def test_s3_copy_object_lock():
     client.put_object(
         Bucket=bucket_name,
         Key=source_key,
-        Body="test",
+        Body=b"test",
         ObjectLockMode="GOVERNANCE",
         ObjectLockRetainUntilDate=retain_until,
+        ContentMD5=generate_content_md5(b"test"),
     )
 
     head_object = client.head_object(Bucket=bucket_name, Key=source_key)
@@ -909,12 +912,11 @@ def test_copy_object_calculates_checksum(algorithm, checksum):
 
     checksum_key = f"Checksum{algorithm}"
 
-    resp = client.put_object(
+    client.put_object(
         Bucket=bucket,
         Key=source_key,
         Body=body,
     )
-    assert checksum_key not in resp
 
     resp = client.copy_object(
         Bucket=bucket,

--- a/tests/test_s3/test_s3_object_attributes.py
+++ b/tests/test_s3/test_s3_object_attributes.py
@@ -69,9 +69,6 @@ class TestS3ObjectAttributes:
         )
         resp.pop("ResponseMetadata")
 
-        # Checksum is not returned, because it's not set
-        assert set(resp.keys()) == {"LastModified"}
-
         # Retrieve checksum from key that was created with CRC32
         resp = self.client.get_object_attributes(
             Bucket=self.bucket_name, Key="cs", ObjectAttributes=["Checksum"]


### PR DESCRIPTION
The latest version of `botocore` adds some customizations to the S3 client that break some of our S3 tests:

* S3 client behavior is updated to always calculate a CRC32 checksum by default for operations that support it (such as PutObject or UploadPart), or require it (such as DeleteObjects). 
* Botocore will no longer automatically compute and populate the Content-MD5 header.

This PR removes assertions around the default checksum behavior (as it now varies across `botocore` versions).  It also manually supplies the `ContentMD5` parameter for API calls that require it, as `botocore` no longer automatically computes it.

This PR also contains minor `request.body` processing tweaks for S3 as well as during `proxy` or `recording` mode, due to the new `aws-chunked` encoding and the `AwsChunkedWrapper` object that now wraps some S3 request bodies sent from boto3/botocore. 

> [!NOTE]  
> This PR fixes the `moto` build breakages that occurred as a result of the new "default integrity protections" introduced in the AWS SDK for Python v1.36.0.  It also maintains existing compatibility with earlier SDK versions.  There may be additional issues encountered by users of `moto` as a result of these AWS changes, which will have to be addressed in subsequent PRs as they arise.

Ref: https://github.com/boto/boto3/issues/4392
Ref: https://github.com/boto/botocore/commit/590103bde8c18174afb9d17970c7e3d2520ca25a