### PR TITLE
Resolve `pytest` warning

### DIFF
--- a/tests/test_utilities/test_id_generator.py
+++ b/tests/test_utilities/test_id_generator.py
@@ -28,6 +28,8 @@ def generate_test_id(
 
 
 class TestResourceIdentifier(ResourceIdentifier):
+    __test__ = False  # Prevent pytest discovery
+
     service = SERVICE
     resource = RESOURCE
 


### PR DESCRIPTION
Pytest will attempt to collect test cases from any class whose name starts with "test", so we have to explicitly mark this class as not a test.