### PR TITLE
Silence `utcnow` deprecation warnings from `botocore`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"
+filterwarnings = [
+    # https://github.com/boto/boto3/issues/3889#issuecomment-2578155761
+    "ignore:datetime.datetime.utcnow:DeprecationWarning:botocore"
+]
 markers = [
     "network: requires network connection",
     "requires_docker: requires running docker",


### PR DESCRIPTION
This warning is needlessly filling up the CI logs and is safe to ignore.