### PR TITLE
Organizations: return organization roots for requests made by other accounts within the organization

### DIFF
--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -482,7 +482,16 @@ class OrganizationsBackend(BaseBackend):
         self._reset()
 
     def list_roots(self) -> Dict[str, Any]:
-        return dict(Roots=[ou.describe() for ou in self.ou if isinstance(ou, FakeRoot)])
+        if self.org:
+            return dict(Roots=[ou.describe() for ou in self.ou if isinstance(ou, FakeRoot)])
+
+        if self.account_id in organizations_backends.master_accounts:
+            master_account_id, partition = organizations_backends.master_accounts[
+                self.account_id
+            ]
+            return organizations_backends[master_account_id][partition].list_roots()
+
+        raise AWSOrganizationsNotInUseException
 
     def create_organizational_unit(self, **kwargs: Any) -> Dict[str, Any]:
         new_ou = FakeOrganizationalUnit(self.org, **kwargs)  # type: ignore

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -483,7 +483,9 @@ class OrganizationsBackend(BaseBackend):
 
     def list_roots(self) -> Dict[str, Any]:
         if self.org:
-            return dict(Roots=[ou.describe() for ou in self.ou if isinstance(ou, FakeRoot)])
+            return dict(
+                Roots=[ou.describe() for ou in self.ou if isinstance(ou, FakeRoot)]
+            )
 
         if self.account_id in organizations_backends.master_accounts:
             master_account_id, partition = organizations_backends.master_accounts[


### PR DESCRIPTION
Default account is linked to the organization, whereas other accounts within the organization do not have this reference. This PR fixes this issue.

Once an organization is created and a member account is added, the member account can now retrieve the details of the root account by using the `ListRoots` API.

Plus, if a member account is not part of any organization, the `AWSOrganizationsNotInUseException` exception will be raised, as described in the [AWS documentation](https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListRoots.html).


This PR re-uses approach introduced in the #8260