### PR TITLE
Add test for `download_file` method of boto3 S3 client

### DIFF
--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -959,6 +959,30 @@ def test_upload_file_with_checksum_algorithm():
 
 
 @mock_aws
+def test_download_file(tmp_path):
+    random_bytes = (
+        b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00"
+        b"\x00\xff\n\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\n"
+    )
+    upload_file = tmp_path / "upload.txt"
+    with open(upload_file, mode="wb") as fp:
+        fp.write(random_bytes)
+    client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
+    bucket_name = "test-bucket"
+    object_keys = ["key-for-put-object", "key-for-upload-file"]
+    client.create_bucket(Bucket=bucket_name)
+    # Test both object upload methods.
+    client.put_object(Bucket=bucket_name, Key=object_keys[0], Body=random_bytes)
+    client.upload_file(upload_file, bucket_name, object_keys[1])
+    for object_key in object_keys:
+        download_file = tmp_path / f"download-{object_key}.txt"
+        client.download_file(bucket_name, object_key, download_file)
+        with open(download_file, mode="rb") as fp:
+            downloaded_content = fp.read()
+        assert downloaded_content == random_bytes
+
+
+@mock_aws
 def test_put_large_with_checksum_algorithm():
     s3_client = boto3.client("s3", region_name=DEFAULT_REGION_NAME)
     bucket = "mybucket"


### PR DESCRIPTION
No existing moto S3 tests utilize the `download_file` method of the boto3 S3 client.  

This has come up recently in #8498 and #8527, so this PR ensures that our tests explicitly cover this client call.