### PR TITLE
EC2: Require size/snapshot when creating EBS volume

### DIFF
--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -12,6 +12,7 @@ from ..exceptions import (
     InvalidVolumeAttachmentError,
     InvalidVolumeDetachmentError,
     InvalidVolumeIdError,
+    MissingParameterError,
     VolumeInUseError,
 )
 from ..utils import (
@@ -305,6 +306,10 @@ class EBSBackend:
                 size = snapshot.volume.size
             if snapshot.encrypted:
                 encrypted = snapshot.encrypted
+
+        if size is None:
+            raise MissingParameterError("size/snapshot")
+
         volume = Volume(
             self,
             volume_id=volume_id,

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -1198,3 +1198,17 @@ def test_modify_ebs_default_kms_key_id():
         KmsKeyId=new_default_key["Arn"]
     )["KmsKeyId"]
     assert new_default_ebs_key_arn != original_default_ebs_key_arn
+
+
+@mock_aws
+def test_create_volume_without_size():
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as ex:
+        ec2.create_volume(AvailabilityZone="us-east-1a")
+
+    assert ex.value.response["Error"]["Code"] == "MissingParameter"
+    assert (
+        ex.value.response["Error"]["Message"]
+        == "The request must contain the parameter size/snapshot"
+    )


### PR DESCRIPTION
Related to https://github.com/localstack/localstack/issues/11522