### PR TITLE
ELB: Port and protocol validations for create listener

### DIFF
--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from moto.core.exceptions import RESTError
 
@@ -209,3 +209,18 @@ class ValidationError(ELBClientError):
 class InvalidConfigurationRequest(ELBClientError):
     def __init__(self, msg: str):
         super().__init__("InvalidConfigurationRequest", msg)
+
+
+class InvalidProtocol(ELBClientError):
+    def __init__(self, protocol: str, valid_protocols: List[str]):
+        msg = f"Listener protocol '{protocol}' must be one of '{', '.join(valid_protocols)}'"
+        super().__init__("ValidationError", msg)
+
+
+class InvalidProtocolValue(ELBClientError):
+    def __init__(self, protocol: str, valid_protocols: List[str]):
+        msg = (
+            f"1 validation error detected: Value '{protocol}' at 'protocol' failed to satisfy constraint: "
+            f"Member must satisfy enum value set: [{', '.join(valid_protocols)}]"
+        )
+        super().__init__("ValidationError", msg)

--- a/other_langs/terraform/elb/load_balancer.tf
+++ b/other_langs/terraform/elb/load_balancer.tf
@@ -12,7 +12,7 @@ data "aws_subnets" "all" {
 resource "aws_lb" "this" {
   name                       = "nlb-test"
   internal                   = true
-  load_balancer_type         = "network"
+  load_balancer_type         = "application"
   subnets                    = data.aws_subnets.all.ids
   enable_deletion_protection = false
 }


### PR DESCRIPTION
When creating a listener, port and protocol should satisfy some conditions base on the load balancer type.

https://docs.aws.amazon.com/cli/latest/reference/elbv2/create-listener.html#options