### PR TITLE
EC2: Handle filtering without Values

### DIFF
--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -98,6 +98,10 @@ def filter_resources(
                 ):
                     result.remove(resource)
                     break
+            elif attrs[0] in filters:
+                # In case the filter exists but the value of the filter is empty, the filter shouldn't match
+                result.remove(resource)
+                break
     return result
 
 

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -77,6 +77,17 @@ def test_availability_zones__parameters():
     assert len(zones) == 1
     assert zones[0]["ZoneId"] == "use1-az1"
 
+    # This shouldn't raise an unhandled exception
+    zones = us_east.describe_availability_zones(Filters=[{"Name": "state"}])[
+        "AvailabilityZones"
+    ]
+    assert len(zones) == 0
+
+    zones = us_east.describe_availability_zones(
+        Filters=[{"Name": "state", "Values": []}]
+    )["AvailabilityZones"]
+    assert len(zones) == 0
+
 
 @mock_aws
 def test_describe_availability_zones_dryrun():

--- a/tests/test_ec2/test_subnets.py
+++ b/tests/test_ec2/test_subnets.py
@@ -330,6 +330,16 @@ def test_get_subnets_filtering():
         with pytest.raises(NotImplementedError):
             client.describe_subnets(Filters=filters)
 
+    # Filter without a Value.
+    subnets_with_invalid_filter = client.describe_subnets(Filters=[{"Name": "vpc-id"}])[
+        "Subnets"
+    ]
+    assert len(subnets_with_invalid_filter) == 0
+    subnets_with_invalid_filter = client.describe_subnets(
+        Filters=[{"Name": "vpc-id", "Values": []}]
+    )["Subnets"]
+    assert len(subnets_with_invalid_filter) == 0
+
 
 @mock_aws
 def test_create_subnet_response_fields():


### PR DESCRIPTION
When a filter is provided that doesn't have `Values` or has an empty list as `Values` moto raises TypeError 


```
% aws ec2 describe-subnets --filters Name=vpc-id
{
    "Subnets": []
}
```

```
% aws ec2 describe-subnets --filters Name=vpc-id --endpoint-url http://127.0.0.1:5000

Unable to parse response (syntax error: line 1, column 0), invalid XML received. Further retries may succeed:
b'<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>\n'
```

from logs:

```
  File "moto/moto/ec2/responses/_base_response.py", line 20, in <dictcomp>
    return {f["Name"]: f["Value"] for f in _filters}
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

Same for 

```
% aws ec2 describe-subnets --filters '[{"Name": "vpc-id", "Values": []}]'            
{
    "Subnets": []
}
```

```
% aws ec2 describe-subnets --filters '[{"Name": "vpc-id", "Values": []}]' --endpoint-url http://127.0.0.1:5000

Unable to parse response (syntax error: line 1, column 0), invalid XML received. Further retries may succeed:
b'<!doctype html>\n<html lang=en>\n<title>500 Internal Server Error</title>\n<h1>Internal Server Error</h1>\n<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>\n'
```

This PR fixes this issue and also returns the same error as AWS for the case that a Name is not provided for a filter

```
 % aws ec2 describe-subnets --filters Values=123

An error occurred (InvalidParameterValue) when calling the DescribeSubnets operation: The filter 'null' is invalid
```


Tests are added for 3 cases 
* describe_images
* describe_subnets
* describe_availability_zones

but it affects more EC2 actions that share the same filtering logic


Issue was originally reported in localstack https://github.com/localstack/localstack/issues/11765
