### PR TITLE
Allow non kms origin in create_key

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -74,6 +74,7 @@ class Key(CloudFormationModel):
         account_id: str,
         region: str,
         multi_region: bool = False,
+        origin: str = "AWS_KMS"
     ):
         self.id = generate_key_id(multi_region)
         self.creation_date = unix_time()
@@ -97,7 +98,7 @@ class Key(CloudFormationModel):
         self.key_rotation_status = False
         self.deletion_date: Optional[datetime] = None
         self.key_material = generate_master_key()
-        self.origin = "AWS_KMS"
+        self.origin = origin
         self.key_manager = "CUSTOMER"
         self.key_spec = key_spec or "SYMMETRIC_DEFAULT"
         self.private_key = generate_private_key(self.key_spec)
@@ -317,6 +318,7 @@ class KmsBackend(BaseBackend):
         description: str,
         tags: Optional[List[Dict[str, str]]],
         multi_region: bool = False,
+        origin: str = "AWS_KMS",
     ) -> Key:
         """
         The provided Policy currently does not need to be valid. If it is valid, Moto will perform authorization checks on key-related operations, just like AWS does.
@@ -336,6 +338,7 @@ class KmsBackend(BaseBackend):
             self.account_id,
             self.region_name,
             multi_region,
+            origin,
         )
         self.keys[key.id] = key
         if tags is not None and len(tags) > 0:

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -123,9 +123,10 @@ class KmsResponse(BaseResponse):
         description = self._get_param("Description")
         tags = self._get_param("Tags")
         multi_region = self._get_param("MultiRegion")
+        origin = self._get_param("Origin") or "AWS_KMS"
 
         key = self.kms_backend.create_key(
-            policy, key_usage, key_spec, description, tags, multi_region
+            policy, key_usage, key_spec, description, tags, multi_region, origin
         )
         return json.dumps(key.to_dict())
 

--- a/tests/test_kms/test_kms_boto3.py
+++ b/tests/test_kms/test_kms_boto3.py
@@ -118,6 +118,10 @@ def test_create_key():
     assert "EncryptionAlgorithms" not in key["KeyMetadata"]
     assert key["KeyMetadata"]["SigningAlgorithms"] == ["ECDSA_SHA_512"]
 
+    key = conn.create_key(Origin="EXTERNAL")
+
+    assert key["KeyMetadata"]["Origin"] == "EXTERNAL"
+
 
 @mock_aws
 def test_create_multi_region_key():


### PR DESCRIPTION
This is a change to allow the 'Origin' parameter in create_key to affect the origin of the mocked key.
