### PR TITLE
SES: Fix AlreadyExists and DoesNotExist error messages

### DIFF
--- a/moto/ses/exceptions.py
+++ b/moto/ses/exceptions.py
@@ -56,14 +56,9 @@ class TemplateDoesNotExist(SesError):
         super().__init__("TemplateDoesNotExist", message)
 
 
-class RuleSetNameAlreadyExists(SesError):
+class AlreadyExists(SesError):
     def __init__(self, message: str):
-        super().__init__("RuleSetNameAlreadyExists", message)
-
-
-class RuleAlreadyExists(SesError):
-    def __init__(self, message: str):
-        super().__init__("RuleAlreadyExists", message)
+        super().__init__("AlreadyExists", message)
 
 
 class RuleSetDoesNotExist(SesError):

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -13,16 +13,15 @@ from moto.core.utils import utcnow
 from moto.sns.models import sns_backends
 
 from .exceptions import (
+    AlreadyExists,
     ConfigurationSetAlreadyExists,
     ConfigurationSetDoesNotExist,
     EventDestinationAlreadyExists,
     InvalidParameterValue,
     InvalidRenderingParameterException,
     MessageRejectedError,
-    RuleAlreadyExists,
     RuleDoesNotExist,
     RuleSetDoesNotExist,
-    RuleSetNameAlreadyExists,
     TemplateDoesNotExist,
     TemplateNameAlreadyExists,
     ValidationError,
@@ -616,15 +615,15 @@ class SESBackend(BaseBackend):
 
     def create_receipt_rule_set(self, rule_set_name: str) -> None:
         if self.receipt_rule_set.get(rule_set_name) is not None:
-            raise RuleSetNameAlreadyExists("Duplicate Receipt Rule Set Name.")
+            raise AlreadyExists(f"Rule set already exists: {rule_set_name}")
         self.receipt_rule_set[rule_set_name] = []
 
     def create_receipt_rule(self, rule_set_name: str, rule: Dict[str, Any]) -> None:
         rule_set = self.receipt_rule_set.get(rule_set_name)
         if rule_set is None:
-            raise RuleSetDoesNotExist("Invalid Rule Set Name.")
+            raise RuleSetDoesNotExist(f"Rule set does not exist: {rule_set_name}")
         if rule in rule_set:
-            raise RuleAlreadyExists("Duplicate Rule Name.")
+            raise AlreadyExists(f"Rule already exists: {rule['name']}")
         rule_set.append(rule)
         self.receipt_rule_set[rule_set_name] = rule_set
 
@@ -642,13 +641,13 @@ class SESBackend(BaseBackend):
         rule_set = self.receipt_rule_set.get(rule_set_name)
 
         if rule_set is None:
-            raise RuleSetDoesNotExist("Invalid Rule Set Name.")
+            raise RuleSetDoesNotExist(f"Rule set does not exist: {rule_set_name}")
 
         for receipt_rule in rule_set:
             if receipt_rule["name"] == rule_name:
                 return receipt_rule
 
-        raise RuleDoesNotExist("Invalid Rule Name.")
+        raise RuleDoesNotExist(f"Rule does not exist: {rule_name}")
 
     def update_receipt_rule(self, rule_set_name: str, rule: Dict[str, Any]) -> None:
         rule_set = self.receipt_rule_set.get(rule_set_name)

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -636,7 +636,10 @@ def test_create_receipt_rule_set():
     with pytest.raises(ClientError) as ex:
         conn.create_receipt_rule_set(RuleSetName="testRuleSet")
 
-    assert ex.value.response["Error"]["Code"] == "RuleSetNameAlreadyExists"
+    assert ex.value.response["Error"]["Code"] == "AlreadyExists"
+    assert (
+        ex.value.response["Error"]["Message"] == "Rule set already exists: testRuleSet"
+    )
 
 
 @mock_aws
@@ -704,7 +707,8 @@ def test_create_receipt_rule():
             },
         )
 
-    assert ex.value.response["Error"]["Code"] == "RuleAlreadyExists"
+    assert ex.value.response["Error"]["Code"] == "AlreadyExists"
+    assert ex.value.response["Error"]["Message"] == "Rule already exists: testRule"
 
     with pytest.raises(ClientError) as ex:
         conn.create_receipt_rule(
@@ -736,6 +740,10 @@ def test_create_receipt_rule():
         )
 
     assert ex.value.response["Error"]["Code"] == "RuleSetDoesNotExist"
+    assert (
+        ex.value.response["Error"]["Message"]
+        == "Rule set does not exist: InvalidRuleSetaName"
+    )
 
 
 @mock_aws
@@ -897,6 +905,10 @@ def test_describe_receipt_rule():
         conn.describe_receipt_rule(RuleSetName="invalidRuleSetName", RuleName=rule_name)
 
     assert error.value.response["Error"]["Code"] == "RuleSetDoesNotExist"
+    assert (
+        error.value.response["Error"]["Message"]
+        == "Rule set does not exist: invalidRuleSetName"
+    )
 
     with pytest.raises(ClientError) as error:
         conn.describe_receipt_rule(
@@ -904,6 +916,10 @@ def test_describe_receipt_rule():
         )
 
     assert error.value.response["Error"]["Code"] == "RuleDoesNotExist"
+    assert (
+        error.value.response["Error"]["Message"]
+        == "Rule does not exist: invalidRuleName"
+    )
 
 
 @mock_aws


### PR DESCRIPTION
[CreateReceiptRule](https://docs.aws.amazon.com/ses/latest/APIReference/API_CreateReceiptRule.html) and [CreateReceiptRuleSet](https://docs.aws.amazon.com/ses/latest/APIReference/API_CreateReceiptRuleSet.html) should raise `AlreadyExists` error according to the docs.

 Also, updating messages for `RuleDoesNotExist` and `RuleSetDoesNotExist` to match what AWS returns.