### PR TITLE
Properly handle CopyObject with content length 0

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -188,7 +188,10 @@ class S3Response(BaseResponse):
             and request.headers.get("Content-Encoding", "") == "aws-chunked"
             and hasattr(request, "input_stream")
         ):
-            self.body = request.input_stream.getvalue()
+            if isinstance(request.input_stream, io.BytesIO):
+                self.body = request.input_stream.getvalue()
+            else:
+                self.body = request.input_stream
         if (
             self.request.headers.get("x-amz-content-sha256")
             == "STREAMING-UNSIGNED-PAYLOAD-TRAILER"


### PR DESCRIPTION
This fixes #8592

It was broken with the checksum workaround.  Admittedly there are no test updates here, which is not bar-raising, so I'm working on that.

I cannot reproduce this with a moto unit test.  Canceling this PR until we know the root cause.