### PR TITLE
EC2: Properly handle disableApiStop in instance lifecycle

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -689,6 +689,14 @@ class OperationNotPermitted4(EC2ClientError):
         )
 
 
+class OperationDisableApiStopNotPermitted(EC2ClientError):
+    def __init__(self, instance_id: str):
+        super().__init__(
+            "OperationNotPermitted",
+            f"The instance '{instance_id}' may not be terminated. Modify its 'disableApiStop' instance attribute and try again.",
+        )
+
+
 # Raised when attempting to accept or reject a VPC peering connection request for a VPC not belonging to self
 class OperationNotPermitted5(EC2ClientError):
     def __init__(self, account_id: str, pcx_id: str, operation: str):

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -754,8 +754,6 @@ class InstanceBackend:
     ) -> List[Tuple[Instance, InstanceState]]:
         started_instances = []
         for instance in self.get_multi_instances_by_id(instance_ids):
-            if instance.disable_api_stop == "true":
-                raise OperationDisableApiStopNotPermitted(instance.id)
             previous_state = instance.start()
             started_instances.append((instance, previous_state))
 
@@ -766,6 +764,8 @@ class InstanceBackend:
     ) -> List[Tuple[Instance, InstanceState]]:
         stopped_instances = []
         for instance in self.get_multi_instances_by_id(instance_ids):
+            if instance.disable_api_stop == "true":
+                raise OperationDisableApiStopNotPermitted(instance.id)
             previous_state = instance.stop()
             stopped_instances.append((instance, previous_state))
 

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -74,6 +74,7 @@ class InstanceResponse(EC2BaseResponse):
             "associate_public_ip": self._get_param("AssociatePublicIpAddress"),
             "tags": self._parse_tag_specification(),
             "ebs_optimized": self._get_param("EbsOptimized") or False,
+            "disable_api_stop": self._get_param("DisableApiStop") or False,
             "instance_market_options": self._get_param(
                 "InstanceMarketOptions.MarketType"
             )

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2151,6 +2151,7 @@ def test_describe_instance_attribute():
         "groupSet",
         "ebsOptimized",
         "sriovNetSupport",
+        "disableApiStop",
     ]
 
     for valid_instance_attribute in valid_instance_attributes:
@@ -2290,6 +2291,37 @@ def test_instance_termination_protection():
     assert len(instances) == 1
     instance = instances[0]
     assert instance["State"]["Name"] == "terminated"
+
+
+@mock_aws
+def test_instance_stop_protection():
+    client = boto3.client("ec2", region_name="us-west-1")
+
+    response = client.run_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, DisableApiStop=True
+    )
+    instance_id = response["Instances"][0]["InstanceId"]
+
+    response = client.describe_instance_attribute(
+        InstanceId=instance_id, Attribute="disableApiStop"
+    )
+    assert response["DisableApiStop"]["Value"] is True
+
+    # can't stop an instance with stop protection
+    with pytest.raises(ClientError) as ex:
+        client.stop_instances(InstanceIds=[instance_id])
+    error = ex.value.response["Error"]
+    assert error["Code"] == "OperationNotPermitted"
+
+    # stopping an instance without stop protection works
+    client.modify_instance_attribute(
+        InstanceId=instance_id, Attribute="disableApiStop", Value="false"
+    )
+    response = client.stop_instances(InstanceIds=[instance_id])
+    assert response["StoppingInstances"][0]["CurrentState"]["Name"] in [
+        "stopping",
+        "stopped",
+    ]
 
 
 @mock_aws


### PR DESCRIPTION
Hi moto team 👋🏼 

I'm opening this PR to tacke these two issues:

- The EC2 parameter`DisableApiStop` is not propagated when running an instance, instead uses default (`DisableApiStop=False`).
This leads to inconsistencies when trying to create ec2 instances with localstack with terraform & pulumi, due to these changes not being stored in the instance so these IAC detect changes and modify the instance when running corresponding iac scripts.

- On the other side, took advantage to throw the corresponding exception when trying to stop an ec2 instance that was created with  `DisableApiStop=True` as that was not handled.


