### PR TITLE
DynamoDB: Add attribute name use checks to validation layer

### DIFF
--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -44,10 +44,7 @@ from moto.dynamodb.models.table_export import TableExport
 from moto.dynamodb.models.table_import import TableImport
 from moto.dynamodb.parsing import partiql
 from moto.dynamodb.parsing.executors import UpdateExpressionExecutor
-from moto.dynamodb.parsing.expressions import (  # type: ignore
-    ExpressionAttributeName,
-    UpdateExpressionParser,
-)
+from moto.dynamodb.parsing.expressions import UpdateExpressionParser  # type: ignore
 from moto.dynamodb.parsing.validators import UpdateExpressionValidator
 
 
@@ -530,23 +527,6 @@ class DynamoDBBackend(BaseBackend):
             except ItemSizeTooLarge:
                 raise ItemSizeToUpdateTooLarge()
 
-            # Ensure all ExpressionAttributeNames are requested
-            # Either in the Condition, or in the UpdateExpression
-            attr_name_clauses = update_expression_ast.find_clauses(
-                [ExpressionAttributeName]
-            )
-            attr_names_in_expression = [
-                attr.get_attribute_name_placeholder() for attr in attr_name_clauses
-            ]
-            attr_names_in_condition = condition_expression_parser.expr_attr_names_found
-            for attr_name in expression_attribute_names or []:
-                if (
-                    attr_name not in attr_names_in_expression
-                    and attr_name not in attr_names_in_condition
-                ):
-                    raise MockValidationException(
-                        f"Value provided in ExpressionAttributeNames unused in expressions: keys: {{{attr_name}}}"
-                    )
         else:
             item.update_with_attribute_updates(attribute_updates)  # type: ignore
         if table.stream_shard is not None:

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -1252,11 +1252,11 @@ class DynamoHandler(BaseResponse):
         # Validate first - we should error before we start the transaction
         for item in transact_items:
             # This logic is common among all types of write items
-            item_values = list(item.values())[0] # Each item only has one of Put, Update, Delete, ConditionCheck
+            item_values = list(item.values())[
+                0
+            ]  # Each item only has one of Put, Update, Delete, ConditionCheck
             condition_expression = item_values.get("ConditionExpression")
-            expression_attribute_names = item_values.get(
-                "ExpressionAttributeNames", {}
-            )
+            expression_attribute_names = item_values.get("ExpressionAttributeNames", {})
             expression_attribute_values = item_values.get(
                 "ExpressionAttributeValues", {}
             )
@@ -1302,7 +1302,9 @@ class DynamoHandler(BaseResponse):
                     attr.get_attribute_name_placeholder() for attr in attr_name_clauses
                 ]
 
-            validate_attribute_names_used(expression_attribute_names, expression_attribute_names_used)
+            validate_attribute_names_used(
+                expression_attribute_names, expression_attribute_names_used
+            )
 
         self.dynamodb_backend.transact_write_items(transact_items)
         response: Dict[str, Any] = {"ConsumedCapacity": [], "ItemCollectionMetrics": {}}

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -6,9 +6,13 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
+from moto.dynamodb.comparisons import create_condition_expression_parser
 from moto.dynamodb.models import DynamoDBBackend, Table, dynamodb_backends
 from moto.dynamodb.models.utilities import dynamo_json_dump
-from moto.dynamodb.parsing.expressions import UpdateExpressionParser  # type: ignore
+from moto.dynamodb.parsing.expressions import (  # type: ignore
+    ExpressionAttributeName,
+    UpdateExpressionParser,
+)
 from moto.dynamodb.parsing.key_condition_expression import parse_expression
 from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
 from moto.utilities.aws_headers import amz_crc32
@@ -153,6 +157,17 @@ def validate_put_has_gsi_keys_set_to_none(item: Dict[str, Any], table: Table) ->
                 )
 
 
+def validate_attribute_names_used(
+    attribute_names: Optional[Dict[str, str]], names_used: List[str]
+) -> None:
+    if attribute_names:
+        for name in attribute_names:
+            if name not in names_used:
+                raise MockValidationException(
+                    f"Value provided in ExpressionAttributeNames unused in expressions: keys: {{{name}}}"
+                )
+
+
 def check_projection_expression(expression: str) -> None:
     if expression.upper() in ReservedKeywords.get_reserved_keywords():
         raise MockValidationException(
@@ -166,6 +181,45 @@ def check_projection_expression(expression: str) -> None:
         raise MockValidationException(
             "ProjectionExpression: Attribute name contains white space"
         )
+
+
+class ProjectionExpressionParser:
+    def __init__(
+        self,
+        projection_expression: Optional[str],
+        expression_attribute_names: Optional[Dict[str, str]],
+    ):
+        self.projection_expression = projection_expression
+        self.expression_attribute_names = (
+            expression_attribute_names if expression_attribute_names else {}
+        )
+
+        self.expr_attr_names_found: List[str] = []
+
+    def parse(self) -> List[List[str]]:
+        """
+        lvl1.lvl2.attr1,lvl1.attr2 --> [["lvl1", "lvl2", "attr1"], ["lvl1", "attr2]]
+        """
+
+        if self.projection_expression:
+            expressions = [x.strip() for x in self.projection_expression.split(",")]
+            duplicates = extract_duplicates(expressions)
+            if duplicates:
+                raise InvalidProjectionExpression(duplicates)
+            for expression in expressions:
+                check_projection_expression(expression)
+            output = []
+            for nested_expr in expressions:
+                nested_array = []
+                for expr in nested_expr.split("."):
+                    if self.expression_attribute_names.get(expr):
+                        self.expr_attr_names_found.append(expr)
+                        nested_array.append(self.expression_attribute_names[expr])
+                    else:
+                        nested_array.append(expr)
+                output.append(nested_array)
+            return output
+        return []
 
 
 class DynamoHandler(BaseResponse):
@@ -499,6 +553,16 @@ class DynamoHandler(BaseResponse):
         expression_attribute_names = self.body.get("ExpressionAttributeNames", {})
         expression_attribute_values = self._get_expr_attr_values()
 
+        parser = create_condition_expression_parser(
+            condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+        )
+        parser.parse()
+        validate_attribute_names_used(
+            expression_attribute_names, parser.expr_attr_names_found
+        )
+
         if condition_expression:
             overwrite = False
 
@@ -597,8 +661,13 @@ class DynamoHandler(BaseResponse):
             raise ProvidedKeyDoesNotExist
 
         expression_attribute_names = expression_attribute_names or {}
-        projection_expressions = self._adjust_projection_expression(
+        parser = ProjectionExpressionParser(
             projection_expression, expression_attribute_names
+        )
+        projection_expressions = parser.parse()
+
+        validate_attribute_names_used(
+            expression_attribute_names, parser.expr_attr_names_found
         )
 
         item = self.dynamodb_backend.get_item(name, key, projection_expressions)
@@ -649,8 +718,12 @@ class DynamoHandler(BaseResponse):
                 "ExpressionAttributeNames", {}
             )
 
-            projection_expressions = self._adjust_projection_expression(
+            parser = ProjectionExpressionParser(
                 projection_expression, expression_attribute_names
+            )
+            projection_expressions = parser.parse()
+            validate_attribute_names_used(
+                expression_attribute_names, parser.expr_attr_names_found
             )
 
             results["Responses"][table_name] = []
@@ -693,9 +766,17 @@ class DynamoHandler(BaseResponse):
         filter_expression = self._get_filter_expression()
         expression_attribute_values = self._get_expr_attr_values()
 
-        projection_expressions = self._adjust_projection_expression(
+        condition_parser = create_condition_expression_parser(
+            filter_expression, expression_attribute_names, expression_attribute_values
+        )
+        condition_parser.parse()
+        expression_attribute_names_used = condition_parser.expr_attr_names_found
+
+        projection_parser = ProjectionExpressionParser(
             projection_expression, expression_attribute_names
         )
+        projection_expressions = projection_parser.parse()
+        expression_attribute_names_used += projection_parser.expr_attr_names_found
 
         filter_kwargs = {}
 
@@ -704,11 +785,19 @@ class DynamoHandler(BaseResponse):
             schema = self.dynamodb_backend.get_schema(
                 table_name=name, index_name=index_name
             )
-            hash_key, range_comparison, range_values = parse_expression(
+            (
+                hash_key,
+                range_comparison,
+                range_values,
+                expression_attribute_names_used_by_key_condition,
+            ) = parse_expression(
                 key_condition_expression=key_condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
                 schema=schema,
+            )
+            expression_attribute_names_used += (
+                expression_attribute_names_used_by_key_condition
             )
         else:
             # 'KeyConditions': {u'forum_name': {u'ComparisonOperator': u'EQ', u'AttributeValueList': [{u'S': u'the-key'}]}}
@@ -749,6 +838,10 @@ class DynamoHandler(BaseResponse):
                             range_values = []
             if query_filters:
                 filter_kwargs.update(query_filters)
+
+        validate_attribute_names_used(
+            expression_attribute_names, expression_attribute_names_used
+        )
         index_name = self.body.get("IndexName")
         exclusive_start_key = self.body.get("ExclusiveStartKey")
         limit = self.body.get("Limit")
@@ -785,30 +878,6 @@ class DynamoHandler(BaseResponse):
 
         return dynamo_json_dump(result)
 
-    def _adjust_projection_expression(
-        self, projection_expression: Optional[str], expr_attr_names: Dict[str, str]
-    ) -> List[List[str]]:
-        """
-        lvl1.lvl2.attr1,lvl1.attr2 --> [["lvl1", "lvl2", "attr1"], ["lvl1", "attr2]]
-        """
-
-        def _adjust(expression: str) -> str:
-            return (expr_attr_names or {}).get(expression, expression)
-
-        if projection_expression:
-            expressions = [x.strip() for x in projection_expression.split(",")]
-            duplicates = extract_duplicates(expressions)
-            if duplicates:
-                raise InvalidProjectionExpression(duplicates)
-            for expression in expressions:
-                check_projection_expression(expression)
-            return [
-                [_adjust(expr) for expr in nested_expr.split(".")]
-                for nested_expr in expressions
-            ]
-
-        return []
-
     @include_consumed_capacity()
     def scan(self) -> str:
         name = self.body["TableName"]
@@ -825,7 +894,25 @@ class DynamoHandler(BaseResponse):
         filter_expression = self._get_filter_expression()
         expression_attribute_values = self._get_expr_attr_values()
         expression_attribute_names = self.body.get("ExpressionAttributeNames", {})
+
+        filter_parser = create_condition_expression_parser(
+            filter_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+        )
+        try:
+            filter_parser.parse()
+        except ValueError as err:
+            raise MockValidationException(f"Bad Filter Expression: {err}")
+        expression_attribute_names_used = filter_parser.expr_attr_names_found
+
         projection_expression = self._get_projection_expression()
+        projection_parser = ProjectionExpressionParser(
+            projection_expression, expression_attribute_names
+        )
+        projection_expressions = projection_parser.parse()
+        expression_attribute_names_used += projection_parser.expr_attr_names_found
+
         exclusive_start_key = self.body.get("ExclusiveStartKey")
         limit = self.body.get("Limit")
         index_name = self.body.get("IndexName")
@@ -849,8 +936,8 @@ class DynamoHandler(BaseResponse):
                 f"The Segment parameter is zero-based and must be less than parameter TotalSegments: Segment: {segment} is not less than TotalSegments: {total_segments}"
             )
 
-        projection_expressions = self._adjust_projection_expression(
-            projection_expression, expression_attribute_names
+        validate_attribute_names_used(
+            expression_attribute_names, expression_attribute_names_used
         )
 
         try:
@@ -900,6 +987,16 @@ class DynamoHandler(BaseResponse):
             "ReturnValuesOnConditionCheckFailure"
         )
 
+        parser = create_condition_expression_parser(
+            condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+        )
+        parser.parse()
+        validate_attribute_names_used(
+            expression_attribute_names, parser.expr_attr_names_found
+        )
+
         item = self.dynamodb_backend.delete_item(
             name,
             key,
@@ -937,8 +1034,17 @@ class DynamoHandler(BaseResponse):
                 raise MockValidationException(
                     "Invalid UpdateExpression: The expression can not be empty;"
                 )
+            update_expression_ast = UpdateExpressionParser.make(update_expression)
+            attr_name_clauses = update_expression_ast.find_clauses(
+                [ExpressionAttributeName]
+            )
+            expression_attribute_names_used = [
+                attr.get_attribute_name_placeholder() for attr in attr_name_clauses
+            ]
+
         else:
             update_expression = ""
+            expression_attribute_names_used = []
 
         return_values_on_condition_check_failure = self.body.get(
             "ReturnValuesOnConditionCheckFailure"
@@ -969,6 +1075,16 @@ class DynamoHandler(BaseResponse):
         condition_expression = self.body.get("ConditionExpression")
         expression_attribute_names = self.body.get("ExpressionAttributeNames", {})
         expression_attribute_values = self._get_expr_attr_values()
+        condition_parser = create_condition_expression_parser(
+            condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+        )
+        condition_parser.parse()
+        expression_attribute_names_used += condition_parser.expr_attr_names_found
+        validate_attribute_names_used(
+            expression_attribute_names, expression_attribute_names_used
+        )
 
         item = self.dynamodb_backend.update_item(
             name,
@@ -1142,6 +1258,25 @@ class DynamoHandler(BaseResponse):
                 item_attrs = item["Put"]["Item"]
                 table = self.dynamodb_backend.get_table(item["Put"]["TableName"])
                 validate_put_has_empty_keys(item_attrs, table)
+
+                condition_expression = item["Put"].get("ConditionExpression")
+                expression_attribute_names = item["Put"].get(
+                    "ExpressionAttributeNames", {}
+                )
+                expression_attribute_values = item["Put"].get(
+                    "ExpressionAttributeValues", {}
+                )
+
+                parser = create_condition_expression_parser(
+                    condition_expression,
+                    expression_attribute_names,
+                    expression_attribute_values,
+                )
+                parser.parse()
+                validate_attribute_names_used(
+                    expression_attribute_names, parser.expr_attr_names_found
+                )
+
             if "Update" in item:
                 if item["Update"].get("ExpressionAttributeValues") == {}:
                     raise ExpressionAttributeValuesEmpty
@@ -1153,10 +1288,75 @@ class DynamoHandler(BaseResponse):
                     table,
                     custom_error_msg="One or more parameter values are not valid. The AttributeValue for a key attribute cannot contain an empty string value. Key: {}",
                 )
+
                 update_expression = item["Update"]["UpdateExpression"]
                 UpdateExpressionParser.make(update_expression).validate(
                     limit_set_actions=True
                 )
+                update_expression_ast = UpdateExpressionParser.make(update_expression)
+                update_expression_ast.validate(limit_set_actions=True)
+                attr_name_clauses = update_expression_ast.find_clauses(
+                    [ExpressionAttributeName]
+                )
+                expression_attribute_names_used = [
+                    attr.get_attribute_name_placeholder() for attr in attr_name_clauses
+                ]
+
+                condition_expression = item["Update"].get("ConditionExpression")
+                expression_attribute_names = item["Update"].get(
+                    "ExpressionAttributeNames", {}
+                )
+                expression_attribute_values = item["Update"].get(
+                    "ExpressionAttributeValues", {}
+                )
+                parser = create_condition_expression_parser(
+                    condition_expression,
+                    expression_attribute_names,
+                    expression_attribute_values,
+                )
+                parser.parse()
+                expression_attribute_names_used += parser.expr_attr_names_found
+
+                validate_attribute_names_used(
+                    expression_attribute_names, expression_attribute_names_used
+                )
+            if "Delete" in item:
+                condition_expression = item["Delete"].get("ConditionExpression")
+                expression_attribute_names = item["Delete"].get(
+                    "ExpressionAttributeNames", {}
+                )
+                expression_attribute_values = item["Delete"].get(
+                    "ExpressionAttributeValues", {}
+                )
+
+                parser = create_condition_expression_parser(
+                    condition_expression,
+                    expression_attribute_names,
+                    expression_attribute_values,
+                )
+                parser.parse()
+                validate_attribute_names_used(
+                    expression_attribute_names, parser.expr_attr_names_found
+                )
+            if "ConditionCheck" in item:
+                condition_expression = item["ConditionCheck"].get("ConditionExpression")
+                expression_attribute_names = item["ConditionCheck"].get(
+                    "ExpressionAttributeNames", {}
+                )
+                expression_attribute_values = item["ConditionCheck"].get(
+                    "ExpressionAttributeValues", {}
+                )
+
+                parser = create_condition_expression_parser(
+                    condition_expression,
+                    expression_attribute_names,
+                    expression_attribute_values,
+                )
+                parser.parse()
+                validate_attribute_names_used(
+                    expression_attribute_names, parser.expr_attr_names_found
+                )
+
         self.dynamodb_backend.transact_write_items(transact_items)
         response: Dict[str, Any] = {"ConsumedCapacity": [], "ItemCollectionMetrics": {}}
         return dynamo_json_dump(response)

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -358,7 +358,7 @@ def test_query_unused_attribute_name(table_name=None):
 
     with pytest.raises(ClientError) as exc:
         table.query(
-            KeyConditionExpression="(#0 = 1) AND (begins_with(#1, a))",
+            KeyConditionExpression="(#0 = x) AND (begins_with(#1, a))",
             ExpressionAttributeNames={"#0": "pk", "#1": "sk", "#count": "count"},
         )
     err = exc.value.response["Error"]

--- a/tests/test_dynamodb/models/test_key_condition_expression_parser.py
+++ b/tests/test_dynamodb/models/test_key_condition_expression_parser.py
@@ -10,7 +10,7 @@ class TestHashKey:
     @pytest.mark.parametrize("expression", ["job_id = :id", "job_id = :id "])
     def test_hash_key_only(self, expression):
         eav = {":id": {"S": "asdasdasd"}}
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values=eav,
             key_condition_expression=expression,
             schema=self.schema,
@@ -84,7 +84,7 @@ class TestHashAndRangeKey:
     )
     def test_begin_with(self, expr):
         eav = {":id": "pk", ":sk": "19"}
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values=eav,
             key_condition_expression=expr,
             schema=self.schema,
@@ -119,7 +119,7 @@ class TestHashAndRangeKey:
     )
     def test_in_between(self, expr):
         eav = {":id": "pk", ":sk1": "19", ":sk2": "21"}
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values=eav,
             key_condition_expression=expr,
             schema=self.schema,
@@ -133,7 +133,7 @@ class TestHashAndRangeKey:
     def test_numeric_comparisons(self, operator):
         eav = {":id": "pk", ":sk": "19"}
         expr = f"job_id = :id and start_date{operator}:sk"
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values=eav,
             key_condition_expression=expr,
             schema=self.schema,
@@ -154,7 +154,7 @@ class TestHashAndRangeKey:
     )
     def test_reverse_keys(self, expr):
         eav = {":id": "pk", ":sk1": "19", ":sk2": "21"}
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values=eav,
             key_condition_expression=expr,
             schema=self.schema,
@@ -171,7 +171,7 @@ class TestHashAndRangeKey:
         ],
     )
     def test_brackets(self, expr):
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values={":id": "pk", ":sk": "19"},
             key_condition_expression=expr,
             schema=self.schema,
@@ -187,7 +187,7 @@ class TestNamesAndValues:
         kce = ":j = :id"
         ean = {":j": "job_id"}
         eav = {":id": {"S": "asdasdasd"}}
-        desired_hash_key, comparison, range_values = parse_expression(
+        desired_hash_key, comparison, range_values, _ = parse_expression(
             expression_attribute_values=eav,
             key_condition_expression=kce,
             schema=self.schema,
@@ -196,3 +196,18 @@ class TestNamesAndValues:
         assert desired_hash_key == eav[":id"]
         assert comparison is None
         assert range_values == []
+
+
+def test_expression_attribute_names_found():
+    kce = ":j = :id"
+    ean = {":j": "job_id"}
+    eav = {":id": {"S": "asdasdasd"}}
+    desired_hash_key, comparison, range_values, expression_attribute_names_used = (
+        parse_expression(
+            expression_attribute_values=eav,
+            key_condition_expression=kce,
+            schema=[{"AttributeName": "job_id", "KeyType": "HASH"}],
+            expression_attribute_names=ean,
+        )
+    )
+    assert expression_attribute_names_used == [":j"]

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -1131,7 +1131,7 @@ def test_nested_projection_expression_using_scan_with_attr_expression_names():
     # Test a scan
     results = table.scan(
         FilterExpression=Key("forum_name").eq("key1"),
-        ProjectionExpression="nested.level1.id, nested.level2",
+        ProjectionExpression="#nst.level1.id, #nst.#lvl2",
         ExpressionAttributeNames={"#nst": "nested", "#lvl2": "level2"},
     )["Items"]
     assert results == [

--- a/tests/test_dynamodb/test_dynamodb_condition_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_condition_expressions.py
@@ -227,7 +227,7 @@ def test_condition_expressions():
             Key={"client": {"S": "client1"}, "app": {"S": "app1"}},
             ConditionExpression="attribute_not_exists(#existing)",
             ExpressionAttributeValues={":match": {"S": "match"}},
-            ExpressionAttributeNames={"#existing": "existing", "#match": "match"},
+            ExpressionAttributeNames={"#existing": "existing"},
         )
 
 


### PR DESCRIPTION
This addresses issue https://github.com/getmoto/moto/issues/8474

In the responses file, I added validation checks that every attribute name is used in the various expressions that each request takes. Without major changes, these validations have to be done at the responses level instead of the backend level, because some response functions call the same backend functions, and which expressions need to be included in the check varies between request types.

I had to adapt a couple of the parsers to track which attribute names they used during parsing.

I skipped batch_write_items because [boto doesn't support any expressions in it](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb/client/batch_write_item.html), for some reason. I also skipped transact_get_items because it looks like *moto* doesn't support expressions for that call, even though moto does.

I used the aws.verified tag to get the tests working, but I actually haven't verified it against AWS. I was wondering if you had some tips for setting up a proper environment? I have no idea where to get started even.