### PR TITLE
Admin: Add CPP tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
         mkdir .mypy_cache
         make lint
 
+  cpptest:
+    needs: lint
+    uses: ./.github/workflows/tests_sdk_cpp.yml
+
   javatest:
     needs: lint
     uses: ./.github/workflows/tests_sdk_java.yml

--- a/.github/workflows/tests_sdk_cpp.yml
+++ b/.github/workflows/tests_sdk_cpp.yml
@@ -1,0 +1,39 @@
+name: C++ SDK test
+on: [workflow_call]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.8"
+    - name: Start MotoServer
+      run: |
+        pip install build
+        python -m build
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
+        python scripts/ci_wait_for_server.py
+
+    - name: Check build cache
+      id: build-cache
+      uses: actions/cache@v4
+      with:
+        path: other_langs/tests_cpp/build/hello_s3
+        key: cpp-build-${{ hashFiles('other_langs/tests_cpp/hello_s3.cpp') }}
+
+    - name: Build Project
+      if: steps.build-cache.outputs.cache-hit != 'true'
+      working-directory: other_langs/tests_cpp
+      run: |
+        make build
+
+    - name: Run tests
+      working-directory: other_langs/tests_cpp
+      run: |
+        make test

--- a/other_langs/tests_cpp/CMakeLists.txt
+++ b/other_langs/tests_cpp/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# snippet-start:[cpp.example_code.s3.hello_s3.cmake]
+# Set the minimum required version of CMake for this project.
+cmake_minimum_required(VERSION 3.13)
+
+# Set the AWS service components used by this project.
+set(SERVICE_COMPONENTS s3)
+
+# Set this project's name.
+project("hello_s3")
+
+# Set the C++ standard to use to build this target.
+# At least C++ 11 is required for the AWS SDK for C++.
+set(CMAKE_CXX_STANDARD 11)
+
+# Use the MSVC variable to determine if this is a Windows build.
+set(WINDOWS_BUILD ${MSVC})
+
+if (WINDOWS_BUILD) # Set the location where CMake can find the installed libraries for the AWS SDK.
+    string(REPLACE ";" "/aws-cpp-sdk-all;" SYSTEM_MODULE_PATH "${CMAKE_SYSTEM_PREFIX_PATH}/aws-cpp-sdk-all")
+    list(APPEND CMAKE_PREFIX_PATH ${SYSTEM_MODULE_PATH})
+endif ()
+
+# Find the AWS SDK for C++ package.
+list(APPEND CMAKE_PREFIX_PATH "./build/vcpkg/scripts/cmake")
+find_package(aws-cpp-sdk-core REQUIRED)
+find_package(AWSSDK REQUIRED COMPONENTS ${SERVICE_COMPONENTS})
+
+if (WINDOWS_BUILD AND AWSSDK_INSTALL_AS_SHARED_LIBS)
+    # Copy relevant AWS SDK for C++ libraries into the current binary directory for running and debugging.
+
+    # set(BIN_SUB_DIR "/Debug") # if you are building from the command line you may need to uncomment this
+    # and set the proper subdirectory to the executables' location.
+
+    AWSSDK_CPY_DYN_LIBS(SERVICE_COMPONENTS "" ${CMAKE_CURRENT_BINARY_DIR}${BIN_SUB_DIR})
+endif ()
+
+add_executable(${PROJECT_NAME}
+        hello_s3.cpp)
+
+target_link_libraries(${PROJECT_NAME}
+        ${AWSSDK_LINK_LIBRARIES})
+# snippet-end:[cpp.example_code.s3.hello_s3.cmake]

--- a/other_langs/tests_cpp/Makefile
+++ b/other_langs/tests_cpp/Makefile
@@ -1,0 +1,14 @@
+build:
+	pwd
+	ls -la
+	mkdir -p build/vcpkg
+	git clone https://github.com/microsoft/vcpkg.git build/vcpkg
+	ls -la build
+	ls -la build/vcpkg
+	./build/vcpkg/bootstrap-vcpkg.sh --disableMetrics
+	./build/vcpkg/vcpkg install "aws-sdk-cpp[s3]" --recurse
+	cmake -S . -B build/ -DCMAKE_TOOLCHAIN_FILE=build/vcpkg/scripts/buildsystems/vcpkg.cmake
+	cmake --build build
+
+test:
+	./build/hello_s3

--- a/other_langs/tests_cpp/hello_s3.cpp
+++ b/other_langs/tests_cpp/hello_s3.cpp
@@ -1,0 +1,142 @@
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/CreateBucketRequest.h>
+#include <aws/s3/model/BucketLocationConstraint.h>
+#include <aws/s3/model/CopyObjectRequest.h>
+#include <iostream>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+using namespace Aws;
+using namespace Aws::Auth;
+
+
+bool createBucket(const Aws::String &bucketName,
+                              const Aws::S3::S3ClientConfiguration &clientConfig) {
+    Aws::S3::S3Client client(clientConfig);
+    Aws::S3::Model::CreateBucketRequest request;
+    request.SetBucket(bucketName);
+
+    if (clientConfig.region != "us-east-1") {
+        Aws::S3::Model::CreateBucketConfiguration createBucketConfig;
+        createBucketConfig.SetLocationConstraint(
+                Aws::S3::Model::BucketLocationConstraintMapper::GetBucketLocationConstraintForName(
+                        clientConfig.region));
+        request.SetCreateBucketConfiguration(createBucketConfig);
+    }
+
+    Aws::S3::Model::CreateBucketOutcome outcome = client.CreateBucket(request);
+    if (!outcome.IsSuccess()) {
+        auto err = outcome.GetError();
+        std::cerr << "Error: createBucket: " <<
+                  err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
+    } else {
+        std::cout << "Created bucket " << bucketName <<
+                  " in the specified AWS Region." << std::endl;
+    }
+
+    return outcome.IsSuccess();
+}
+
+bool putObject(const Aws::String &bucketName,
+                           const Aws::String &fileName,
+                           const Aws::S3::S3ClientConfiguration &clientConfig) {
+    Aws::S3::S3Client s3Client(clientConfig);
+
+    Aws::S3::Model::PutObjectRequest request;
+    request.SetBucket(bucketName);
+    //We are using the name of the file as the key for the object in the bucket.
+    //However, this is just a string and can be set according to your retrieval needs.
+    request.SetKey(fileName);
+
+    Aws::S3::Model::PutObjectOutcome outcome =
+            s3Client.PutObject(request);
+
+    if (!outcome.IsSuccess()) {
+        std::cerr << "Error: putObject: " <<
+                  outcome.GetError().GetMessage() << std::endl;
+    } else {
+        std::cout << "Added object '" << fileName << "' to bucket '"
+                  << bucketName << "'.";
+    }
+
+    return outcome.IsSuccess();
+}
+
+bool listBuckets(const Aws::S3::S3ClientConfiguration &clientConfig) {
+    Aws::S3::S3Client client(clientConfig);
+
+    auto outcome = client.ListBuckets();
+
+    bool result = true;
+    if (!outcome.IsSuccess()) {
+        std::cerr << "Failed with error: " << outcome.GetError() << std::endl;
+        result = false;
+    } else {
+        std::cout << "Found " << outcome.GetResult().GetBuckets().size() << " buckets\n";
+        for (auto &&b: outcome.GetResult().GetBuckets()) {
+            std::cout << b.GetName() << std::endl;
+        }
+    }
+
+    return result;
+}
+
+bool copyObject(const Aws::String &objectKey, const Aws::String &fromBucket, const Aws::String &toBucket,
+                            const Aws::S3::S3ClientConfiguration &clientConfig) {
+    Aws::S3::S3Client client(clientConfig);
+    Aws::S3::Model::CopyObjectRequest request;
+
+    request.WithCopySource(fromBucket + "/" + objectKey)
+            .WithKey(objectKey)
+            .WithBucket(toBucket);
+
+    Aws::S3::Model::CopyObjectOutcome outcome = client.CopyObject(request);
+    if (!outcome.IsSuccess()) {
+        const Aws::S3::S3Error &err = outcome.GetError();
+        std::cerr << "Error: copyObject: " <<
+                  err.GetExceptionName() << ": " << err.GetMessage() << std::endl;
+
+    } else {
+        std::cout << "Successfully copied " << objectKey << " from " << fromBucket <<
+                  " to " << toBucket << "." << std::endl;
+    }
+
+    return outcome.IsSuccess();
+}
+
+
+int main(int argc, char **argv) {
+    Aws::SDKOptions options;
+    // Optionally change the log level for debugging.
+//   options.loggingOptions.logLevel = Utils::Logging::LogLevel::Debug;
+    Aws::InitAPI(options); // Should only be called once.
+    int result = 0;
+    {
+        Aws::Client::ClientConfiguration clientConfig;
+        // Optional: Set to the AWS Region (overrides config file).
+        // clientConfig.region = "us-east-1";
+        clientConfig.endpointOverride = "http://localhost:5000";
+
+        // You don't normally have to test that you are authenticated. But the S3 service permits anonymous requests, thus the s3Client will return "success" and 0 buckets even if you are unauthenticated, which can be confusing to a new user.
+        auto provider = Aws::MakeShared<DefaultAWSCredentialsProviderChain>("alloc-tag");
+        auto creds = provider->GetAWSCredentials();
+
+        Aws::S3::S3Client s3Client(clientConfig);
+        listBuckets(clientConfig);
+
+        Aws::String uuid1 = Aws::Utils::UUID::RandomUUID();
+        Aws::String uuid2 = Aws::Utils::UUID::RandomUUID();
+        Aws::String bucket1 = Aws::Utils::StringUtils::ToLower(uuid1.c_str());
+        Aws::String bucket2 = Aws::Utils::StringUtils::ToLower(uuid2.c_str());
+
+        createBucket(bucket1, clientConfig);
+        createBucket(bucket2, clientConfig);
+
+        putObject(bucket1, "test.txt", clientConfig);
+
+        copyObject("test.txt", bucket1, bucket2, clientConfig);
+    }
+
+    Aws::ShutdownAPI(options); // Should only be called once.
+    return result;
+}


### PR DESCRIPTION
Some very simple tests using C++, just to verify that the MotoServer works against this SDK. I've included a cache for the actual build output as well. Downloading all build tools + building the project takes 5 minutes, so including a cache should avoid some unnecessary compute time.

The need to have this was raised in #8592, a bug report that only occurred when using C++ SDK.

This PR only includes smoke tests - it does not create the exact conditions described in #8592, and therefore does not test this scenario.

Documentation used:
 - https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/sdk-from-pm.html
 - https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/cpp_s3_code_examples.html

Outstanding tasks:
 - Rework this to use proper unit tests (for example by using [GTest](https://google.github.io/googletest/))
 - Include a test to verify the CopyObject scenario works, so that we can prevent it in the future

(FWIW, this is the first time I've touched C++, ever, so excuse the code quality. I'm just happy it works for now :shrug: )