### PR TITLE
Admin: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.8, 3.9, "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ 3.9, "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests_decoratormode.yml
+++ b/.github/workflows/tests_decoratormode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_sdk_dotnet.yml
+++ b/.github/workflows/tests_sdk_dotnet.yml
@@ -9,10 +9,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.12"
     - name: Start MotoServer
       run: |
         pip install build

--- a/.github/workflows/tests_sdk_java.yml
+++ b/.github/workflows/tests_sdk_java.yml
@@ -9,10 +9,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Start MotoServer
       run: |
         pip install build

--- a/.github/workflows/tests_sdk_ruby.yml
+++ b/.github/workflows/tests_sdk_ruby.yml
@@ -16,10 +16,10 @@ jobs:
         uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Start MotoServer
         run: |
           pip install build

--- a/.github/workflows/tests_servermode.yml
+++ b/.github/workflows/tests_servermode.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests_terraform_examples.yml
+++ b/.github/workflows/tests_terraform_examples.yml
@@ -34,10 +34,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.8"
+        python-version: "3.12"
     - name: Start MotoServer
       run: |
         pip install build

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -1,6 +1,5 @@
 import re
 import string
-import sys
 from functools import lru_cache
 from threading import RLock
 from typing import (
@@ -28,15 +27,6 @@ from .utils import ISO_REGION_DOMAINS, convert_regex_to_flask_path
 
 if TYPE_CHECKING:
     from moto.core.common_models import BaseModel
-
-    if sys.version_info >= (3, 9):
-        from builtins import type as Type
-    else:
-        # https://github.com/python/mypy/issues/10068
-        # Legacy generic type annotation classes
-        # Deprecated in Python 3.9
-        # Remove once we no longer support Python 3.8 or lower
-        from typing import Type
 
 
 class InstanceTrackerMeta(type):
@@ -339,7 +329,7 @@ class BackendDict(Dict[str, AccountSpecificBackend[SERVICE_BACKEND]]):
 
     def __init__(
         self,
-        backend: "Type[SERVICE_BACKEND]",
+        backend: type[SERVICE_BACKEND],
         service_name: str,
         use_boto3_regions: bool = True,
         additional_regions: Optional[List[str]] = None,

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -101,9 +101,7 @@ class RESTError(HTTPException):
 
     @classmethod
     def extended_environment(cls, extended_templates: Dict[str, str]) -> Environment:
-        # Can be simplified to cls.templates | extended_templates when we drop Python 3.8 support
-        # https://docs.python.org/3/library/stdtypes.html#mapping-types-dict
-        templates = dict(cls.templates.items() | extended_templates.items())
+        templates = cls.templates | extended_templates
         return Environment(loader=DictLoader(templates))
 
 

--- a/moto/core/versions.py
+++ b/moto/core/versions.py
@@ -4,7 +4,6 @@ from importlib.metadata import version
 from moto.utilities.distutils_version import LooseVersion
 
 PYTHON_VERSION_INFO = sys.version_info
-PYTHON_39 = sys.version_info >= (3, 9)
 PYTHON_311 = sys.version_info >= (3, 11)
 RESPONSES_VERSION = version("responses")
 WERKZEUG_VERSION = version("werkzeug")

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -217,11 +217,7 @@ def compute_checksum(body: bytes, algorithm: str, encode_base64: bool = True) ->
 
 
 def _hash(fn: Any, args: Any) -> bytes:
-    try:
-        return fn(*args, usedforsecurity=False).digest()
-    except TypeError:
-        # The usedforsecurity-parameter is only available as of Python 3.9
-        return fn(*args).digest()
+    return fn(*args, usedforsecurity=False).digest()
 
 
 def cors_matches_origin(origin_header: str, allowed_origins: List[str]) -> bool:

--- a/moto/utilities/collections.py
+++ b/moto/utilities/collections.py
@@ -1,7 +1,5 @@
 from typing import Any, List
 
-from moto.core.versions import PYTHON_39
-
 
 def select_attributes(obj: Any, attributes: List[str]) -> Any:
     """Select a subset of attributes from the given dict (returns a copy)"""
@@ -17,9 +15,6 @@ def select_from_typed_dict(typed_dict: Any, obj: Any, filter: bool = False) -> A
     :param filter: if True, remove all keys with an empty (e.g., empty string or dictionary) or `None` value
     :return: the resulting dictionary (it returns a copy)
     """
-    if not PYTHON_39:
-        # Python 3.8 does not have __required_keys__, __optional_keys__
-        return dict(obj)
     selection = select_attributes(
         obj, [*typed_dict.__required_keys__, *typed_dict.__optional_keys__]
     )

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -111,11 +111,7 @@ def md5_hash(data: Any = None) -> Any:
     Required for Moto to work in FIPS-enabled systems
     """
     args = (data,) if data else ()
-    try:
-        return hashlib.md5(*args, usedforsecurity=False)  # type: ignore
-    except TypeError:
-        # The usedforsecurity-parameter is only available as of Python 3.9
-        return hashlib.md5(*args)
+    return hashlib.md5(*args, usedforsecurity=False)  # type: ignore
 
 
 class LowercaseDict(MutableMapping[str, Any]):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ license = Apache License 2.0
 test_suite = tests
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -26,7 +25,7 @@ project_urls =
     Changelog = https://github.com/getmoto/moto/blob/master/CHANGELOG.md
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     boto3>=1.9.201
     botocore>=1.14.0,!=1.35.45,!=1.35.46

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1756,7 +1756,8 @@ def test_head_object(size, bucket_name=None):
         client.head_object(Bucket=bucket_name, Key="hello.txt", PartNumber=2)
     err = exc.value.response["Error"]
     assert err["Code"] == "416"
-    assert err["Message"] == "Requested Range Not Satisfiable"
+    # Exact message depends on the werkzeug version - AWS returns 'Requested Range Not Satisfiable'
+    assert "Range Not Satisfiable" in err["Message"]
 
     with pytest.raises(ClientError) as exc:
         client.head_object(Bucket=bucket_name, Key="hello_bad.txt")
@@ -1791,7 +1792,8 @@ def test_get_object(size, bucket_name=None):
         client.head_object(Bucket=bucket_name, Key="hello.txt", PartNumber=2)
     err = exc.value.response["Error"]
     assert err["Code"] == "416"
-    assert err["Message"] == "Requested Range Not Satisfiable"
+    # Exact message depends on the werkzeug version - AWS returns 'Requested Range Not Satisfiable'
+    assert "Range Not Satisfiable" in err["Message"]
 
     with pytest.raises(ClientError) as exc:
         s3_resource.Object(bucket_name, "hello2.txt").get()


### PR DESCRIPTION
Now that we no longer support for 3.8 we can also simplify a bunch of types - i.e. `List[str]` can become `list[str]`, same for Set->set, etc.

That is a bigger change though, so I'll tackle that later.