### PR TITLE
Admin: Remove typing_extensions module

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -9,9 +9,18 @@ import string
 from collections import OrderedDict, defaultdict
 from functools import lru_cache, partialmethod
 from re import compile as re_compile
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
-
-from typing_extensions import Literal, Protocol, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Tuple,
+    Union,
+)
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -2111,9 +2120,9 @@ class RDSBackend(BaseBackend):
     def get_snapshot(
         self,
         identifier: str,
-        resource_type: Type[DBSnapshot] | Type[DBClusterSnapshot],
-        not_found_exception: Type[DBSnapshotNotFoundFault]
-        | Type[DBClusterSnapshotNotFoundError],
+        resource_type: type[DBSnapshot] | type[DBClusterSnapshot],
+        not_found_exception: type[DBSnapshotNotFoundFault]
+        | type[DBClusterSnapshotNotFoundError],
     ) -> DBSnapshot | DBClusterSnapshot:
         region = self.region_name
         if identifier.startswith("arn"):
@@ -2138,7 +2147,7 @@ class RDSBackend(BaseBackend):
     )
 
     def get_shared_snapshots(
-        self, resource_type: Type[DBSnapshot] | Type[DBClusterSnapshot]
+        self, resource_type: type[DBSnapshot] | type[DBClusterSnapshot]
     ) -> List[DBSnapshot | DBClusterSnapshot]:
         snapshots_shared = []
         for backend_container in rds_backends.values():

--- a/moto/rds/serialize.py
+++ b/moto/rds/serialize.py
@@ -17,11 +17,10 @@ from botocore.model import (
     StructureShape,
 )
 from botocore.utils import parse_to_aware_datetime
-from typing_extensions import TypeAlias
 
 from .utils import get_service_model
 
-Serialized: TypeAlias = MutableMapping[str, Any]
+Serialized = MutableMapping[str, Any]
 
 
 class ErrorShape(StructureShape):


### PR DESCRIPTION
Fixes #8627 

FYI @bpandola - a little refactoring to get rid of this dependency. I replaced `TypeAlias` completely because it is a) only introduced in 3.10, and b) [was deprecated again in 3.12](https://docs.python.org/3/library/typing.html#typing.TypeAlias). It seems to run fine without it, so I think it's OK? Happy to be corrected though, typing is not my strong suit. :)