### PR TITLE
DynamoDB: Path overlap check for all types of updates

### DIFF
--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -304,16 +304,16 @@ class InvalidAttributeTypeError(MockValidationException):
 
 
 class DuplicateUpdateExpression(InvalidUpdateExpression):
-    def __init__(self, name_1: List[str], name_2: List[str]):
+    def __init__(self, name_1: str, name_2: str):
         super().__init__(
-            f"Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{", ".join(name_1)}], path two: [{", ".join(name_2)}]"
+            f"Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{', '.join(name_1.split('.'))}], path two: [{', '.join(name_2.split('.'))}]"
         )
 
 
 class InvalidProjectionExpression(MockValidationException):
-    def __init__(self, path_1: List[str], path_2: List[str]):
+    def __init__(self, path_1: str, path_2: str):
         super().__init__(
-            f"Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{", ".join(path_1)}], path two: [{", ".join(path_2)}]"
+            f"Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{', '.join(path_1.split('.'))}], path two: [{', '.join(path_2.split('.'))}]"
         )
 
 

--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -304,9 +304,9 @@ class InvalidAttributeTypeError(MockValidationException):
 
 
 class DuplicateUpdateExpression(InvalidUpdateExpression):
-    def __init__(self, names: List[str]):
+    def __init__(self, name_1: List[str], name_2: List[str]):
         super().__init__(
-            f"Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{names[0]}], path two: [{names[1]}]"
+            f"Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{", ".join(name_1)}], path two: [{", ".join(name_2)}]"
         )
 
 

--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -311,14 +311,10 @@ class DuplicateUpdateExpression(InvalidUpdateExpression):
 
 
 class InvalidProjectionExpression(MockValidationException):
-    msg = (
-        "Invalid ProjectionExpression: "
-        "Two document paths overlap with each other; must remove or rewrite one of these paths; "
-        "path one: [{paths[0]}], path two: [{paths[1]}]"
-    )
-
-    def __init__(self, paths: List[str]):
-        super().__init__(self.msg.format(paths=paths))
+    def __init__(self, path_1: List[str], path_2: List[str]):
+        super().__init__(
+            f"Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{", ".join(path_1)}], path two: [{", ".join(path_2)}]"
+        )
 
 
 class TooManyClauses(InvalidUpdateExpression):

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -677,10 +677,10 @@ class DynamoDBBackend(BaseBackend):
                         expression_attribute_values=expression_attribute_values,
                     )
                 errors.append((None, None, None))
-            except MultipleTransactionsException:
+            except (MultipleTransactionsException, MockValidationException):
                 # Rollback to the original state, and reraise the error
                 self.tables = original_table_state
-                raise MultipleTransactionsException()
+                raise
             except ConditionalCheckFailed as e:
                 errors.append(("ConditionalCheckFailed", str(e.message), original_item))  # type: ignore
             except Exception as e:  # noqa: E722 Do not use bare except

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -442,7 +442,6 @@ class DynamoDBBackend(BaseBackend):
             # Parse expression to get validation errors
             update_expression_ast = UpdateExpressionParser.make(update_expression)
             update_expression = re.sub(r"\s*([=\+-])\s*", "\\1", update_expression)
-            update_expression_ast.validate()
 
         if all([table.hash_key_attr in key, table.range_key_attr in key]):
             # Covers cases where table has hash and range keys, ``key`` param

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -26,7 +26,7 @@ from .exceptions import (
     ResourceNotFoundException,
     UnknownKeyType,
 )
-from .utils import extract_duplicates
+from .utils import find_path_overlaps
 
 TRANSACTION_MAX_ITEMS = 25
 
@@ -1290,11 +1290,7 @@ class DynamoHandler(BaseResponse):
                 )
 
                 update_expression = item["Update"]["UpdateExpression"]
-                UpdateExpressionParser.make(update_expression).validate(
-                    limit_set_actions=True
-                )
                 update_expression_ast = UpdateExpressionParser.make(update_expression)
-                update_expression_ast.validate(limit_set_actions=True)
                 attr_name_clauses = update_expression_ast.find_clauses(
                     [ExpressionAttributeName]
                 )

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -13,6 +13,7 @@ from moto.dynamodb.parsing.expressions import (  # type: ignore
     ExpressionAttributeName,
     UpdateExpressionParser,
 )
+from moto.dynamodb.utils import find_duplicates
 from moto.dynamodb.parsing.key_condition_expression import parse_expression
 from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
 from moto.utilities.aws_headers import amz_crc32
@@ -203,9 +204,9 @@ class ProjectionExpressionParser:
 
         if self.projection_expression:
             expressions = [x.strip() for x in self.projection_expression.split(",")]
-            duplicates = extract_duplicates(expressions)
+            duplicates = find_duplicates(expressions)
             if duplicates:
-                raise InvalidProjectionExpression(duplicates)
+                raise InvalidProjectionExpression(*duplicates)
             for expression in expressions:
                 check_projection_expression(expression)
             output = []

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -13,9 +13,9 @@ from moto.dynamodb.parsing.expressions import (  # type: ignore
     ExpressionAttributeName,
     UpdateExpressionParser,
 )
-from moto.dynamodb.utils import find_duplicates
 from moto.dynamodb.parsing.key_condition_expression import parse_expression
 from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
+from moto.dynamodb.utils import find_duplicates
 from moto.utilities.aws_headers import amz_crc32
 
 from .exceptions import (
@@ -27,7 +27,6 @@ from .exceptions import (
     ResourceNotFoundException,
     UnknownKeyType,
 )
-from .utils import find_path_overlaps
 
 TRANSACTION_MAX_ITEMS = 25
 

--- a/moto/dynamodb/utils.py
+++ b/moto/dynamodb/utils.py
@@ -1,17 +1,27 @@
 from typing import List
 
 
-def extract_duplicates(input_list: List[str]) -> List[List[str]]:
+def find_duplicates(input_list: List[str]) -> List[str]:
     input_list_copy = input_list.copy()
     while len(input_list_copy) > 0:
         # start at front of list
         item = input_list_copy.pop(0)
         if item in input_list_copy:
-            return [[item], [item]]
+            return [item, item]
+    return []
+
+
+def find_path_overlaps(input_list: List[str]) -> List[str]:
+    input_list_copy = input_list.copy()
+    while len(input_list_copy) > 0:
+        # start at front of list
+        item = input_list_copy.pop(0)
+        if item in input_list_copy:
+            return [item, item]
         else:
             for second_item in input_list_copy:
                 if second_item.startswith(item + "."):
-                    return [[item], second_item.split(".")]
+                    return [item, second_item]
                 elif item.startswith(second_item + "."):
-                    return [item.split("."), [second_item]]
+                    return [item, second_item]
     return []

--- a/moto/dynamodb/utils.py
+++ b/moto/dynamodb/utils.py
@@ -1,5 +1,17 @@
 from typing import List
 
 
-def extract_duplicates(input_list: List[str]) -> List[str]:
-    return [item for item in input_list if input_list.count(item) > 1]
+def extract_duplicates(input_list: List[str]) -> List[List[str]]:
+    input_list_copy = input_list.copy()
+    while len(input_list_copy) > 0:
+        # start at front of list
+        item = input_list_copy.pop(0)
+        if item in input_list_copy:
+            return [[item], [item]]
+        else:
+            for second_item in input_list_copy:
+                if second_item.startswith(item + "."):
+                    return [[item], second_item.split(".")]
+                elif item.startswith(second_item + "."):
+                    return [item.split("."), [second_item]]
+    return []

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -283,11 +283,17 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             self.table.update_item(
                 Key={"pk": "foo"},
                 UpdateExpression="set #stringSet = :h, #nestedStringSet = :w",
-                ExpressionAttributeNames={"#stringSet": "string_set", "#nestedStringSet": "string_set.nested"},
+                ExpressionAttributeNames={
+                    "#stringSet": "string_set",
+                    "#nestedStringSet": "string_set.nested",
+                },
                 ExpressionAttributeValues={":h": "H", ":w": "W"},
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
-        assert exc.value.response["Error"]["Message"] == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set, nested]"
+        assert (
+            exc.value.response["Error"]["Message"]
+            == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set, nested]"
+        )
 
     def test_delete_and_add_on_different_set(self):
         self.table.update_item(

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -260,6 +260,35 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             "Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
+    def test_remove_and_add_on_same_set(self):
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "foo"},
+                UpdateExpression="ADD #stringSet :addSet REMOVE #stringSet",
+                ExpressionAttributeNames={"#stringSet": "string_set"},
+                ExpressionAttributeValues={":addSet": {"c"}},
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
+        assert exc.value.response["Error"]["Message"].startswith(
+            "Invalid UpdateExpression: Two document paths overlap with each other;"
+        )
+
+    def test_set_path_overlap(self):
+        record = {
+            "pk": "foo",
+            "string_set": {"nested": "h"},
+        }
+        self.table.put_item(Item=record)
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "foo"},
+                UpdateExpression="set #stringSet = :h, #nestedStringSet = :w",
+                ExpressionAttributeNames={"#stringSet": "string_set", "#nestedStringSet": "string_set.nested"},
+                ExpressionAttributeValues={":h": "H", ":w": "W"},
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
+        assert exc.value.response["Error"]["Message"] == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set, nested]"
+
     def test_delete_and_add_on_different_set(self):
         self.table.update_item(
             Key={"pk": "the-key"},

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -247,6 +247,20 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             == 'Invalid UpdateExpression: The "REMOVE" section can only be used once in an update expression;'
         )
 
+    def test_multiple_set_clauses(self):
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "the-key"},
+                UpdateExpression="SET current_user = :current_user SET some_param = :current_user",
+                ExpressionAttributeValues={":current_user": {"name": "Jane"}},
+            )
+        err = exc.value.response["Error"]
+        assert err["Code"] == "ValidationException"
+        assert (
+            err["Message"]
+            == 'Invalid UpdateExpression: The "SET" section can only be used once in an update expression;'
+        )
+
     def test_delete_and_add_on_same_set(self):
         with pytest.raises(ClientError) as exc:
             self.table.update_item(
@@ -265,7 +279,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             self.table.update_item(
                 Key={"pk": "foo"},
                 UpdateExpression="ADD #stringSet :addSet REMOVE #stringSet",
-                ExpressionAttributeNames={"#stringSet": "string_set"},
+                ExpressionAttributeNames={"#stringSet": "string_set.nested"},
                 ExpressionAttributeValues={":addSet": {"c"}},
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
@@ -273,26 +287,84 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             "Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
-    def test_set_path_overlap(self):
-        record = {
-            "pk": "foo",
-            "string_set": {"nested": "h"},
-        }
-        self.table.put_item(Item=record)
+    def test_set_and_remove_on_overlapping_paths(self):
         with pytest.raises(ClientError) as exc:
             self.table.update_item(
                 Key={"pk": "foo"},
-                UpdateExpression="set #stringSet = :h, #nestedStringSet = :w",
-                ExpressionAttributeNames={
-                    "#stringSet": "string_set",
-                    "#nestedStringSet": "string_set.nested",
-                },
-                ExpressionAttributeValues={":h": "H", ":w": "W"},
+                UpdateExpression="REMOVE string_set SET string_set.nested = :h",
+                ExpressionAttributeValues={":h": "H"},
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
+        assert exc.value.response["Error"]["Message"].startswith(
+            "Invalid UpdateExpression: Two document paths overlap with each other;"
+        )
+
+    def test_set_path_overlap(self):
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "foo"},
+                UpdateExpression="SET string_set = :h, string_set.nested = :h",
+                ExpressionAttributeValues={":h": "H"},
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
+        assert exc.value.response["Error"]["Message"].startswith(
+            "Invalid UpdateExpression: Two document paths overlap with each other;"
+        )
+
+    def test_path_overlap_error_uses_expression_attribute_name(self):
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "foo"},
+                UpdateExpression="SET #stringSet = :h, #stringSet = :h",
+                ExpressionAttributeNames={"#stringSet": "string_set"},
+                ExpressionAttributeValues={":h": "H"},
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert (
             exc.value.response["Error"]["Message"]
-            == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set, nested]"
+            == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set]"
+        )
+
+    def test_path_overlap_error_splits_paths(self):
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "foo"},
+                UpdateExpression="SET string_set.nested = :h, string_set.nested = :h",
+                ExpressionAttributeValues={":h": "H"},
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
+        assert (
+            exc.value.response["Error"]["Message"]
+            == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set, nested], path two: [string_set, nested]"
+        )
+
+    # pretty weird AWS behavior with the next two tests, seems like a bug
+    def test_no_overlapping_paths_error_if_one_of_the_overlapping_paths_is_an_expression_attribute_name(
+        self,
+    ):
+        self.table.update_item(
+            Key={"pk": "foo"},
+            UpdateExpression="SET string_set = :h, #nested = :h",
+            ExpressionAttributeNames={"#nested": "string_set.nested"},
+            ExpressionAttributeValues={":h": "H"},
+        )
+
+    def test_overlapping_paths_error_if_identical_paths_are_expression_attribute_names(
+        self,
+    ):
+        with pytest.raises(ClientError) as exc:
+            self.table.update_item(
+                Key={"pk": "foo"},
+                UpdateExpression="SET #stringSet = :h, #nested = :h",
+                ExpressionAttributeNames={
+                    "#stringSet": "string_set",
+                    "#nested": "string_set",
+                },
+                ExpressionAttributeValues={":h": "H"},
+            )
+        assert exc.value.response["Error"]["Code"] == "ValidationException"
+        assert exc.value.response["Error"]["Message"].startswith(
+            "Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
     def test_delete_and_add_on_different_set(self):
@@ -998,7 +1070,6 @@ def test_update_item_non_existent_table():
     "expression",
     [
         "set example_column = :example_column, example_column = :example_column",
-        "set example_column = :example_column ADD x :y set example_column = :example_column",
     ],
 )
 def test_update_item_with_duplicate_expressions(expression):

--- a/tests/test_dynamodb/exceptions/test_dynamodb_transactions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_transactions.py
@@ -94,7 +94,7 @@ def test_transact_write_items__update_with_multiple_set_clauses(table_name=None)
                 {
                     "Update": {
                         "TableName": table_name,
-                        "Key": {"pk": {"S": "s"}},
+                        "Key": {"pk": {"S": "s"}, "sk": {"S": "t"}},
                         "UpdateExpression": "SET expire_at_utc = :expire_at_utc SET is_final = :true ADD version :one",
                         "ExpressionAttributeValues": {
                             ":true": {"BOOL": True},

--- a/tests/test_dynamodb/test_dynamodb_utils.py
+++ b/tests/test_dynamodb/test_dynamodb_utils.py
@@ -1,0 +1,25 @@
+from moto.dynamodb.utils import find_duplicates, find_path_overlaps
+
+
+def test_find_duplicates_simple_duplicate():
+    assert find_duplicates(["a", "a"]) == ["a", "a"]
+
+
+def test_find_duplicates_no_duplicates():
+    assert find_duplicates(["a", "b"]) == []
+
+
+def test_find_duplicates_out_of_order():
+    assert find_duplicates(["b", "a", "b"]) == ["b", "b"]
+
+
+def test_find_path_overlaps_simple_overlap():
+    assert find_path_overlaps(["a", "a.b"]) == ["a", "a.b"]
+
+
+def test_find_path_overlaps_no_overlap():
+    assert find_path_overlaps(["a", "b"]) == []
+
+
+def test_find_path_overlaps_reverse_overlap():
+    assert find_path_overlaps(["a.b", "a"]) == ["a.b", "a"]


### PR DESCRIPTION
This addresses [issue 8582](https://github.com/getmoto/moto/issues/8582).

I discovered a lot about the AWS api's handling of overlapping paths while making test cases for this one:

- AWS does substitute attribute names in the error messages
- AWS only catches overlapping paths if neither path is an attribute name
- AWS does detect duplicate paths if one or more of them is an attribute name
- AWS splits the path into a list in the error message

Based on this, I found the following issues with the current validation:

- it only checked for conflicts between adds and deletes, or between set actions
- it only checked for duplicate paths
- it didn't handle attribute name substitution

I realized that by limiting a validation to an UpdateExpression, I could add top-level checks to the already existing set of validations for update statements. I felt this was more natural, and the expression names were already available, so I moved the validations that previously belongs to the AST object into the update expression validator.

However, this made it more difficult to do the update validation at the response level for transact_write_items. Rather than duplicate the whole thing, I had the transact_write_items backend pipe validation errors through the transaction failure error handling, since in AWS the validation occurs before any transaction execution.

As part of this I discovered that both updates and transactions can only have one "set" statement, so I added it to the validations as well.