### PR TITLE
Add AWS Protocol Serializers

### DIFF
--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -1,0 +1,840 @@
+# mypy: disable-error-code="misc, override, var-annotated"
+"""Response serializers for the various AWS protocol specifications.
+
+There are some similarities among the different protocols with respect
+to response serialization, so the code is structured in a way to avoid
+code duplication where possible.  The diagram below illustrates the
+inheritance hierarchy of the response serializer classes.
+
+                           +--------------------+
+                           | ResponseSerializer |
+                           +--------------------+
+                             ^       ^       ^
+         +-------------------+       |       +---------------------+
+         |                           |                             |
+    +----+--------------+  +---------+----------+  +---------------+----+
+    | BaseXMLSerializer |  | BaseRestSerializer |  | BaseJSONSerializer |
+    +-------------------+  +--------------------+  +--------------------+
+         ^             ^          ^           ^           ^           ^
+         |             |          |           |           |           |
+         |         +---+----------+----+  +---+-----------+----+      |
+         |         | RestXMLSerializer |  | RestJSONSerializer |      |
+         |         +-------------------+  +--------------------+      |
+         |                                                            |
+    +----+------------+                                  +------------+---+
+    | QuerySerializer |                                  | JSONSerializer |
+    +-----------------+                                  +----------------+
+         ^
+         |
+    +----+----------+
+    | EC2Serializer |
+    +---------------+
+
+Return Value
+============
+
+The response serializers expose a single public method: ``serialize()``
+This method takes in any result (dict, object, Exception, etc.) and
+returns a serialized ResponseDict of the following form:
+
+    {
+        "body": <RESPONSE_BODY>,
+        "headers": <RESPONSE_HEADERS>,
+        "status_code": <RESPONSE_HTTP_STATUS_CODE>,
+    }
+
+The body serialization output is text (Python strings), not bytes, mostly
+for ease of inspection while debugging (pretty printing is also supported).
+The exception is blob types, which are assumed to be binary and will be
+encoded as ``utf-8``.
+
+"""
+
+from __future__ import annotations
+
+import base64
+import calendar
+import json
+from datetime import datetime
+from typing import Any, Mapping, MutableMapping, Optional, TypedDict, Union
+
+import xmltodict
+from botocore.compat import formatdate
+from botocore.model import (
+    ListShape,
+    MapShape,
+    NoShapeFoundError,
+    OperationModel,
+    Shape,
+    StructureShape,
+)
+from botocore.utils import is_json_value_header, parse_to_aware_datetime
+
+Serialized = MutableMapping[str, Any]
+
+
+class ResponseDict(TypedDict):
+    body: str
+    headers: MutableMapping[str, str]
+    status_code: int
+
+
+class SerializationContext:
+    def __init__(self, request_id: Optional[str] = None) -> None:
+        self.request_id = request_id or "request-id"
+
+
+class ErrorShape(StructureShape):
+    # Overriding super class property to keep mypy happy...
+    @property
+    def error_code(self) -> str:
+        code = str(super().error_code)
+        return code
+
+
+class ShapeHelpersMixin:
+    @staticmethod
+    def get_serialized_name(shape: Shape, default_name: str) -> str:
+        return shape.serialization.get("name", default_name)
+
+    @staticmethod
+    def is_flattened(shape: Shape) -> bool:
+        return shape.serialization.get("flattened", False)
+
+    @staticmethod
+    def is_http_header_trait(shape: Shape) -> bool:
+        return hasattr(shape, "serialization") and shape.serialization.get(
+            "location"
+        ) in ["header", "headers"]
+
+    @staticmethod
+    def is_not_bound_to_body(shape: Shape) -> bool:
+        return hasattr(shape, "serialization") and "location" in shape.serialization
+
+
+class TimestampSerializer:
+    TIMESTAMP_FORMAT_ISO8601 = "iso8601"
+    TIMESTAMP_FORMAT_RFC822 = "rfc822"
+    TIMESTAMP_FORMAT_UNIX = "unixtimestamp"
+
+    ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
+    ISO8601_MICRO = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+    def __init__(self, default_format: str) -> None:
+        self.default_format = default_format
+
+    def serialize(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        timestamp_format = shape.serialization.get(
+            "timestampFormat", self.default_format
+        )
+        serialized_value = self._convert_timestamp_to_str(value, timestamp_format)
+        serialized[key] = serialized_value
+
+    def _timestamp_iso8601(self, value: datetime) -> str:
+        if value.microsecond > 0:
+            timestamp_format = self.ISO8601_MICRO
+        else:
+            timestamp_format = self.ISO8601
+        return value.strftime(timestamp_format)
+
+    @staticmethod
+    def _timestamp_unixtimestamp(value: datetime) -> float:
+        return int(calendar.timegm(value.timetuple()))
+
+    def _timestamp_rfc822(self, value: Union[datetime, float]) -> str:
+        if isinstance(value, datetime):
+            value = self._timestamp_unixtimestamp(value)
+        return formatdate(value, usegmt=True)
+
+    def _convert_timestamp_to_str(
+        self, value: Union[int, str, datetime], timestamp_format: str
+    ) -> str:
+        timestamp_format = timestamp_format.lower()
+        converter = getattr(self, "_timestamp_%s" % timestamp_format)
+        datetime_obj = parse_to_aware_datetime(value)  # type: ignore
+        final_value = converter(datetime_obj)
+        return final_value
+
+
+class HeaderSerializer(ShapeHelpersMixin):
+    # https://smithy.io/2.0/spec/http-bindings.html#httpheader-serialization-rules
+    DEFAULT_ENCODING = "utf-8"
+    DEFAULT_TIMESTAMP_FORMAT = TimestampSerializer.TIMESTAMP_FORMAT_RFC822
+
+    def __init__(self, **kwargs: Mapping[str, Any]) -> None:
+        super().__init__(**kwargs)
+        self._timestamp_serializer = TimestampSerializer(self.DEFAULT_TIMESTAMP_FORMAT)
+
+    def serialize(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        method = getattr(
+            self, "_serialize_type_%s" % shape.type_name, self._default_serialize
+        )
+        method(serialized, value, shape, key)
+
+    @staticmethod
+    def _default_serialize(
+        serialized: Serialized, value: Any, _: Shape, key: str
+    ) -> None:
+        serialized[key] = str(value)
+
+    def _serialize_type_boolean(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        boolean_value = "true" if value else "false"
+        self._default_serialize(serialized, boolean_value, shape, key)
+
+    def _serialize_type_list(
+        self, serialized: Serialized, value: Any, shape: ListShape, key: str
+    ) -> None:
+        list_value = ",".join(value)
+        self._default_serialize(serialized, list_value, shape, key)
+
+    def _serialize_type_map(
+        self, serialized: Serialized, value: Any, shape: MapShape, _: str
+    ) -> None:
+        header_prefix = self.get_serialized_name(shape, "")
+        for key, val in value.items():
+            full_key = header_prefix + key
+            self._default_serialize(serialized, val, shape, full_key)
+
+    def _serialize_type_string(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        string_value = value
+        if is_json_value_header(shape):
+            json_value = json.dumps(value, separators=(",", ":"))
+            string_value = self._base64(json_value)
+        self._default_serialize(serialized, string_value, shape, key)
+
+    def _serialize_type_timestamp(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        wrapper = {}
+        self._timestamp_serializer.serialize(wrapper, value, shape, "timestamp")
+        self._default_serialize(serialized, wrapper["timestamp"], shape, key)
+
+    def _base64(self, value: Union[str, bytes]) -> str:
+        if isinstance(value, str):
+            value = value.encode(self.DEFAULT_ENCODING)
+        return base64.b64encode(value).strip().decode(self.DEFAULT_ENCODING)
+
+
+class ResponseSerializer(ShapeHelpersMixin):
+    CONTENT_TYPE = "text"
+    DEFAULT_ENCODING = "utf-8"
+    DEFAULT_RESPONSE_CODE = 200
+    DEFAULT_ERROR_RESPONSE_CODE = 400
+    # From the spec, the default timestamp format if not specified is iso8601.
+    DEFAULT_TIMESTAMP_FORMAT = TimestampSerializer.TIMESTAMP_FORMAT_ISO8601
+    # Clients can change this to a different MutableMapping (i.e. OrderedDict) if they want.
+    # This is used in the compliance test to match the hash ordering used in the tests.
+    # NOTE: This is no longer necessary because dicts post 3.6 are ordered:
+    # https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
+    MAP_TYPE = dict
+
+    def __init__(
+        self,
+        operation_model: OperationModel,
+        context: Optional[SerializationContext] = None,
+        pretty_print: Optional[bool] = False,
+        value_picker: Any = None,
+    ) -> None:
+        self.operation_model = operation_model
+        self.context = context or SerializationContext()
+        self.pretty_print = pretty_print
+        if value_picker is None:
+            value_picker = self._default_value_picker
+        self._value_picker = value_picker
+        self._timestamp_serializer = TimestampSerializer(self.DEFAULT_TIMESTAMP_FORMAT)
+
+    def _create_default_response(self) -> ResponseDict:
+        response_dict: ResponseDict = {
+            "body": "",
+            "headers": {},
+            "status_code": self.DEFAULT_RESPONSE_CODE,
+        }
+        return response_dict
+
+    def serialize(self, result: Any) -> ResponseDict:
+        resp = self._create_default_response()
+        if self._is_error_result(result):
+            resp = self._serialize_error(resp, result)
+        else:
+            resp = self._serialize_result(resp, result)
+        return resp
+
+    def _serialize_error(
+        self,
+        resp: ResponseDict,
+        error: Exception,
+    ) -> ResponseDict:
+        error_shape = self._get_error_shape(error)
+        serialized_error = self.MAP_TYPE()
+        self._serialize_error_metadata(serialized_error, error, error_shape)
+        return self._serialized_error_to_response(
+            resp, error, error_shape, serialized_error
+        )
+
+    def _serialize_result(self, resp: ResponseDict, result: Any) -> ResponseDict:
+        output_shape = self.operation_model.output_shape
+        serialized_result = self.MAP_TYPE()
+        if output_shape is not None:
+            assert isinstance(output_shape, StructureShape)  # mypy hint
+            self._serialize(serialized_result, result, output_shape, "")
+        return self._serialized_result_to_response(
+            resp, result, output_shape, serialized_result
+        )
+
+    def _serialized_error_to_response(
+        self,
+        resp: ResponseDict,
+        error: Exception,
+        shape: ErrorShape,
+        serialized_error: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        raise NotImplementedError("Must be implemented in subclass.")
+
+    def _serialized_result_to_response(
+        self,
+        resp: ResponseDict,
+        result: Any,
+        shape: Optional[StructureShape],
+        serialized_result: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        raise NotImplementedError("Must be implemented in subclass.")
+
+    def _serialize_error_metadata(
+        self,
+        serialized: Serialized,
+        error: Exception,
+        shape: ErrorShape,
+    ) -> None:
+        raise NotImplementedError("Must be implemented in subclass.")
+
+    def _serialize_body(self, body: Any) -> str:
+        raise NotImplementedError("Must be implemented in subclass.")
+
+    # Some extra utility methods subclasses can use.
+    @staticmethod
+    def _is_error_result(result: object) -> bool:
+        return isinstance(result, Exception)
+
+    def _base64(self, value: Union[str, bytes]) -> str:
+        if isinstance(value, str):
+            value = value.encode(self.DEFAULT_ENCODING)
+        return base64.b64encode(value).strip().decode(self.DEFAULT_ENCODING)
+
+    @staticmethod
+    def _default_value_picker(obj: Any, key: str, _: Shape, default: Any = None) -> Any:
+        if not hasattr(obj, "__getitem__"):
+            return getattr(obj, key, default)
+
+        try:
+            return obj[key]
+        except (KeyError, IndexError, TypeError, AttributeError):
+            return getattr(obj, key, default)
+
+    def _get_value(self, value: Any, key: str, shape: Shape) -> Any:
+        return self._value_picker(value, key, shape)
+
+    @staticmethod
+    def _get_error_shape_name(error: Exception) -> str:
+        shape_name = getattr(error, "code", error.__class__.__name__)
+        return shape_name
+
+    def _get_error_shape(self, error: Exception) -> ErrorShape:
+        shape_name = self._get_error_shape_name(error)
+        try:
+            # TODO: there is also an errors array in the operation model,
+            # but I think it only includes the possible errors for that
+            # operation.  Maybe we try that first, then try all shapes?
+            shape = self.operation_model.service_model.shape_for(shape_name)
+            # We convert to ErrorShape to keep mypy happy...
+            shape = ErrorShape(
+                shape_name,
+                shape._shape_model,  # type: ignore[attr-defined]
+                shape._shape_resolver,  # type: ignore[attr-defined]
+            )
+        except NoShapeFoundError:
+            generic_error_model = {
+                "exception": True,
+                "type": "structure",
+                "members": {},
+                "error": {
+                    "code": shape_name,
+                },
+            }
+            shape = ErrorShape(shape_name, generic_error_model)
+        return shape
+
+    #
+    # Default serializers for the various model Shape types.
+    # These can be overridden in subclasses to provide protocol-specific implementations.
+    #
+    def _serialize(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        method = getattr(
+            self, "_serialize_type_%s" % shape.type_name, self._default_serialize
+        )
+        method(serialized, value, shape, key)
+
+    @staticmethod
+    def _default_serialize(
+        serialized: Serialized, value: Any, _: Shape, key: str
+    ) -> None:
+        serialized[key] = value
+
+    def _serialize_type_structure(
+        self, serialized: Serialized, value: Any, shape: StructureShape, key: str
+    ) -> None:
+        if value is None:
+            return
+        if key:
+            new_serialized = self.MAP_TYPE()
+            serialized[key] = new_serialized
+            serialized = new_serialized
+        for member_key, member_shape in shape.members.items():
+            self._serialize_structure_member(
+                serialized, value, member_shape, member_key
+            )
+
+    def _serialize_structure_member(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        member_value = self._get_value(value, key, shape)
+        if member_value is not None:
+            key_name = self.get_serialized_name(shape, key)
+            self._serialize(serialized, member_value, shape, key_name)
+
+    def _serialize_type_map(
+        self, serialized: Serialized, value: Any, shape: MapShape, key: str
+    ) -> None:
+        map_list = []
+        if self.is_flattened(shape):
+            items_name = key
+            serialized[items_name] = map_list
+        else:
+            items_name = "entry"
+            serialized[key] = {items_name: map_list}
+        key_shape = shape.key
+        assert isinstance(key_shape, Shape)
+        value_shape = shape.value
+        assert isinstance(value_shape, Shape)
+        for key in value:
+            wrapper = {"__current__": {}}
+            key_prefix = self.get_serialized_name(key_shape, "key")
+            value_prefix = self.get_serialized_name(value_shape, "value")
+            self._serialize(wrapper["__current__"], key, key_shape, key_prefix)
+            self._serialize(
+                wrapper["__current__"], value[key], value_shape, value_prefix
+            )
+            map_list.append(wrapper["__current__"])
+
+    def _serialize_type_timestamp(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        value_wrapper = {}
+        value_key = "timestamp"
+        self._timestamp_serializer.serialize(value_wrapper, value, shape, value_key)
+        self._default_serialize(serialized, value_wrapper[value_key], shape, key)
+
+    def _serialize_type_blob(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        blob_value = self._base64(value)
+        self._default_serialize(serialized, blob_value, shape, key)
+
+
+class BaseJSONSerializer(ResponseSerializer):
+    DEFAULT_TIMESTAMP_FORMAT = "unixtimestamp"
+
+    def _serialized_result_to_response(
+        self,
+        resp: ResponseDict,
+        result: Any,
+        shape: Optional[StructureShape],
+        serialized_result: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        resp["body"] = self._serialize_body(serialized_result)
+        return resp
+
+    def _serialized_error_to_response(
+        self,
+        resp: ResponseDict,
+        error: Exception,
+        shape: ErrorShape,
+        serialized_error: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        resp["body"] = self._serialize_body(serialized_error)
+        status_code = shape.metadata.get("error", {}).get(
+            "httpStatusCode", self.DEFAULT_ERROR_RESPONSE_CODE
+        )
+        resp["status_code"] = status_code
+        error_code = self._get_protocol_specific_error_code(shape.error_code)
+        resp["headers"]["X-Amzn-Errortype"] = error_code
+        return resp
+
+    def _get_protocol_specific_error_code(
+        self,
+        error_code: str,
+    ) -> str:
+        # https://smithy.io/2.0/aws/protocols/aws-json-1_1-protocol.html#operation-error-serialization
+        service_metadata = self.operation_model.service_model.metadata
+        json_version = service_metadata.get("jsonVersion")
+        prefix = service_metadata.get("targetPrefix")
+        if json_version == "1.0" and prefix is not None:
+            error_code = prefix + "#" + error_code
+        return error_code
+
+    def _serialize_error_metadata(
+        self,
+        serialized: Serialized,
+        error: Exception,
+        shape: ErrorShape,
+    ) -> None:
+        error_code = self._get_protocol_specific_error_code(shape.error_code)
+        serialized["__type"] = error_code
+        message = getattr(error, "message", None) or str(error)
+        if shape is not None:
+            self._serialize(serialized, error, shape, "")
+        if message:
+            serialized["Message"] = message
+
+    def _serialize_body(self, body: Mapping[str, Any]) -> str:
+        body_encoded = json.dumps(body, indent=4 if self.pretty_print else None)
+        return body_encoded
+
+    def _serialize_type_map(
+        self, serialized: Serialized, value: Any, shape: MapShape, key: str
+    ) -> None:
+        map_obj = self.MAP_TYPE()
+        serialized[key] = map_obj
+        for sub_key, sub_value in value.items():
+            assert isinstance(shape.value, Shape)  # mypy hint
+            self._serialize(map_obj, sub_value, shape.value, sub_key)
+
+    def _serialize_type_list(
+        self, serialized: Serialized, value: Any, shape: ListShape, key: str
+    ) -> None:
+        list_obj = []
+        serialized[key] = list_obj
+        for list_item in value:
+            wrapper = {}
+            # The JSON list serialization is the only case where we aren't
+            # setting a key on a dict.  We handle this by using
+            # a __current__ key on a wrapper dict to serialize each
+            # list item before appending it to the serialized list.
+            assert isinstance(shape.member, Shape)  # mypy hint
+            self._serialize(wrapper, list_item, shape.member, "__current__")
+            if "__current__" in wrapper:
+                list_obj.append(wrapper["__current__"])
+            else:
+                list_obj.append(list_item)
+
+    def _serialize_type_structure(
+        self, serialized: Serialized, value: Any, shape: StructureShape, key: str
+    ) -> None:
+        if shape.is_document_type:
+            serialized[key] = value
+            return
+        super()._serialize_type_structure(serialized, value, shape, key)
+
+
+class BaseXMLSerializer(ResponseSerializer):
+    CONTENT_TYPE = "text/xml"
+
+    def _serialize_namespace_attribute(self, serialized: Serialized) -> None:
+        if (
+            self.CONTENT_TYPE == "text/xml"
+            and "xmlNamespace" in self.operation_model.metadata
+        ):
+            namespace = self.operation_model.metadata["xmlNamespace"]
+            serialized["@xmlns"] = namespace
+
+    def _serialized_error_to_response(
+        self,
+        resp: ResponseDict,
+        error: Exception,
+        shape: ErrorShape,
+        serialized_error: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        error_wrapper = {
+            "ErrorResponse": {
+                "Error": serialized_error,
+                "RequestId": self.context.request_id,
+            }
+        }
+        self._serialize_namespace_attribute(error_wrapper["ErrorResponse"])
+        resp["body"] = self._serialize_body(error_wrapper)
+        status_code = shape.metadata.get("error", {}).get(
+            "httpStatusCode", self.DEFAULT_ERROR_RESPONSE_CODE
+        )
+        resp["status_code"] = status_code
+        return resp
+
+    def _serialized_result_to_response(
+        self,
+        resp: ResponseDict,
+        result: Any,
+        shape: Optional[StructureShape],
+        serialized_result: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        result_key = f"{self.operation_model.name}Result"
+        result_wrapper = {
+            result_key: serialized_result,
+        }
+        self._serialize_namespace_attribute(result_wrapper[result_key])
+        resp["body"] = self._serialize_body(result_wrapper)
+        return resp
+
+    def _serialize_error_metadata(
+        self,
+        serialized: Serialized,
+        error: Exception,
+        shape: ErrorShape,
+    ) -> None:
+        sender_fault = shape.metadata.get("error", {}).get("senderFault", True)
+        serialized["Type"] = "Sender" if sender_fault else "Receiver"
+        serialized["Code"] = shape.error_code
+        message = getattr(error, "message", None)
+        if message is not None:
+            serialized["Message"] = message
+        # Serialize any error model attributes.
+        self._serialize(serialized, error, shape, "")
+
+    def _serialize_body(self, body: Serialized) -> str:
+        body_encoded = xmltodict.unparse(
+            body,
+            full_document=False,
+            short_empty_elements=True,
+            pretty=self.pretty_print,
+        )
+        return body_encoded
+
+    def _serialize_type_list(
+        self, serialized: Serialized, value: Any, shape: ListShape, key: str
+    ) -> None:
+        assert isinstance(shape.member, Shape)  # mypy hinting
+        list_obj = []
+        if self.is_flattened(shape):
+            items_name = self.get_serialized_name(shape.member, key)
+            serialized[items_name] = list_obj
+        else:
+            items_name = self.get_serialized_name(shape.member, "member")
+            serialized[key] = {items_name: list_obj}
+        for list_item in value:
+            wrapper = {}
+            self._serialize(wrapper, list_item, shape.member, "__current__")
+            list_obj.append(wrapper["__current__"])
+        if not list_obj:
+            serialized[key] = ""
+
+
+class BaseRestSerializer(ResponseSerializer):
+    EMPTY_BODY: Serialized = ResponseSerializer.MAP_TYPE()
+    REQUIRES_EMPTY_BODY = False
+
+    def _serialized_result_to_response(
+        self,
+        resp: ResponseDict,
+        result: Any,
+        shape: Optional[StructureShape],
+        serialized_result: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        if "payload" in serialized_result:
+            # Payload trumps all and is delivered as-is.
+            resp["body"] = serialized_result["payload"]
+        else:
+            if not serialized_result["body"]:
+                if self.REQUIRES_EMPTY_BODY:
+                    resp["body"] = self._serialize_body(self.EMPTY_BODY)
+            else:
+                resp = super()._serialized_result_to_response(
+                    resp, result, shape, serialized_result.get("body", {})
+                )
+        if "headers" in serialized_result:
+            resp["headers"].update(serialized_result["headers"])
+        return resp
+
+    def _serialize_result(self, resp: ResponseDict, result: Any) -> ResponseDict:
+        output_shape = self.operation_model.output_shape
+        serialized_result = {
+            "body": {},
+            "headers": {},
+        }
+        assert isinstance(output_shape, StructureShape)
+        self._serialize(serialized_result, result, output_shape, "")
+        payload_member = output_shape.serialization.get("payload")
+        if payload_member is not None:
+            payload_shape = output_shape.members[payload_member]
+            payload_value = self._get_value(result, payload_member, payload_shape)
+            self._serialize_payload(serialized_result, payload_value, payload_shape)
+
+        return self._serialized_result_to_response(
+            resp, result, output_shape, serialized_result
+        )
+
+    def _serialize_payload(
+        self,
+        serialized: Serialized,
+        payload: Any,
+        payload_shape: Shape,
+    ) -> None:
+        if payload_shape.type_name in ["blob", "string"]:
+            # If it's streaming, then the body is just the value of the payload.
+            serialized["payload"] = payload
+        else:
+            # If there's a payload member, we serialize only that one member to the body.
+            serialized["body"] = self.MAP_TYPE()
+            self._serialize(serialized["body"], payload, payload_shape, "")
+
+    def _serialize_structure_member(
+        self, serialized: Serialized, value: Any, shape: Shape, key: str
+    ) -> None:
+        if self.is_not_bound_to_body(shape):
+            if self.is_http_header_trait(shape) and "headers" in serialized:
+                member_value = self._get_value(value, key, shape)
+                if member_value is not None:
+                    key_name = self.get_serialized_name(shape, key)
+                    header_serializer = HeaderSerializer()
+                    header_serializer.serialize(
+                        serialized["headers"], member_value, shape, key_name
+                    )
+        elif "body" in serialized:
+            if not serialized["body"]:
+                serialized["body"] = self.MAP_TYPE()
+            # we're at the top-level structure
+            super()._serialize_structure_member(serialized["body"], value, shape, key)
+        else:
+            # we're in nested structure
+            super()._serialize_structure_member(serialized, value, shape, key)
+
+
+class RestXMLSerializer(BaseRestSerializer, BaseXMLSerializer):
+    DEFAULT_TIMESTAMP_FORMAT = TimestampSerializer.TIMESTAMP_FORMAT_ISO8601
+
+
+class RestJSONSerializer(BaseRestSerializer, BaseJSONSerializer):
+    REQUIRES_EMPTY_BODY = True
+
+
+class JSONSerializer(BaseJSONSerializer):
+    pass
+
+
+class QuerySerializer(BaseXMLSerializer):
+    def _serialized_error_to_response(
+        self,
+        resp: ResponseDict,
+        error: Exception,
+        shape: ErrorShape,
+        serialized_error: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        error_wrapper = {
+            "ErrorResponse": {
+                "Error": serialized_error,
+                "RequestId": self.context.request_id,
+            }
+        }
+        self._serialize_namespace_attribute(error_wrapper["ErrorResponse"])
+        resp["body"] = self._serialize_body(error_wrapper)
+        status_code = shape.metadata.get("error", {}).get(
+            "httpStatusCode", self.DEFAULT_ERROR_RESPONSE_CODE
+        )
+        resp["status_code"] = status_code
+        return resp
+
+    def _serialized_result_to_response(
+        self,
+        resp: ResponseDict,
+        result: Any,
+        shape: Optional[StructureShape],
+        serialized_result: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        response_key = f"{self.operation_model.name}Response"
+        response_wrapper = {response_key: {}}
+        if shape is not None:
+            result_key = shape.serialization.get("resultWrapper", f"{shape.name}Result")
+            response_wrapper[response_key][result_key] = serialized_result
+        response_wrapper[response_key]["ResponseMetadata"] = {
+            "RequestId": self.context.request_id
+        }
+        self._serialize_namespace_attribute(response_wrapper[response_key])
+        resp["body"] = self._serialize_body(response_wrapper)
+        resp["headers"]["Content-Type"] = self.CONTENT_TYPE
+        return resp
+
+
+class EC2Serializer(QuerySerializer):
+    def _serialize_body(self, body: Mapping[str, Any]) -> str:
+        body_serialized = xmltodict.unparse(
+            body,
+            full_document=True,
+            pretty=self.pretty_print,
+            short_empty_elements=True,
+        )
+        return body_serialized
+
+    def _serialize_error_metadata(
+        self,
+        serialized: MutableMapping[str, Any],
+        error: Exception,
+        shape: ErrorShape,
+    ) -> None:
+        serialized["Code"] = shape.error_code
+        message = getattr(error, "message", None)
+        if message is not None:
+            serialized["Message"] = message
+        # Serialize any error model attributes.
+        self._serialize(serialized, error, shape, "")
+
+    def _serialized_error_to_response(
+        self,
+        resp: ResponseDict,
+        error: Exception,
+        shape: ErrorShape,
+        serialized_error: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        error_wrapper = {
+            "Response": {
+                "Errors": [{"Error": serialized_error}],
+                "RequestID": self.context.request_id,
+            }
+        }
+        self._serialize_namespace_attribute(error_wrapper["Response"])
+        resp["body"] = self._serialize_body(error_wrapper)
+        status_code = shape.metadata.get("error", {}).get(
+            "httpStatusCode", self.DEFAULT_ERROR_RESPONSE_CODE
+        )
+        resp["status_code"] = status_code
+        return resp
+
+    def _serialized_result_to_response(
+        self,
+        resp: ResponseDict,
+        result: Any,
+        shape: StructureShape,
+        serialized_result: MutableMapping[str, Any],
+    ) -> ResponseDict:
+        response_key = f"{self.operation_model.name}Response"
+        result_wrapper = {
+            response_key: serialized_result,
+        }
+        result_wrapper[response_key]["requestId"] = self.context.request_id
+        self._serialize_namespace_attribute(result_wrapper[response_key])
+        resp["body"] = self._serialize_body(result_wrapper)
+        return resp
+
+
+SERIALIZERS = {
+    "ec2": EC2Serializer,
+    "json": JSONSerializer,
+    "query": QuerySerializer,
+    "rest-json": RestJSONSerializer,
+    "rest-xml": RestXMLSerializer,
+}

--- a/tests/test_core/protocols/output/ec2.json
+++ b/tests/test_core/protocols/output/ec2.json
@@ -1,0 +1,612 @@
+[
+  {
+    "description": "Scalar members",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType",
+            "locationName": "FooNum"
+          },
+          "FalseBool": {
+            "shape": "BooleanType"
+          },
+          "TrueBool": {
+            "shape": "BooleanType"
+          },
+          "Float": {
+            "shape": "FloatType"
+          },
+          "Double": {
+            "shape": "DoubleType"
+          },
+          "Long": {
+            "shape": "LongType"
+          },
+          "Char": {
+            "shape": "CharType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "CharType": {
+        "type": "character"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "myname",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><Str>myname</Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Blob",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Blob": {
+            "shape": "BlobType"
+          }
+        }
+      },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Blob": "value"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><Blob>dmFsdWU=</Blob><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["abc", "123"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><ListMember><member>abc</member><member>123</member></ListMember><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "List with custom member name",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "locationName": "item"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["abc", "123"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><ListMember><item>abc</item><item>123</item></ListMember><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened List",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListType",
+            "flattened": true
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["abc", "123"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><ListMember>abc</ListMember><ListMember>123</ListMember><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Normal map",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StructureType"
+        }
+      },
+      "StructureType": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": {
+              "foo": "bar"
+            },
+            "baz": {
+              "foo": "bam"
+            }
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><Map><entry><key>qux</key><value><foo>bar</foo></value></entry><entry><key>baz</key><value><foo>bam</foo></value></entry></Map><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened map",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "MapType",
+            "flattened": true
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar",
+            "baz": "bam"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><Map><key>qux</key><value>bar</value></Map><Map><key>baz</key><value>bam</value></Map><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Named map",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "MapType",
+            "flattened": true
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType",
+          "locationName": "foo"
+        },
+        "value": {
+          "shape": "StringType",
+          "locationName": "bar"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar",
+            "baz": "bam"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><Map><foo>qux</foo><bar>bar</bar></Map><Map><foo>baz</foo><bar>bam</bar></Map><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Empty string",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Foo": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><Foo/><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeFormat": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<OperationNameResponse><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember><requestId>request-id</requestId></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "OtherExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+              "shape": "StringType"
+          }
+        }
+      },
+      "StatusShape": {
+        "type": "integer"
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Response><Errors><Error><Code>ExceptionShape</Code><Message>mymessage</Message><BodyMember>mybody</BodyMember></Error></Errors><RequestID>request-id</RequestID></Response>"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody"
+        },
+        "errorCode": "OtherExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Response><Errors><Error><Code>OtherExceptionShape</Code><Message>mymessage</Message><BodyMember>mybody</BodyMember></Error></Errors><RequestID>request-id</RequestID></Response>"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {},
+        "errorCode": "UndefinedShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Response><Errors><Error><Code>UndefinedShape</Code><Message>mymessage</Message></Error></Errors><RequestID>request-id</RequestID></Response>"
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_core/protocols/output/json.json
+++ b/tests/test_core/protocols/output/json.json
@@ -1,0 +1,822 @@
+[
+  {
+    "description": "Scalar members",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType"
+          },
+          "FalseBool": {
+            "shape": "BooleanType"
+          },
+          "TrueBool": {
+            "shape": "BooleanType"
+          },
+          "Float": {
+            "shape": "FloatType"
+          },
+          "Double": {
+            "shape": "DoubleType"
+          },
+          "Long": {
+            "shape": "LongType"
+          },
+          "Char": {
+            "shape": "CharType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "CharType": {
+        "type": "character"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "myname",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"Str\": \"myname\", \"Num\": 123, \"FalseBool\": false, \"TrueBool\": true, \"Float\": 1.2, \"Double\": 1.3, \"Long\": 200, \"Char\": \"a\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Blob members",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "BlobMember": {
+            "shape": "BlobType"
+          },
+          "StructMember": {
+            "shape": "BlobContainer"
+          }
+        }
+      },
+      "BlobType": {
+        "type": "blob"
+      },
+      "BlobContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "BlobType"
+          }
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "BlobMember": "hi!",
+          "StructMember": {
+            "foo": "there!"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"BlobMember\": \"aGkh\", \"StructMember\": {\"foo\": \"dGhlcmUh\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "iso8601",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeFormat": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"TimeArg\": 1398796238, \"TimeCustom\": \"Tue, 29 Apr 2014 18:30:38 GMT\", \"TimeFormat\": \"2014-04-29T18:30:38Z\", \"StructMember\": {\"foo\": 1398796238, \"bar\": \"2014-04-29T18:30:38Z\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListType"
+          },
+          "ListMemberMap": {
+            "shape": "ListTypeMap"
+          },
+          "ListMemberStruct": {
+            "shape": "ListTypeStruct"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "ListTypeMap": {
+        "type": "list",
+        "member": {
+          "shape": "MapType"
+        }
+      },
+      "ListTypeStruct": {
+        "type": "list",
+        "member": {
+          "shape": "StructType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "StructType": {
+        "type": "structure",
+        "members": {
+        }
+      },
+      "MapType": {
+        "type": "string",
+        "key": { "shape": "StringType" },
+        "value": { "shape": "StringType" }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["a", "b"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"ListMember\": [\"a\", \"b\"]}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["a", null],
+          "ListMemberMap": [{}, null, null, {}],
+          "ListMemberStruct": [{}, null, null, {}]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"ListMember\": [\"a\", null], \"ListMemberMap\": [{}, null, null, {}], \"ListMemberStruct\": [{}, null, null, {}]}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Maps",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "MapMember": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "NumberList"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "NumberList": {
+        "type": "list",
+        "member": {
+          "shape": "IntegerType"
+        }
+      },
+      "IntegerType": {
+        "type": "integer"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "MapMember": {
+            "a": [1, 2],
+            "b": [3, 4]
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"MapMember\": {\"a\": [1, 2], \"b\": [3, 4]}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Ignores extra data",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "StrType": {
+            "shape": "StrType"
+          }
+        }
+      },
+      "StrType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": { "foo": "bar" },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "RPC JSON Event Stream",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "Payload": {"shape": "EventStream"},
+            "InitialResponse": {"shape": "StringType"}
+        }
+      },
+      "EventStream": {
+          "type": "structure",
+          "eventstream": true,
+          "members": {
+              "TypeA": {"shape": "TypeAEvent"},
+              "TypeB": {"shape": "TypeBEvent"}
+          }
+      },
+      "TypeAEvent": {
+          "type": "structure",
+          "event": true,
+          "members": {
+              "Payload": {
+                  "shape": "BlobType",
+                  "eventpayload": true
+              }
+          }
+      },
+      "TypeBEvent": {
+          "type": "structure",
+          "event": true,
+          "members": {
+              "Details": {
+                  "shape": "Details",
+                  "eventpayload": true
+              }
+          }
+      },
+      "Details": {
+          "type": "structure",
+          "members": {
+              "StringField": {"shape": "StringType"},
+              "IntegerField": {"shape": "IntegerType"}
+          }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "InitialResponse": "sometext",
+          "Payload": [
+              {
+                  "TypeA": {"Payload": "somebytes"}
+              },
+              {
+                  "TypeB": {
+                      "Details": {
+                          "StringField": "somestring",
+                          "IntegerField": 123
+                      }
+                  }
+              }
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "AAAAfgAAAE/Fo93GDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcAEGluaXRpYWwtcmVzcG9uc2UNOmNvbnRlbnQtdHlwZQcACXRleHQvanNvbnsiSW5pdGlhbFJlc3BvbnNlIjogInNvbWV0ZXh0In32mCSDAAAAbAAAAFPLgkVrDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVR5cGVBDTpjb250ZW50LXR5cGUHABhhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW1zb21lYnl0ZXMesj2HAAAAhgAAAEQqNR/SDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVR5cGVCDTpjb250ZW50LXR5cGUHAAl0ZXh0L2pzb257IlN0cmluZ0ZpZWxkIjogInNvbWVzdHJpbmciLCAiSW50ZWdlckZpZWxkIjogMTIzfffGN30="
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Code": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "OtherExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+              "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody",
+          "Code": "OtherExceptionShape",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"ExceptionShape\", \"BodyMember\": \"mybody\", \"Code\": \"OtherExceptionShape\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody"
+        },
+        "errorCode": "OtherExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"OtherExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {},
+        "errorCode": "UndefinedShape",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"UndefinedShape\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions with jsonVersion 1.0",
+    "metadata": {
+      "protocol": "json",
+      "jsonVersion": "1.0",
+      "targetPrefix": "FooPrefix"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"FooPrefix#ExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serialize document with standalone primitive type in a JSON response",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "inlineDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": "foo"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": \"foo\"}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": 123
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": 123}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": 1.2
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": 1.2}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": true
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": true}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": \"\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serialize inline document in a JSON response",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "inlineDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "inlineDocument": {"foo": "bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"inlineDocument\": {\"foo\": \"bar\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serialize aggregate documents in a JSON response",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "parentDocument": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "parentDocument": {
+              "str": "test",
+              "num": 123,
+              "float": 1.2,
+              "bool": true,
+              "null": "",
+              "document": {"foo": false},
+              "list": ["myname", 321, 1.3, true, "", {"nested": true}, [200, ""]]
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"parentDocument\": {\"str\": \"test\", \"num\": 123, \"float\": 1.2, \"bool\": true, \"null\": \"\", \"document\": {\"foo\": false}, \"list\": [\"myname\", 321, 1.3, true, \"\", {\"nested\": true}, [200, \"\"]]}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "parentDocument": [
+              "test",
+              123,
+              1.2,
+              true,
+              "",
+              {"str": "myname", "num": 321, "float": 1.3, "bool": true, "null": "", "document": {"nested": true}, "list": [200, ""]},
+              ["foo", false]
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"parentDocument\": [\"test\", 123, 1.2, true, \"\", {\"str\": \"myname\", \"num\": 321, \"float\": 1.3, \"bool\": true, \"null\": \"\", \"document\": {\"nested\": true}, \"list\": [200, \"\"]}, [\"foo\", false]]}"
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_core/protocols/output/query.json
+++ b/tests/test_core/protocols/output/query.json
@@ -1,0 +1,977 @@
+[
+  {
+    "description": "Scalar members",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType",
+            "locationName": "FooNum"
+          },
+          "FalseBool": {
+            "shape": "BooleanType"
+          },
+          "TrueBool": {
+            "shape": "BooleanType"
+          },
+          "Float": {
+            "shape": "FloatType"
+          },
+          "Double": {
+            "shape": "DoubleType"
+          },
+          "Long": {
+            "shape": "LongType"
+          },
+          "Char": {
+            "shape": "CharType"
+          },
+          "Timestamp": {
+            "shape": "TimestampType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "CharType": {
+        "type": "character"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "myname",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Str>myname</Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><Timestamp>2015-01-25T08:00:00Z</Timestamp></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Not all members in response",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "myname"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Str>myname</Str></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Blob",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Blob": {
+            "shape": "BlobType"
+          }
+        }
+      },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Blob": "value"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Blob>dmFsdWU=</Blob></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": [
+            "abc",
+            "123"
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><ListMember><member>abc</member><member>123</member></ListMember></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "List with custom member name",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "locationName": "item"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": [
+            "abc",
+            "123"
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><ListMember><item>abc</item><item>123</item></ListMember></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened List",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "flattened": true,
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": [
+            "abc",
+            "123"
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><ListMember>abc</ListMember><ListMember>123</ListMember></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened single element list",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "flattened": true,
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": [
+            "abc"
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><ListMember>abc</ListMember></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "List of structures",
+    "metadata": {
+      "protocol": "query",
+      "xmlNamespace": "https://service.amazonaws.com/doc/2010-05-08/"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "List": {
+            "shape": "ListOfStructs"
+          }
+        }
+      },
+      "ListOfStructs": {
+        "type": "list",
+        "member": {
+          "shape": "StructureShape"
+        }
+      },
+      "StructureShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringShape"
+          },
+          "Bar": {
+            "shape": "StringShape"
+          },
+          "Baz": {
+            "shape": "StringShape"
+          }
+        }
+      },
+      "StringShape": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "List": [
+            {
+              "Foo": "firstfoo",
+              "Bar": "firstbar",
+              "Baz": "firstbaz"
+            },
+            {
+              "Foo": "secondfoo",
+              "Bar": "secondbar",
+              "Baz": "secondbaz"
+            }
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><List><member><Foo>firstfoo</Foo><Bar>firstbar</Bar><Baz>firstbaz</Baz></member><member><Foo>secondfoo</Foo><Bar>secondbar</Bar><Baz>secondbaz</Baz></member></List></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened list of structures",
+    "metadata": {
+      "protocol": "query",
+      "xmlNamespace": "https://service.amazonaws.com/doc/2010-05-08/"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "resultWrapper": "OperationNameResult",
+        "members": {
+          "List": {
+            "shape": "ListOfStructs"
+          }
+        }
+      },
+      "ListOfStructs": {
+        "type": "list",
+        "flattened": true,
+        "member": {
+          "shape": "StructureShape"
+        }
+      },
+      "StructureShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringShape"
+          },
+          "Bar": {
+            "shape": "StringShape"
+          },
+          "Baz": {
+            "shape": "StringShape"
+          }
+        }
+      },
+      "StringShape": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "List": [
+            {
+              "Foo": "firstfoo",
+              "Bar": "firstbar",
+              "Baz": "firstbaz"
+            },
+            {
+              "Foo": "secondfoo",
+              "Bar": "secondbar",
+              "Baz": "secondbaz"
+            }
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><List><Foo>firstfoo</Foo><Bar>firstbar</Bar><Baz>firstbaz</Baz></List><List><Foo>secondfoo</Foo><Bar>secondbar</Bar><Baz>secondbaz</Baz></List></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened list with location name",
+    "metadata": {
+      "protocol": "query",
+      "xmlNamespace": "https://service.amazonaws.com/doc/2010-05-08/"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "List": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "flattened": true,
+        "member": {
+          "shape": "StringShape",
+          "locationName": "NamedList"
+        }
+      },
+      "StringShape": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "List": [
+            "a",
+            "b"
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><NamedList>a</NamedList><NamedList>b</NamedList></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Normal map",
+    "metadata": {
+      "protocol": "query",
+      "xmlNamespace": "https://service.amazonaws.com/doc/2010-05-08/"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "StringMap"
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StructType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "StructType": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "StringType"
+          }
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": {
+              "foo": "bar"
+            },
+            "baz": {
+              "foo": "bam"
+            }
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse xmlns=\"https://service.amazonaws.com/doc/2010-05-08/\"><OperationNameResult><Map><entry><key>qux</key><value><foo>bar</foo></value></entry><entry><key>baz</key><value><foo>bam</foo></value></entry></Map></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened map",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "StringMap",
+            "flattened": true
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar",
+            "baz": "bam"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Map><key>qux</key><value>bar</value></Map><Map><key>baz</key><value>bam</value></Map></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened map in shape definition",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "StringMap",
+            "locationName": "Attribute"
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType",
+          "locationName": "Name"
+        },
+        "value": {
+          "shape": "StringType",
+          "locationName": "Value"
+        },
+        "flattened": true,
+        "locationName": "Attribute"
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Attribute><Name>qux</Name><Value>bar</Value></Attribute></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Named map",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "flattened": true,
+        "key": {
+          "locationName": "foo",
+          "shape": "StringType"
+        },
+        "value": {
+          "locationName": "bar",
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar",
+            "baz": "bam"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Map><foo>qux</foo><bar>bar</bar></Map><Map><foo>baz</foo><bar>bam</bar></Map></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Empty string",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Foo": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OperationNameResult><Foo/></OperationNameResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeFormat": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><OutputShapeResult><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember></OutputShapeResult><ResponseMetadata><RequestId>request-id</RequestId></ResponseMetadata></OperationNameResponse>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "OtherExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {
+              "shape": "ExceptionShape"
+            }
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<ErrorResponse><Error><Type>Sender</Type><Code>ExceptionShape</Code><Message>mymessage</Message><BodyMember>mybody</BodyMember></Error><RequestId>request-id</RequestId></ErrorResponse>"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {
+              "shape": "ExceptionShape"
+            }
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody"
+        },
+        "errorCode": "OtherExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<ErrorResponse><Error><Type>Sender</Type><Code>OtherExceptionShape</Code><Message>mymessage</Message><BodyMember>mybody</BodyMember></Error><RequestId>request-id</RequestId></ErrorResponse>"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {
+              "shape": "ExceptionShape"
+            }
+          ],
+          "name": "OperationName"
+        },
+        "error": {},
+        "errorCode": "UndefinedShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<ErrorResponse><Error><Type>Sender</Type><Code>UndefinedShape</Code><Message>mymessage</Message></Error><RequestId>request-id</RequestId></ErrorResponse>"
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_core/protocols/output/rest-json.json
+++ b/tests/test_core/protocols/output/rest-json.json
@@ -1,0 +1,1226 @@
+[
+  {
+    "description": "Scalar members",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ImaHeader": {
+            "shape": "HeaderShape"
+          },
+          "ImaHeaderLocation": {
+            "shape": "HeaderShape",
+            "locationName": "X-Foo"
+          },
+          "Status": {
+            "shape": "StatusShape",
+            "location": "statusCode"
+          },
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType"
+          },
+          "FalseBool": {
+            "shape": "BooleanType"
+          },
+          "TrueBool": {
+            "shape": "BooleanType"
+          },
+          "Float": {
+            "shape": "FloatType"
+          },
+          "Double": {
+            "shape": "DoubleType"
+          },
+          "Long": {
+            "shape": "LongType"
+          },
+          "Char": {
+            "shape": "CharType"
+          }
+        }
+      },
+      "HeaderShape": {
+        "type": "string",
+        "location": "header"
+      },
+      "StatusShape": {
+        "type": "integer"
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "CharType": {
+        "type": "character"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Status": 200,
+          "Str": "myname",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "ImaHeader": "test",
+            "X-Foo": "abc"
+          },
+          "body": "{\"Str\": \"myname\", \"Num\": 123, \"FalseBool\": false, \"TrueBool\": true, \"Float\": 1.2, \"Double\": 1.3, \"Long\": 200, \"Char\": \"a\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Blob members",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "BlobMember": {
+            "shape": "BlobType"
+          },
+          "StructMember": {
+            "shape": "BlobContainer"
+          }
+        }
+      },
+      "BlobType": {
+        "type": "blob"
+      },
+      "BlobContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "BlobType"
+          }
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "BlobMember": "hi!",
+          "StructMember": {
+            "foo": "there!"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"BlobMember\": \"aGkh\", \"StructMember\": {\"foo\": \"dGhlcmUh\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeArgInHeader": {
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timearg"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeCustomInHeader": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timecustom"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "TimeFormatInHeader": {
+            "shape": "TimestampFormatType",
+            "location": "header",
+            "locationName": "x-amz-timeformat"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "iso8601",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeArgInHeader": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeCustomInHeader": 1398796238,
+          "TimeFormat": 1398796238,
+          "TimeFormatInHeader": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-amz-timearg": "Tue, 29 Apr 2014 18:30:38 GMT",
+            "x-amz-timecustom": "1398796238",
+            "x-amz-timeformat": "2014-04-29T18:30:38Z"
+          },
+          "body": "{\"TimeArg\": 1398796238, \"TimeCustom\": \"Tue, 29 Apr 2014 18:30:38 GMT\", \"TimeFormat\": \"2014-04-29T18:30:38Z\", \"StructMember\": {\"foo\": 1398796238, \"bar\": \"2014-04-29T18:30:38Z\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["a", "b"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"ListMember\": [\"a\", \"b\"]}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists with structure member",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListType"
+          }
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "SingleStruct"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "SingleStruct": {
+        "type": "structure",
+        "members": {
+            "Foo": {
+              "shape": "StringType"
+            }
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": [{"Foo": "a"}, {"Foo": "b"}]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"ListMember\": [{\"Foo\": \"a\"}, {\"Foo\": \"b\"}]}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Maps",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "MapMember": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "ListType"
+        }
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "IntegerType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "MapMember": {
+            "a": [1, 2],
+            "b": [3, 4]
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"MapMember\": {\"a\": [1, 2], \"b\": [3, 4]}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Complex Map Values",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "MapMember": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "TimeType"
+        }
+      },
+      "TimeType": {
+        "type": "timestamp"
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "MapMember": {
+            "a": 1398796238,
+            "b": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"MapMember\": {\"a\": 1398796238, \"b\": 1398796238}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Supports header maps",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "AllHeaders": {
+            "shape": "HeaderMap",
+            "location": "headers"
+          },
+          "PrefixedHeaders": {
+            "shape": "HeaderMap",
+            "location": "headers",
+            "locationName": "XX-"
+          }
+        }
+      },
+      "HeaderMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "AllHeaders": {
+            "Content-Length": "10",
+            "x-Foo": "bar",
+            "X-bam": "boo"
+          },
+          "PrefixedHeaders": {
+            "Foo": "bar",
+            "bam": "boo"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "Content-Length": "10",
+            "x-Foo": "bar",
+            "X-bam": "boo",
+            "XX-Foo": "bar",
+            "XX-bam": "boo"
+          },
+          "body": "{}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "JSON payload",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "payload": "Data",
+        "members": {
+          "Header": {
+            "shape": "StringType",
+            "location": "header",
+            "locationName": "X-Foo"
+          },
+          "Data": {
+            "shape": "BodyStructure"
+          }
+        }
+      },
+      "BodyStructure": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Header": "baz",
+          "Data": {
+            "Foo": "abc"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "X-Foo": "baz"
+          },
+          "body": "{\"Foo\": \"abc\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Streaming payload",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "payload": "Stream",
+        "members": {
+          "Stream": {
+            "shape": "Stream"
+          }
+        }
+      },
+      "Stream": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Stream": "abc"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "abc"
+        }
+      }
+    ]
+  },
+  {
+    "description": "JSON value trait",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Attr": {
+            "shape": "StringType",
+              "jsonvalue": true,
+              "location": "header",
+              "locationName": "X-Amz-Foo"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Attr": {"Foo":"Bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
+          "body": "{}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "ImaHeader": {
+            "shape": "HeaderShape"
+          },
+          "ImaHeaderLocation": {
+            "shape": "HeaderShape",
+            "locationName": "X-Foo"
+          },
+          "Status": {
+            "shape": "StatusShape",
+            "location": "statusCode"
+          },
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "OtherExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+            "BodyMember": {
+                "shape": "StringType"
+            }
+        }
+      },
+      "HeaderShape": {
+        "type": "string",
+        "location": "header"
+      },
+      "StatusShape": {
+        "type": "integer"
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Status": 400,
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {
+            "X-Amzn-Errortype": "ExceptionShape"
+          },
+          "body": "{\"__type\": \"ExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Status": 400,
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"ExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Status": 400,
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {
+            "X-Amzn-Errortype": "ExceptionShape"
+          },
+          "body": "{\"__type\": \"ExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+            "BodyMember": "mybody"
+        },
+        "errorCode": "OtherExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {
+            "X-Amzn-Errortype": "OtherExceptionShape"
+          },
+          "body": "{\"__type\": \"OtherExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+            "BodyMember": "mybody"
+        },
+        "errorCode": "OtherExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"OtherExceptionShape\", \"BodyMember\": \"mybody\", \"Message\": \"mymessage\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {},
+        "errorCode": "UndefinedShape",
+        "response": {
+          "status_code": 400,
+          "headers": {
+            "X-Amzn-Errortype": "UndefinedShape"
+          },
+          "body": "{\"__type\": \"UndefinedShape\"}"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {},
+        "errorCode": "UndefinedShape",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"__type\": \"UndefinedShape\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes document with standalone primitive as part of the JSON response payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "documentValue": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": "foo"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": \"foo\"}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": 123
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": 123}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": 1.2
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": 1.2}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": true
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": true}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": \"\"}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes inline documents as part of the JSON response payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "documentValue": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": {"foo": "bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": {\"foo\": \"bar\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Serializes aggregate documents as part of the JSON response payload with no escaping.",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "documentValue": {
+                "shape": "DocumentType"
+            }
+        }
+      },
+      "DocumentType": {
+          "type": "structure",
+          "document": true
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": {
+              "str": "test",
+              "num": 123,
+              "float": 1.2,
+              "bool": true,
+              "null": "",
+              "document": {"foo": false},
+              "list": ["myname", 321, 1.3, true, "", {"nested": true}, [200, ""]]
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": {\"str\": \"test\", \"num\": 123, \"float\": 1.2, \"bool\": true, \"null\": \"\", \"document\": {\"foo\": false}, \"list\": [\"myname\", 321, 1.3, true, \"\", {\"nested\": true}, [200, \"\"]]}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "documentValue": [
+              "test",
+              123,
+              1.2,
+              true,
+              "",
+              {"str": "myname", "num": 321, "float": 1.3, "bool": true, "null": "", "document": {"nested": true}, "list": [200, ""]},
+              ["foo", false]
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"documentValue\": [\"test\", 123, 1.2, true, \"\", {\"str\": \"myname\", \"num\": 321, \"float\": 1.3, \"bool\": true, \"null\": \"\", \"document\": {\"nested\": true}, \"list\": [200, \"\"]}, [\"foo\", false]]}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Tagged Unions",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "UnionMember": {
+            "shape": "UnionType"
+          }
+        }
+      },
+      "UnionType": {
+        "type": "structure",
+        "members": {
+          "S":{"shape":"StringType"},
+          "L": {"shape": "ListType"}
+        },
+        "union": true
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "UnionMember": {"S":  "mystring"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"S\": \"mystring\"}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "UnionMember": {"L":  ["a", "b"]}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"L\": [\"a\", \"b\"]}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "List in header",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape",
+            "location": "header",
+            "locationName": "x-amz-list-member"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "EnumType"
+        }
+      },
+      "EnumType": {
+        "type": "string",
+        "enum": ["one", "two", "three"]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["one", "two", "three"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+              "x-amz-list-member": "one,two,three"
+          },
+          "body": "{}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Number in header",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "IntegerMember": {
+            "shape": "IntegerShape",
+            "location": "header",
+            "locationName": "x-amz-integer-member"
+          },
+          "LongMember": {
+            "shape": "LongShape",
+            "location": "header",
+            "locationName": "x-amz-long-member"
+          }
+        }
+      },
+      "IntegerShape": {
+        "type": "integer"
+      },
+      "LongShape": {
+        "type": "long"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "IntegerMember": 123,
+          "LongMember": 200
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+              "x-amz-integer-member": "123",
+              "x-amz-long-member": "200"
+          },
+          "body": "{}"
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_core/protocols/output/rest-xml.json
+++ b/tests/test_core/protocols/output/rest-xml.json
@@ -1,0 +1,1245 @@
+[
+  {
+    "description": "Scalar members",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ImaHeader": {
+            "shape": "HeaderShape"
+          },
+          "ImaHeaderLocation": {
+            "shape": "HeaderShape",
+            "locationName": "X-Foo"
+          },
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType",
+            "locationName": "FooNum"
+          },
+          "FalseBool": {
+            "shape": "BooleanType"
+          },
+          "TrueBool": {
+            "shape": "BooleanType"
+          },
+          "Float": {
+            "shape": "FloatType"
+          },
+          "Double": {
+            "shape": "DoubleType"
+          },
+          "Long": {
+            "shape": "LongType"
+          },
+          "Char": {
+            "shape": "CharType"
+          },
+          "Timestamp": {
+            "shape": "TimestampType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "CharType": {
+        "type": "character"
+      },
+      "HeaderShape": {
+        "type": "string",
+        "location": "header"
+      },
+      "StatusShape": {
+        "type": "integer",
+        "location": "statusCode"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Str": "myname",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "ImaHeader": "test",
+            "X-Foo": "abc"
+          },
+          "body": "<OperationNameResult><Str>myname</Str><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><Timestamp>2015-01-25T08:00:00Z</Timestamp></OperationNameResult>"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Str": "",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "ImaHeader": "test",
+            "X-Foo": "abc"
+          },
+          "body": "<OperationNameResult><Str/><FooNum>123</FooNum><FalseBool>false</FalseBool><TrueBool>true</TrueBool><Float>1.2</Float><Double>1.3</Double><Long>200</Long><Char>a</Char><Timestamp>2015-01-25T08:00:00Z</Timestamp></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Blob",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Blob": {
+            "shape": "BlobType"
+          }
+        }
+      },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Blob": "value"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><Blob>dmFsdWU=</Blob></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["abc", "123"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><ListMember><member>abc</member><member>123</member></ListMember></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "List with custom member name",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "locationName": "item"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["abc", "123"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><ListMember><item>abc</item><item>123</item></ListMember></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened List",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "StringList",
+            "flattened": true
+          }
+        }
+      },
+      "StringList": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["abc", "123"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><ListMember>abc</ListMember><ListMember>123</ListMember></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Normal map",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "StringMap"
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "SingleStructure"
+        }
+      },
+      "SingleStructure": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": {
+              "foo": "bar"
+            },
+            "baz": {
+              "foo": "bam"
+            }
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><Map><entry><key>qux</key><value><foo>bar</foo></value></entry><entry><key>baz</key><value><foo>bam</foo></value></entry></Map></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Flattened map",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "StringMap",
+            "flattened": true
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar",
+            "baz": "bam"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><Map><key>qux</key><value>bar</value></Map><Map><key>baz</key><value>bam</value></Map></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Named map",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "StringMap"
+          }
+        }
+      },
+      "StringMap": {
+        "type": "map",
+        "key": {
+          "shape": "StringType",
+          "locationName": "foo"
+        },
+        "value": {
+          "shape": "StringType",
+          "locationName": "bar"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Map": {
+            "qux": "bar",
+            "baz": "bam"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><Map><entry><foo>qux</foo><bar>bar</bar></entry><entry><foo>baz</foo><bar>bam</bar></entry></Map></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "XML payload",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "payload": "Data",
+        "members": {
+          "Header": {
+            "shape": "StringType",
+            "location": "header",
+            "locationName": "X-Foo"
+          },
+          "Data": {
+            "shape": "SingleStructure"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "SingleStructure": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Header": "baz",
+          "Data": {
+            "Foo": "abc"
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "X-Foo": "baz"
+          },
+          "body": "<OperationNameResult><Foo>abc</Foo></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Streaming payload",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "payload": "Stream",
+        "members": {
+          "Stream": {
+            "shape": "BlobStream"
+          }
+        }
+      },
+      "BlobStream": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Stream": "abc"
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "abc"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Scalar members in headers",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "locationName": "x-str",
+            "shape": "StringHeaderType"
+          },
+          "Integer": {
+            "locationName": "x-int",
+            "shape": "IntegerHeaderType"
+          },
+          "TrueBool": {
+            "locationName": "x-true-bool",
+            "shape": "BooleanHeaderType"
+          },
+          "FalseBool": {
+            "locationName": "x-false-bool",
+            "shape": "BooleanHeaderType"
+          },
+          "Float": {
+            "locationName": "x-float",
+            "shape": "FloatHeaderType"
+          },
+          "Double": {
+            "locationName": "x-double",
+            "shape": "DoubleHeaderType"
+          },
+          "Long": {
+            "locationName": "x-long",
+            "shape": "LongHeaderType"
+          },
+          "Char": {
+            "locationName": "x-char",
+            "shape": "CharHeaderType"
+          },
+          "Timestamp": {
+            "locationName": "x-timestamp",
+            "shape": "TimestampHeaderType"
+          }
+        }
+      },
+      "StringHeaderType": {
+        "location": "header",
+        "type": "string"
+      },
+      "IntegerHeaderType": {
+        "location": "header",
+        "type": "integer"
+      },
+      "BooleanHeaderType": {
+        "location": "header",
+        "type": "boolean"
+      },
+      "FloatHeaderType": {
+        "location": "header",
+        "type": "float"
+      },
+      "DoubleHeaderType": {
+        "location": "header",
+        "type": "double"
+      },
+      "LongHeaderType": {
+        "location": "header",
+        "type": "long"
+      },
+      "CharHeaderType": {
+        "location": "header",
+        "type": "character"
+      },
+      "TimestampHeaderType": {
+        "location": "header",
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "string",
+          "Integer": 1,
+          "TrueBool": true,
+          "FalseBool": false,
+          "Float": 1.5,
+          "Double": 1.5,
+          "Long": 100,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-str": "string",
+            "x-int": "1",
+            "x-true-bool": "true",
+            "x-false-bool": "false",
+            "x-float": "1.5",
+            "x-double": "1.5",
+            "x-long": "100",
+            "x-char": "a",
+            "x-timestamp": "Sun, 25 Jan 2015 08:00:00 GMT"
+          },
+          "body": ""
+        }
+      }
+    ]
+  },
+  {
+    "description": "Empty string",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Foo": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Foo": ""
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResult><Foo/></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "JSON value trait",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Attr": {
+            "shape": "StringType",
+              "jsonvalue": true,
+              "location": "header",
+              "locationName": "X-Amz-Foo"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Attr": {"Foo":"Bar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
+          "body": ""
+        }
+      }
+    ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeArgInHeader": {
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timearg"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeCustomInHeader": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timecustom"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "TimeFormatInHeader": {
+            "shape": "TimestampFormatType",
+            "location": "header",
+            "locationName": "x-amz-timeformat"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeArgInHeader": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeCustomInHeader": 1398796238,
+          "TimeFormat": 1398796238,
+          "TimeFormatInHeader": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-amz-timearg": "Tue, 29 Apr 2014 18:30:38 GMT",
+            "x-amz-timecustom": "1398796238",
+            "x-amz-timeformat": "1398796238"
+          },
+          "body": "<OperationNameResult><TimeArg>2014-04-29T18:30:38Z</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><StructMember><foo>2014-04-29T18:30:38Z</foo><bar>1398796238</bar></StructMember></OperationNameResult>"
+        }
+      }
+    ]
+  },
+  {
+    "description": "REST XML Event Stream",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+            "Payload": {"shape": "EventStream"}
+        },
+        "payload": "Payload"
+      },
+      "EventStream": {
+          "type": "structure",
+          "eventstream": true,
+          "members": {
+              "TypeA": {"shape": "TypeAEvent"},
+              "TypeB": {"shape": "TypeBEvent"},
+              "TypeC": {"shape": "TypeCEvent"}
+          }
+      },
+      "TypeAEvent": {
+          "type": "structure",
+          "event": true,
+          "members": {
+              "Payload": {
+                  "shape": "BlobType",
+                  "eventpayload": true
+              }
+          }
+      },
+      "TypeBEvent": {
+          "type": "structure",
+          "event": true,
+          "members": {
+              "Details": {
+                  "shape": "Details",
+                  "eventpayload": true
+              }
+          }
+      },
+      "TypeCEvent": {
+          "type": "structure",
+          "event": true,
+          "members": {
+              "Details": {
+                  "shape": "Details",
+                  "eventpayload": true
+              },
+              "Boolean": {
+                  "shape": "BooleanType",
+                  "eventheader": true
+              },
+              "Integer": {
+                  "shape": "IntegerType",
+                  "eventheader": true
+              },
+              "Blob": {
+                  "shape": "BlobType",
+                  "eventheader": true
+              },
+              "String": {
+                  "shape": "StringType",
+                  "eventheader": true
+              },
+              "Timestamp": {
+                  "shape": "TimestampType",
+                  "eventheader": true
+              }
+          }
+      },
+      "Details": {
+          "type": "structure",
+          "members": {
+              "StringField": {"shape": "StringType"},
+              "IntegerField": {"shape": "IntegerType"}
+          }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Payload": [
+              {
+                  "TypeA": {"Payload": "somebytes"}
+              },
+              {
+                  "TypeB": {
+                      "Details": {
+                          "StringField": "somestring",
+                          "IntegerField": 123
+                      }
+                  }
+              }
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "AAAAbAAAAFPLgkVrDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVR5cGVBDTpjb250ZW50LXR5cGUHABhhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW1zb21lYnl0ZXMesj2HAAAAsAAAAEOaMMdXDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVR5cGVCDTpjb250ZW50LXR5cGUHAAh0ZXh0L3htbDxUeXBlQiB4bWxucz0iIj48U3RyaW5nRmllbGQ+c29tZXN0cmluZzwvU3RyaW5nRmllbGQ+PEludGVnZXJGaWVsZD4xMjM8L0ludGVnZXJGaWVsZD48L1R5cGVCPiwthPo="
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Payload": [
+              {
+                  "TypeC": {
+                      "Boolean": true,
+                      "Integer": 123,
+                      "Blob": "someblob",
+                      "String": "somestring",
+                      "Timestamp": 1422172800,
+                      "Details": {
+                          "StringField": "somestring",
+                          "IntegerField": 123
+                      }
+                  }
+              }
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "AAABAQAAAJBjEbY4DTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVR5cGVDDTpjb250ZW50LXR5cGUHAAh0ZXh0L3htbAdCb29sZWFuAAdJbnRlZ2VyBAAAAHsEQmxvYgYACHNvbWVibG9iBlN0cmluZwcACnNvbWVzdHJpbmcJVGltZXN0YW1wCAAAAUsgGsQAPERldGFpbHMgeG1sbnM9IiI+PFN0cmluZ0ZpZWxkPnNvbWVzdHJpbmc8L1N0cmluZ0ZpZWxkPjxJbnRlZ2VyRmllbGQ+MTIzPC9JbnRlZ2VyRmllbGQ+PC9EZXRhaWxzPhGUvKo="
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Payload": []
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": ""
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "ImaHeader": {
+            "shape": "HeaderShape"
+          },
+          "ImaHeaderLocation": {
+            "shape": "HeaderShape",
+            "locationName": "X-Foo"
+          },
+          "Status": {
+            "shape": "StatusShape",
+            "location": "statusCode"
+          },
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "OtherExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+              "shape": "StringType"
+          }
+        }
+      },
+      "HeaderShape": {
+        "type": "string",
+        "location": "header"
+      },
+      "StatusShape": {
+        "type": "integer"
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "ImaHeader": "test",
+          "ImaHeaderLocation": "abc",
+          "Status": 400,
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<ErrorResponse><Error><Type>Sender</Type><Code>ExceptionShape</Code><Message>mymessage</Message><BodyMember>mybody</BodyMember></Error><RequestId>request-id</RequestId></ErrorResponse>"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody"
+        },
+        "errorCode": "OtherExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<ErrorResponse><Error><Type>Sender</Type><Code>OtherExceptionShape</Code><Message>mymessage</Message><BodyMember>mybody</BodyMember></Error><RequestId>request-id</RequestId></ErrorResponse>"
+        }
+      },
+      {
+        "given": {
+          "errors": [
+            {"shape": "ExceptionShape"}
+          ],
+          "name": "OperationName"
+        },
+        "error": {},
+        "errorCode": "UndefinedShape",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "<ErrorResponse><Error><Type>Sender</Type><Code>UndefinedShape</Code></Error><RequestId>request-id</RequestId></ErrorResponse>"
+        }
+      }
+    ]
+  },
+  {
+      "description": "Unions",
+      "metadata": {
+          "protocol": "rest-xml"
+      },
+      "shapes": {
+          "OutputShape": {
+              "type": "structure",
+              "members": {
+                  "UnionMember": {
+                      "shape": "UnionType"
+                  }
+              }
+          },
+          "UnionType": {
+              "type": "structure",
+              "members": {
+                  "S":{"shape":"StringType"},
+                  "L": {"shape": "ListType"}
+              },
+              "union": true
+          },
+          "ListType": {
+              "type": "list",
+              "member": {
+                  "shape": "StringType"
+              }
+          },
+          "StringType": {
+              "type": "string"
+          }
+      },
+      "cases": [
+          {
+              "given": {
+                  "output": {
+                      "shape": "OutputShape"
+                  },
+                  "name": "OperationName"
+              },
+              "result": {
+                  "UnionMember": {"S":  "string value"}
+              },
+              "response": {
+                  "status_code": 200,
+                  "headers": {},
+                  "body": "<OperationNameResult><UnionMember><S>string value</S></UnionMember></OperationNameResult>"
+              }
+          },
+          {
+              "given": {
+                  "output": {
+                      "shape": "OutputShape"
+                  },
+                  "name": "OperationName"
+              },
+              "result": {
+                  "UnionMember": {"L":  ["a", "b"]}
+              },
+              "response": {
+                  "status_code": 200,
+                  "headers": {},
+                  "body": "<OperationNameResult><UnionMember><L><member>a</member><member>b</member></L></UnionMember></OperationNameResult>"
+              }
+          }
+      ]
+  },
+  {
+    "description": "List in header",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape",
+            "location": "header",
+            "locationName": "x-amz-list-member"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "EnumType"
+        }
+      },
+      "EnumType": {
+        "type": "string",
+        "enum": ["one", "two", "three"]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["one", "two", "three"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+              "x-amz-list-member": "one,two,three"
+          },
+          "body": ""
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_core/test_protocols.py
+++ b/tests/test_core/test_protocols.py
@@ -1,0 +1,88 @@
+# mypy: ignore-errors
+import copy
+import json
+import os
+from enum import Enum
+
+import pytest
+from botocore.model import OperationModel, ServiceModel
+
+from moto.core.serialize import SERIALIZERS
+
+TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "protocols")
+PROTOCOL_TEST_BLACKLIST = [
+    "REST XML Event Stream",
+    "RPC JSON Event Stream",
+]
+
+
+class TestType(Enum):
+    __test__ = False  # Tell test runner to ignore this class
+
+    INPUT = "input"
+    OUTPUT = "output"
+
+
+def _compliance_tests(test_type=None):
+    inp = test_type is None or test_type is TestType.INPUT
+    out = test_type is None or test_type is TestType.OUTPUT
+
+    for full_path in _walk_files():
+        if full_path.endswith(".json"):
+            for model, case, protocol in _load_cases(full_path):
+                if model.get("description") in PROTOCOL_TEST_BLACKLIST:
+                    continue
+                description = case["description"]
+                test_name = f"{protocol}-protocol-{description}"
+                if "params" in case and inp:
+                    yield pytest.param(model, case, protocol, id=test_name)
+                elif "response" in case and out:
+                    yield pytest.param(model, case, protocol, id=test_name)
+
+
+def _walk_files():
+    for root, _, filenames in os.walk(TEST_DIR):
+        for filename in filenames:
+            yield os.path.join(root, filename)
+
+
+def _load_cases(full_path):
+    all_test_data = json.load(open(full_path))
+    protocol = os.path.basename(full_path).split(".")[0]
+    for test_data in all_test_data:
+        cases = test_data.pop("cases")
+        description = test_data["description"]
+        for index, case in enumerate(cases):
+            case["description"] = description
+            case["id"] = index
+            yield test_data, case, protocol
+
+
+@pytest.mark.parametrize(
+    "json_description, case, protocol", _compliance_tests(TestType.OUTPUT)
+)
+def test_output_compliance(json_description: dict, case: dict, protocol):
+    service_description = copy.deepcopy(json_description)
+    model = ServiceModel(service_description)
+    operation_model = OperationModel(case["given"], model)
+    protocol_serializer = SERIALIZERS[protocol]
+    serializer = protocol_serializer(operation_model)
+    result = case["result"] if "error" not in case else _create_exception(case)
+    resp = serializer.serialize(result)  # _to_response(result)
+    assert resp["body"] == case["response"]["body"]
+    headers_expected = case["response"]["headers"]
+    # TODO: Get rid of this once we get the headers sorted for all responses
+    if headers_expected:
+        assert resp["headers"] == headers_expected
+    assert resp["status_code"] == case["response"]["status_code"]
+
+
+def _create_exception(case):
+    exc = Exception()
+    exc.code = case["errorCode"]
+    if "errorMessage" in case:
+        exc.message = case["errorMessage"]
+        exc.Message = case["errorMessage"]
+    for key, value in case["error"].items():
+        setattr(exc, key, value)
+    return exc

--- a/tests/test_core/test_serialize.py
+++ b/tests/test_core/test_serialize.py
@@ -1,0 +1,145 @@
+# mypy: ignore-errors
+"""Additional tests for response serialization.
+
+While there are compliance tests in ``test_protocols.py``, where the majority
+of the response serialization is tested, this file contains additional tests
+that go above and beyond the specification(s) for a number of reasons:
+
+* We are testing Python-specific behavior that doesn't make sense as a
+  compliance test.
+* We are testing behavior that is not strictly part of the specification.
+  These may result in a coverage gap that would otherwise be untested.
+
+"""
+
+import time
+
+from botocore.model import ServiceModel
+from xmltodict import parse
+
+from moto.core.serialize import QuerySerializer
+
+
+def test_serialize_from_object() -> None:
+    model = {
+        "metadata": {"protocol": "query", "apiVersion": "2014-01-01"},
+        "documentation": "",
+        "operations": {
+            "TestOperation": {
+                "name": "TestOperation",
+                "http": {
+                    "method": "POST",
+                    "requestUri": "/",
+                },
+                "output": {"shape": "OutputShape"},
+            }
+        },
+        "shapes": {
+            "OutputShape": {
+                "type": "structure",
+                "members": {
+                    "string": {"shape": "StringType"},
+                },
+            },
+            "StringType": {
+                "type": "string",
+            },
+        },
+    }
+
+    class TestObject:
+        string = "test-string"
+
+    service_model = ServiceModel(model)
+    operation_model = service_model.operation_model("TestOperation")
+    serializer = QuerySerializer(operation_model)
+    serialized = serializer.serialize(TestObject())
+    assert serialized
+
+
+def test_datetime_with_microseconds() -> None:
+    model = {
+        "metadata": {"protocol": "query", "apiVersion": "2014-01-01"},
+        "documentation": "",
+        "operations": {
+            "TestOperation": {
+                "name": "TestOperation",
+                "http": {
+                    "method": "POST",
+                    "requestUri": "/",
+                },
+                "output": {"shape": "OutputShape"},
+            }
+        },
+        "shapes": {
+            "OutputShape": {
+                "type": "structure",
+                "members": {
+                    "microseconds": {"shape": "TimestampType"},
+                },
+            },
+            "TimestampType": {
+                "type": "timestamp",
+            },
+        },
+    }
+
+    class TestObject:
+        microseconds = time.time()
+
+    service_model = ServiceModel(model)
+    operation_model = service_model.operation_model("TestOperation")
+    serializer = QuerySerializer(operation_model)
+    serialized = serializer.serialize(TestObject())
+    assert serialized
+    parsed = parse(serialized["body"])
+    time_str = parsed["TestOperationResponse"]["OutputShapeResult"]["microseconds"]
+    assert "." in time_str
+    assert time_str[-1] == "Z"
+
+
+def test_pretty_print_with_short_elements_and_list() -> None:
+    model = {
+        "metadata": {"protocol": "query", "apiVersion": "2014-01-01"},
+        "documentation": "",
+        "operations": {
+            "TestOperation": {
+                "name": "TestOperation",
+                "http": {
+                    "method": "POST",
+                    "requestUri": "/",
+                },
+                "output": {"shape": "OutputShape"},
+            }
+        },
+        "shapes": {
+            "OutputShape": {
+                "type": "structure",
+                "members": {
+                    "DBInstances": {
+                        "shape": "DBInstanceList",
+                    }
+                },
+            },
+            "DBInstanceList": {
+                "type": "list",
+                "member": {"shape": "DBInstance", "locationName": "DBInstance"},
+            },
+            "DBInstance": {
+                "type": "structure",
+                "members": {
+                    "DBInstanceIdentifier": {
+                        "shape": "String",
+                    }
+                },
+            },
+            "String": {"type": "string"},
+        },
+    }
+    service_model = ServiceModel(model)
+    operation_model = service_model.operation_model("TestOperation")
+    serializer = QuerySerializer(operation_model, **{"pretty_print": True})
+    empty_list_to_serialize = {"DBInstances": []}
+    serialized = serializer.serialize(empty_list_to_serialize)
+    expected_shortened_list_element = "<DBInstances/>"
+    assert expected_shortened_list_element in serialized["body"]


### PR DESCRIPTION
These serializers translate any backend result into a properly formatted HTTP response according to the [AWS protocol specifications](https://smithy.io/2.0/aws/protocols/index.html) and the `botocore` model data for a particular service/operation.

This PR contains a battery of low-level protocol tests to ensure adherence to the specifications.  Some future tweaks may be required for integration with individual AWS services.

Benefits:
* No need for Jinja XML templates in response classes.
* No need for `.to_dict()` methods on backend objects.
* No need for manually string formatting date values or coercing boolean values.

Next Steps:
These serializers will be slowly integrated into each individual service backend, starting with the services that will benefit the most (e.g. Query protocol-based services).  Additional features will be added as needs arise; defects will be addressed as they are encountered.  