### PR TITLE
WAFv2: fix incorrect ARNs in Cloudfront scope

### DIFF
--- a/moto/wafv2/responses.py
+++ b/moto/wafv2/responses.py
@@ -127,7 +127,11 @@ class WAFV2Response(BaseResponse):
 
     def list_tags_for_resource(self) -> TYPE_RESPONSE:
         arn = self._get_param("ResourceARN")
-        self.region = arn.split(":")[3]
+
+        # select correct backend - ARN region is not indicative by itself in case of WAF for Cloudfront
+        scope = "CLOUDFRONT" if arn.split(":")[5].startswith("global") else "REGIONAL"
+        self.region = GLOBAL_REGION if scope == "CLOUDFRONT" else arn.split(":")[3]
+
         limit = self._get_int_param("Limit")
         next_marker = self._get_param("NextMarker")
         tags, next_marker = self.wafv2_backend.list_tags_for_resource(
@@ -143,7 +147,11 @@ class WAFV2Response(BaseResponse):
     def tag_resource(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)
         arn = body.get("ResourceARN")
-        self.region = arn.split(":")[3]
+
+        # select correct backend - ARN region is not indicative by itself in case of WAF for Cloudfront
+        scope = "CLOUDFRONT" if arn.split(":")[5].startswith("global") else "REGIONAL"
+        self.region = GLOBAL_REGION if scope == "CLOUDFRONT" else arn.split(":")[3]
+
         tags = body.get("Tags")
         self.wafv2_backend.tag_resource(arn, tags)
         return 200, {}, "{}"
@@ -151,7 +159,11 @@ class WAFV2Response(BaseResponse):
     def untag_resource(self) -> TYPE_RESPONSE:
         body = json.loads(self.body)
         arn = body.get("ResourceARN")
-        self.region = arn.split(":")[3]
+
+        # select correct backend - ARN region is not indicative by itself in case of WAF for Cloudfront
+        scope = "CLOUDFRONT" if arn.split(":")[5].startswith("global") else "REGIONAL"
+        self.region = GLOBAL_REGION if scope == "CLOUDFRONT" else arn.split(":")[3]
+
         tag_keys = body.get("TagKeys")
         self.wafv2_backend.untag_resource(arn, tag_keys)
         return 200, {}, "{}"

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -10,6 +10,10 @@ def make_arn(
         scope = "regional"
     elif scope == "CLOUDFRONT":
         scope = "global"
+        # cloudfront global scope is managed from us-east-1 region: https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateIPSet.html#WAF-CreateIPSet-request-Scope
+        # base_backend stores global region as "aws": https://github.com/getmoto/moto/blob/d00aa025b6c3d37977508b5d5e81ecad4ca15159/moto/core/base_backend.py#L272
+        # Therefore needs to be overriden here to correctly form the ARN
+        region_name = "us-east-1"
 
     if region_name in PARTITION_NAMES:
         region_name = "global"

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from moto.utilities.utils import PARTITION_NAMES, get_partition
+from moto.utilities.utils import get_partition
 
 
 def make_arn(
@@ -15,11 +15,7 @@ def make_arn(
         # Therefore needs to be overriden here to correctly form the ARN
         region_name = "us-east-1"
 
-    if region_name in PARTITION_NAMES:
-        region_name = "global"
-    partition = (
-        region_name if region_name in PARTITION_NAMES else get_partition(region_name)
-    )
+    partition = get_partition(region_name)
 
     return f"arn:{partition}:wafv2:{region_name}:{account_id}:{scope}/{resource}/{name}/{_id}"
 

--- a/tests/test_wafv2/test_server.py
+++ b/tests/test_wafv2/test_server.py
@@ -64,7 +64,7 @@ def test_create_web_acl():
     )
     web_acl = res.json["Summary"]
     assert web_acl.get("ARN").startswith(
-        f"arn:aws:wafv2:global:{ACCOUNT_ID}:global/webacl/Carl/"
+        f"arn:aws:wafv2:us-east-1:{ACCOUNT_ID}:global/webacl/Carl/"
     )
 
 

--- a/tests/test_wafv2/test_utils.py
+++ b/tests/test_wafv2/test_utils.py
@@ -4,16 +4,29 @@ from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.wafv2.utils import make_arn_for_wacl
 
 
-def test_make_arn_for_wacl():
+def test_make_arn_for_wacl_in_regional_scope():
     uniqueID = str(uuid.uuid4())
     region = "us-east-1"
     name = "testName"
     scope = "REGIONAL"
+
     arn = make_arn_for_wacl(name, ACCOUNT_ID, region, uniqueID, scope)
+
     assert (
         arn == f"arn:aws:wafv2:{region}:{ACCOUNT_ID}:regional/webacl/{name}/{uniqueID}"
     )
 
+
+def test_make_arn_for_wacl_in_cloudfront_scope():
+    uniqueID = str(uuid.uuid4())
+    backend_region = "aws"  # see https://github.com/getmoto/moto/blob/d00aa025b6c3d37977508b5d5e81ecad4ca15159/moto/core/base_backend.py#L272
+    arn_region = "us-east-1"
+    name = "testName"
     scope = "CLOUDFRONT"
-    arn = make_arn_for_wacl(name, ACCOUNT_ID, region, uniqueID, scope)
-    assert arn == f"arn:aws:wafv2:{region}:{ACCOUNT_ID}:global/webacl/{name}/{uniqueID}"
+
+    arn = make_arn_for_wacl(name, ACCOUNT_ID, backend_region, uniqueID, scope)
+
+    assert (
+        arn
+        == f"arn:aws:wafv2:{arn_region}:{ACCOUNT_ID}:global/webacl/{name}/{uniqueID}"
+    )

--- a/tests/test_wafv2/test_wafv2.py
+++ b/tests/test_wafv2/test_wafv2.py
@@ -34,7 +34,7 @@ def test_create_web_acl(region, partition):
     res = conn.create_web_acl(**CREATE_WEB_ACL_BODY("Carl", "CLOUDFRONT"))
     web_acl = res["Summary"]
     assert web_acl.get("ARN").startswith(
-        f"arn:aws:wafv2:global:{ACCOUNT_ID}:global/webacl/Carl/"
+        f"arn:aws:wafv2:us-east-1:{ACCOUNT_ID}:global/webacl/Carl/"
     )
 
 

--- a/tests/test_wafv2/test_wafv2_rules.py
+++ b/tests/test_wafv2/test_wafv2_rules.py
@@ -359,7 +359,7 @@ def test_list_rule_groups():
     cf_groups = client.list_rule_groups(Scope="CLOUDFRONT")["RuleGroups"]
     assert len(cf_groups) == 8
     assert cf_groups[0]["ARN"].startswith(
-        f"arn:aws:wafv2:global:{ACCOUNT_ID}:global/rulegroup/test-group-2/"
+        f"arn:aws:wafv2:us-east-1:{ACCOUNT_ID}:global/rulegroup/test-group-2/"
     )
 
     page1 = client.list_rule_groups(Scope="CLOUDFRONT", Limit=2)


### PR DESCRIPTION
### Issue
Reported in https://github.com/localstack/localstack/issues/12272.

ARN for WAF resources in Cloudfront scope should specify `us-east-1` region. Currently region is being set to `global` in moto.

I checked in AWS console that it stands true for all WAF resources: Web ACLs, IP sets, Regex pattern sets, Rule groups.

The regression was likely introduced in #7710.

### Solution
Region for global scope backend [defaults](https://github.com/getmoto/moto/blob/d00aa025b6c3d37977508b5d5e81ecad4ca15159/moto/core/base_backend.py#L272) to `"aws"`. It needs to be overridden with `us-east-1` for ARN purposes as Cloudfront-related resources are [managed from](https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateIPSet.html#WAF-CreateIPSet-request-Scope) `us-east-1` and have it specified in ARN. However backend itself should stay separate for global and regional, to distinguish between WAF for us-east-1 and WAF for Cloudfront.

ARNs for global and regional resources for `us-east-1` differ only in resource name prefix - `global/` and `regional/` respectively.