### PR TITLE
RDS: Add `DBCluster.AutoMinorVersionUpgrade` attribute

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -389,6 +389,7 @@ class DBCluster(RDSBaseModel):
         db_cluster_identifier: str,
         engine: str,
         allocated_storage: Optional[int] = None,
+        auto_minor_version_upgrade: bool = True,
         engine_version: Optional[str] = None,
         master_username: Optional[str] = None,
         master_user_password: Optional[str] = None,
@@ -413,6 +414,7 @@ class DBCluster(RDSBaseModel):
         self.database_name = database_name
         self.db_cluster_identifier = db_cluster_identifier
         self.db_cluster_instance_class = kwargs.get("db_cluster_instance_class")
+        self.auto_minor_version_upgrade = auto_minor_version_upgrade
         self.deletion_protection = deletion_protection
         self.engine = engine
         if self.engine not in ClusterEngine.list_cluster_engines():

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -61,6 +61,7 @@ def test_create_database(client):
         DBSecurityGroups=["my_sg"],
         VpcSecurityGroupIds=["sg-123456"],
         EnableCloudwatchLogsExports=["audit", "error"],
+        AutoMinorVersionUpgrade=False,
     )
     db_instance = database["DBInstance"]
     assert db_instance["AllocatedStorage"] == 10
@@ -83,6 +84,7 @@ def test_create_database(client):
     assert db_instance["EnabledCloudwatchLogsExports"] == ["audit", "error"]
     assert db_instance["Endpoint"]["Port"] == 1234
     assert db_instance["DbInstancePort"] == 1234
+    assert db_instance["AutoMinorVersionUpgrade"] is False
 
 
 @mock_aws

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -337,10 +337,13 @@ def test_create_db_cluster_additional_parameters(client):
         },
         VpcSecurityGroupIds=["sg1", "sg2"],
         EnableIAMDatabaseAuthentication=True,
+        AutoMinorVersionUpgrade=False,
     )
 
     cluster = resp["DBCluster"]
 
+    assert cluster["AutoMinorVersionUpgrade"] is False
+    assert cluster["DBClusterIdentifier"] == "cluster-id"
     assert cluster["AvailabilityZones"] == ["eu-north-1b"]
     assert cluster["DatabaseName"] == "users"
     assert cluster["Engine"] == "aurora-postgresql"


### PR DESCRIPTION
Pulled from #8634 to separate unrelated changes (RDS and TimestreamWrite).