### PR TITLE
Add code hooks for new response serialization flow

### DIFF
--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -4,6 +4,52 @@ from typing import Any, Dict, List, Optional, Tuple
 from jinja2 import DictLoader, Environment
 from werkzeug.exceptions import HTTPException
 
+
+class ServiceException(Exception):
+    """
+    The base class for all (serializable) Moto service exceptions.
+
+    Attributes:
+        code (str): AWS service error code, e.g. ``InvalidParameterCombination``.
+        message (str): A descriptive error message.
+
+    The ``code`` and ``message`` attributes can be set as class attributes or
+    provided at initialization, or a combination thereof.
+
+    A single argument will explicitly set the message attribute:
+    >>> raise ServiceException("A specific error has occurred.")
+
+    Both class attributes overridden at initialization:
+    >>> raise ServiceException("ErrorCode", "Error message")
+
+    Notes:
+       * The ``code`` value should match an exception ShapeID in the AWS model
+         specification for a given service.  When the exception is serialized as
+         part of a Moto server response, additional metadata from the model will
+         be included (e.g. an HTTP status code).
+       * If the AWS error model expects specific attributes in addition to ``message``,
+         they can be set directly on the ``ServiceException`` (or subclass) object as
+         class or instance attributes.
+    """
+
+    code = "UnspecifiedErrorCode"
+    message = "An unspecified service error occurred"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        if len(args) == 1:
+            msg = args[0]
+        elif len(args) == 2:
+            self.code = args[0]
+            msg = args[1]
+        else:
+            msg = self.message.format(**kwargs)
+        Exception.__init__(self, msg)
+        self.message = msg
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}"
+
+
 SINGLE_ERROR_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
 <Error>
     <Code>{{error_type}}</Code>

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -270,6 +270,17 @@ class ActionAuthenticatorMixin(object):
         return decorator
 
 
+class ActionResult:
+    """Wrapper class for serializable results returned from `responses.py` methods."""
+
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    @property
+    def result(self) -> object:
+        return self._result
+
+
 class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     default_region = "us-east-1"
     # to extract region, use [^.]

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -29,9 +29,11 @@ from werkzeug.exceptions import HTTPException
 
 from moto import settings
 from moto.core.common_types import TYPE_IF_NONE, TYPE_RESPONSE
-from moto.core.exceptions import DryRunClientError
+from moto.core.exceptions import DryRunClientError, ServiceException
+from moto.core.serialize import SERIALIZERS, XFormedAttributePicker
 from moto.core.utils import (
     camelcase_to_underscores,
+    get_service_model,
     gzip_decompress,
     method_names_from_class,
     params_sort_function,
@@ -582,6 +584,18 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         # get action from method and uri
         return self._get_action_from_method_and_request_uri(self.method, self.raw_path)
 
+    def serialized(self, action_result: ActionResult) -> TYPE_RESPONSE:
+        service_model = get_service_model(self.service_name)
+        operation_model = service_model.operation_model(self._get_action())
+        serializer_cls = SERIALIZERS[service_model.protocol]
+        serializer = serializer_cls(
+            operation_model=operation_model,
+            pretty_print=settings.PRETTIFY_RESPONSES,
+            value_picker=XFormedAttributePicker(),
+        )
+        serialized = serializer.serialize(action_result.result)
+        return serialized["status_code"], serialized["headers"], serialized["body"]  # type: ignore[return-value]
+
     def call_action(self) -> TYPE_RESPONSE:
         headers = self.response_headers
         if hasattr(self, "_determine_resource"):
@@ -605,6 +619,8 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             method = getattr(self, action)
             try:
                 response = method()
+            except ServiceException as e:
+                response = ActionResult(e)  # type: ignore[assignment]
             except HTTPException as http_error:
                 response_headers: Dict[str, Union[str, int]] = dict(
                     http_error.get_headers() or []
@@ -612,7 +628,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
                 response_headers["status"] = http_error.code  # type: ignore[assignment]
                 response = http_error.description, response_headers  # type: ignore[assignment]
 
-            if isinstance(response, str):
+            if isinstance(response, ActionResult):
+                status, headers, body = self.serialized(response)
+            elif isinstance(response, str):
                 status = 200
                 body = response
             else:

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -461,6 +461,7 @@ class BaseJSONSerializer(ResponseSerializer):
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         resp["body"] = self._serialize_body(serialized_result)
+        resp["headers"]["Content-Type"] = self.CONTENT_TYPE
         return resp
 
     def _serialized_error_to_response(
@@ -477,6 +478,7 @@ class BaseJSONSerializer(ResponseSerializer):
         resp["status_code"] = status_code
         error_code = self._get_protocol_specific_error_code(shape.error_code)
         resp["headers"]["X-Amzn-Errortype"] = error_code
+        resp["headers"]["Content-Type"] = self.CONTENT_TYPE
         return resp
 
     def _get_protocol_specific_error_code(
@@ -750,6 +752,7 @@ class RestXMLSerializer(BaseRestSerializer, BaseXMLSerializer):
 
 
 class RestJSONSerializer(BaseRestSerializer, BaseJSONSerializer):
+    CONTENT_TYPE = "application/json"
     REQUIRES_EMPTY_BODY = True
 
 

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -699,13 +699,14 @@ class BaseRestSerializer(ResponseSerializer):
             "body": {},
             "headers": {},
         }
-        assert isinstance(output_shape, StructureShape)
-        self._serialize(serialized_result, result, output_shape, "")
-        payload_member = output_shape.serialization.get("payload")
-        if payload_member is not None:
-            payload_shape = output_shape.members[payload_member]
-            payload_value = self._get_value(result, payload_member, payload_shape)
-            self._serialize_payload(serialized_result, payload_value, payload_shape)
+        if output_shape is not None:
+            assert isinstance(output_shape, StructureShape)
+            self._serialize(serialized_result, result, output_shape, "")
+            payload_member = output_shape.serialization.get("payload")
+            if payload_member is not None:
+                payload_shape = output_shape.members[payload_member]
+                payload_value = self._get_value(result, payload_member, payload_shape)
+                self._serialize_payload(serialized_result, payload_value, payload_shape)
 
         return self._serialized_result_to_response(
             resp, result, output_shape, serialized_result

--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -1,7 +1,9 @@
 from typing import Optional
 
+from moto.core.exceptions import ServiceException
 
-class RDSClientError(Exception):
+
+class RDSClientError(ServiceException):
     def __init__(self, code: str, message: str):
         super().__init__(message)
         self.code = code
@@ -45,7 +47,7 @@ class DBSubnetGroupNotFoundError(RDSClientError):
 class DBParameterGroupNotFoundError(RDSClientError):
     def __init__(self, db_parameter_group_name: str):
         super().__init__(
-            "DBParameterGroupNotFound",
+            "DBParameterGroupNotFoundFault",
             f"DB Parameter Group {db_parameter_group_name} not found.",
         )
 

--- a/tests/test_core/test_exceptions.py
+++ b/tests/test_core/test_exceptions.py
@@ -1,0 +1,26 @@
+from moto.core.exceptions import ServiceException
+
+
+class TestServiceException:
+    class TestException(ServiceException):
+        code = "ExceptionCode"
+        message = "default message"
+
+    def test_exception_string(self) -> None:
+        exc = TestServiceException.TestException()
+        assert str(exc) == "ExceptionCode: default message"
+
+    def test_formatted_exception_message(self) -> None:
+        class FormattedException(ServiceException):
+            message = "The {resource_type} resource {resource_id} was not found!"
+
+        exc = FormattedException(resource_type="DBCluster", resource_id="cluster-id")
+        assert exc.message == "The DBCluster resource cluster-id was not found!"
+
+    def test_override_exception_message(self) -> None:
+        exc = TestServiceException.TestException("Override message")
+        assert str(exc) == "ExceptionCode: Override message"
+
+    def test_override_exception_message_and_code(self) -> None:
+        exc = TestServiceException.TestException("OverrideCode", "Override message")
+        assert str(exc) == "OverrideCode: Override message"

--- a/tests/test_core/test_exceptions.py
+++ b/tests/test_core/test_exceptions.py
@@ -2,12 +2,12 @@ from moto.core.exceptions import ServiceException
 
 
 class TestServiceException:
-    class TestException(ServiceException):
+    class ServiceError(ServiceException):
         code = "ExceptionCode"
         message = "default message"
 
     def test_exception_string(self) -> None:
-        exc = TestServiceException.TestException()
+        exc = TestServiceException.ServiceError()
         assert str(exc) == "ExceptionCode: default message"
 
     def test_formatted_exception_message(self) -> None:
@@ -18,9 +18,9 @@ class TestServiceException:
         assert exc.message == "The DBCluster resource cluster-id was not found!"
 
     def test_override_exception_message(self) -> None:
-        exc = TestServiceException.TestException("Override message")
+        exc = TestServiceException.ServiceError("Override message")
         assert str(exc) == "ExceptionCode: Override message"
 
     def test_override_exception_message_and_code(self) -> None:
-        exc = TestServiceException.TestException("OverrideCode", "Override message")
+        exc = TestServiceException.ServiceError("OverrideCode", "Override message")
         assert str(exc) == "OverrideCode: Override message"

--- a/tests/test_core/test_protocols.py
+++ b/tests/test_core/test_protocols.py
@@ -73,6 +73,8 @@ def test_output_compliance(json_description: dict, case: dict, protocol):
     headers_expected = case["response"]["headers"]
     # TODO: Get rid of this once we get the headers sorted for all responses
     if headers_expected:
+        if "Content-Type" in resp["headers"]:
+            del resp["headers"]["Content-Type"]
         assert resp["headers"] == headers_expected
     assert resp["status_code"] == case["response"]["status_code"]
 


### PR DESCRIPTION
This PR adds the following base classes to facilitate integration of our new AWS protocol response serializers:

`ActionResult` - a thin wrapper over any object, dict, etc. returned from a `responses.py` method
`ServiceException` - a base class mapping `moto` service exceptions to `botocore` error models

Additionally, this PR adds code hooks in `BaseResponse` to pass instances of these classes directly to the appropriate response serializer.  Because any `ActionResult` returned or any raised exception derived from `ServiceException` will trigger the new serialization flow, we can gradually remove serialization concerns from the backend one service (or even one method or exception) at a time, without interfering with the existing flow.

The RDS backend, which was already making use of the new serialization code, has been updated to utilize the hooks provided in this PR.