### PR TITLE
Core: add response serialization reference implementations for each AWS protocol

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2088,12 +2088,12 @@ class LambdaBackend(BaseBackend):
 
         ddbstream_backend = dynamodbstreams_backends[self.account_id][self.region_name]
         ddb_backend = dynamodb_backends[self.account_id][self.region_name]
-        for stream in json.loads(ddbstream_backend.list_streams())["Streams"]:
-            if stream["StreamArn"] == spec["EventSourceArn"]:
+        for ddbstream in ddbstream_backend.list_streams():
+            if ddbstream["StreamArn"] == spec["EventSourceArn"]:
                 spec.update({"FunctionArn": func.function_arn})
                 esm = EventSourceMapping(spec)
                 self._event_source_mappings[esm.uuid] = esm
-                table_name = stream["TableName"]
+                table_name = ddbstream["TableName"]
                 table = ddb_backend.get_table(table_name)
                 table.lambda_event_source_mappings[esm.function_arn] = esm
                 return esm

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -52,6 +52,7 @@ from .exceptions import (
     GenericResourcNotFound,
     InvalidParameterValueException,
     InvalidRoleFormat,
+    LambdaClientError,
     UnknownAliasException,
     UnknownEventConfig,
     UnknownFunctionException,
@@ -926,11 +927,12 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 )["images"]
 
                 if len(images) == 0:
-                    raise ImageNotFoundException(image_id, repo_name, registry_id)  # type: ignore
+                    exc = ImageNotFoundException(image_id, repo_name, registry_id)  # type: ignore
+                    raise LambdaClientError(exc.code, exc.message)
                 else:
-                    manifest = json.loads(images[0]["imageManifest"])
-                    self.code_sha_256 = images[0]["imageId"]["imageDigest"].replace(
-                        "sha256:", ""
+                    manifest = json.loads(images[0].image_manifest)
+                    self.code_sha_256 = (
+                        images[0].image_id["imageDigest"].replace("sha256:", "")
                     )
                     self.code_size = manifest["config"]["size"]
             if from_update:

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -926,6 +926,10 @@ class XFormedAttributePicker:
                 short_key = key[len(class_name) :]
                 if short_key:  # Will be empty string if class name same as key
                     possible_keys.append(self.xform_name(short_key))
+        if shape is not None:
+            serialization_key = shape.serialization.get("name", key)
+            if serialization_key != key:
+                possible_keys.append(serialization_key)
         for key in possible_keys:
             new_value = ResponseSerializer._default_value_picker(value, key, shape)
             if new_value is not None:

--- a/moto/dynamodbstreams/responses.py
+++ b/moto/dynamodbstreams/responses.py
@@ -1,25 +1,27 @@
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse
 
 from .models import DynamoDBStreamsBackend, dynamodbstreams_backends
 
 
 class DynamoDBStreamsHandler(BaseResponse):
     def __init__(self) -> None:
-        super().__init__(service_name="dynamodb-streams")
+        super().__init__(service_name="dynamodbstreams")
 
     @property
     def backend(self) -> DynamoDBStreamsBackend:
         return dynamodbstreams_backends[self.current_account][self.region]
 
-    def describe_stream(self) -> str:
+    def describe_stream(self) -> ActionResult:
         arn = self._get_param("StreamArn")
-        return self.backend.describe_stream(arn)
+        stream = self.backend.describe_stream(arn)
+        return ActionResult({"StreamDescription": stream})
 
-    def list_streams(self) -> str:
+    def list_streams(self) -> ActionResult:
         table_name = self._get_param("TableName")
-        return self.backend.list_streams(table_name)
+        streams = self.backend.list_streams(table_name)
+        return ActionResult({"Streams": streams})
 
-    def get_shard_iterator(self) -> str:
+    def get_shard_iterator(self) -> ActionResult:
         arn = self._get_param("StreamArn")
         shard_id = self._get_param("ShardId")
         shard_iterator_type = self._get_param("ShardIteratorType")
@@ -28,13 +30,15 @@ class DynamoDBStreamsHandler(BaseResponse):
         if isinstance(sequence_number, str):
             sequence_number = int(sequence_number)
 
-        return self.backend.get_shard_iterator(
+        iterator = self.backend.get_shard_iterator(
             arn, shard_id, shard_iterator_type, sequence_number
         )
+        return ActionResult({"ShardIterator": iterator.arn})
 
-    def get_records(self) -> str:
+    def get_records(self) -> ActionResult:
         arn = self._get_param("ShardIterator")
         limit = self._get_param("Limit")
         if limit is None:
             limit = 1000
-        return self.backend.get_records(arn, limit)
+        result = self.backend.get_records(arn, limit)
+        return ActionResult(result)

--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -21,7 +21,7 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
         "DnsSupport": "enable",
         "MulticastSupport": "disable",
         "PropagationDefaultRouteTableId": "tgw-rtb-0d571391e50cf8514",
-        "TransitGatewayCidrBlocks": None,
+        "TransitGatewayCidrBlocks": [],
         "VpnEcmpSupport": "enable",
     }
 
@@ -39,11 +39,15 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
         self._created_at = utcnow()
 
     @property
+    def tags(self) -> List[Dict[str, str]]:
+        return self.get_tags()
+
+    @property
     def physical_resource_id(self) -> str:
         return self.id
 
     @property
-    def create_time(self) -> str:
+    def creation_time(self) -> str:
         return iso_8601_datetime_with_milliseconds(self._created_at)
 
     @property

--- a/moto/ec2/responses/transit_gateways.py
+++ b/moto/ec2/responses/transit_gateways.py
@@ -1,8 +1,10 @@
+from moto.core.responses import ActionResult
+
 from ._base_response import EC2BaseResponse
 
 
 class TransitGateways(EC2BaseResponse):
-    def create_transit_gateway(self) -> str:
+    def create_transit_gateway(self) -> ActionResult:
         description = self._get_param("Description") or None
         options = self._get_multi_param_dict("Options")
         tags = self._get_multi_param("TagSpecification")
@@ -28,26 +30,22 @@ class TransitGateways(EC2BaseResponse):
         transit_gateway.options["PropagationDefaultRouteTableId"] = (
             transit_gateway_route_table.id
         )
+        return ActionResult({"TransitGateway": transit_gateway})
 
-        template = self.response_template(CREATE_TRANSIT_GATEWAY_RESPONSE)
-        return template.render(transit_gateway=transit_gateway)
-
-    def delete_transit_gateway(self) -> str:
+    def delete_transit_gateway(self) -> ActionResult:
         transit_gateway_id = self._get_param("TransitGatewayId")
         transit_gateway = self.ec2_backend.delete_transit_gateway(transit_gateway_id)
-        template = self.response_template(DELETE_TRANSIT_GATEWAY_RESPONSE)
-        return template.render(transit_gateway=transit_gateway)
+        return ActionResult({"TransitGateway": transit_gateway})
 
-    def describe_transit_gateways(self) -> str:
+    def describe_transit_gateways(self) -> ActionResult:
         transit_gateway_ids = self._get_multi_param("TransitGatewayIds")
         filters = self._filters_from_querystring()
         transit_gateways = self.ec2_backend.describe_transit_gateways(
             filters, transit_gateway_ids
         )
-        template = self.response_template(DESCRIBE_TRANSIT_GATEWAY_RESPONSE)
-        return template.render(transit_gateways=transit_gateways)
+        return ActionResult({"TransitGateways": transit_gateways})
 
-    def modify_transit_gateway(self) -> str:
+    def modify_transit_gateway(self) -> ActionResult:
         transit_gateway_id = self._get_param("TransitGatewayId")
         description = self._get_param("Description") or None
         options = self._get_multi_param_dict("Options")
@@ -56,120 +54,4 @@ class TransitGateways(EC2BaseResponse):
             description=description,
             options=options,
         )
-        template = self.response_template(MODIFY_TRANSIT_GATEWAY_RESPONSE)
-        return template.render(transit_gateway=transit_gateway)
-
-
-CREATE_TRANSIT_GATEWAY_RESPONSE = """<CreateTransitGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
-    <transitGateway>
-        <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
-        <transitGatewayArn>{{ transit_gateway.arn }}</transitGatewayArn>
-        <ownerId>{{ transit_gateway.owner_id }}</ownerId>
-        <description>{{ transit_gateway.description or '' }}</description>
-        <createTime>{{ transit_gateway.create_time }}</createTime>
-        <state>{{ transit_gateway.state }}</state>
-        {% if transit_gateway.options %}
-        <options>
-            <amazonSideAsn>{{ transit_gateway.options.AmazonSideAsn }}</amazonSideAsn>
-            <autoAcceptSharedAttachments>{{ transit_gateway.options.AutoAcceptSharedAttachments }}</autoAcceptSharedAttachments>
-            <defaultRouteTableAssociation>{{ transit_gateway.options.DefaultRouteTableAssociation }}</defaultRouteTableAssociation>
-            <defaultRouteTablePropagation>{{ transit_gateway.options.DefaultRouteTablePropagation }}</defaultRouteTablePropagation>
-            <dnsSupport>{{ transit_gateway.options.DnsSupport }}</dnsSupport>
-            <propagationDefaultRouteTableId>{{ transit_gateway.options.PropagationDefaultRouteTableId }}</propagationDefaultRouteTableId>
-            <vpnEcmpSupport>{{ transit_gateway.options.VpnEcmpSupport }}</vpnEcmpSupport>
-            <transitGatewayCidrBlocks>{{ transit_gateway.options.TransitGatewayCidrBlocks }}</transitGatewayCidrBlocks>
-        </options>
-        {% endif %}
-        <tagSet>
-            {% for tag in transit_gateway.get_tags() %}
-                <item>
-                    <key>{{ tag.key }}</key>
-                    <value>{{ tag.value }}</value>
-                </item>
-            {% endfor %}
-        </tagSet>
-    </transitGateway>
-</CreateTransitGatewayResponse>
-"""
-
-DESCRIBE_TRANSIT_GATEWAY_RESPONSE = """<DescribeTransitGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
-    <transitGatewaySet>
-    {% for transit_gateway in transit_gateways %}
-        <item>
-            <creationTime>{{ transit_gateway.create_time }}</creationTime>
-            <description>{{ transit_gateway.description or '' }}</description>
-            {% if transit_gateway.options %}
-            <options>
-                <amazonSideAsn>{{ transit_gateway.options.AmazonSideAsn }}</amazonSideAsn>
-                <associationDefaultRouteTableId>{{ transit_gateway.options.AssociationDefaultRouteTableId }}</associationDefaultRouteTableId>
-                <autoAcceptSharedAttachments>{{ transit_gateway.options.AutoAcceptSharedAttachments }}</autoAcceptSharedAttachments>
-                <defaultRouteTableAssociation>{{ transit_gateway.options.DefaultRouteTableAssociation }}</defaultRouteTableAssociation>
-                <defaultRouteTablePropagation>{{ transit_gateway.options.DefaultRouteTablePropagation }}</defaultRouteTablePropagation>
-                <dnsSupport>{{ transit_gateway.options.DnsSupport }}</dnsSupport>
-                <propagationDefaultRouteTableId>{{ transit_gateway.options.PropagationDefaultRouteTableId }}</propagationDefaultRouteTableId>
-                <vpnEcmpSupport>{{ transit_gateway.options.VpnEcmpSupport }}</vpnEcmpSupport>
-                <transitGatewayCidrBlocks>{{ transit_gateway.options.TransitGatewayCidrBlocks }}</transitGatewayCidrBlocks>
-            </options>
-            {% endif %}
-            <ownerId>{{ transit_gateway.owner_id }}</ownerId>
-            <state>{{ transit_gateway.state }}</state>
-            <tagSet>
-                {% for tag in transit_gateway.get_tags() %}
-                    <item>
-                        <key>{{ tag.key }}</key>
-                        <value>{{ tag.value }}</value>
-                    </item>
-                {% endfor %}
-            </tagSet>
-            <transitGatewayArn>{{ transit_gateway.arn }}</transitGatewayArn>
-            <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
-        </item>
-    {% endfor %}
-    </transitGatewaySet>
-</DescribeTransitGatewaysResponse>
-"""
-
-DELETE_TRANSIT_GATEWAY_RESPONSE = """<DeleteTransitGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
-    <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
-</DeleteTransitGatewayResponse>
-"""
-
-
-MODIFY_TRANSIT_GATEWAY_RESPONSE = """<ModifyTransitGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
-    <transitGatewaySet>
-    <item>
-        <creationTime>{{ transit_gateway.create_time }}</creationTime>
-        <description>{{ transit_gateway.description or '' }}</description>
-        {% if transit_gateway.options %}
-        <options>
-            <amazonSideAsn>{{ transit_gateway.options.AmazonSideAsn }}</amazonSideAsn>
-            <associationDefaultRouteTableId>{{ transit_gateway.options.AssociationDefaultRouteTableId }}</associationDefaultRouteTableId>
-            <autoAcceptSharedAttachments>{{ transit_gateway.options.AutoAcceptSharedAttachments }}</autoAcceptSharedAttachments>
-            <defaultRouteTableAssociation>{{ transit_gateway.options.DefaultRouteTableAssociation }}</defaultRouteTableAssociation>
-            <defaultRouteTablePropagation>{{ transit_gateway.options.DefaultRouteTablePropagation }}</defaultRouteTablePropagation>
-            <dnsSupport>{{ transit_gateway.options.DnsSupport }}</dnsSupport>
-            <propagationDefaultRouteTableId>{{ transit_gateway.options.PropagationDefaultRouteTableId }}</propagationDefaultRouteTableId>
-            <vpnEcmpSupport>{{ transit_gateway.options.VpnEcmpSupport }}</vpnEcmpSupport>
-            <transitGatewayCidrBlocks>{{ transit_gateway.options.TransitGatewayCidrBlocks }}</transitGatewayCidrBlocks>
-        </options>
-        {% endif %}
-        <ownerId>{{ transit_gateway.owner_id }}</ownerId>
-        <state>{{ transit_gateway.state }}</state>
-        <tagSet>
-            {% for tag in transit_gateway.get_tags() %}
-                <item>
-                    <key>{{ tag.key }}</key>
-                    <value>{{ tag.value }}</value>
-                </item>
-            {% endfor %}
-        </tagSet>
-        <transitGatewayArn>{{ transit_gateway.arn }}</transitGatewayArn>
-        <transitGatewayId>{{ transit_gateway.id }}</transitGatewayId>
-    </item>
-    </transitGatewaySet>
-</ModifyTransitGatewaysResponse>
-"""
+        return ActionResult({"TransitGateway": transit_gateway})

--- a/moto/ecr/exceptions.py
+++ b/moto/ecr/exceptions.py
@@ -1,112 +1,93 @@
-from moto.core.exceptions import JsonRESTError
+from moto.core.exceptions import ServiceException
 
 
-class LifecyclePolicyNotFoundException(JsonRESTError):
-    code = 400
+class LifecyclePolicyNotFoundException(ServiceException):
+    code = "LifecyclePolicyNotFoundException"
 
     def __init__(self, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="LifecyclePolicyNotFoundException",
-            message=(
-                "Lifecycle policy does not exist "
-                f"for the repository with name '{repository_name}' "
-                f"in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"Lifecycle policy does not exist "
+            f"for the repository with name '{repository_name}' "
+            f"in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class LimitExceededException(JsonRESTError):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            error_type="LimitExceededException",
-            message=("The scan quota per image has been exceeded. Wait and try again."),
-        )
+class LimitExceededException(ServiceException):
+    code = "LimitExceededException"
+    message = "The scan quota per image has been exceeded. Wait and try again."
 
 
-class RegistryPolicyNotFoundException(JsonRESTError):
-    code = 400
+class RegistryPolicyNotFoundException(ServiceException):
+    code = "RegistryPolicyNotFoundException"
 
     def __init__(self, registry_id: str):
-        super().__init__(
-            error_type="RegistryPolicyNotFoundException",
-            message=(
-                f"Registry policy does not exist in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"Registry policy does not exist in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class RepositoryAlreadyExistsException(JsonRESTError):
-    code = 400
+class RepositoryAlreadyExistsException(ServiceException):
+    code = "RepositoryAlreadyExistsException"
 
     def __init__(self, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="RepositoryAlreadyExistsException",
-            message=(
-                f"The repository with name '{repository_name}' already exists "
-                f"in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"The repository with name '{repository_name}' already exists "
+            f"in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class RepositoryNotEmptyException(JsonRESTError):
-    code = 400
+class RepositoryNotEmptyException(ServiceException):
+    code = "RepositoryNotEmptyException"
 
     def __init__(self, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="RepositoryNotEmptyException",
-            message=(
-                f"The repository with name '{repository_name}' "
-                f"in registry with id '{registry_id}' "
-                "cannot be deleted because it still contains images"
-            ),
+        message = (
+            f"The repository with name '{repository_name}' "
+            f"in registry with id '{registry_id}' "
+            f"cannot be deleted because it still contains images"
         )
+        super().__init__(message)
 
 
-class RepositoryNotFoundException(JsonRESTError):
-    code = 400
+class RepositoryNotFoundException(ServiceException):
+    code = "RepositoryNotFoundException"
 
     def __init__(self, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="RepositoryNotFoundException",
-            message=(
-                f"The repository with name '{repository_name}' does not exist "
-                f"in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"The repository with name '{repository_name}' does not exist "
+            f"in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class RepositoryPolicyNotFoundException(JsonRESTError):
-    code = 400
+class RepositoryPolicyNotFoundException(ServiceException):
+    code = "RepositoryPolicyNotFoundException"
 
     def __init__(self, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="RepositoryPolicyNotFoundException",
-            message=(
-                "Repository policy does not exist "
-                f"for the repository with name '{repository_name}' "
-                f"in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"Repository policy does not exist "
+            f"for the repository with name '{repository_name}' "
+            f"in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class ImageNotFoundException(JsonRESTError):
-    code = 400
+class ImageNotFoundException(ServiceException):
+    code = "ImageNotFoundException"
 
     def __init__(self, image_id: str, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="ImageNotFoundException",
-            message=(
-                f"The image with imageId {image_id} does not exist "
-                f"within the repository with name '{repository_name}' "
-                f"in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"The image with imageId {image_id} does not exist "
+            f"within the repository with name '{repository_name}' "
+            f"in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class ImageAlreadyExistsException(JsonRESTError):
-    code = 400
+class ImageAlreadyExistsException(ServiceException):
+    code = "ImageAlreadyExistsException"
 
     def __init__(
         self,
@@ -115,39 +96,29 @@ class ImageAlreadyExistsException(JsonRESTError):
         digest: str,
         image_tag: str,
     ):
-        super().__init__(
-            error_type="ImageAlreadyExistsException",
-            message=(
-                f"Image with digest '{digest}' and tag '{image_tag}' already exists "
-                f"in the repository with name '{repository_name}' "
-                f"in registry with id '{registry_id}'"
-            ),
+        message = (
+            f"Image with digest '{digest}' and tag '{image_tag}' already exists "
+            f"in the repository with name '{repository_name}' "
+            f"in registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class InvalidParameterException(JsonRESTError):
-    code = 400
-
-    def __init__(self, message: str):
-        super().__init__(error_type="InvalidParameterException", message=message)
+class InvalidParameterException(ServiceException):
+    code = "InvalidParameterException"
 
 
-class ScanNotFoundException(JsonRESTError):
-    code = 400
+class ScanNotFoundException(ServiceException):
+    code = "ScanNotFoundException"
 
     def __init__(self, image_id: str, repository_name: str, registry_id: str):
-        super().__init__(
-            error_type="ScanNotFoundException",
-            message=(
-                f"Image scan does not exist for the image with '{image_id}' "
-                f"in the repository with name '{repository_name}' "
-                f"in the registry with id '{registry_id}'"
-            ),
+        message = (
+            f"Image scan does not exist for the image with '{image_id}' "
+            f"in the repository with name '{repository_name}' "
+            f"in the registry with id '{registry_id}'"
         )
+        super().__init__(message)
 
 
-class ValidationException(JsonRESTError):
-    code = 400
-
-    def __init__(self, message: str):
-        super().__init__(error_type="ValidationException", message=message)
+class ValidationException(ServiceException):
+    code = "ValidationException"

--- a/moto/ecr/responses.py
+++ b/moto/ecr/responses.py
@@ -1,9 +1,9 @@
-import json
+import copy
 import time
 from base64 import b64encode
 from datetime import datetime
 
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse
 
 from .models import ECRBackend, ecr_backends
 
@@ -16,7 +16,7 @@ class ECRResponse(BaseResponse):
     def ecr_backend(self) -> ECRBackend:
         return ecr_backends[self.current_account][self.region]
 
-    def create_repository(self) -> str:
+    def create_repository(self) -> ActionResult:
         repository_name = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         encryption_config = self._get_param("encryptionConfiguration")
@@ -32,18 +32,18 @@ class ECRResponse(BaseResponse):
             image_tag_mutablility=image_tag_mutablility,
             tags=tags,
         )
-        return json.dumps({"repository": repository.response_object})
+        return ActionResult({"repository": repository})
 
-    def describe_repositories(self) -> str:
+    def describe_repositories(self) -> ActionResult:
         describe_repositories_name = self._get_param("repositoryNames")
         registry_id = self._get_param("registryId")
 
         repositories = self.ecr_backend.describe_repositories(
             repository_names=describe_repositories_name, registry_id=registry_id
         )
-        return json.dumps({"repositories": repositories, "failures": []})
+        return ActionResult({"repositories": repositories, "failures": []})
 
-    def delete_repository(self) -> str:
+    def delete_repository(self) -> ActionResult:
         repository_str = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         force = self._get_param("force")
@@ -51,9 +51,9 @@ class ECRResponse(BaseResponse):
         repository = self.ecr_backend.delete_repository(
             repository_str, registry_id, force
         )
-        return json.dumps({"repository": repository.response_object})
+        return ActionResult({"repository": repository})
 
-    def put_image(self) -> str:
+    def put_image(self) -> ActionResult:
         repository_str = self._get_param("repositoryName")
         image_manifest = self._get_param("imageManifest")
         image_tag = self._get_param("imageTag")
@@ -62,10 +62,9 @@ class ECRResponse(BaseResponse):
         image = self.ecr_backend.put_image(
             repository_str, image_manifest, image_tag, image_manifest_media_type, digest
         )
+        return ActionResult({"image": image})
 
-        return json.dumps({"image": image.response_object})
-
-    def list_images(self) -> str:
+    def list_images(self) -> ActionResult:
         repository_str = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         images = self.ecr_backend.list_images(repository_str, registry_id)
@@ -73,18 +72,25 @@ class ECRResponse(BaseResponse):
         for image in images:
             for tag in image.image_tags or [None]:  # type: ignore
                 resp.append({"imageDigest": image.image_digest, "imageTag": tag})
-        return json.dumps({"imageIds": resp})
+        return ActionResult({"imageIds": resp})
 
-    def describe_images(self) -> str:
+    def describe_images(self) -> ActionResult:
         repository_str = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         image_ids = self._get_param("imageIds")
         images = self.ecr_backend.describe_images(
             repository_str, registry_id, image_ids
         )
-        return json.dumps(
-            {"imageDetails": [image.response_describe_object for image in images]}
-        )
+        # We have to do a bit of manipulation here because a real AWS ECR backend
+        # does not serialize `imageTags` if it's an empty array (and we already
+        # have a test that asserts this behavior).
+        dto_images = []
+        for image in images:
+            dto_image = copy.copy(image)
+            if not dto_image.image_tags:
+                del dto_image.image_tags
+            dto_images.append(dto_image)
+        return ActionResult({"imageDetails": dto_images})
 
     def batch_check_layer_availability(self) -> None:
         self.error_on_dryrun()
@@ -92,7 +98,7 @@ class ECRResponse(BaseResponse):
             "ECR.batch_check_layer_availability is not yet implemented"
         )
 
-    def batch_delete_image(self) -> str:
+    def batch_delete_image(self) -> ActionResult:
         repository_str = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         image_ids = self._get_param("imageIds")
@@ -100,9 +106,9 @@ class ECRResponse(BaseResponse):
         response = self.ecr_backend.batch_delete_image(
             repository_str, registry_id, image_ids
         )
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def batch_get_image(self) -> str:
+    def batch_get_image(self) -> ActionResult:
         repository_str = self._get_param("repositoryName")
         registry_id = self._get_param("registryId")
         image_ids = self._get_param("imageIds")
@@ -110,14 +116,14 @@ class ECRResponse(BaseResponse):
         response = self.ecr_backend.batch_get_image(
             repository_str, registry_id, image_ids
         )
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def batch_get_repository_scanning_configuration(self) -> str:
+    def batch_get_repository_scanning_configuration(self) -> ActionResult:
         names = self._get_param("repositoryNames")
         configs, missing = self.ecr_backend.batch_get_repository_scanning_configuration(
             names
         )
-        return json.dumps(
+        return ActionResult(
             {
                 "scanningConfigurations": configs,
                 "failures": [
@@ -135,17 +141,17 @@ class ECRResponse(BaseResponse):
         self.error_on_dryrun()
         raise NotImplementedError("ECR.complete_layer_upload is not yet implemented")
 
-    def delete_repository_policy(self) -> str:
+    def delete_repository_policy(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.delete_repository_policy(
                 registry_id=registry_id, repository_name=repository_name
             )
         )
 
-    def get_authorization_token(self) -> str:
+    def get_authorization_token(self) -> ActionResult:
         registry_ids = self._get_param("registryIds")
         if not registry_ids:
             registry_ids = [self.current_account]
@@ -160,7 +166,7 @@ class ECRResponse(BaseResponse):
                     "proxyEndpoint": f"https://{registry_id}.dkr.ecr.{self.region}.amazonaws.com",
                 }
             )
-        return json.dumps({"authorizationData": auth_data})
+        return ActionResult({"authorizationData": auth_data})
 
     def get_download_url_for_layer(self) -> None:
         self.error_on_dryrun()
@@ -168,11 +174,11 @@ class ECRResponse(BaseResponse):
             "ECR.get_download_url_for_layer is not yet implemented"
         )
 
-    def get_repository_policy(self) -> str:
+    def get_repository_policy(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.get_repository_policy(
                 registry_id=registry_id, repository_name=repository_name
             )
@@ -182,7 +188,7 @@ class ECRResponse(BaseResponse):
         self.error_on_dryrun()
         raise NotImplementedError("ECR.initiate_layer_upload is not yet implemented")
 
-    def set_repository_policy(self) -> str:
+    def set_repository_policy(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
         policy_text = self._get_param("policyText")
@@ -190,7 +196,7 @@ class ECRResponse(BaseResponse):
         # but this would need a much deeper validation of the provided policy
         # force = self._get_param("force")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.set_repository_policy(
                 registry_id=registry_id,
                 repository_name=repository_name,
@@ -202,31 +208,31 @@ class ECRResponse(BaseResponse):
         self.error_on_dryrun()
         raise NotImplementedError("ECR.upload_layer_part is not yet implemented")
 
-    def list_tags_for_resource(self) -> str:
+    def list_tags_for_resource(self) -> ActionResult:
         arn = self._get_param("resourceArn")
 
-        return json.dumps(self.ecr_backend.list_tags_for_resource(arn))
+        return ActionResult(self.ecr_backend.list_tags_for_resource(arn))
 
-    def tag_resource(self) -> str:
+    def tag_resource(self) -> ActionResult:
         arn = self._get_param("resourceArn")
         tags = self._get_param("tags", [])
 
         self.ecr_backend.tag_resource(arn, tags)
-        return "{}"
+        return ActionResult({})
 
-    def untag_resource(self) -> str:
+    def untag_resource(self) -> ActionResult:
         arn = self._get_param("resourceArn")
         tag_keys = self._get_param("tagKeys", [])
 
         self.ecr_backend.untag_resource(arn, tag_keys)
-        return "{}"
+        return ActionResult({})
 
-    def put_image_tag_mutability(self) -> str:
+    def put_image_tag_mutability(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
         image_tag_mutability = self._get_param("imageTagMutability")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.put_image_tag_mutability(
                 registry_id=registry_id,
                 repository_name=repository_name,
@@ -234,12 +240,12 @@ class ECRResponse(BaseResponse):
             )
         )
 
-    def put_image_scanning_configuration(self) -> str:
+    def put_image_scanning_configuration(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
         image_scan_config = self._get_param("imageScanningConfiguration")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.put_image_scanning_configuration(
                 registry_id=registry_id,
                 repository_name=repository_name,
@@ -247,12 +253,12 @@ class ECRResponse(BaseResponse):
             )
         )
 
-    def put_lifecycle_policy(self) -> str:
+    def put_lifecycle_policy(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
         lifecycle_policy_text = self._get_param("lifecyclePolicyText")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.put_lifecycle_policy(
                 registry_id=registry_id,
                 repository_name=repository_name,
@@ -260,43 +266,45 @@ class ECRResponse(BaseResponse):
             )
         )
 
-    def get_lifecycle_policy(self) -> str:
+    def get_lifecycle_policy(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.get_lifecycle_policy(
                 registry_id=registry_id, repository_name=repository_name
             )
         )
 
-    def delete_lifecycle_policy(self) -> str:
+    def delete_lifecycle_policy(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.delete_lifecycle_policy(
                 registry_id=registry_id, repository_name=repository_name
             )
         )
 
-    def put_registry_policy(self) -> str:
+    def put_registry_policy(self) -> ActionResult:
         policy_text = self._get_param("policyText")
 
-        return json.dumps(self.ecr_backend.put_registry_policy(policy_text=policy_text))
+        return ActionResult(
+            self.ecr_backend.put_registry_policy(policy_text=policy_text)
+        )
 
-    def get_registry_policy(self) -> str:
-        return json.dumps(self.ecr_backend.get_registry_policy())
+    def get_registry_policy(self) -> ActionResult:
+        return ActionResult(self.ecr_backend.get_registry_policy())
 
-    def delete_registry_policy(self) -> str:
-        return json.dumps(self.ecr_backend.delete_registry_policy())
+    def delete_registry_policy(self) -> ActionResult:
+        return ActionResult(self.ecr_backend.delete_registry_policy())
 
-    def start_image_scan(self) -> str:
+    def start_image_scan(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
         image_id = self._get_param("imageId")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.start_image_scan(
                 registry_id=registry_id,
                 repository_name=repository_name,
@@ -304,12 +312,12 @@ class ECRResponse(BaseResponse):
             )
         )
 
-    def describe_image_scan_findings(self) -> str:
+    def describe_image_scan_findings(self) -> ActionResult:
         registry_id = self._get_param("registryId")
         repository_name = self._get_param("repositoryName")
         image_id = self._get_param("imageId")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.describe_image_scan_findings(
                 registry_id=registry_id,
                 repository_name=repository_name,
@@ -317,33 +325,33 @@ class ECRResponse(BaseResponse):
             )
         )
 
-    def put_replication_configuration(self) -> str:
+    def put_replication_configuration(self) -> ActionResult:
         replication_config = self._get_param("replicationConfiguration")
 
-        return json.dumps(
+        return ActionResult(
             self.ecr_backend.put_replication_configuration(
                 replication_config=replication_config
             )
         )
 
-    def get_registry_scanning_configuration(self) -> str:
+    def get_registry_scanning_configuration(self) -> ActionResult:
         registry_scanning_config = (
             self.ecr_backend.get_registry_scanning_configuration()
         )
-        return json.dumps(
+        return ActionResult(
             {
                 "registryId": self.current_account,
                 "scanningConfiguration": registry_scanning_config,
             }
         )
 
-    def put_registry_scanning_configuration(self) -> str:
+    def put_registry_scanning_configuration(self) -> ActionResult:
         scan_type = self._get_param("scanType")
         rules = self._get_param("rules")
         self.ecr_backend.put_registry_scanning_configuration(scan_type, rules)
-        return json.dumps(
+        return ActionResult(
             {"registryScanningConfiguration": {"scanType": scan_type, "rules": rules}}
         )
 
-    def describe_registry(self) -> str:
-        return json.dumps(self.ecr_backend.describe_registry())
+    def describe_registry(self) -> ActionResult:
+        return ActionResult(self.ecr_backend.describe_registry())

--- a/moto/mq/exceptions.py
+++ b/moto/mq/exceptions.py
@@ -1,47 +1,43 @@
-import json
-
-from moto.core.exceptions import JsonRESTError
+from moto.core.exceptions import ServiceException
 
 
-class MQError(JsonRESTError):
-    pass
+class NotFoundException(ServiceException):
+    code = "NotFoundException"
 
 
-class UnknownBroker(MQError):
+class UnknownBroker(NotFoundException):
+    error_attribute = "broker-id"
+
     def __init__(self, broker_id: str):
-        super().__init__("NotFoundException", "Can't find requested broker")
-        body = {
-            "errorAttribute": "broker-id",
-            "message": f"Can't find requested broker [{broker_id}]. Make sure your broker exists.",
-        }
-        self.description = json.dumps(body)
+        message = (
+            f"Can't find requested broker [{broker_id}]. Make sure your broker exists."
+        )
+        super().__init__(message)
 
 
-class UnknownConfiguration(MQError):
+class UnknownConfiguration(NotFoundException):
+    error_attribute = "configuration_id"
+
     def __init__(self, config_id: str):
-        super().__init__("NotFoundException", "Can't find requested configuration")
-        body = {
-            "errorAttribute": "configuration_id",
-            "message": f"Can't find requested configuration [{config_id}]. Make sure your configuration exists.",
-        }
-        self.description = json.dumps(body)
+        message = f"Can't find requested configuration [{config_id}]. Make sure your configuration exists."
+        super().__init__(message)
 
 
-class UnknownUser(MQError):
+class UnknownUser(NotFoundException):
+    error_attribute = "username"
+
     def __init__(self, username: str):
-        super().__init__("NotFoundException", "Can't find requested user")
-        body = {
-            "errorAttribute": "username",
-            "message": f"Can't find requested user [{username}]. Make sure your user exists.",
-        }
-        self.description = json.dumps(body)
+        message = f"Can't find requested user [{username}]. Make sure your user exists."
+        super().__init__(message)
 
 
-class UnknownEngineType(MQError):
+class BadRequestException(ServiceException):
+    code = "BadRequestException"
+
+
+class UnknownEngineType(BadRequestException):
+    error_attribute = "engineType"
+
     def __init__(self, engine_type: str):
-        super().__init__("BadRequestException", "")
-        body = {
-            "errorAttribute": "engineType",
-            "message": f"Broker engine type [{engine_type}] is invalid. Valid values are: [ACTIVEMQ]",
-        }
-        self.description = json.dumps(body)
+        message = f"Broker engine type [{engine_type}] is invalid. Valid values are: [ACTIVEMQ]"
+        super().__init__(message)

--- a/tests/test_core/test_protocols.py
+++ b/tests/test_core/test_protocols.py
@@ -70,11 +70,19 @@ def test_output_compliance(json_description: dict, case: dict, protocol):
     result = case["result"] if "error" not in case else _create_exception(case)
     resp = serializer.serialize(result)  # _to_response(result)
     assert resp["body"] == case["response"]["body"]
+    assert "Content-Type" in resp["headers"]
+    protocol_to_content_type = {
+        "ec2": "text/xml",
+        "json": "application/x-amz-json-1.0",
+        "query": "text/xml",
+        "rest-xml": "text/xml",
+        "rest-json": "application/json",
+    }
+    assert resp["headers"]["Content-Type"] == protocol_to_content_type[protocol]
     headers_expected = case["response"]["headers"]
-    # TODO: Get rid of this once we get the headers sorted for all responses
+    # TODO: Get rid of this if once we get the headers sorted for all responses
     if headers_expected:
-        if "Content-Type" in resp["headers"]:
-            del resp["headers"]["Content-Type"]
+        del resp["headers"]["Content-Type"]
         assert resp["headers"] == headers_expected
     assert resp["status_code"] == case["response"]["status_code"]
 

--- a/tests/test_core/test_serialize.py
+++ b/tests/test_core/test_serialize.py
@@ -14,7 +14,7 @@ that go above and beyond the specification(s) for a number of reasons:
 
 import time
 
-from botocore.model import ServiceModel
+from botocore.model import ServiceModel, ShapeResolver
 from xmltodict import parse
 
 from moto.core.serialize import QuerySerializer, XFormedAttributePicker
@@ -152,6 +152,25 @@ class TestXFormedAttributePicker:
         obj = dict()
         value = self.picker(obj, "Attribute", None)
         assert value is None
+
+    def test_serialization_key(self):
+        shape_map = {
+            "Foo": {
+                "type": "structure",
+                "members": {
+                    "Baz": {"shape": "StringType", "locationName": "other"},
+                },
+            },
+            "StringType": {"type": "string"},
+        }
+        resolver = ShapeResolver(shape_map)
+        shape = resolver.resolve_shape_ref(
+            {"shape": "StringType", "locationName": "other"}
+        )
+        assert shape
+        obj = {"other": "found me"}
+        value = self.picker(obj, "StringType", shape)
+        assert value == "found me"
 
     def test_short_key(self):
         class Role:

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -62,8 +62,6 @@ def test_create_transit_gateway():
         gateways[0]["Options"]["AssociationDefaultRouteTableId"]
         == gateways[0]["Options"]["PropagationDefaultRouteTableId"]
     )
-    del gateways[0]["CreationTime"]
-    del gateways[0]["Options"]["AssociationDefaultRouteTableId"]
     assert gateway == gateways[0]
 
 

--- a/tests/test_ecr/test_ecr_policy_validation.py
+++ b/tests/test_ecr/test_ecr_policy_validation.py
@@ -70,8 +70,7 @@ def test_validate_error_parse(policy):
 
     # then
     ex = e.value
-    assert ex.code == 400
-    assert ex.error_type == "InvalidParameterException"
+    assert ex.code == "InvalidParameterException"
     assert (
         ex.message
         == "Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: 'Lifecycle policy validation failure: Could not map policyString into LifecyclePolicy.'"
@@ -107,8 +106,7 @@ def test_validate_error_extract_rules(policy):
 
     # then
     ex = e.value
-    assert ex.code == 400
-    assert ex.error_type == "InvalidParameterException"
+    assert ex.code == "InvalidParameterException"
     assert (
         ex.message
         == "Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: 'Lifecycle policy validation failure: object has missing required properties ([\"rules\"])'"
@@ -126,8 +124,7 @@ def test_validate_error_rule_type(rule):
 
     # then
     ex = e.value
-    assert ex.code == 400
-    assert ex.error_type == "InvalidParameterException"
+    assert ex.code == "InvalidParameterException"
     assert ex.message == (
         "Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: "
         "'Lifecycle policy validation failure: "
@@ -196,8 +193,7 @@ def test_validate_error_rule_properties(rule, error_msg):
 
     # then
     ex = e.value
-    assert ex.code == 400
-    assert ex.error_type == "InvalidParameterException"
+    assert ex.code == "InvalidParameterException"
     assert (
         ex.message
         == f"Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: 'Lifecycle policy validation failure: {error_msg}"
@@ -251,8 +247,7 @@ def test_validate_error_action_properties(action, error_msg):
 
     # then
     ex = e.value
-    assert ex.code == 400
-    assert ex.error_type == "InvalidParameterException"
+    assert ex.code == "InvalidParameterException"
     assert (
         ex.message
         == f"Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: 'Lifecycle policy validation failure: {error_msg}"
@@ -370,8 +365,7 @@ def test_validate_error_selection_properties(selection, error_msg):
 
     # then
     ex = e.value
-    assert ex.code == 400
-    assert ex.error_type == "InvalidParameterException"
+    assert ex.code == "InvalidParameterException"
     assert (
         ex.message
         == f"Invalid parameter at 'LifecyclePolicyText' failed to satisfy constraint: 'Lifecycle policy validation failure: {error_msg}"

--- a/tests/test_mq/test_mq.py
+++ b/tests/test_mq/test_mq.py
@@ -305,12 +305,16 @@ def test_describe_broker_unknown():
 
     with pytest.raises(ClientError) as exc:
         client.describe_broker(BrokerId="unknown")
-    err = exc.value.response["Error"]
-    assert err["Code"] == "NotFoundException"
+    resp = exc.value.response
+    error = resp["Error"]
+    metadata = resp["ResponseMetadata"]
+    assert metadata["HTTPStatusCode"] == 404
+    assert error["Code"] == "NotFoundException"
     assert (
-        err["Message"]
+        error["Message"]
         == "Can't find requested broker [unknown]. Make sure your broker exists."
     )
+    assert resp.get("ErrorAttribute") == "broker-id"
 
 
 @mock_aws


### PR DESCRIPTION
| Protocol | Service | Comments |
| :-----------------------: | --- | --- |
| `ec2` | Amazon Elastic Compute Cloud | Only migrated `TransitGateway` responses, which illustrates how this can be done piecemeal for larger service backends.  Still a good chunk of XML template code deleted, even for this one small part of EC2! |
| `json` - `1.0` | Amazon DynamoDB Streams | Currently has an open issue related to serialization (#8622). Very simple backend (no `exceptions.py` file). |
| `json` - `1.1` | Amazon Elastic Container Registry | This service had a lot of specialized serialization code polluting the backend models.  All gone now! |
| `rest-json` | AmazonMQ | Currently has an open issue related to serialization (#8632).  Lots of `.to_json()` methods deleted.  A good example of modelled exceptions (where HTTP status codes and extra error attributes are serialized according to the AWS service definition).|
| `rest-xml` | N/A | There are only a few backends for this protocol (`cloudfront`, `route53`, and `s3`) but they are complex and will need the AWS protocol-based request parsing I plan to add before we can proceed on converting them.
| `query` | Amazon Relational Database Service | Not part of this PR, but already integrated with the AWS response serializers. |

The diff here is actually pretty readable (especially if each commit is viewed on its own), but I have added some individual comments directly to areas of the changeset whose purpose may not be immediately obvious.  With one notable exception (called out in a commit message/code comment), any test updates were simply to increase coverage and provide additional assertions.

@bblommers - Let me know if you have any questions or concerns.  I was thinking I might also add a pinned issue detailing this ongoing effort.