### PR TITLE
Fix: Dynamodb account-based endpoint urls

### DIFF
--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -49,7 +49,7 @@ backend_url_patterns = [
     ("ds", re.compile("https?://ds\\.(.+)\\.amazonaws\\.com")),
     ("dsql", re.compile("https?://dsql\\.(.+)\\.api\\.aws")),
     ("dynamodb", re.compile("https?://dynamodb\\.(.+)\\.amazonaws\\.com")),
-    ("dynamodb", re.compile("https?://(.+).ddb\\.(.+)\\.amazonaws\\.com")),
+    ("dynamodb", re.compile("https?://(.+)\\.ddb\\.(.+)\\.amazonaws\\.com")),
     (
         "dynamodbstreams",
         re.compile("https?://streams\\.dynamodb\\.(.+)\\.amazonaws.com"),

--- a/moto/dynamodb/urls.py
+++ b/moto/dynamodb/urls.py
@@ -2,7 +2,7 @@ from .responses import DynamoHandler
 
 url_bases = [
     r"https?://dynamodb\.(.+)\.amazonaws\.com",
-    r"https?://(.+).ddb\.(.+)\.amazonaws\.com",
+    r"https?://(.+)\.ddb\.(.+)\.amazonaws\.com",
 ]
 
 url_paths = {"{0}/": DynamoHandler.dispatch}

--- a/tests/test_core/test_url_base_regex.py
+++ b/tests/test_core/test_url_base_regex.py
@@ -20,3 +20,14 @@ class TestMockBucketStartingWithServiceName:
                 Bucket=bucket_name,
                 CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
             )
+
+
+@mock_aws
+def test_dynamodb_account_based_endpoint() -> None:
+    dynamodb_account_based_endpoint_service_name = "ddb"
+    s3_client = boto3.client("s3", "us-east-1")
+    bucket_name = (
+        f"bucket-name-ends-with-{dynamodb_account_based_endpoint_service_name}"
+    )
+    resp = s3_client.create_bucket(Bucket=bucket_name)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200


### PR DESCRIPTION
There have been a number of (seemingly) random CI failures lately ([1](https://github.com/getmoto/moto/actions/runs/13835470472/job/38709588990), [2](https://github.com/getmoto/moto/actions/runs/13863398864/job/38797171887), [3](https://github.com/getmoto/moto/actions/runs/13817630158/job/38655165818)) resulting in the following error:

```
botocore.exceptions.ClientError: An error occurred (404) when calling the CreateBucket operation: Not Found
```
Looking deeper at the logs in some of these cases revealed a pattern:

```
operation_name = 'CreateBucket'
api_params = {'Bucket': '99de52f2-6849-40c0-b76c-99da9acaaddb'}
```
```
operation_name = 'CreateBucket'
api_params = {'Bucket': '68d04331-de3b-43eb-8988-a5bba5a3eddb'}
```
```
operation_name = 'CreateBucket'
api_params = {'Bucket': '0d92652c-9af9-435b-9ae8-5c9b507ecddb'}
```
For some strange reason, it appeared that any bucket name that ended in `ddb` failed with a 404 error.  I was able to reproduce this directly with a test case, and after a bit of troubleshooting found the culprit: a simple unescaped period in a regex recently added to support [AWS account-based endpoints for DynamoDB](https://docs.aws.amazon.com/sdkref/latest/guide/feature-account-endpoints.html) (#8621):
![image](https://github.com/user-attachments/assets/2336795e-ef76-40d5-8a38-e7aa0213647e)
This PR contains the simple fix and a (now passing) test case.