### PR TITLE
EC2: ModifyLaunchTemplate

### DIFF
--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -228,6 +228,22 @@ class LaunchTemplateBackend:
         self.launch_template_insert_order.append(template.id)
         return template
 
+    def modify_launch_template(
+        self,
+        default_version: str,
+        template_name: Optional[str] = None,
+        template_id: Optional[str] = None,
+    ) -> LaunchTemplate:
+        if template_name:
+            template_id = self.launch_template_name_to_ids.get(template_name)
+        if template_id is None:
+            raise MissingParameterError("launch template ID or launch template name")
+        if template_id not in self.launch_templates:
+            raise InvalidLaunchTemplateNameNotFoundError()
+        self.launch_templates[template_id].default_version_number = int(default_version)
+        template = self.launch_templates[template_id]
+        return template
+
     def get_launch_template(self, template_id: str) -> LaunchTemplate:
         return self.launch_templates[template_id]
 

--- a/moto/ec2/responses/launch_templates.py
+++ b/moto/ec2/responses/launch_templates.py
@@ -264,6 +264,35 @@ class LaunchTemplates(EC2BaseResponse):
         template = self.response_template(GET_LAUNCH_TEMPLATE_DATA_RESPONSE)
         return template.render(i=instance)
 
+    def modify_launch_template(self) -> str:
+        template_name = self._get_param("LaunchTemplateName")
+        template_id = self._get_param("LaunchTemplateId")
+        default_version = self._get_param("SetDefaultVersion")
+
+        self.error_on_dryrun()
+
+        template = self.ec2_backend.modify_launch_template(
+            template_name=template_name,
+            template_id=template_id,
+            default_version=default_version,
+        )
+
+        tree = xml_root("ModifyLaunchTemplateVersion")
+        xml_serialize(
+            tree,
+            "LaunchTemplate",
+            {
+                "createTime": template.create_time,
+                "createdBy": f"arn:{self.partition}:iam::{self.current_account}:root",
+                "defaultVersionNumber": template.default_version_number,
+                "latestVersionNumber": template.latest_version_number,
+                "launchTemplateId": template.id,
+                "launchTemplateName": template.name,
+                "tags": template.tags,
+            },
+        )
+        return pretty_xml(tree)
+
 
 GET_LAUNCH_TEMPLATE_DATA_RESPONSE = """<GetLaunchTemplateDataResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>801986a5-0ee2-46bd-be02-abcde1234567</requestId>


### PR DESCRIPTION
Hi, this pull request is to add the ModifyLaunchTemplate response to EC2. The action is used to set the default version of the launch template (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/modify_launch_template.html). I have linted the commits according to the contribution guide and tests pass.

This is my first pull request, and if there is additional work required or other feedback, I'm happy to work through that.