### PR TITLE
Application Autoscaling: Add ARN for scalable targets

### DIFF
--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -418,6 +418,7 @@ class FakeScalableTarget(BaseModel):
         self.role_arn = role_arn
         self.suspended_state = suspended_state
         self.creation_time = time.time()
+        self.arn = f"arn:{get_partition(backend.region_name)}:application-autoscaling:{backend.region_name}:{backend.account_id}:scalable-target/{mock_random.get_random_string(length=36, lower_case=True)}"
 
     def update(
         self,

--- a/moto/applicationautoscaling/responses.py
+++ b/moto/applicationautoscaling/responses.py
@@ -46,7 +46,7 @@ class ApplicationAutoScalingResponse(BaseResponse):
     def register_scalable_target(self) -> str:
         """Registers or updates a scalable target."""
         self._validate_params()
-        self.applicationautoscaling_backend.register_scalable_target(
+        target = self.applicationautoscaling_backend.register_scalable_target(
             self._get_param("ServiceNamespace"),
             self._get_param("ResourceId"),
             self._get_param("ScalableDimension"),
@@ -55,7 +55,7 @@ class ApplicationAutoScalingResponse(BaseResponse):
             role_arn=self._get_param("RoleARN"),
             suspended_state=self._get_param("SuspendedState"),
         )
-        return json.dumps({})
+        return json.dumps({"ScalableTargetARN": target.arn})
 
     def deregister_scalable_target(self) -> str:
         """Deregisters a scalable target."""
@@ -197,12 +197,13 @@ class ApplicationAutoScalingResponse(BaseResponse):
 def _build_target(t: FakeScalableTarget) -> Dict[str, Any]:
     return {
         "CreationTime": t.creation_time,
-        "ServiceNamespace": t.service_namespace,
+        "MaxCapacity": t.max_capacity,
+        "MinCapacity": t.min_capacity,
         "ResourceId": t.resource_id,
         "RoleARN": t.role_arn,
         "ScalableDimension": t.scalable_dimension,
-        "MaxCapacity": t.max_capacity,
-        "MinCapacity": t.min_capacity,
+        "ServiceNamespace": t.service_namespace,
+        "ScalableTargetARN": t.arn,
         "SuspendedState": t.suspended_state,
     }
 

--- a/tests/test_applicationautoscaling/test_applicationautoscaling.py
+++ b/tests/test_applicationautoscaling/test_applicationautoscaling.py
@@ -304,7 +304,7 @@ def test_register_scalable_target_updates_existing_target():
         "ScheduledScalingSuspended": False,
     }
 
-    client.register_scalable_target(
+    response = client.register_scalable_target(
         ServiceNamespace=DEFAULT_SERVICE_NAMESPACE,
         ResourceId=DEFAULT_RESOURCE_ID,
         ScalableDimension=DEFAULT_SCALABLE_DIMENSION,
@@ -312,12 +312,16 @@ def test_register_scalable_target_updates_existing_target():
         MaxCapacity=updated_max_capacity,
         SuspendedState=updated_suspended_state,
     )
+    expected_arn_prefix = f"arn:aws:application-autoscaling:{DEFAULT_REGION}:{ACCOUNT_ID}:scalable-target/"
+    assert response["ScalableTargetARN"].startswith(expected_arn_prefix)
+
     response = client.describe_scalable_targets(
         ServiceNamespace=DEFAULT_SERVICE_NAMESPACE
     )
 
     assert len(response["ScalableTargets"]) == 1
     t = response["ScalableTargets"][0]
+    assert t["ScalableTargetARN"].startswith(expected_arn_prefix)
     assert t["MinCapacity"] == updated_min_capacity
     assert t["MaxCapacity"] == updated_max_capacity
     assert (


### PR DESCRIPTION
This PR makes [`RegisterScalableTarget`](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_RegisterScalableTarget.html) and [`DescribeScalableTargets`](https://docs.aws.amazon.com/autoscaling/application/APIReference/API_DescribeScalableTargets.html) return the [ARN of the scalable target](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsapplicationautoscaling.html#awsapplicationautoscaling-resources-for-iam-policies).

```
$ aws application-autoscaling register-scalable-target \                                                                                                                                          
  --service-namespace dynamodb \                                                                                                                                                                                  
  --resource-id table/tab001 \                                                                                                                                                                                    
  --scalable-dimension dynamodb:table:ReadCapacityUnits \                                                                                                                                                         
  --min-capacity 1 \                                                                                                                                                                                              
  --max-capacity 10                                                                                      
{                                                                                                        
    "ScalableTargetARN": "arn:aws:application-autoscaling:eu-central-1:XXXXXXXXXXXX:scalable-target/0d2629fb24047a194f8789cc3exxxxxxxxxx"                                                                         
}                                                                                                        

$ aws application-autoscaling describe-scalable-targets --service-namespace dynamodb
{
    "ScalableTargets": [
        {
            "ServiceNamespace": "dynamodb",
            "ResourceId": "table/tab001",
            "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
            "MinCapacity": 1,
            "MaxCapacity": 10,
            "RoleARN": "arn:aws:iam::XXXXXXXXXXXX:role/aws-service-role/dynamodb.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_DynamoDBTable",
            "CreationTime": "2025-03-20T18:43:14.951000+05:30",
            "SuspendedState": {
                "DynamicScalingInSuspended": false,
                "DynamicScalingOutSuspended": false,
                "ScheduledScalingSuspended": false
            },
            "ScalableTargetARN": "arn:aws:application-autoscaling:eu-central-1:XXXXXXXXXXXX:scalable-target/0d2629fb24047a194f8789cc3exxxxxxxxxx"
        }
    ]
}
```