### PR TITLE
Admin: Up minimum botocore version to 1.20.88

### DIFF
--- a/.github/workflows/test_outdated_versions.yml
+++ b/.github/workflows/test_outdated_versions.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        botocore: ["--upgrade boto3 botocore", "--upgrade boto3 botocore && pip install urllib3==2.2.1", "boto3==1.11.0 botocore==1.14.0"]
+        botocore: ["--upgrade boto3 botocore", "--upgrade boto3 botocore && pip install urllib3==2.2.1", "boto3==1.17.0 botocore==1.20.88"]
         python-version: [ "3.11" ]
         responses-version: ["0.15.0", "0.17.0", "0.19.0", "0.20.0" ]
         werkzeug-version: ["2.0.1", "2.1.1", "2.2.2"]
         openapi-spec-validator-version: ["0.5.0"]
-        cryptography-version: ["39.0.0"]
+        cryptography-version: ["35.0.0"]
 
     steps:
     - name: Checkout repository

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ project_urls =
 python_requires = >=3.9
 install_requires =
     boto3>=1.9.201
-    botocore>=1.14.0,!=1.35.45,!=1.35.46
+    botocore>=1.20.88,!=1.35.45,!=1.35.46
     cryptography>=35.0.0
     requests>=2.5
     xmltodict

--- a/tests/test_awslambda/test_lambda_eventsourcemapping.py
+++ b/tests/test_awslambda/test_lambda_eventsourcemapping.py
@@ -1,12 +1,15 @@
 import json
+import sys
 import time
 import uuid
+from unittest import SkipTest
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from moto.utilities.distutils_version import LooseVersion
 
 from ..markers import requires_docker
 from .utilities import (
@@ -18,10 +21,14 @@ from .utilities import (
 
 PYTHON_VERSION = "python3.11"
 _lambda_region = "us-west-2"
+botocore_version = sys.modules["botocore"].__version__
 
 
 @mock_aws
 def test_create_event_source_mapping():
+    if LooseVersion(botocore_version) < LooseVersion("1.23.12"):
+        raise SkipTest("Parameter FilterCriteria is not available in older versions")
+
     function_name = str(uuid.uuid4())[0:6]
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName=f"{function_name}_queue")
@@ -518,6 +525,9 @@ def test_get_event_source_mapping():
 
 @mock_aws
 def test_update_event_source_mapping():
+    if LooseVersion(botocore_version) < LooseVersion("1.23.12"):
+        raise SkipTest("Parameter FilterCriteria is not available in older versions")
+
     function_name = str(uuid.uuid4())[0:6]
     sqs = boto3.resource("sqs", region_name="us-east-1")
     queue = sqs.create_queue(QueueName=f"{function_name}_queue")


### PR DESCRIPTION
Ups the minimum botocore version that supports both `is_document_type` and `error_code` - both properties of `botocore.model` that are now used by the serialization code, but were only introduced in [1.1.6.0](https://github.com/boto/botocore/commit/1d91dbbf23ab883f3c92fe7f6c22e0fc726d5c7d) and [1.20.88](https://github.com/boto/botocore/commit/3b87b23002d99df480b147252897b45fd10241a1) respectively.

Also updates the outdated dependency tests to verify that the tests pass with this version.

FYI @bpandola 