### PR TITLE
EKS: integrate with core AWS response serializer

### DIFF
--- a/moto/eks/responses.py
+++ b/moto/eks/responses.py
@@ -1,9 +1,6 @@
-import json
-from typing import Any
 from urllib.parse import unquote
 
-from moto.core.common_types import TYPE_RESPONSE
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse
 
 from .models import EKSBackend, eks_backends
 
@@ -19,7 +16,7 @@ class EKSResponse(BaseResponse):
     def eks_backend(self) -> EKSBackend:
         return eks_backends[self.current_account][self.region]
 
-    def create_cluster(self) -> TYPE_RESPONSE:
+    def create_cluster(self) -> ActionResult:
         name = self._get_param("name")
         version = self._get_param("version")
         role_arn = self._get_param("roleArn")
@@ -44,9 +41,9 @@ class EKSResponse(BaseResponse):
             remote_network_config=remote_network_config,
         )
 
-        return 200, {}, json.dumps({"cluster": dict(cluster)})
+        return ActionResult({"cluster": cluster})
 
-    def create_fargate_profile(self) -> TYPE_RESPONSE:
+    def create_fargate_profile(self) -> ActionResult:
         fargate_profile_name = self._get_param("fargateProfileName")
         cluster_name = self._get_param("name")
         pod_execution_role_arn = self._get_param("podExecutionRoleArn")
@@ -65,9 +62,9 @@ class EKSResponse(BaseResponse):
             tags=tags,
         )
 
-        return 200, {}, json.dumps({"fargateProfile": dict(fargate_profile)})
+        return ActionResult({"fargateProfile": fargate_profile})
 
-    def create_nodegroup(self) -> TYPE_RESPONSE:
+    def create_nodegroup(self) -> ActionResult:
         cluster_name = self._get_param("name")
         nodegroup_name = self._get_param("nodegroupName")
         scaling_config = self._get_param("scalingConfig")
@@ -106,25 +103,25 @@ class EKSResponse(BaseResponse):
             release_version=release_version,
         )
 
-        return 200, {}, json.dumps({"nodegroup": dict(nodegroup)})
+        return ActionResult({"nodegroup": nodegroup})
 
-    def describe_cluster(self) -> TYPE_RESPONSE:
+    def describe_cluster(self) -> ActionResult:
         name = self._get_param("name")
 
         cluster = self.eks_backend.describe_cluster(name=name)
 
-        return 200, {}, json.dumps({"cluster": dict(cluster)})
+        return ActionResult({"cluster": cluster})
 
-    def describe_fargate_profile(self) -> TYPE_RESPONSE:
+    def describe_fargate_profile(self) -> ActionResult:
         cluster_name = self._get_param("name")
         fargate_profile_name = self._get_param("fargateProfileName")
 
         fargate_profile = self.eks_backend.describe_fargate_profile(
             cluster_name=cluster_name, fargate_profile_name=fargate_profile_name
         )
-        return 200, {}, json.dumps({"fargateProfile": dict(fargate_profile)})
+        return ActionResult({"fargateProfile": fargate_profile})
 
-    def describe_nodegroup(self) -> TYPE_RESPONSE:
+    def describe_nodegroup(self) -> ActionResult:
         cluster_name = self._get_param("name")
         nodegroup_name = self._get_param("nodegroupName")
 
@@ -132,9 +129,9 @@ class EKSResponse(BaseResponse):
             cluster_name=cluster_name, nodegroup_name=nodegroup_name
         )
 
-        return 200, {}, json.dumps({"nodegroup": dict(nodegroup)})
+        return ActionResult({"nodegroup": nodegroup})
 
-    def list_clusters(self) -> TYPE_RESPONSE:
+    def list_clusters(self) -> ActionResult:
         max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
         next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
 
@@ -142,9 +139,9 @@ class EKSResponse(BaseResponse):
             max_results=max_results, next_token=next_token
         )
 
-        return 200, {}, json.dumps(dict(clusters=clusters, nextToken=next_token))
+        return ActionResult(dict(clusters=clusters, nextToken=next_token))
 
-    def list_fargate_profiles(self) -> TYPE_RESPONSE:
+    def list_fargate_profiles(self) -> ActionResult:
         cluster_name = self._get_param("name")
         max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
         next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
@@ -153,15 +150,11 @@ class EKSResponse(BaseResponse):
             cluster_name=cluster_name, max_results=max_results, next_token=next_token
         )
 
-        return (
-            200,
-            {},
-            json.dumps(
-                dict(fargateProfileNames=fargate_profile_names, nextToken=next_token)
-            ),
+        return ActionResult(
+            dict(fargateProfileNames=fargate_profile_names, nextToken=next_token)
         )
 
-    def list_nodegroups(self) -> TYPE_RESPONSE:
+    def list_nodegroups(self) -> ActionResult:
         cluster_name = self._get_param("name")
         max_results = self._get_int_param("maxResults", DEFAULT_MAX_RESULTS)
         next_token = self._get_param("nextToken", DEFAULT_NEXT_TOKEN)
@@ -170,16 +163,16 @@ class EKSResponse(BaseResponse):
             cluster_name=cluster_name, max_results=max_results, next_token=next_token
         )
 
-        return 200, {}, json.dumps(dict(nodegroups=nodegroups, nextToken=next_token))
+        return ActionResult(dict(nodegroups=nodegroups, nextToken=next_token))
 
-    def delete_cluster(self) -> TYPE_RESPONSE:
+    def delete_cluster(self) -> ActionResult:
         name = self._get_param("name")
 
         cluster = self.eks_backend.delete_cluster(name=name)
 
-        return 200, {}, json.dumps({"cluster": dict(cluster)})
+        return ActionResult({"cluster": cluster})
 
-    def delete_fargate_profile(self) -> TYPE_RESPONSE:
+    def delete_fargate_profile(self) -> ActionResult:
         cluster_name = self._get_param("name")
         fargate_profile_name = self._get_param("fargateProfileName")
 
@@ -187,9 +180,9 @@ class EKSResponse(BaseResponse):
             cluster_name=cluster_name, fargate_profile_name=fargate_profile_name
         )
 
-        return 200, {}, json.dumps({"fargateProfile": dict(fargate_profile)})
+        return ActionResult({"fargateProfile": fargate_profile})
 
-    def delete_nodegroup(self) -> TYPE_RESPONSE:
+    def delete_nodegroup(self) -> ActionResult:
         cluster_name = self._get_param("name")
         nodegroup_name = self._get_param("nodegroupName")
 
@@ -197,34 +190,25 @@ class EKSResponse(BaseResponse):
             cluster_name=cluster_name, nodegroup_name=nodegroup_name
         )
 
-        return 200, {}, json.dumps({"nodegroup": dict(nodegroup)})
+        return ActionResult({"nodegroup": nodegroup})
 
-    def tags(self, request: Any, full_url: str, headers: Any) -> TYPE_RESPONSE:  # type: ignore[return]
-        self.setup_class(request, full_url, headers)
-        if request.method == "GET":
-            return self.list_tags_for_resource()
-        if request.method == "POST":
-            return self.tag_resource()
-        if request.method == "DELETE":
-            return self.untag_resource()
-
-    def tag_resource(self) -> TYPE_RESPONSE:
+    def tag_resource(self) -> ActionResult:
         self.eks_backend.tag_resource(
             self._extract_arn_from_path(), self._get_param("tags")
         )
 
-        return 200, {}, ""
+        return ActionResult({})
 
-    def untag_resource(self) -> TYPE_RESPONSE:
+    def untag_resource(self) -> ActionResult:
         self.eks_backend.untag_resource(
             self._extract_arn_from_path(), self._get_param("tagKeys")
         )
 
-        return 200, {}, ""
+        return ActionResult({})
 
-    def list_tags_for_resource(self) -> TYPE_RESPONSE:
+    def list_tags_for_resource(self) -> ActionResult:
         tags = self.eks_backend.list_tags_for_resource(self._extract_arn_from_path())
-        return 200, {}, json.dumps({"tags": tags})
+        return ActionResult({"tags": tags})
 
     def _extract_arn_from_path(self) -> str:
         # /tags/arn_that_may_contain_a_slash

--- a/moto/eks/urls.py
+++ b/moto/eks/urls.py
@@ -15,5 +15,5 @@ url_paths = {
     "{0}/clusters/(?P<name>[^/]+)/node-groups/(?P<nodegroupName>[^/]+)$": response.dispatch,
     "{0}/clusters/(?P<name>[^/]+)/fargate-profiles$": response.dispatch,
     "{0}/clusters/(?P<name>[^/]+)/fargate-profiles/(?P<fargateProfileName>[^/]+)$": response.dispatch,
-    "{0}/tags/(?P<resourceArn>.+)$": response.tags,
+    "{0}/tags/(?P<resourceArn>.+)$": response.dispatch,
 }

--- a/moto/eks/utils.py
+++ b/moto/eks/utils.py
@@ -1,40 +1,8 @@
-import inspect
 import re
 
 from boto3 import Session
 
 from moto.eks.exceptions import InvalidParameterException
-
-
-def get_partition(region: str) -> str:
-    valid_matches = [
-        # (region prefix, aws partition)
-        ("cn-", "aws-cn"),
-        ("us-gov-", "aws-us-gov"),
-        ("us-gov-iso-", "aws-iso"),
-        ("us-gov-iso-b-", "aws-iso-b"),
-    ]
-
-    for prefix, partition in valid_matches:
-        if region.startswith(prefix):
-            return partition
-    return "aws"
-
-
-def method_name(use_parent: bool = False) -> str:
-    """
-    Returns the name of the method which called it from the stack in PascalCase.
-    If `use_parent` is True, returns the parent of the method which called it instead.
-    For example:  False/default will return the name of the method calling it.
-    In a helper method, use True to return the name of the method which called the helper.
-    """
-    return (
-        # stack()[0] is this method, stack()[1] is the method which called this one, etc
-        inspect.stack()[int(use_parent) + 1][0]
-        .f_code.co_name.replace("_", " ")
-        .title()
-        .replace(" ", "")
-    )
 
 
 def validate_role_arn(arn: str) -> None:

--- a/tests/test_eks/test_eks.py
+++ b/tests/test_eks/test_eks.py
@@ -1,14 +1,16 @@
+import datetime
 from copy import deepcopy
 from unittest import SkipTest, mock
+from unittest.mock import PropertyMock
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
-from moto.core.utils import iso_8601_datetime_without_milliseconds
 from moto.eks.exceptions import (
     InvalidParameterException,
     InvalidRequestException,
@@ -36,7 +38,6 @@ from moto.moto_api._internal import mock_random
 from .test_eks_constants import (
     DEFAULT_NAMESPACE,
     DISK_SIZE,
-    FROZEN_TIME,
     INSTANCE_TYPES,
     LAUNCH_TEMPLATE,
     MAX_FARGATE_LABELS,
@@ -324,19 +325,16 @@ def test_create_cluster_generates_valid_cluster_arn(ClusterBuilder):
     )
 
 
-@freeze_time(FROZEN_TIME)
 @mock_aws
 def test_create_cluster_generates_valid_cluster_created_timestamp(ClusterBuilder):
-    _, generated_test_data = ClusterBuilder()
-
-    result_time = iso_8601_datetime_without_milliseconds(
-        generated_test_data.cluster_describe_output[ClusterAttributes.CREATED_AT]
-    )
-
-    if settings.TEST_SERVER_MODE:
-        assert RegExTemplates.ISO8601_FORMAT.match(result_time)
-    else:
-        assert result_time == FROZEN_TIME
+    cluster_create_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    with freeze_time(cluster_create_time):
+        _, generated_test_data = ClusterBuilder()
+    result_time = generated_test_data.cluster_describe_output[
+        ClusterAttributes.CREATED_AT
+    ]
+    if not settings.TEST_SERVER_MODE:
+        assert result_time == cluster_create_time
 
 
 @mock_aws
@@ -565,7 +563,11 @@ def test_create_nodegroup_throws_exception_when_cluster_not_active(NodegroupBuil
         clusterName=generated_test_data.cluster_name
     )
 
-    with mock.patch("moto.eks.models.Cluster.isActive", return_value=False):
+    with mock.patch(
+        "moto.eks.models.Cluster.is_active",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
         with pytest.raises(ClientError) as raised_exception:
             client.create_nodegroup(
                 clusterName=generated_test_data.cluster_name,
@@ -603,36 +605,31 @@ def test_create_nodegroup_generates_valid_nodegroup_arn(NodegroupBuilder):
     )
 
 
-@freeze_time(FROZEN_TIME)
 @mock_aws
 def test_create_nodegroup_generates_valid_nodegroup_created_timestamp(NodegroupBuilder):
-    _, generated_test_data = NodegroupBuilder()
+    ng_create_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    with freeze_time(ng_create_time):
+        _, generated_test_data = NodegroupBuilder()
 
-    result_time = iso_8601_datetime_without_milliseconds(
-        generated_test_data.nodegroup_describe_output[NodegroupAttributes.CREATED_AT]
-    )
-
-    if settings.TEST_SERVER_MODE:
-        assert RegExTemplates.ISO8601_FORMAT.match(result_time)
-    else:
-        assert result_time == FROZEN_TIME
+    result_time = generated_test_data.nodegroup_describe_output[
+        NodegroupAttributes.CREATED_AT
+    ]
+    if not settings.TEST_SERVER_MODE:
+        assert result_time == ng_create_time
 
 
-@freeze_time(FROZEN_TIME)
 @mock_aws
 def test_create_nodegroup_generates_valid_nodegroup_modified_timestamp(
     NodegroupBuilder,
 ):
-    _, generated_test_data = NodegroupBuilder()
-
-    result_time = iso_8601_datetime_without_milliseconds(
-        generated_test_data.nodegroup_describe_output[NodegroupAttributes.MODIFIED_AT]
-    )
-
-    if settings.TEST_SERVER_MODE:
-        assert RegExTemplates.ISO8601_FORMAT.match(result_time)
-    else:
-        assert result_time == FROZEN_TIME
+    ng_mod_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    with freeze_time(ng_mod_time):
+        _, generated_test_data = NodegroupBuilder()
+    result_time = generated_test_data.nodegroup_describe_output[
+        NodegroupAttributes.MODIFIED_AT
+    ]
+    if not settings.TEST_SERVER_MODE:
+        assert result_time == ng_mod_time
 
 
 @mock_aws
@@ -1014,7 +1011,11 @@ def test_create_fargate_profile_throws_exception_when_cluster_not_active(
         clusterName=generated_test_data.cluster_name
     )
 
-    with mock.patch("moto.eks.models.Cluster.isActive", return_value=False):
+    with mock.patch(
+        "moto.eks.models.Cluster.is_active",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
         with pytest.raises(ClientError) as raised_exception:
             client.create_fargate_profile(
                 clusterName=generated_test_data.cluster_name,
@@ -1052,21 +1053,18 @@ def test_create_fargate_profile_generates_valid_profile_arn(FargateProfileBuilde
     )
 
 
-@freeze_time(FROZEN_TIME)
 @mock_aws
 def test_create_fargate_profile_generates_valid_created_timestamp(
     FargateProfileBuilder,
 ):
-    _, generated_test_data = FargateProfileBuilder()
-
-    result_time = iso_8601_datetime_without_milliseconds(
-        generated_test_data.fargate_describe_output[FargateProfileAttributes.CREATED_AT]
-    )
-
-    if settings.TEST_SERVER_MODE:
-        assert RegExTemplates.ISO8601_FORMAT.match(result_time)
-    else:
-        assert result_time == FROZEN_TIME
+    fp_create_time = datetime.datetime(2013, 11, 27, 1, 42, tzinfo=tzutc())
+    with freeze_time(fp_create_time):
+        _, generated_test_data = FargateProfileBuilder()
+    result_time = generated_test_data.fargate_describe_output[
+        FargateProfileAttributes.CREATED_AT
+    ]
+    if not settings.TEST_SERVER_MODE:
+        assert result_time == fp_create_time
 
 
 @mock_aws


### PR DESCRIPTION
* minor test updates needed when making timestamp assertions, which were previously comparing against incorrect iso_8601 string format.
* dead code in `utils.py` deleted.

Fixes #8697 