### PR TITLE
Recorder: fix replay of `chunked` requests

### DIFF
--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -136,6 +136,8 @@ class Recorder:
                 if parsed_url.query:
                     url = f"{url}?{parsed_url.query}"
             headers = row_loaded.get("headers")
+            if headers.get("Transfer-Encoding", "") == "chunked":
+                del headers["Transfer-Encoding"]
             requests.request(method=method, url=url, headers=headers, data=body)
 
         # restore the recording setting

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -184,12 +184,6 @@ class S3Response(BaseResponse):
         self.bucket_name = self.parse_bucket_name_from_url(request, full_url)
         self.request = request
         if (
-            not self.body
-            and request.headers.get("Content-Encoding", "") == "aws-chunked"
-            and hasattr(request, "input_stream")
-        ):
-            self.body = request.input_stream
-        if (
             self.request.headers.get("x-amz-content-sha256")
             == "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
         ):


### PR DESCRIPTION
This started with #8495, which attempted to address breaking changes introduced in boto/boto3#4392.  A key part of those changes was "S3 clients [now] default to enabling an additional checksum on all Put calls".  This trailing checksum is provided via a "chunked" stream (the body of the request is sent with the checksum following).  In #8495, a hacky conditional was added to the S3 responses class to detect this type of request when replayed via moto's `recording` api in order to get the request `body` from the underlying `input_stream`.  

Werkzeug is unable ([for good reason](https://github.com/pallets/werkzeug/issues/2346#issuecomment-1059246951)) to handle a `dechunked` request sent with a `chunked` transfer encoding, which is exactly what happens when the `moto` recorder attempts to replay a(n originally) streaming request.

This PR drops the previous hack and removes the invalid header at the source: in the `Recorder` class.

With this change, the standard `moto` request processing pipeline is able to handle the request and correctly parse the `body`.
