### PR TITLE
Admin: Update project metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,4 +20,3 @@ include moto/ssm/resources/ecs/optimized_amis/*.json
 include moto/support/resources/*.json
 recursive-include moto/moto_server *
 recursive-include tests *
-recursive-exclude tests/terraformtests *

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
-    License :: OSI Approved :: Apache Software License
+    License-Expression :: OSI Approved :: Apache Software License
     Topic :: Software Development :: Testing
 keywords = aws ec2 s3 boto3 mock
 project_urls =


### PR DESCRIPTION
Fixes #8738 

The license-expression was changed recently due to [PEP 639](https://peps.python.org/pep-0639/). [The docs](https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use) now explicitly call out that `License ::` is deprecated in favor of `License-Expression ::`.

The reference to `tests/terraformtests` is very old - that folder was removed ages ago (in favor of `other_langs/terraform`).

With these changes, there are no warnings anymore when building the wheel for Moto.

------
Note: If/when we ever move to the `pyproject.toml` setup, we should consolidate the license-declarations. We currently have two, one as a top-level field and another as a classifier, but Python suggest only using the top-level field `license_expression`.
See https://packaging.python.org/en/latest/specifications/license-expression/