### PR TITLE
DynamoDB: Dont trigger Path overlap on expressions with shared root

### DIFF
--- a/moto/dynamodb/parsing/validators.py
+++ b/moto/dynamodb/parsing/validators.py
@@ -478,7 +478,12 @@ class OverlappingPathsValidator(DepthFirstTraverser):  # type: ignore[misc]
         for action in actions:
             path = action.children[0]
             path_name = path.children[0]
-            if isinstance(path_name, ExpressionAttributeName):
+            # for some reason, if we only have a root expression ('#path1', '#path2'),
+            # AWS only checks for direct matches, not path overlaps
+            if (
+                isinstance(path_name, ExpressionAttributeName)
+                and len(path.children) == 1
+            ):
                 expression_attribute_name_paths.append(
                     self.expression_attribute_names[
                         path_name.get_attribute_name_placeholder()
@@ -487,8 +492,6 @@ class OverlappingPathsValidator(DepthFirstTraverser):  # type: ignore[misc]
             else:
                 plaintext_paths.append(path.to_str())
 
-        # for some reason, AWS only checks expression attribute names for
-        # direct matches, not path overlaps
         overlapping_paths = find_path_overlaps(plaintext_paths)
         if overlapping_paths:
             # There might be more than one attribute duplicated:


### PR DESCRIPTION
Fixes #8740 

If we only have a root name (and not an expression, so 'path' instead of '#path'), AWS only checks for direct matches, not path overlaps. However, this code path should trigger only if we have a root name (`root`, one child) - not with a nested name (`root.child`, which resolves to three children)

@BlizzardOf - considering it's a minor adjustment to [your earlier PR](https://github.com/getmoto/moto/pull/8648) where we introduced path overlap checks, do you want to review this?