### PR TITLE
S3: delete_objects(): BypassGovernanceMode should handle both True and true

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1234,7 +1234,7 @@ class S3Response(BaseResponse):
         template = self.response_template(S3_DELETE_KEYS_RESPONSE)
         body_dict = xmltodict.parse(self.body, strip_whitespace=False)
         bypass_retention = (
-            self.headers.get("x-amz-bypass-governance-retention") == "True"
+            self.headers.get("x-amz-bypass-governance-retention", "").lower() == "true"
         )
 
         objects = body_dict["Delete"].get("Object", [])


### PR DESCRIPTION
Looks like the casing changed (`True` -> `true` in a recent `botocore` update (potentially [this one](https://pypi.org/project/botocore/1.37.25/)), and Moto didn't understand the provided parameter anymore. This should fix the tests on master.