### PR TITLE
Feature/cluster tasks setting

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -77,9 +77,7 @@ class Cluster(BaseObject, CloudFormationModel):
         self.active_services_count = 0
         self.arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:cluster/{cluster_name}"
         self.name = cluster_name
-        self.pending_tasks_count = 0
         self.registered_container_instances_count = 0
-        self.running_tasks_count = 0
         self.status = "ACTIVE"
         self.region_name = region_name
         self.settings = cluster_settings or [
@@ -90,6 +88,23 @@ class Cluster(BaseObject, CloudFormationModel):
         self.default_capacity_provider_strategy = default_capacity_provider_strategy
         self.tags = tags
         self.service_connect_defaults = service_connect_defaults
+
+        try:
+            # negative running count not allowed, set to 0 if so
+            running_tasks_count = max(int(getenv("MOTO_ECS_CLUSTER_RUNNING", 0)), 0)
+        except ValueError:
+            # Unable to parse value of MOTO_ECS_CLUSTER_RUNNING as an integer, set to default 0
+            running_tasks_count = 0
+
+        try:
+            # negative running count not allowed, set to 0 if so
+            pending_tasks_count = max(int(getenv("MOTO_ECS_CLUSTER_PENDING", 0)), 0)
+        except ValueError:
+            # Unable to parse value of MOTO_ECS_CLUSTER_PENDING as an integer, set to default 0
+            pending_tasks_count = 0
+
+        self.running_tasks_count = running_tasks_count
+        self.pending_tasks_count = pending_tasks_count
 
     @property
     def physical_resource_id(self) -> str:

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -48,6 +48,40 @@ def test_create_cluster_with_setting():
 
 
 @mock_aws
+def test_create_cluster_with_running_tasks():
+    running_tasks_count = 3
+    with mock.patch.dict(
+        os.environ, {"MOTO_ECS_CLUSTER_RUNNING": str(running_tasks_count)}
+    ):
+        client = boto3.client("ecs", region_name=ECS_REGION)
+
+        cluster = client.create_cluster(
+            clusterName="test_ecs_cluster",
+        )["cluster"]
+        assert cluster["clusterName"] == "test_ecs_cluster"
+        assert cluster["status"] == "ACTIVE"
+        assert cluster["runningTasksCount"] == running_tasks_count
+        assert cluster["pendingTasksCount"] == 0
+
+
+@mock_aws
+def test_create_cluster_with_pending_tasks():
+    pending_tasks_count = 3
+    with mock.patch.dict(
+        os.environ, {"MOTO_ECS_CLUSTER_PENDING": str(pending_tasks_count)}
+    ):
+        client = boto3.client("ecs", region_name=ECS_REGION)
+
+        cluster = client.create_cluster(
+            clusterName="test_ecs_cluster",
+        )["cluster"]
+        assert cluster["clusterName"] == "test_ecs_cluster"
+        assert cluster["status"] == "ACTIVE"
+        assert cluster["runningTasksCount"] == 0
+        assert cluster["pendingTasksCount"] == pending_tasks_count
+
+
+@mock_aws
 def test_create_cluster_with_capacity_providers():
     client = boto3.client("ecs", region_name=ECS_REGION)
     cluster = client.create_cluster(


### PR DESCRIPTION
Adding a basic setting to allow generating an ECS cluster with pre-generated running tasks or pending tasks.  This is required for some cluster operations I'm looking to do, and doesn't look to be possible when generating tasks or services through those dedicated functions.

To that end, this PR allows setting arbitrary numbers of running or pending tasks on the cluster using the same pattern as is currently used for ECS services.  If this isn't the preferred pattern, let me know and I'll circle around to take another approach.

- [x] Feature is added
- [x] The linter is happy
- [x] Tests are added
- [x] All tests pass, existing and new

