### PR TITLE
[S3] Add Account to Replication

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -3408,6 +3408,7 @@ S3_REPLICATION_CONFIG = """<?xml version="1.0" encoding="UTF-8"?>
   </Filter>
   <Destination>
     <Bucket>{{ rule["Destination"]["Bucket"] }}</Bucket>
+    <Account>{{ rule["Destination"]["Account"] }}</Account>
   </Destination>
 </Rule>
 {% endfor %}

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -3408,7 +3408,9 @@ S3_REPLICATION_CONFIG = """<?xml version="1.0" encoding="UTF-8"?>
   </Filter>
   <Destination>
     <Bucket>{{ rule["Destination"]["Bucket"] }}</Bucket>
+    {% if rule["Destination"].get("Account") %}
     <Account>{{ rule["Destination"]["Account"] }}</Account>
+    {% endif %}
   </Destination>
 </Rule>
 {% endfor %}

--- a/tests/test_s3/test_s3_replication.py
+++ b/tests/test_s3/test_s3_replication.py
@@ -154,6 +154,7 @@ def test_create_and_retrieve_replication_with_multiple_rules():
                     "Destination": {"Bucket": "thirdbucket"},
                     "Status": "Disabled",
                 },
+                {"Destination": {"Bucket": "x-account-bucket", "Account":"1234567890"}, "Status": "Enabled"},
             ],
         },
     )
@@ -169,6 +170,7 @@ def test_create_and_retrieve_replication_with_multiple_rules():
     assert "ID" in first_rule
     assert first_rule["Priority"] == 1
     assert first_rule["Status"] == "Enabled"
+    import pytest; pytest.set_trace()
     assert first_rule["Destination"] == {"Bucket": "secondbucket"}
 
     second = rules[1]
@@ -176,3 +178,4 @@ def test_create_and_retrieve_replication_with_multiple_rules():
     assert second["Priority"] == 2
     assert second["Status"] == "Disabled"
     assert second["Destination"] == {"Bucket": "thirdbucket"}
+

--- a/tests/test_s3/test_s3_replication.py
+++ b/tests/test_s3/test_s3_replication.py
@@ -154,7 +154,13 @@ def test_create_and_retrieve_replication_with_multiple_rules():
                     "Destination": {"Bucket": "thirdbucket"},
                     "Status": "Disabled",
                 },
-                {"Destination": {"Bucket": "x-account-bucket", "Account":"1234567890"}, "Status": "Enabled"},
+                {
+                    "Destination": {
+                        "Bucket": "x-account-bucket",
+                        "Account": "1234567890",
+                    },
+                    "Status": "Enabled",
+                },
             ],
         },
     )
@@ -164,13 +170,12 @@ def test_create_and_retrieve_replication_with_multiple_rules():
     ]
     assert config["Role"] == "myrole"
     rules = config["Rules"]
-    assert len(rules) == 2
+    assert len(rules) == 3
 
     first_rule = rules[0]
     assert "ID" in first_rule
     assert first_rule["Priority"] == 1
     assert first_rule["Status"] == "Enabled"
-    import pytest; pytest.set_trace()
     assert first_rule["Destination"] == {"Bucket": "secondbucket"}
 
     second = rules[1]
@@ -179,3 +184,9 @@ def test_create_and_retrieve_replication_with_multiple_rules():
     assert second["Status"] == "Disabled"
     assert second["Destination"] == {"Bucket": "thirdbucket"}
 
+    third = rules[2]
+    assert third["Status"] == "Enabled"
+    assert third["Destination"] == {
+        "Bucket": "x-account-bucket",
+        "Account": "1234567890",
+    }


### PR DESCRIPTION
Add account ID to bucket replication when provided, to support mocking cross accounts.
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/put_bucket_replication.html