### PR TITLE
EC2: Validate SG Rules tests against AWS

### DIFF
--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -59,8 +59,8 @@ class launch_template_context:
 
 
 @pytest.mark.aws_verified
-@ec2_aws_verified
-def test_launch_template_is_created_properly():
+@ec2_aws_verified()
+def test_launch_template_is_created_properly(ec2_client=None):
     with launch_template_context() as ctxt:
         template = ctxt.ec2.describe_launch_templates()["LaunchTemplates"][0]
         assert template["DefaultVersionNumber"] == 1
@@ -411,8 +411,8 @@ def test_create_fleet_using_launch_template_config__overrides():
 
 
 @pytest.mark.aws_verified
-@ec2_aws_verified
-def test_delete_fleet():
+@ec2_aws_verified()
+def test_delete_fleet(ec2_client=None):
     with launch_template_context() as ctxt:
         fleet_res = ctxt.ec2.create_fleet(
             LaunchTemplateConfigs=[

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -13,6 +13,7 @@ from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.ec2 import ec2_backends
 from tests import aws_verified
+from tests.test_ec2 import ec2_aws_verified
 
 REGION = "us-east-1"
 
@@ -1970,16 +1971,9 @@ def test_filter_group_name():
     assert security_groups[0].group_name == sg1.group_name
 
 
-@mock_aws
-def test_revoke_security_group_ingress():
-    ec2 = boto3.client("ec2", region_name=REGION)
-
-    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
-
-    sg = ec2.create_security_group(
-        Description="Test SG", GroupName=str(uuid4()), VpcId=vpc["Vpc"]["VpcId"]
-    )
-    sg_id = sg["GroupId"]
+@ec2_aws_verified(create_vpc=True, create_sg=True)
+def test_revoke_security_group_ingress(ec2_client=None, vpc_id=None, sg_id=None):
+    ec2 = ec2_client
 
     ec2.authorize_security_group_ingress(
         GroupId=sg_id,
@@ -2019,22 +2013,13 @@ def test_revoke_security_group_ingress():
     assert len(ingress_rules) == 2
 
 
-@mock_aws()
-def test_invalid_security_group_id_in_rules_search():
-    ec2 = boto3.client("ec2", region_name=REGION)
-
-    vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
-    vpc_id = vpc["Vpc"]["VpcId"]
-    group_name = "test-group"
-
-    response = ec2.create_security_group(
-        Description="Inventing a security group", GroupName=group_name, VpcId=vpc_id
-    )
-    group_id = response["GroupId"]
-
+@ec2_aws_verified(create_vpc=True, create_sg=True)
+def test_invalid_security_group_id_in_rules_search(
+    ec2_client=None, vpc_id=None, sg_id=None
+):
     # assert error with invalid sg id
     with pytest.raises(ClientError) as e:
-        ec2.describe_security_group_rules(
+        ec2_client.describe_security_group_rules(
             Filters=[{"Name": "group-id", "Values": ["foobar"]}]
         )
     error = e.value.response["Error"]
@@ -2042,37 +2027,31 @@ def test_invalid_security_group_id_in_rules_search():
     assert "The security group ID 'foobar' is malformed" in error["Message"]
 
     # assert with non-existent sg
-    response = ec2.describe_security_group_rules(
+    response = ec2_client.describe_security_group_rules(
         Filters=[{"Name": "group-id", "Values": ["sg-005216b55886f0fdc"]}]
     )
     assert len(response["SecurityGroupRules"]) == 0
 
     # assert with no rules
-    response = ec2.describe_security_group_rules(
-        Filters=[{"Name": "group-id", "Values": [group_id]}]
+    response = ec2_client.describe_security_group_rules(
+        Filters=[{"Name": "group-id", "Values": [sg_id]}]
     )
     assert len(response["SecurityGroupRules"]) == 1
 
 
-@aws_verified
+@ec2_aws_verified(create_vpc=True, create_sg=True)
 @pytest.mark.aws_verified
 @pytest.mark.parametrize("is_ingress", [True, False], ids=["ingress", "egress"])
-def test_authorize_security_group_rules_with_different_ipranges_or_prefixes(is_ingress):
+def test_authorize_security_group_rules_with_different_ipranges_or_prefixes(
+    is_ingress, ec2_client=None, vpc_id=None, sg_id=None
+):
     is_egress = not is_ingress
     sts = boto3.client("sts", "us-east-1")
     account_id = sts.get_caller_identity()["Account"]
 
-    ec2_client = boto3.client("ec2", "us-east-1")
-    vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/24")
-    vpc_id = vpc["Vpc"]["VpcId"]
-    sg_id = pl_id = None
+    pl_id = None
 
     try:
-        sg = ec2_client.create_security_group(
-            Description="test", GroupName=f"test_{str(uuid4())[0:6]}", VpcId=vpc_id
-        )
-        sg_id = sg["GroupId"]
-
         prefix_list = ec2_client.create_managed_prefix_list(
             PrefixListName=f"test{str(uuid4())[0:6]}",
             AddressFamily="IPv4",
@@ -2331,6 +2310,3 @@ def test_authorize_security_group_rules_with_different_ipranges_or_prefixes(is_i
     finally:
         if pl_id:
             ec2_client.delete_managed_prefix_list(PrefixListId=pl_id)
-        if sg_id:
-            ec2_client.delete_security_group(GroupId=sg_id)
-        ec2_client.delete_vpc(VpcId=vpc_id)


### PR DESCRIPTION
This PR validates some additional EC2 tests against AWS, to make sure that the changes in #8733 are correct.

The `ec2_aws_verified`-fixture has been updated to automatically create/delete VPC's/SecurityGroups, making it a lot more simple to apply this fixture to future tests.