### PR TITLE
Admin: Fix license expression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
-    License-Expression :: OSI Approved :: Apache Software License
+    License-Expression :: Apache-2.0
     Topic :: Software Development :: Testing
 keywords = aws ec2 s3 boto3 mock
 project_urls =


### PR DESCRIPTION
Followup to #8739 - PyPi rejected the original License-Expression.