### PR TITLE
Admin: enable verified RDS tests to run against AWS

### DIFF
--- a/.github/workflows/tests_real_aws.yml
+++ b/.github/workflows/tests_real_aws.yml
@@ -45,4 +45,4 @@ jobs:
       env:
         MOTO_TEST_ALLOW_AWS_REQUEST: ${{ true }}
       run: |
-        pytest -sv -n auto --dist loadfile tests/test_applicationautoscaling/ tests/test_athena/ tests/test_cloudformation/ tests/test_dynamodb/ tests/test_ec2/ tests/test_events/ tests/test_iam/ tests/test_iot/ tests/test_lakeformation/ tests/test_logs/ tests/test_sqs/ tests/test_ses/ tests/test_s3* tests/test_stepfunctions/ tests/test_sns/ tests/test_timestreamwrite/ -m aws_verified
+        pytest -sv -n auto --dist loadfile tests/test_applicationautoscaling/ tests/test_athena/ tests/test_cloudformation/ tests/test_dynamodb/ tests/test_ec2/ tests/test_events/ tests/test_iam/ tests/test_iot/ tests/test_lakeformation/ tests/test_logs/ tests/test_rds/ tests/test_sqs/ tests/test_ses/ tests/test_s3* tests/test_stepfunctions/ tests/test_sns/ tests/test_timestreamwrite/ -m aws_verified

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -1398,9 +1398,10 @@ def test_describe_option_group_options(client):
         )
 
 
-@pytest.mark.aws_verified
 @aws_verified
-def test_modify_option_group(client):
+@pytest.mark.aws_verified
+def test_modify_option_group():
+    client = boto3.client("rds", region_name=DEFAULT_REGION)
     option_group_name = f"og-{str(uuid4())[0:6]}"
     client.create_option_group(
         OptionGroupName=option_group_name,


### PR DESCRIPTION
@bblommers Not sure if there's a process that needs to be followed before enabling, so I've requested your review.

There are only three `aws_verified` RDS tests.  Two in `tests/test_rds/test_integrations.py` (which I recently committed) and one that you wrote some time ago (that required a minor change in this PR because a subsequent commit from someone else made `client` a fixture [with mocking enabled]).

I did a one-off run for the tests I wrote, and they do pass:
![image](https://github.com/user-attachments/assets/d5d6481c-4dd3-471b-8bb9-d332b0378e2e)
Link to run: https://github.com/getmoto/moto/actions/runs/14187655393/job/39745796366 