### PR TITLE
RDS: support case-insensitive identifiers

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -3937,7 +3937,7 @@ class DBParameterGroup(CloudFormationModel, RDSBaseModel):
         super().__init__(backend)
         self.name = db_parameter_group_name
         self.description = description
-        self.family = db_parameter_group_family
+        self.family: str | None = db_parameter_group_family
         self.tags = tags or []
         self.parameters: Dict[str, Any] = defaultdict(dict)
 

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -332,6 +332,14 @@ class GlobalCluster(RDSBaseModel):
         self.status = "available"
 
     @property
+    def global_cluster_identifier(self) -> str:
+        return self._global_cluster_identifier
+
+    @global_cluster_identifier.setter
+    def global_cluster_identifier(self, value: str) -> None:
+        self._global_cluster_identifier = value.lower()
+
+    @property
     def resource_id(self) -> str:
         return self.global_cluster_identifier
 
@@ -897,9 +905,12 @@ class DBClusterSnapshot(SnapshotAttributesMixin, RDSBaseModel):
         "db-cluster-id": FilterDef(
             ["db_cluster_arn", "db_cluster_identifier"],
             "DB Cluster Identifiers",
+            case_insensitive=True,
         ),
         "db-cluster-snapshot-id": FilterDef(
-            ["db_cluster_snapshot_identifier"], "DB Cluster Snapshot Identifiers"
+            ["db_cluster_snapshot_identifier"],
+            "DB Cluster Snapshot Identifiers",
+            case_insensitive=True,
         ),
         "snapshot-type": FilterDef(["snapshot_type"], "Snapshot Types"),
         "engine": FilterDef(["cluster.engine"], "Engine Names"),
@@ -945,6 +956,14 @@ class DBClusterSnapshot(SnapshotAttributesMixin, RDSBaseModel):
         self.storage_encrypted = self.cluster.storage_encrypted
 
     @property
+    def db_cluster_snapshot_identifier(self) -> str:
+        return self._db_cluster_snapshot_identifier
+
+    @db_cluster_snapshot_identifier.setter
+    def db_cluster_snapshot_identifier(self, value: str) -> None:
+        self._db_cluster_snapshot_identifier = value.lower()
+
+    @property
     def resource_id(self) -> str:
         return self.db_cluster_snapshot_identifier
 
@@ -983,7 +1002,9 @@ class DBLogFile(XFormedAttributeAccessMixin):
 class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
     BOTOCORE_MODEL = "DBInstance"
     SUPPORTED_FILTERS = {
-        "db-cluster-id": FilterDef(["db_cluster_identifier"], "DB Cluster Identifiers"),
+        "db-cluster-id": FilterDef(
+            ["db_cluster_identifier"], "DB Cluster Identifiers", case_insensitive=True
+        ),
         "db-instance-id": FilterDef(
             ["db_instance_arn", "db_instance_identifier"],
             "DB Instance Identifiers",
@@ -1732,9 +1753,10 @@ class DBSnapshot(EventMixin, SnapshotAttributesMixin, RDSBaseModel):
         "db-instance-id": FilterDef(
             ["database.db_instance_arn", "database.db_instance_identifier"],
             "DB Instance Identifiers",
+            case_insensitive=True,
         ),
         "db-snapshot-id": FilterDef(
-            ["db_snapshot_identifier"], "DB Snapshot Identifiers"
+            ["db_snapshot_identifier"], "DB Snapshot Identifiers", case_insensitive=True
         ),
         "dbi-resource-id": FilterDef(["database.dbi_resource_id"], "Dbi Resource Ids"),
         "snapshot-type": FilterDef(["snapshot_type"], "Snapshot Types"),
@@ -1783,6 +1805,14 @@ class DBSnapshot(EventMixin, SnapshotAttributesMixin, RDSBaseModel):
         self.instance_create_time = database.created
         self.master_username = database.master_username
         self.port = database.port
+
+    @property
+    def db_snapshot_identifier(self) -> str:
+        return self._db_snapshot_identifier
+
+    @db_snapshot_identifier.setter
+    def db_snapshot_identifier(self, value: str) -> None:
+        self._db_snapshot_identifier = value.lower()
 
     @property
     def resource_id(self) -> str:
@@ -1969,6 +1999,14 @@ class DBSubnetGroup(CloudFormationModel, RDSBaseModel):
         self.subnet_group_status = "Complete"
         self.tags = tags
         self.vpc_id = self._subnets[0].vpc_id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value.lower()
 
     @property
     def resource_id(self) -> str:
@@ -3849,6 +3887,14 @@ class OptionGroup(RDSBaseModel):
         self.tags = tags or []
 
     @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value.lower()
+
+    @property
     def resource_id(self) -> str:
         return self.name
 
@@ -3894,6 +3940,14 @@ class DBParameterGroup(CloudFormationModel, RDSBaseModel):
         self.family = db_parameter_group_family
         self.tags = tags or []
         self.parameters: Dict[str, Any] = defaultdict(dict)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value.lower()
 
     @property
     def resource_id(self) -> str:
@@ -3959,6 +4013,14 @@ class DBClusterParameterGroup(CloudFormationModel, RDSBaseModel):
         self.description = description
         self.db_parameter_group_family = family
         self.parameters: Dict[str, Any] = defaultdict(dict)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = value.lower()
 
     @property
     def resource_id(self) -> str:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -559,11 +559,11 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 yield {"ResourceARN": group.arn, "Tags": tags}
 
         # RDS resources
-        resource_map: Dict[str, Dict[str, Any]] = {
-            "rds:cluster": self.rds_backend.clusters,
-            "rds:db": self.rds_backend.databases,
-            "rds:snapshot": self.rds_backend.database_snapshots,
-            "rds:cluster-snapshot": self.rds_backend.cluster_snapshots,
+        resource_map: dict[str, dict[str, Any]] = {
+            "rds:cluster": dict(self.rds_backend.clusters),
+            "rds:db": dict(self.rds_backend.databases),
+            "rds:snapshot": dict(self.rds_backend.database_snapshots),
+            "rds:cluster-snapshot": dict(self.rds_backend.cluster_snapshots),
             "rds:db-proxy": self.rds_backend.db_proxies,
         }
         for resource_type, resource_source in resource_map.items():

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -178,7 +178,7 @@ class CamelToUnderscoresWalker:
         return x
 
 
-class CaseInsensitiveDict(_CaseInsensitiveDict[str]):
+class CaseInsensitiveDict(_CaseInsensitiveDict):  # type: ignore[type-arg]
     """Proxy for requests.structures.CaseInsensitiveDict"""
 
     pass

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -5,6 +5,8 @@ import pkgutil
 from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Tuple, TypeVar
 from uuid import UUID
 
+from requests.structures import CaseInsensitiveDict as _CaseInsensitiveDict
+
 DEFAULT_PARTITION = "aws"
 REGION_PREFIX_TO_PARTITION = {
     # (region prefix, aws partition)
@@ -174,3 +176,9 @@ class CamelToUnderscoresWalker:
     @staticmethod
     def parse_scalar(x: Any) -> Any:  # type: ignore[misc]
         return x
+
+
+class CaseInsensitiveDict(_CaseInsensitiveDict[str]):
+    """Proxy for requests.structures.CaseInsensitiveDict"""
+
+    pass

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -3616,7 +3616,7 @@ def snapshot_validation_helper(exc, expected_message):
 
 
 @mock_aws
-def test_db_instance_identifier_is_lower_cased(client):
+def test_db_instance_identifier_is_case_insensitive(client):
     instance = create_db_instance(DBInstanceIdentifier="FooBar")
     assert instance["DBInstanceIdentifier"] == "foobar"
 


### PR DESCRIPTION
Most RDS backend entity resource identifiers are stored as lower case strings.  Describing or filtering for a particular entity on a real AWS backend is done using case-insensitive comparisons.  Modeling this behavior in `moto` required the following changes:

* store all identifier attributes as lower-case strings
* ensure all identifier-based filters make case-insensitive comparisons
* use `CaseInsensitiveDict` for entity containers 