### PR TITLE
RDS: snapshot type should be `manual` when stopping a DBInstance

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2690,7 +2690,7 @@ class RDSBackend(BaseBackend):
         if database.status != "available":
             raise InvalidDBInstanceStateError(db_instance_identifier, "stop")
         if db_snapshot_identifier:
-            self.create_auto_snapshot(db_instance_identifier, db_snapshot_identifier)
+            self.create_db_snapshot(db_instance_identifier, db_snapshot_identifier)
         database.status = "stopped"
         return database
 

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -289,6 +289,7 @@ def test_start_database(client):
     assert response["DBInstance"]["DBInstanceStatus"] == "stopped"
     response = client.describe_db_snapshots(DBSnapshotIdentifier="rocky4570-rds-snap")
     assert response["DBSnapshots"][0]["DBSnapshotIdentifier"] == "rocky4570-rds-snap"
+    assert response["DBSnapshots"][0]["SnapshotType"] == "manual"
     response = client.start_db_instance(
         DBInstanceIdentifier=mydb["DBInstanceIdentifier"]
     )


### PR DESCRIPTION
Fixes #8779 