### PR TITLE
feat(ec2): Support instance-level tags for EC2 fleets with type="instant"

### DIFF
--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -329,6 +329,114 @@ def test_create_fleet_request_with_tags():
 
 
 @mock_aws
+def test_create_fleet_request_with_instance_tags_and_fleet_type_instant():
+    conn = boto3.client("ec2", region_name="us-west-2")
+
+    launch_template_id, _ = get_launch_template(conn)
+    tags = [
+        {"Key": "Name", "Value": "test-fleet"},
+        {"Key": "Another", "Value": "tag"},
+    ]
+    fleet_res = conn.create_fleet(
+        DryRun=False,
+        SpotOptions={
+            "AllocationStrategy": "lowestPrice",
+            "InstanceInterruptionBehavior": "terminate",
+        },
+        LaunchTemplateConfigs=[
+            {
+                "LaunchTemplateSpecification": {
+                    "LaunchTemplateId": launch_template_id,
+                    "Version": "1",
+                },
+            },
+        ],
+        TargetCapacitySpecification={
+            "DefaultTargetCapacityType": "spot",
+            "OnDemandTargetCapacity": 1,
+            "SpotTargetCapacity": 2,
+            "TotalTargetCapacity": 3,
+        },
+        Type="instant",
+        ValidFrom="2020-01-01T00:00:00Z",
+        ValidUntil="2020-12-31T00:00:00Z",
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": tags,
+            },
+        ],
+    )
+    fleet_id = fleet_res["FleetId"]
+
+    instance_res = conn.describe_fleet_instances(FleetId=fleet_id)
+    instances = conn.describe_instances(
+        InstanceIds=[i["InstanceId"] for i in instance_res["ActiveInstances"]]
+    )
+    for instance in instances["Reservations"][0]["Instances"]:
+        for tag in tags:
+            assert tag in instance["Tags"]
+
+
+@mock_aws
+def test_create_fleet_request_rejects_instance_tags_when_type_request():
+    conn = boto3.client("ec2", region_name="us-west-2")
+
+    launch_template_id, _ = get_launch_template(conn)
+    tags = [
+        {"Key": "Name", "Value": "test-fleet"},
+        {"Key": "Another", "Value": "tag"},
+    ]
+    tags_instance = [
+        {"Key": "test", "Value": "value"},
+        {"Key": "Name", "Value": "test"},
+    ]
+    fleet_res = conn.create_fleet(
+        DryRun=False,
+        SpotOptions={
+            "AllocationStrategy": "lowestPrice",
+            "InstanceInterruptionBehavior": "terminate",
+        },
+        LaunchTemplateConfigs=[
+            {
+                "LaunchTemplateSpecification": {
+                    "LaunchTemplateId": launch_template_id,
+                    "Version": "1",
+                },
+            },
+        ],
+        TargetCapacitySpecification={
+            "DefaultTargetCapacityType": "spot",
+            "OnDemandTargetCapacity": 1,
+            "SpotTargetCapacity": 2,
+            "TotalTargetCapacity": 3,
+        },
+        Type="request",
+        ValidFrom="2020-01-01T00:00:00Z",
+        ValidUntil="2020-12-31T00:00:00Z",
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": tags,
+            },
+        ],
+    )
+    fleet_id = fleet_res["FleetId"]
+
+    instance_res = conn.describe_fleet_instances(FleetId=fleet_id)
+    instances = conn.describe_instances(
+        InstanceIds=[i["InstanceId"] for i in instance_res["ActiveInstances"]]
+    )
+    for instance in instances["Reservations"][0]["Instances"]:
+        for tag in tags_instance:
+            assert tag in instance["Tags"]
+        for tag in tags:
+            # When fleet_type="request", TagSpecifications with ResourceType="instance" are ignored
+            # according to the AWS spec. So we assert that these tags are not applied to instances.
+            assert tag not in instance["Tags"]
+
+
+@mock_aws
 @pytest.mark.parametrize(
     "overrides", [{"InstanceType": "t2.nano"}, {"AvailabilityZone": "us-west-1"}]
 )


### PR DESCRIPTION
## Background

In the current implementation, instance-level tags were not being applied to EC2 instances when the fleet type was set to "instant". According to the [AWS documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/create_fleet.html), instance tags should be applied when the fleet type is `instant`, but not when it's `request` and `maintain `. 

## Changes

- Added support for instance-level tags when the fleet type is set to "instant".
  
## Testing

- Added unit tests to verify that instance tags are correctly applied when the fleet type is `instant`.
- Added tests to ensure that instance tags are not applied for fleet types of `request`, aligning with AWS specifications.

## Impact

This change primarily affects the EC2 Fleet tag handling. There are no major impacts on other parts of the codebase. The update ensures compatibility with AWS's tagging rules, improving the consistency of fleet creation operations.

## Create Copilot OverView

This pull request includes changes to the `moto` library, specifically targeting the EC2 fleets model. The key modifications involve updating the handling of tag specifications for different fleet types and adding new tests to ensure the correct behavior.

### Updates to tag specification handling:

* [`moto/ec2/models/fleets.py`](diffhunk://#diff-99317e63d7e3306d834779dcec18a45378afc6849cd80b88bee6a5fa38df78f7L45-R53): Updated the `__init__` method to handle instance tags based on the fleet type. For "instant" fleet type, instance tags are included, while for "maintain" or "request" types, only fleet tags are applied.
* [`moto/ec2/models/fleets.py`](diffhunk://#diff-99317e63d7e3306d834779dcec18a45378afc6849cd80b88bee6a5fa38df78f7L90-R96): Modified the tag specifications to merge instance tags when the fleet type is "instant".

### Added tests:

* [`tests/test_ec2/test_fleets.py`](diffhunk://#diff-fb19d8e43745347445988bb98b5728f307c5e0d358720ef3f76810c86779d6dcR331-R442): Added `test_create_fleet_request_with_instance_tags_and_fleet_type_instant` to verify that instance tags are correctly applied when the fleet type is "instant".
* [`tests/test_ec2/test_fleets.py`](diffhunk://#diff-fb19d8e43745347445988bb98b5728f307c5e0d358720ef3f76810c86779d6dcR331-R442): Added `test_create_fleet_request_rejects_instance_tags_when_type_request` to ensure that instance tags are ignored when the fleet type is "request".