### PR TITLE
[S3] inventory_configuration support

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -130,6 +130,16 @@ class MissingVersion(S3ClientError):
         super().__init__("NoSuchVersion", "The specified version does not exist.")
 
 
+class MissingInventoryConfig(S3ClientError):
+    code = 404
+
+    def __init__(self) -> None:
+        super().__init__(
+            "NoSuchInventoryConfig",
+            "The specified inventory configuration does not exist.",
+        )
+
+
 class InvalidVersion(S3ClientError):
     code = 400
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1659,6 +1659,7 @@ class FakeBucketInventoryConfiguration(BaseModel):
         schedule: Dict[str, Any],
         filters: Optional[Dict[str, Any]] = None,
     ):
+        self.id = id
         self.destination = destination
         self.is_enabled = is_enabled
         self.schedule = schedule
@@ -3154,14 +3155,15 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             filters=inventory_configuration.get("Filter"),
         )
 
-        self.inventory_configurations[inv_config.id] = inv_config
+        self.inventory_configs[inv_config.id] = inv_config
+        import pytest; pytest.set_trace()
 
         return
 
     def get_bucket_inventory_configuration(
-        self, bucket, id, expected_bucket_owner
+        self, bucket: str, id: str, expected_bucket_owner: Optional[str] = None
     ) -> FakeBucketInventoryConfiguration:
-        inv_config = self.inventory_configurations.get(id)
+        inv_config = self.inventory_configs.get(id)
         return inv_config
 
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -1103,7 +1103,7 @@ class S3Response(BaseResponse):
             s3_bucket_config=inventory_configuration.destination["S3BucketDestination"],
         )
 
-    def list_bucket_inventory_configurations(self):
+    def list_bucket_inventory_configurations(self) -> str:
         inventory_configuration_list = (
             self.backend.list_bucket_inventory_configurations(
                 bucket_name=self.bucket_name,

--- a/scripts/scaffold.py
+++ b/scripts/scaffold.py
@@ -448,6 +448,10 @@ def get_response_restxml_template(service, operation):
         list(client._service_model._service_description["operations"].keys()),
     )
     op_model = client._service_model.operation_model(aws_operation_name)
+    # Resolves https://github.com/getmoto/moto/issues/8726
+    if not hasattr(op_model.output_shape, "output"):
+        # Response has no output
+        return ""
     result_wrapper = op_model._operation_model["output"]["shape"]
     response_wrapper = result_wrapper.replace("Result", "Response")
     metadata = op_model.metadata

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3590,7 +3590,7 @@ def enable_versioning(bucket_name, s3_client):
 
 
 @mock_aws
-def test_put_bucket_inventory_configuration():
+def test_put_and_get_bucket_inventory_configuration():
     client = boto3.client("s3", region_name="us-east-1")
     bucket = "mybucket"
     bucket2 = "mybucket2"
@@ -3623,11 +3623,8 @@ def test_put_bucket_inventory_configuration():
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-
-@mock_aws
-@pytest.mark.skip()
-def test_get_bucket_inventory_configuration():
-    client = boto3.client("s3", region_name="eu-west-1")
-    resp = client.get_bucket_inventory_configuration()
-
-    raise Exception("NotYetImplemented")
+    # Retrieve the configuration
+    resp = client.get_bucket_inventory_configuration(Bucket=bucket, Id=id)
+    assert resp["InventoryConfiguration"]["Id"] == id
+    assert resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"]["Bucket"] == f"arn:aws:s3:::{bucket2}"
+    assert resp["InventoryConfiguration"]["IsEnabled"] is True

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3599,7 +3599,7 @@ def test_put_and_get_bucket_inventory_configuration():
         "Destination": {
             "S3BucketDestination": {
                 "AccountId": DEFAULT_ACCOUNT_ID,
-                "Bucket": bucket2,
+                "Bucket": f"arn:aws:s3:::{bucket2}",
                 "Format": "CSV",
                 "Prefix": "test",
                 "Encryption": {"SSEKMS": {"KeyId": "key-12345"}},
@@ -3609,7 +3609,7 @@ def test_put_and_get_bucket_inventory_configuration():
         "Filter": {"Prefix": "folder1/"},
         "Id": id,
         "IncludedObjectVersions": "All",
-        "OptionalFields": ["Size"],
+        "OptionalFields": ["Size", "ETag"],
         "Schedule": {"Frequency": "Daily"},
     }
 
@@ -3626,5 +3626,32 @@ def test_put_and_get_bucket_inventory_configuration():
     # Retrieve the configuration
     resp = client.get_bucket_inventory_configuration(Bucket=bucket, Id=id)
     assert resp["InventoryConfiguration"]["Id"] == id
-    assert resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"]["Bucket"] == f"arn:aws:s3:::{bucket2}"
+    assert (
+        resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"][
+            "AccountId"
+        ]
+        == DEFAULT_ACCOUNT_ID
+    )
+    assert (
+        resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"]["Bucket"]
+        == f"arn:aws:s3:::{bucket2}"
+    )
+    assert (
+        resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"]["Format"]
+        == "CSV"
+    )
+    assert (
+        resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"]["Prefix"]
+        == "test"
+    )
+    assert (
+        resp["InventoryConfiguration"]["Destination"]["S3BucketDestination"][
+            "Encryption"
+        ]["SSEKMS"]["KeyId"]
+        == "key-12345"
+    )
     assert resp["InventoryConfiguration"]["IsEnabled"] is True
+    assert resp["InventoryConfiguration"]["Filter"]["Prefix"] == "folder1/"
+    assert resp["InventoryConfiguration"]["IncludedObjectVersions"] == "All"
+    assert resp["InventoryConfiguration"]["OptionalFields"] == ["Size", "ETag"]
+    assert resp["InventoryConfiguration"]["Schedule"]["Frequency"] == "Daily"

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -3587,3 +3587,47 @@ def enable_versioning(bucket_name, s3_client):
     while resp.get("Status") != "Enabled":
         sleep(0.1)
         resp = s3_client.get_bucket_versioning(Bucket=bucket_name)
+
+
+@mock_aws
+def test_put_bucket_inventory_configuration():
+    client = boto3.client("s3", region_name="us-east-1")
+    bucket = "mybucket"
+    bucket2 = "mybucket2"
+    id = "my-inventory-config"
+    inventory_configuration = {
+        "Destination": {
+            "S3BucketDestination": {
+                "AccountId": DEFAULT_ACCOUNT_ID,
+                "Bucket": bucket2,
+                "Format": "CSV",
+                "Prefix": "test",
+                "Encryption": {"SSEKMS": {"KeyId": "key-12345"}},
+            }
+        },
+        "IsEnabled": True,
+        "Filter": {"Prefix": "folder1/"},
+        "Id": id,
+        "IncludedObjectVersions": "All",
+        "OptionalFields": ["Size"],
+        "Schedule": {"Frequency": "Daily"},
+    }
+
+    client.create_bucket(Bucket=bucket)
+    client.create_bucket(Bucket=bucket2)
+    resp = client.put_bucket_inventory_configuration(
+        Bucket=bucket,
+        Id=id,
+        InventoryConfiguration=inventory_configuration,
+        ExpectedBucketOwner=DEFAULT_ACCOUNT_ID,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+@mock_aws
+@pytest.mark.skip()
+def test_get_bucket_inventory_configuration():
+    client = boto3.client("s3", region_name="eu-west-1")
+    resp = client.get_bucket_inventory_configuration()
+
+    raise Exception("NotYetImplemented")


### PR DESCRIPTION
Adds support for:
- [put_bucket_inventory_configurations](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/put_bucket_inventory_configuration.html)
- [get_bucket_inventory_configuration](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/get_bucket_inventory_configuration.html)
- [list_bucket_inventory_configuration](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/list_bucket_inventory_configurations.html)


** Including minor scaffolding fix to resolve #8726 