### PR TITLE
EC2: refactor `DescribeSecurityGroupRules` filtering

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -197,6 +197,14 @@ class InvalidSecurityGroupNotFoundError(EC2ClientError):
         )
 
 
+class InvalidSecurityGroupRuleIdNotFoundError(EC2ClientError):
+    def __init__(self, name: Any):
+        super().__init__(
+            "InvalidSecurityGroupRuleId.NotFound",
+            f"The security group rule ID '{name}' does not exist",
+        )
+
+
 class InvalidPermissionNotFoundError(EC2ClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -196,20 +196,10 @@ class SecurityGroups(EC2BaseResponse):
         return template.render(groups=groups)
 
     def describe_security_group_rules(self) -> str:
-        group_id = self._get_param("GroupId")
-        sg_rule_ids = self._get_param("SecurityGroupRuleId.1")
-        filters = self._filters_from_querystring()
-
         self.error_on_dryrun()
-
-        # if sg rule ids are not None then wrap in a list
-        # as expected by ec2_backend.describe_security_group_rules
-        if sg_rule_ids:
-            sg_rule_ids = [sg_rule_ids]
-
-        rules = self.ec2_backend.describe_security_group_rules(
-            group_id, sg_rule_ids, filters
-        )
+        sg_rule_ids = self._get_multi_param("SecurityGroupRuleId")
+        filters = self._filters_from_querystring()
+        rules = self.ec2_backend.describe_security_group_rules(sg_rule_ids, filters)
         template = self.response_template(DESCRIBE_SECURITY_GROUP_RULES_RESPONSE)
         return template.render(rules=rules)
 

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -903,21 +903,21 @@ def test_description_in_ip_permissions():
     )
     assert len(result["SecurityGroupRules"]) == 3
 
-    assert result["SecurityGroupRules"][0]["Description"] == "austin"
-    assert result["SecurityGroupRules"][0]["CidrIpv4"] == "1.2.3.4/32"
-    assert result["SecurityGroupRules"][0]["IsEgress"] is False
-    assert result["SecurityGroupRules"][0]["FromPort"] == 27017
-    assert result["SecurityGroupRules"][0]["ToPort"] == 27018
+    assert result["SecurityGroupRules"][0]["IsEgress"] is True
+    assert result["SecurityGroupRules"][0]["FromPort"] == -1
+    assert result["SecurityGroupRules"][0]["ToPort"] == -1
 
-    assert result["SecurityGroupRules"][1]["Description"] == "powers"
-    assert result["SecurityGroupRules"][1]["CidrIpv4"] == "2.3.4.5/32"
+    assert result["SecurityGroupRules"][1]["Description"] == "austin"
+    assert result["SecurityGroupRules"][1]["CidrIpv4"] == "1.2.3.4/32"
     assert result["SecurityGroupRules"][1]["IsEgress"] is False
     assert result["SecurityGroupRules"][1]["FromPort"] == 27017
     assert result["SecurityGroupRules"][1]["ToPort"] == 27018
 
-    assert result["SecurityGroupRules"][2]["IsEgress"] is True
-    assert result["SecurityGroupRules"][2]["FromPort"] == -1
-    assert result["SecurityGroupRules"][2]["ToPort"] == -1
+    assert result["SecurityGroupRules"][2]["Description"] == "powers"
+    assert result["SecurityGroupRules"][2]["CidrIpv4"] == "2.3.4.5/32"
+    assert result["SecurityGroupRules"][2]["IsEgress"] is False
+    assert result["SecurityGroupRules"][2]["FromPort"] == 27017
+    assert result["SecurityGroupRules"][2]["ToPort"] == 27018
 
     result = conn.describe_security_groups(GroupIds=[sg["GroupId"]])
     group = result["SecurityGroups"][0]

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -2068,6 +2068,7 @@ def test_revoke_security_group_ingress(ec2_client=None, vpc_id=None, sg_id=None)
 
 
 @ec2_aws_verified(create_vpc=True, create_sg=True)
+@pytest.mark.aws_verified
 def test_invalid_security_group_id_in_rules_search(
     ec2_client=None, vpc_id=None, sg_id=None
 ):
@@ -2079,6 +2080,19 @@ def test_invalid_security_group_id_in_rules_search(
     error = e.value.response["Error"]
     assert "InvalidGroupId.Malformed" == error["Code"]
     assert "The security group ID 'foobar' is malformed" in error["Message"]
+
+    # assert error with non-existent sgr id
+    non_existent_sgr_id = "sgr-0f80c7e764c18b3c0"
+    with pytest.raises(ClientError) as e:
+        ec2_client.describe_security_group_rules(
+            SecurityGroupRuleIds=[non_existent_sgr_id]
+        )
+    error = e.value.response["Error"]
+    assert "InvalidSecurityGroupRuleId.NotFound" == error["Code"]
+    assert (
+        f"The security group rule ID '{non_existent_sgr_id}' does not exist"
+        in error["Message"]
+    )
 
     # assert with non-existent sg
     response = ec2_client.describe_security_group_rules(

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -670,11 +670,29 @@ def test_security_group_rule_filtering_tags():
         Filters=[{"Name": "tag:Partner", "Values": ["test"]}]
     )
 
+    response3 = client.describe_security_group_rules(
+        Filters=[{"Name": "tag-key", "Values": ["Partner"]}]
+    )
+
+    response4 = client.describe_security_group_rules(
+        Filters=[
+            {"Name": "group-id", "Values": [sg["GroupId"]]},
+            {"Name": "tag-key", "Values": ["Partner"]},
+        ]
+    )
+
     # Verify
     assert response1["SecurityGroupRules"][0]["Tags"] == tags
     assert "Tags" in response2["SecurityGroupRules"][0]
     assert response2["SecurityGroupRules"][0]["Tags"][1]["Key"] == "Partner"
     assert response2["SecurityGroupRules"][0]["Tags"][1]["Value"] == "test"
+    assert len(response3["SecurityGroupRules"]) == 1
+    assert response3["SecurityGroupRules"][0]["Tags"][1]["Key"] == "Partner"
+    assert response3["SecurityGroupRules"][0]["Tags"][1]["Value"] == "test"
+    assert len(response4["SecurityGroupRules"]) == 1
+    assert response4["SecurityGroupRules"][0]["GroupId"] == sg["GroupId"]
+    assert response4["SecurityGroupRules"][0]["Tags"][1]["Key"] == "Partner"
+    assert response4["SecurityGroupRules"][0]["Tags"][1]["Value"] == "test"
 
 
 @mock_aws


### PR DESCRIPTION
Applies the standard `moto` EC2 filtering pattern to security group rules, simplifying the backend implementation. 

Closes #8735 