### PR TITLE
CognityIdentity: Handle unauthenticated requests (without region) to `get_id()`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
         mkdir .mypy_cache
         make lint
 
+  clitest:
+    needs: lint
+    uses: ./.github/workflows/tests_cli.yml
+
   cpptest:
     needs: lint
     uses: ./.github/workflows/tests_sdk_cpp.yml

--- a/.github/workflows/tests_cli.yml
+++ b/.github/workflows/tests_cli.yml
@@ -1,0 +1,27 @@
+name: AWS CLI test
+on: [workflow_call]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Start MotoServer
+      run: |
+        pip install build
+        python -m build
+        docker run --rm -t --name motoserver -e TEST_SERVER_MODE=true -e AWS_SECRET_ACCESS_KEY=server_secret -e AWS_ACCESS_KEY_ID=server_key -v `pwd`:/moto -p 5000:5000 -v /var/run/docker.sock:/var/run/docker.sock python:3.10-slim /moto/scripts/ci_moto_server.sh &
+        python scripts/ci_wait_for_server.py
+    - name: Install BATS
+      run: sudo apt-get install bats -y
+    - name: Run tests
+      run: |
+        mkdir ~/.aws && touch ~/.aws/credentials && echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
+        bats other_langs/tests_cli

--- a/other_langs/tests_cli/test_cognity_identity.bats
+++ b/other_langs/tests_cli/test_cognity_identity.bats
@@ -1,0 +1,8 @@
+@test "get-id in non-default region" {
+  result=$(aws cognito-identity create-identity-pool --identity-pool-name mypool --allow-unauthenticated-identities --endpoint-url http://localhost:5000 --region us-west-2 --output json)
+  echo $result
+
+  id=$(echo $result | jq -r '.IdentityPoolId')
+  echo $id
+  aws cognito-identity get-id --identity-pool-id $id --endpoint-url http://localhost:5000 --region us-west-2
+}


### PR DESCRIPTION
Fixes #8719 

The `get_id()` method is authenticated, which means we do not always know which region it was sent to. 
 - If it is sent to `us-east-1`, then we're lucky, because we always default to that region if we can't find any
 - If botocore is used, we're lucky, because it adds a specific `region` header (even if there is no Authorization-header)
 - If the CLI is used, for a non-standard region, we're in trouble, because then we cannot determine which region the request was sent to.

But: he identity_pool_id is always prefixed with the region it was created in, so we assume that is also the region the request was sent to.

Also adds new test cases using [the Bats-framework](https://bats-core.readthedocs.io/en/stable/) to test this scenario against the CLI.