### PR TITLE
EC2: RunInstances must raise if default and request subnet is missing

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -59,6 +59,16 @@ class DependencyViolationError(EC2ClientError):
         super().__init__("DependencyViolation", message)
 
 
+class MissingInputError(EC2ClientError):
+    def __init__(self, message: str):
+        super().__init__("MissingInput", message)
+
+
+class InvalidInputError(EC2ClientError):
+    def __init__(self, message: str):
+        super().__init__("InvalidInput", message)
+
+
 class MissingParameterError(EC2ClientError):
     def __init__(self, parameter: str):
         super().__init__(
@@ -111,6 +121,14 @@ class InvalidKeyPairFormatError(EC2ClientError):
     def __init__(self) -> None:
         super().__init__(
             "InvalidKeyPair.Format", "Key is not in valid OpenSSH public key format"
+        )
+
+
+class VPCIdNotSpecifiedError(EC2ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "VPCIdNotSpecified",
+            "No default VPC for this user. GroupName is only supported for EC2-Classic and default VPC.",
         )
 
 

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2841,7 +2841,7 @@ def test_instance_with_ipv6_address():
 @mock_aws
 def test_instance_without_default_subnet():
     # Ensure that in an account without a default subnet, launching instances without specifying a subnet raises.
-    client = boto3.client("ec2", region_name="us-east-1")
+    client = boto3.client("ec2", region_name="ap-south-1")
 
     # Delete all VPCs and subnets
     subnets = client.describe_subnets()
@@ -2876,7 +2876,7 @@ def test_instance_without_default_subnet():
     )
 
     # Create default subnet in an AZ
-    client.create_default_subnet(AvailabilityZone="us-east-1c")
+    client.create_default_subnet(AvailabilityZone="ap-south-1c")
 
     # Ensure RunInstances without a subnet, in a different AZ raises
     with pytest.raises(ClientError) as exc:
@@ -2884,12 +2884,12 @@ def test_instance_without_default_subnet():
             ImageId=EXAMPLE_AMI_ID,
             MinCount=1,
             MaxCount=1,
-            Placement={"AvailabilityZone": "us-east-1b"},
+            Placement={"AvailabilityZone": "ap-south-1b"},
         )
     assert exc.value.response["Error"]["Code"] == "InvalidInput"
     assert (
         exc.value.response["Error"]["Message"]
-        == "No default subnet for availability zone: 'us-east-1b'."
+        == "No default subnet for availability zone: 'ap-south-1b'."
     )
 
     # Ensure RunInstances without a subnet where a default subnet exists succeeds
@@ -2897,7 +2897,7 @@ def test_instance_without_default_subnet():
         ImageId=EXAMPLE_AMI_ID,
         MinCount=1,
         MaxCount=1,
-        Placement={"AvailabilityZone": "us-east-1c"},
+        Placement={"AvailabilityZone": "ap-south-1c"},
     )
 
     # Create another VPC and subnet


### PR DESCRIPTION
On AWS, EC2 [RunInstances](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html) does not require a subnet ID. By default, it uses the [default subnet](https://docs.aws.amazon.com/vpc/latest/userguide/work-with-default-vpc.html) from the default VPC. However, if the default subnet and VPCs are not available (i.e. if they were manually deleted), the subnet ID is mandatory.

This PR implements this behaviour in Moto.