### PR TITLE
EC2: Implement CreateDefaultSubnet operation

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -2497,7 +2497,7 @@
 - [ ] create_coip_cidr
 - [ ] create_coip_pool
 - [X] create_customer_gateway
-- [ ] create_default_subnet
+- [X] create_default_subnet
 - [X] create_default_vpc
 - [X] create_dhcp_options
 - [X] create_egress_only_internet_gateway

--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -85,7 +85,7 @@ ec2
 - [ ] create_coip_cidr
 - [ ] create_coip_pool
 - [X] create_customer_gateway
-- [ ] create_default_subnet
+- [X] create_default_subnet
 - [X] create_default_vpc
 - [X] create_dhcp_options
 - [X] create_egress_only_internet_gateway

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -38,6 +38,22 @@ class DefaultVpcAlreadyExists(EC2ClientError):
         )
 
 
+class DefaultVpcDoesNotExistError(EC2ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "DefaultVpcDoesNotExist",
+            "No default VPC exists for this account in this region.",
+        )
+
+
+class DefaultSubnetAlreadyExistsInAvailabilityZoneError(EC2ClientError):
+    def __init__(self, subnet_id: str, availability_zone: str) -> None:
+        super().__init__(
+            "DefaultSubnetAlreadyExistsInAvailabilityZone",
+            f"'{subnet_id}' is already the default subnet in {availability_zone}.",
+        )
+
+
 class DependencyViolationError(EC2ClientError):
     def __init__(self, message: str):
         super().__init__("DependencyViolation", message)

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -152,17 +152,6 @@ class EC2Backend(
 
         self.default_vpc = vpc
 
-        # Create default subnet for each availability zone
-        ip, _ = vpc.cidr_block.split("/")
-        ip = ip.split(".")  # type: ignore
-        ip[2] = 0  # type: ignore
-
-        for zone in self.describe_availability_zones():
-            az_name = zone.name
-            cidr_block = ".".join(str(i) for i in ip) + "/20"
-            self.create_subnet(vpc.id, cidr_block, availability_zone=az_name)
-            ip[2] += 16  # type: ignore
-
     # Use this to generate a proper error template response when in a response
     # handler.
     def raise_error(self, code: str, message: str) -> None:

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -528,10 +528,8 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
                     nic_subnet: Subnet = self.ec2_backend.get_subnet(nic["SubnetId"])
                 else:
                     # Get default Subnet
-                    zone = self._placement.zone
-                    nic_subnet = self.ec2_backend.get_default_subnet(
-                        availability_zone=zone
-                    )
+                    default_subnets = self.ec2_backend.get_default_subnets()
+                    nic_subnet = default_subnets[self._placement.zone]
 
                 group_ids = nic.get("SecurityGroupId") or []
                 if security_groups:

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -378,7 +378,7 @@ class SubnetBackend:
 
         # if this is the first subnet for an availability zone,
         # consider it the default
-        default_for_az = str(availability_zone not in self.subnets).lower()
+        default_for_az = str(len(self.subnets.get(availability_zone, [])) == 0).lower()  # type: ignore[arg-type]
         map_public_ip_on_launch = default_for_az
 
         if availability_zone is None and not availability_zone_id:

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -303,14 +303,12 @@ class SubnetBackend:
                 return subnets_per_zone[subnet_id]
         raise InvalidSubnetIdError(subnet_id)
 
-    def get_default_subnet(self, availability_zone: str) -> Subnet:
-        return [
-            subnet
-            for subnet in self.describe_subnets(
-                filters={"availabilityZone": availability_zone}
-            )
+    def get_default_subnets(self) -> Dict[str, Subnet]:
+        return {
+            subnet.availability_zone: subnet
+            for subnet in self.describe_subnets()
             if subnet.default_for_az
-        ][0]
+        }
 
     def create_subnet(
         self,

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -709,7 +709,17 @@ class VPCBackend:
         if default_vpc:
             raise DefaultVpcAlreadyExists
         cidr_block = "172.31.0.0/16"
-        return self.create_vpc(cidr_block=cidr_block, is_default=True)
+        vpc = self.create_vpc(cidr_block=cidr_block, is_default=True)
+
+        for zone in self.describe_availability_zones():  # type: ignore[attr-defined]
+            self.create_default_subnet(zone.name)  # type: ignore[attr-defined]
+        return vpc
+
+    def get_default_vpc(self) -> Optional[VPC]:
+        for vpc in self.vpcs.values():
+            if vpc.is_default == "true":
+                return vpc
+        return None
 
     def create_vpc(
         self,

--- a/moto/ec2/responses/subnets.py
+++ b/moto/ec2/responses/subnets.py
@@ -28,6 +28,13 @@ class Subnets(EC2BaseResponse):
         template = self.response_template(CREATE_SUBNET_RESPONSE)
         return template.render(subnet=subnet)
 
+    def create_default_subnet(self) -> str:
+        availability_zone = self._get_param("AvailabilityZone")
+
+        subnet = self.ec2_backend.create_default_subnet(availability_zone)
+        template = self.response_template(CREATE_DEFAULT_SUBNET_RESPONSE)
+        return template.render(subnet=subnet)
+
     def delete_subnet(self) -> str:
         subnet_id = self._get_param("SubnetId")
         subnet = self.ec2_backend.delete_subnet(subnet_id)
@@ -118,6 +125,36 @@ CREATE_SUBNET_RESPONSE = """
     </tagSet>
   </subnet>
 </CreateSubnetResponse>"""
+
+CREATE_DEFAULT_SUBNET_RESPONSE = """
+<?xml version="1.0" encoding="UTF-8"?>
+<CreateDefaultSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>68b1ebc6-3ff3-4f5b-9f2c-a468cb0a5030</requestId>
+    <subnet>
+        <assignIpv6AddressOnCreation>{{ 'false' if not subnet.assign_ipv6_address_on_creation or subnet.assign_ipv6_address_on_creation == 'false' else 'true'}}</assignIpv6AddressOnCreation>
+        <availabilityZone>{{ subnet._availability_zone.name }}</availabilityZone>
+        <availabilityZoneId>{{ subnet._availability_zone.zone_id }}</availabilityZoneId>
+        <availableIpAddressCount>{{ subnet.available_ip_addresses or '0' }}</availableIpAddressCount>
+        <cidrBlock>{{ subnet.cidr_block }}</cidrBlock>
+        <defaultForAz>{{ subnet.default_for_az }}</defaultForAz>
+        <enableDns64>false</enableDns64>
+        <ipv6CidrBlockAssociationSet/>
+        <ipv6Native>false</ipv6Native>
+        <mapCustomerOwnedIpOnLaunch>false</mapCustomerOwnedIpOnLaunch>
+        <mapPublicIpOnLaunch>{{ subnet.map_public_ip_on_launch }}</mapPublicIpOnLaunch>
+        <ownerId>{{ subnet.owner_id }}</ownerId>
+        <privateDnsNameOptionsOnLaunch>
+            <enableResourceNameDnsAAAARecord>false</enableResourceNameDnsAAAARecord>
+            <enableResourceNameDnsARecord>false</enableResourceNameDnsARecord>
+            <hostnameType>ip-name</hostnameType>
+        </privateDnsNameOptionsOnLaunch>
+        <state>available</state>
+        <subnetId>{{ subnet.id }}</subnetId>
+        <tagSet/>
+        <vpcId>{{ subnet.vpc_id }}</vpcId>
+    </subnet>
+</CreateDefaultSubnetResponse>
+"""
 
 DELETE_SUBNET_RESPONSE = """
 <DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -309,10 +309,8 @@ class ELBBackend(BaseBackend):
             subnet = ec2_backend.get_subnet(subnets[0])
             vpc_id = subnet.vpc_id
         elif zones:
-            subnets = [
-                ec2_backend.get_default_subnet(availability_zone=zone).id
-                for zone in zones
-            ]
+            default_subnets = ec2_backend.get_default_subnets()
+            subnets = [default_subnets[zone].id for zone in zones]
             subnet = ec2_backend.get_subnet(subnets[0])
             vpc_id = subnet.vpc_id
         if name in self.load_balancers:

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -23,6 +23,11 @@ def test_creating_a_vpc_in_empty_region_does_not_make_this_vpc_the_default():
     client = boto3.client("ec2", region_name="eu-north-1")
     all_vpcs = retrieve_all_vpcs(client)
     for vpc in all_vpcs:
+        subnets = client.describe_subnets(
+            Filters=[{"Name": "vpc-id", "Values": [vpc["VpcId"]]}]
+        )["Subnets"]
+        for subnet in subnets:
+            client.delete_subnet(SubnetId=subnet["SubnetId"])
         client.delete_vpc(VpcId=vpc["VpcId"])
     # create vpc
     client.create_vpc(CidrBlock="10.0.0.0/16")
@@ -40,6 +45,11 @@ def test_create_default_vpc():
     client = boto3.client("ec2", region_name="eu-north-1")
     all_vpcs = retrieve_all_vpcs(client)
     for vpc in all_vpcs:
+        subnets = client.describe_subnets(
+            Filters=[{"Name": "vpc-id", "Values": [vpc["VpcId"]]}]
+        )["Subnets"]
+        for subnet in subnets:
+            client.delete_subnet(SubnetId=subnet["SubnetId"])
         client.delete_vpc(VpcId=vpc["VpcId"])
     # create default vpc
     client.create_default_vpc()


### PR DESCRIPTION
This PR implements the EC2 [CreateDefaultSubnet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateDefaultSubnet.html) operation.

> `CreateDefaultSubnet` operation creates a default subnet with a size `/20` IPv4 CIDR block in the specified Availability Zone in your default VPC. You can have only one default subnet per Availability Zone.

Moto already supports the EC2 [CreateDefaultVpc](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateDefaultVpc.html) and this is updated such that it also [creates the default subnets](https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc-components.html).

The implementation assigns the `/20` CIDR blocks to AZs in sequence as follows, but that's not always the case on AWS:
- ...a: `172.31.0.0/20`
- ...b: `172.31.16.0/20`
- ...c: `172.31.32.0/20`
- etc.