### PR TITLE
CF: Support removal of resources out of order

### DIFF
--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1361,13 +1361,16 @@ def test_update_stack_deleted_resources_can_reference_deleted_resources():
             "AWSTemplateFormatVersion": "2010-09-09",
             "Parameters": {"TimeoutParameter": {"Default": 61, "Type": "String"}},
             "Resources": {
-                "Subnet": {
-                    "Type": "AWS::EC2::Subnet",
-                    "Properties": {"VpcId": {"Ref": "VPC"}, "CidrBlock": "10.0.0.0/24"},
-                },
+                # Note that we're listing the VPC first on purpose, even though the dependency between them
+                # means that the Subnet should be deleted first, before the VPC can be deleted
+                # Our implementation needs to handle deletion of resources regardless of the order
                 "VPC": {
                     "Type": "AWS::EC2::VPC",
                     "Properties": {"CidrBlock": "10.0.0.0/16"},
+                },
+                "Subnet": {
+                    "Type": "AWS::EC2::Subnet",
+                    "Properties": {"VpcId": {"Ref": "VPC"}, "CidrBlock": "10.0.0.0/24"},
                 },
             },
         }


### PR DESCRIPTION
When updating a CloudFormation stack and removing both a VPC and a Subnet, the order in which they are specified should not matter. To achieve this, we keep retrying the deletion of resources until it succeeds - or throw an error if it doesn't.

Note that there are three possible ways where we need to handle resource dependencies:
1. on update (resource A now references resource B that doesn't exist yet)
2. on delete (resource A contains resource B, and resource B needs to be deleted first)
3. on removing resources during an update - functionally equivalent to scenario 2, but a different code path

Scenario 1 and 2 are already supported - this PR adds the required logic for scenario 3 to work.

### Background
Original implementation: https://github.com/getmoto/moto/commit/a600deb96a2391454ac913d8731469e2e2e91235
PR that exposed this bug: #8811 

FYI @viren-nadkarni 