### PR TITLE
S3: RestoreObject: Remove validation around Days-parameter

### DIFF
--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -620,26 +620,6 @@ class HeadOnDeleteMarker(Exception):
         self.marker = marker
 
 
-class DaysMustNotProvidedForSelectRequest(S3ClientError):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            "DaysMustNotProvidedForSelectRequest",
-            "`Days` must not be provided for select requests",
-        )
-
-
-class DaysMustProvidedExceptForSelectRequest(S3ClientError):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            "DaysMustProvidedExceptForSelectRequest",
-            "`Days` must be provided except for select requests",
-        )
-
-
 class MethodNotAllowed(S3ClientError):
     code = 405
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -40,8 +40,6 @@ from moto.s3.exceptions import (
     BucketNeedsToBeNew,
     CopyObjectMustChangeSomething,
     CrossLocationLoggingProhibitted,
-    DaysMustNotProvidedForSelectRequest,
-    DaysMustProvidedExceptForSelectRequest,
     EntityTooSmall,
     HeadOnDeleteMarker,
     InvalidBucketName,
@@ -3103,12 +3101,6 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         key = self.get_object(bucket_name, key_name)
         if not key:
             raise MissingKey
-
-        if days is None and type_ is None:
-            raise DaysMustProvidedExceptForSelectRequest()
-
-        if days and type_:
-            raise DaysMustNotProvidedForSelectRequest()
 
         if key.storage_class not in ARCHIVE_STORAGE_CLASSES:
             raise InvalidObjectState(storage_class=key.storage_class)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -712,32 +712,6 @@ def test_cannot_restore_standard_class_object():
 
 
 @mock_aws
-def test_restore_object_invalid_request_params():
-    if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't set transition directly in ServerMode")
-
-    s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
-    bucket = s3_resource.Bucket("foobar")
-    bucket.create()
-
-    key = bucket.put_object(Key="the-key", Body=b"somedata", StorageClass="GLACIER")
-
-    # `Days` must be provided except for select requests
-    with pytest.raises(ClientError) as exc:
-        key.restore_object(RestoreRequest={})
-    err = exc.value.response["Error"]
-    assert err["Code"] == "DaysMustProvidedExceptForSelectRequest"
-    assert err["Message"] == "`Days` must be provided except for select requests"
-
-    # `Days` must not be provided for select requests
-    with pytest.raises(ClientError) as exc:
-        key.restore_object(RestoreRequest={"Days": 1, "Type": "SELECT"})
-    err = exc.value.response["Error"]
-    assert err["Code"] == "DaysMustNotProvidedForSelectRequest"
-    assert err["Message"] == "`Days` must not be provided for select requests"
-
-
-@mock_aws
 def test_get_versioning_status():
     s3_resource = boto3.resource("s3", region_name=DEFAULT_REGION_NAME)
     bucket = s3_resource.Bucket("foobar")


### PR DESCRIPTION
Originally introduced in #7468. The validation surrounding the Days-parameter is a lot more complicated then the docs suggest, so the current implementation throws the exception when it shouldn't.

I've tried testing this against AWS, but they keep returning a `MalformedXML`-exception without explaining what's wrong - so that makes it a lot more difficult to determine how this is supposed to work. Hence the current 'fix', that just removes the validation - better to have no validation, then wrong validation.

Fixes #8635 