### PR TITLE
feat(acm): implement `GetAccountConfiguration` and `PutAccountConfiguration` APIs

### DIFF
--- a/docs/docs/services/acm.rst
+++ b/docs/docs/services/acm.rst
@@ -18,12 +18,12 @@ acm
 - [X] delete_certificate
 - [X] describe_certificate
 - [X] export_certificate
-- [ ] get_account_configuration
+- [X] get_account_configuration
 - [X] get_certificate
 - [X] import_certificate
 - [X] list_certificates
 - [ ] list_tags_for_certificate
-- [ ] put_account_configuration
+- [X] put_account_configuration
 - [X] remove_tags_from_certificate
 - [ ] renew_certificate
 - [X] request_certificate

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -435,6 +435,14 @@ class CertBundle(BaseModel):
         return "<Certificate>"
 
 
+class AccountConfiguration:
+    def __init__(self, days_before_expiry: int = 45):
+        self.days_before_expiry = days_before_expiry
+
+    def to_dict(self):
+        return {"ExpiryEvents": {"DaysBeforeExpiry": self.days_before_expiry}}
+
+
 class AWSCertificateManagerBackend(BaseBackend):
     MIN_PASSPHRASE_LEN = 4
 
@@ -442,6 +450,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self._certificates: Dict[str, CertBundle] = {}
         self._idempotency_tokens: Dict[str, Any] = {}
+        self._account_config = AccountConfiguration()
 
     def set_certificate_in_use_by(self, arn: str, load_balancer_name: str) -> None:
         if arn not in self._certificates:
@@ -603,6 +612,24 @@ class AWSCertificateManagerBackend(BaseBackend):
         private_key = cert_bundle.serialize_pk(passphrase_bytes)
 
         return certificate, certificate_chain, private_key
+
+    def get_account_configuration(self) -> Dict[str, Any]:
+        return self._account_config.to_dict()
+
+    def put_account_configuration(
+        self, days_before_expiry: int, idempotency_token: str
+    ) -> None:
+        if idempotency_token is not None:
+            arn = self._get_arn_from_idempotency_token(idempotency_token)
+            if arn:
+                return
+
+        if days_before_expiry < 1 or days_before_expiry > 90:
+            raise AWSValidationException("DaysBeforeExpiry must be between 1 and 90")
+
+        self._account_config = AccountConfiguration(days_before_expiry)
+        if idempotency_token is not None:
+            self._set_idempotency_token_arn(idempotency_token, "account_config")
 
 
 acm_backends = BackendDict(AWSCertificateManagerBackend, "acm")

--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -439,7 +439,7 @@ class AccountConfiguration:
     def __init__(self, days_before_expiry: int = 45):
         self.days_before_expiry = days_before_expiry
 
-    def to_dict(self):
+    def to_dict(self):  # type: ignore
         return {"ExpiryEvents": {"DaysBeforeExpiry": self.days_before_expiry}}
 
 
@@ -614,7 +614,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         return certificate, certificate_chain, private_key
 
     def get_account_configuration(self) -> Dict[str, Any]:
-        return self._account_config.to_dict()
+        return self._account_config.to_dict()  # type: ignore
 
     def put_account_configuration(
         self, days_before_expiry: int, idempotency_token: str

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -251,3 +251,31 @@ class AWSCertificateManagerResponse(BaseResponse):
                 PrivateKey=private_key,
             )
         )
+
+    def get_account_configuration(self) -> str:
+        config = self.acm_backend.get_account_configuration()
+        return json.dumps(config)
+
+    def put_account_configuration(self) -> str:
+        expiry_events = self._get_param("ExpiryEvents")
+        idempotency_token = self._get_param("IdempotencyToken")
+
+        if expiry_events is None:
+            msg = "A required parameter for the specified action is not supplied."
+            return (
+                json.dumps({"__type": "MissingParameter", "message": msg}),
+                dict(status=400),
+            )
+
+        days_before_expiry = expiry_events.get("DaysBeforeExpiry")
+        if days_before_expiry is None:
+            msg = "DaysBeforeExpiry is required in ExpiryEvents."
+            return (
+                json.dumps({"__type": "ValidationException", "message": msg}),
+                dict(status=400),
+            )
+
+        self.acm_backend.put_account_configuration(
+            days_before_expiry, idempotency_token
+        )
+        return "{}"

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -262,7 +262,7 @@ class AWSCertificateManagerResponse(BaseResponse):
 
         if expiry_events is None:
             msg = "A required parameter for the specified action is not supplied."
-            return (
+            return (  # type: ignore
                 json.dumps({"__type": "MissingParameter", "message": msg}),
                 dict(status=400),
             )
@@ -270,7 +270,7 @@ class AWSCertificateManagerResponse(BaseResponse):
         days_before_expiry = expiry_events.get("DaysBeforeExpiry")
         if days_before_expiry is None:
             msg = "DaysBeforeExpiry is required in ExpiryEvents."
-            return (
+            return (  # type: ignore
                 json.dumps({"__type": "ValidationException", "message": msg}),
                 dict(status=400),
             )


### PR DESCRIPTION
## Description

Adds support for the following in ACM:

- https://docs.aws.amazon.com/acm/latest/APIReference/API_GetAccountConfiguration.html
- https://docs.aws.amazon.com/acm/latest/APIReference/API_PutAccountConfiguration.html