### PR TITLE
EC2: Update describe_instance_status filter logic to require all filters to match

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -595,16 +595,18 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
     def applies(self, filters: List[Dict[str, Any]]) -> bool:
         if filters:
-            applicable = False
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_instances.html
+            # Filters Section in the boto3 documentation
+            # If you specify multiple filters, the filters are joined with an AND, and the request returns only results that match all of the specified filters.
             for f in filters:
                 acceptable_values = f["values"]
                 if f["name"] == "instance-state-name":
-                    if self._state.name in acceptable_values:
-                        applicable = True
+                    if self._state.name not in acceptable_values:
+                        return False
                 if f["name"] == "instance-state-code":
-                    if str(self._state.code) in acceptable_values:
-                        applicable = True
-            return applicable
+                    if str(self._state.code) not in acceptable_values:
+                        return False
+            return True
         # If there are no filters, all instances are valid
         return True
 


### PR DESCRIPTION
This PR updates the filtering logic used in describe_instance_status to align with AWS EC2's behavior, where multiple filters must all match (AND condition).　As documented in the [describe_instance_status boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_instance_status.html) is written 
> If you specify multiple filters, the filters are joined with an AND, and the request returns only results that match all of the specified filters.

Previously, filters were evaluated in a way that allowed instances to match if any single filter matched (OR behavior). This has now been corrected.

Changes include:
- Filtering logic in describe_instance_status now requires all filters to match.
- Tests added to confirm correct behavior with:
  - Matching running and stopped instances
  - Matching only running or only stopped
  - Contradictory filters (e.g. state-name is "running" but state-code is "80") resulting in no matches

## Copilot's summary

This pull request refines the filtering logic for EC2 instance states in the `moto` library and enhances test coverage to validate the changes. The key updates include modifying the `applies` method to align with the `boto3` documentation and adding comprehensive tests for filtering instances by state.

### Filtering Logic Improvements:
* Updated the `applies` method in `moto/ec2/models/instances.py` to ensure that multiple filters are combined using an AND operation, as per the `boto3` documentation. The logic now returns `False` immediately if any filter condition is not met, and `True` only if all conditions are satisfied.

### Test Enhancements:
* Added new test cases in `tests/test_ec2/test_instances.py` to validate instance filtering by state code and state name. The tests cover scenarios for multiple states (`running_and_stopped`), single states (`running`, `stopped`), and contradictory filters (`contradiction`). These tests ensure the filtering logic behaves as expected.
