### PR TITLE
EC2: Update describe_instance_status instance ID filtering logic

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -917,7 +917,10 @@ class InstanceBackend:
         self, instance_ids: List[str], include_all_instances: bool, filters: Any
     ) -> List[Instance]:
         if instance_ids:
-            return self.get_multi_instances_by_id(instance_ids, filters)
+            instances = self.get_multi_instances_by_id(instance_ids, filters)
+            if include_all_instances:
+                return instances
+            return [instance for instance in instances if instance.is_running()]
         elif include_all_instances:
             return self.all_instances(filters)
         else:

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -854,18 +854,20 @@ class InstanceBackend:
         :return: A list with instance objects
         """
         result = []
-
+        all_instance_ids = {}
         for reservation in self.all_reservations():
             for instance in reservation.instances:
-                if instance.id in instance_ids:
-                    if instance.applies(filters):
-                        result.append(instance)
-
-        if instance_ids and len(instance_ids) > len(result):
-            result_ids = [i.id for i in result]
-            missing_instance_ids = [i for i in instance_ids if i not in result_ids]
-            raise InvalidInstanceIdError(missing_instance_ids)
-
+                all_instance_ids[instance.id] = instance
+        not_found_instance_ids = []
+        for instance_id in instance_ids:
+            if instance_id not in all_instance_ids:
+                not_found_instance_ids.append(instance_id)
+                continue
+            instance = all_instance_ids[instance_id]
+            if instance.applies(filters):
+                result.append(instance)
+        if not_found_instance_ids:
+            raise InvalidInstanceIdError(not_found_instance_ids)
         return result
 
     def get_instance_by_id(self, instance_id: str) -> Optional[Instance]:

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2057,7 +2057,7 @@ def test_describe_instance_status_with_stopped_instance_filter_and_instance_ids(
     client = boto3.client("ec2", region_name="us-east-1")
     ec2 = boto3.resource("ec2", region_name="us-east-1")
     reservation = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
-    instance1 = reservation
+    instance1 = reservation[0]
     instance1.stop()
 
     stopped_status = client.describe_instance_status(


### PR DESCRIPTION
# Overview
This pull request updates the behavior of `describe_instance_status` to conform to the AWS API specification regarding how filters interact with the `InstanceIds` parameter.

## Changes
### 1. Correct filtering behavior for `InstanceIds`
- Previously, the internal `get_multi_instances_by_id` method enforced that all specified instance IDs must also satisfy any provided filters, which does not match AWS behavior.
- As per [boto3 describe_instance_status documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_instance_status.html):
  > A filter name and value pair that is used to return a more specific list of results from a describe operation. Filters can be used to match a set of resources by specific criteria, such as tags, attributes, or IDs.
- Therefore, the updated logic:
  - First narrows down the target set using the provided `InstanceIds`.
  - Then applies the filters to that set to determine the final results.
- This fix removes incorrect validation that required all instances to pass filters.

### 2. Correct handling of `IncludeAllInstances`
- The behavior now ensures stopped instances are included **only when** `IncludeAllInstances=True`, even if specific `InstanceIds` are supplied.
- This mimics AWS's actual response behavior, which uses this flag to determine whether to include non-running instances.

### 3. Added comprehensive test coverage
- Three new tests validate partial ID selection, filter application, and `IncludeAllInstances` behavior:
  - `test_describe_instance_status_with_partial_instance_ids`
  - `test_describe_instance_status_with_partial_instance_id_stopped`
  - `test_describe_instance_status_with_stopped_instance_filter_and_instance_ids`


## Copilot's summary
This pull request refactors the `get_multi_instances_by_id` method in `moto`'s EC2 instance model to improve efficiency and updates the `describe_instance_status` method to handle additional scenarios. It also includes new tests to validate these changes. Below are the key changes grouped by theme:

### Refactoring and Efficiency Improvements:
* Refactored `get_multi_instances_by_id` in `moto/ec2/models/instances.py` to use a dictionary (`all_instance_ids`) for faster lookup of instances by ID, reducing the need for nested loops. This change also simplifies error handling for missing instance IDs.

### Feature Enhancements:
* Updated `describe_instance_status` in `moto/ec2/models/instances.py` to support filtering by running instances when `include_all_instances` is `False`. This ensures only running instances are returned unless explicitly requested.

### Test Coverage:
* Added new tests in `tests/test_ec2/test_instances.py` to validate the behavior of `describe_instance_status`:
  - [`test_describe_instance_status_with_partial_instance_ids`](diffhunk://#diff-249c7d983d2a969f97127640a774de5622e7165a09fd00ad0f377bed9ef1695eR2017-R2076): Ensures only specified instance IDs are returned.
  - [`test_describe_instance_status_with_partial_instance_id_stopped`](diffhunk://#diff-249c7d983d2a969f97127640a774de5622e7165a09fd00ad0f377bed9ef1695eR2017-R2076): Validates filtering of stopped instances and the behavior of the `IncludeAllInstances` flag.
  - [`test_describe_instance_status_with_stopped_instance_filter_and_instance_ids`](diffhunk://#diff-249c7d983d2a969f97127640a774de5622e7165a09fd00ad0f377bed9ef1695eR2017-R2076): Confirms correct filtering of stopped instances using filters and `IncludeAllInstances`.