### PR TITLE
RDS: make failover target parameter optional

### DIFF
--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -104,6 +104,11 @@ class InvalidDBInstanceStateError(RDSClientError):
         )
 
 
+class InvalidDBInstanceStateFault(RDSClientError):
+    def __init__(self, message: str):
+        super().__init__("InvalidDBInstanceStateFault", message)
+
+
 class SnapshotQuotaExceededFault(RDSClientError):
     # This is used for both DBSnapshots and DBClusterSnapshots
     def __init__(self) -> None:

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2669,18 +2669,26 @@ class RDSBackend(BaseBackend):
         return self.create_db_cluster(new_cluster_props)
 
     def failover_db_cluster(
-        self, db_cluster_identifier: str, target_db_instance_identifier: str = ""
+        self,
+        db_cluster_identifier: str,
+        target_db_instance_identifier: str = "",
     ) -> DBCluster:
         cluster = self.clusters[db_cluster_identifier]
 
-        if not target_db_instance_identifier:
-            for instance_id, instance in self.databases.items():
-                if not instance.is_cluster_writer:
-                    target_db_instance_identifier = instance_id
+        if len(cluster.members) == 1:
+            raise InvalidDBClusterStateFault(
+                f"Database cluster:{cluster.db_cluster_identifier} should have at least two database instances for failover"
+            )
 
-        instance = self.databases[target_db_instance_identifier]
-        assert isinstance(instance, DBInstanceClustered)
-        cluster.failover(instance)
+        if not target_db_instance_identifier:
+            for instance in cluster.members:
+                if not instance.is_cluster_writer:
+                    target_db_instance_identifier = instance.db_instance_identifier
+                    break
+
+        target_instance = self.databases[target_db_instance_identifier]
+        assert isinstance(target_instance, DBInstanceClustered)
+        cluster.failover(target_instance)
         return cluster
 
     def stop_db_instance(

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2669,9 +2669,15 @@ class RDSBackend(BaseBackend):
         return self.create_db_cluster(new_cluster_props)
 
     def failover_db_cluster(
-        self, db_cluster_identifier: str, target_db_instance_identifier: str
+        self, db_cluster_identifier: str, target_db_instance_identifier: str = ""
     ) -> DBCluster:
         cluster = self.clusters[db_cluster_identifier]
+
+        if not target_db_instance_identifier:
+            for instance_id, instance in self.databases.items():
+                if not instance.is_cluster_writer:
+                    target_db_instance_identifier = instance_id
+
         instance = self.databases[target_db_instance_identifier]
         assert isinstance(instance, DBInstanceClustered)
         cluster.failover(instance)

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -1838,6 +1838,43 @@ def test_failover_db_cluster(client):
 
 
 @mock_aws
+def test_failover_db_cluster_without_target_instance_specified(client):
+    cluster_identifier = "cluster-1"
+    create_db_cluster(
+        DBClusterIdentifier=cluster_identifier,
+        Engine="aurora-postgresql",
+    )
+    create_db_instance(
+        DBInstanceIdentifier="test-instance-primary",
+        Engine="aurora-postgresql",
+        DBClusterIdentifier=cluster_identifier,
+    )
+    create_db_instance(
+        DBInstanceIdentifier="test-instance-replica",
+        Engine="aurora-postgresql",
+        DBClusterIdentifier=cluster_identifier,
+    )
+    cluster = client.describe_db_clusters(DBClusterIdentifier=cluster_identifier)[
+        "DBClusters"
+    ][0]
+    cluster_members = cluster["DBClusterMembers"]
+    assert len(cluster_members) == 2
+    assert cluster_members[0]["DBInstanceIdentifier"] == "test-instance-primary"
+    assert cluster_members[0]["IsClusterWriter"] is True
+    assert cluster_members[1]["DBInstanceIdentifier"] == "test-instance-replica"
+    assert cluster_members[1]["IsClusterWriter"] is False
+    cluster_failed_over = client.failover_db_cluster(
+        DBClusterIdentifier=cluster_identifier,
+    )["DBCluster"]
+    cluster_members = cluster_failed_over["DBClusterMembers"]
+    assert len(cluster_members) == 2
+    assert cluster_members[0]["DBInstanceIdentifier"] == "test-instance-primary"
+    assert cluster_members[0]["IsClusterWriter"] is False
+    assert cluster_members[1]["DBInstanceIdentifier"] == "test-instance-replica"
+    assert cluster_members[1]["IsClusterWriter"] is True
+
+
+@mock_aws
 def test_db_cluster_writer_promotion(client):
     client.create_db_cluster(
         DBClusterIdentifier="cluster-1",

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -1902,6 +1902,28 @@ def test_failover_db_cluster_with_single_instance_cluster(client):
 
 
 @mock_aws
+def test_failover_db_cluster_exceptions(client):
+    with pytest.raises(ClientError) as ex:
+        client.failover_db_cluster(
+            DBClusterIdentifier="non-existent-cluster",
+            TargetDBInstanceIdentifier="non-existent-instance",
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "InvalidParameterValue"
+    create_db_instance(
+        DBInstanceIdentifier="now-existent-instance",
+        Engine="postgres",
+    )
+    with pytest.raises(ClientError) as ex:
+        client.failover_db_cluster(
+            DBClusterIdentifier="non-existent-cluster",
+            TargetDBInstanceIdentifier="now-existent-instance",
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "DBClusterNotFoundFault"
+
+
+@mock_aws
 def test_db_cluster_writer_promotion(client):
     client.create_db_cluster(
         DBClusterIdentifier="cluster-1",


### PR DESCRIPTION
**Make** `target_db_instance_identifier` **parameter optional in** `failover_db_cluster`

In the previous implementation, target_db_instance_identifier was a required parameter. This change aligns the behavior with the AWS API, where the failover target can be selected automatically if the parameter is omitted.

A unit test has been added to cover this updated behavior.

