### PR TITLE
RDS: store managed secret as json with appropriate fields

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -429,7 +429,7 @@ class MasterUserSecret:
         secret = self.secretsmanager.create_managed_secret(
             service_name="rds",
             secret_id=self._generate_secret_name(),
-            secret_string=json.dumps({"username": "admin", "password": "P@55w0rd!"}),
+            secret_string=self._generate_secret_string(),
             description=self._generate_secret_description(),
             kms_key_id=kms_key_id,
             tags=self._generate_secret_tags(),
@@ -445,6 +445,11 @@ class MasterUserSecret:
         resource_type = self.resource.__class__.__name__[2:].lower()
         description = f"The secret associated with the primary RDS DB {resource_type}: {self.resource.arn}"
         return description
+
+    def _generate_secret_string(self) -> str:
+        credentials = {"username": "admin", "password": "P@55w0rd!"}
+        secret_string = json.dumps(credentials)
+        return secret_string
 
     def _generate_secret_tags(self) -> list[dict[str, str]]:
         resource_type = self.resource.__class__.__name__

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import math
 import os
 import re
@@ -428,7 +429,7 @@ class MasterUserSecret:
         secret = self.secretsmanager.create_managed_secret(
             service_name="rds",
             secret_id=self._generate_secret_name(),
-            secret_string="P@55w0rd!",
+            secret_string=json.dumps({"username": "admin", "password": "P@55w0rd!"}),
             description=self._generate_secret_description(),
             kms_key_id=kms_key_id,
             tags=self._generate_secret_tags(),

--- a/tests/test_rds/test_integrations.py
+++ b/tests/test_rds/test_integrations.py
@@ -206,6 +206,15 @@ def test_db_instance_managed_master_user_password_lifecycle():
     master_user_secret = db_instance["MasterUserSecret"]
     assert master_user_secret["SecretStatus"] == "active"
 
+    # check that managed secret has correct structure
+    master_user_secret_value = secretsmanager.get_secret_value(SecretId=secret_arn)[
+        "SecretString"
+    ]
+    assert json.loads(master_user_secret_value) == {
+        "username": "admin",
+        "password": "P@55w0rd!",
+    }
+
     # Disable password management
     resp = rds.modify_db_instance(
         DBInstanceIdentifier=db_instance_identifier,

--- a/tests/test_rds/test_integrations.py
+++ b/tests/test_rds/test_integrations.py
@@ -1,5 +1,6 @@
 """RDS tests covering integrations with other service backends."""
 
+import json
 import uuid
 
 import boto3
@@ -62,6 +63,15 @@ def test_db_cluster_managed_master_user_password_lifecycle():
     db_cluster = resp["DBClusters"][0]
     master_user_secret = db_cluster["MasterUserSecret"]
     assert master_user_secret["SecretStatus"] == "active"
+
+    # check that managed secret has correct structure
+    master_user_secret_value = secretsmanager.get_secret_value(SecretId=secret_arn)[
+        "SecretString"
+    ]
+    assert json.loads(master_user_secret_value) == {
+        "username": "admin",
+        "password": "P@55w0rd!",
+    }
 
     # Disable password management
     resp = rds.modify_db_cluster(

--- a/tests/test_rds/test_integrations.py
+++ b/tests/test_rds/test_integrations.py
@@ -63,15 +63,11 @@ def test_db_cluster_managed_master_user_password_lifecycle():
     db_cluster = resp["DBClusters"][0]
     master_user_secret = db_cluster["MasterUserSecret"]
     assert master_user_secret["SecretStatus"] == "active"
-
-    # check that managed secret has correct structure
-    master_user_secret_value = secretsmanager.get_secret_value(SecretId=secret_arn)[
-        "SecretString"
-    ]
-    assert json.loads(master_user_secret_value) == {
-        "username": "admin",
-        "password": "P@55w0rd!",
-    }
+    # Check that managed secret has correct structure
+    resp = secretsmanager.get_secret_value(SecretId=secret_arn)
+    secret = json.loads(resp["SecretString"])
+    assert "username" in secret
+    assert "password" in secret
 
     # Disable password management
     resp = rds.modify_db_cluster(
@@ -205,15 +201,11 @@ def test_db_instance_managed_master_user_password_lifecycle():
     db_instance = resp["DBInstances"][0]
     master_user_secret = db_instance["MasterUserSecret"]
     assert master_user_secret["SecretStatus"] == "active"
-
-    # check that managed secret has correct structure
-    master_user_secret_value = secretsmanager.get_secret_value(SecretId=secret_arn)[
-        "SecretString"
-    ]
-    assert json.loads(master_user_secret_value) == {
-        "username": "admin",
-        "password": "P@55w0rd!",
-    }
+    # Check that managed secret has correct structure
+    resp = secretsmanager.get_secret_value(SecretId=secret_arn)
+    secret = json.loads(resp["SecretString"])
+    assert "username" in secret
+    assert "password" in secret
 
     # Disable password management
     resp = rds.modify_db_instance(


### PR DESCRIPTION
As far as I can tell, the managed secret for an RDS cluster is a json object dumped as string. Sadly I cannot find any official documentation, only confirmation from AWS Support.

At least https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_secret_json_structure.html mentions that secrets for RDS/Aurora are supposed to have JSON structure