### PR TITLE
feat (acm-pca): implement `ListCertificateAuthorities` API

### DIFF
--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -15,6 +15,7 @@ from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
+from moto.core.paginator import paginate
 
 from .exceptions import (
     InvalidS3ObjectAclInCrlConfiguration,
@@ -336,6 +337,15 @@ class CertificateAuthority(BaseModel):
 class ACMPCABackend(BaseBackend):
     """Implementation of ACMPCA APIs."""
 
+    PAGINATION_MODEL = {
+        "list_certificate_authorities": {
+            "input_token": "next_token",
+            "limit_key": "max_results",
+            "limit_default": 100,
+            "unique_attribute": "arn",
+        }
+    }
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.certificate_authorities: Dict[str, CertificateAuthority] = dict()
@@ -483,6 +493,27 @@ class ACMPCABackend(BaseBackend):
         """
         ca = self.describe_certificate_authority(resource_arn)
         ca.policy = None
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_certificate_authorities(
+        self,
+        resource_owner: Optional[str] = None,
+    ) -> List[CertificateAuthority]:
+        """
+        Lists the private certificate authorities that you created by using the CreateCertificateAuthority action.
+        """
+        cas = list(self.certificate_authorities.values())
+        
+        # Filter by resource owner if specified
+        if resource_owner == "OTHER_ACCOUNTS":
+            cas = [ca for ca in cas if ca.account_id != self.account_id]
+        elif resource_owner == "SELF" or resource_owner is None:
+            cas = [ca for ca in cas if ca.account_id == self.account_id]
+        
+        # Sort CAs by creation date in descending order
+        cas.sort(key=lambda x: x.created_at, reverse=True)
+        
+        return cas
 
 
 acmpca_backends = BackendDict(ACMPCABackend, "acm-pca")

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -13,9 +13,9 @@ from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
+from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
-from moto.core.paginator import paginate
 
 from .exceptions import (
     InvalidS3ObjectAclInCrlConfiguration,
@@ -503,16 +503,14 @@ class ACMPCABackend(BaseBackend):
         Lists the private certificate authorities that you created by using the CreateCertificateAuthority action.
         """
         cas = list(self.certificate_authorities.values())
-        
-        # Filter by resource owner if specified
+
         if resource_owner == "OTHER_ACCOUNTS":
             cas = [ca for ca in cas if ca.account_id != self.account_id]
         elif resource_owner == "SELF" or resource_owner is None:
             cas = [ca for ca in cas if ca.account_id == self.account_id]
-        
-        # Sort CAs by creation date in descending order
+
         cas.sort(key=lambda x: x.created_at, reverse=True)
-        
+
         return cas
 
 

--- a/moto/acmpca/responses.py
+++ b/moto/acmpca/responses.py
@@ -194,3 +194,28 @@ class ACMPCAResponse(BaseResponse):
         resource_arn = params.get("ResourceArn")
         self.acmpca_backend.delete_policy(resource_arn=resource_arn)
         return "{}"
+
+    def list_certificate_authorities(self) -> str:
+        """
+        Handler for ListCertificateAuthorities API request
+        """
+        params = json.loads(self.body)
+        max_results = params.get("MaxResults")
+        next_token = params.get("NextToken")
+        resource_owner = params.get("ResourceOwner")
+        
+        # Get paginated results and next token from backend
+        cas, next_token = self.acmpca_backend.list_certificate_authorities(
+            max_results=max_results,
+            next_token=next_token,
+            resource_owner=resource_owner,
+        )
+        
+        response = {
+            "CertificateAuthorities": [ca.to_json() for ca in cas]
+        }
+        
+        if next_token:
+            response["NextToken"] = next_token
+            
+        return json.dumps(response)

--- a/moto/acmpca/responses.py
+++ b/moto/acmpca/responses.py
@@ -203,19 +203,17 @@ class ACMPCAResponse(BaseResponse):
         max_results = params.get("MaxResults")
         next_token = params.get("NextToken")
         resource_owner = params.get("ResourceOwner")
-        
+
         # Get paginated results and next token from backend
         cas, next_token = self.acmpca_backend.list_certificate_authorities(
             max_results=max_results,
             next_token=next_token,
             resource_owner=resource_owner,
         )
-        
-        response = {
-            "CertificateAuthorities": [ca.to_json() for ca in cas]
-        }
-        
+
+        response = {"CertificateAuthorities": [ca.to_json() for ca in cas]}
+
         if next_token:
             response["NextToken"] = next_token
-            
+
         return json.dumps(response)

--- a/tests/test_acmpca/test_acmpca.py
+++ b/tests/test_acmpca/test_acmpca.py
@@ -702,7 +702,7 @@ def test_policy_operations():
 @mock_aws
 def test_list_certificate_authorities():
     client = boto3.client("acm-pca", region_name="us-east-1")
-    
+
     # Create first CA
     ca1_arn = client.create_certificate_authority(
         CertificateAuthorityConfiguration={
@@ -713,7 +713,7 @@ def test_list_certificate_authorities():
         CertificateAuthorityType="SUBORDINATE",
         IdempotencyToken="token1",
     )["CertificateAuthorityArn"]
-    
+
     # Create second CA
     ca2_arn = client.create_certificate_authority(
         CertificateAuthorityConfiguration={
@@ -724,20 +724,20 @@ def test_list_certificate_authorities():
         CertificateAuthorityType="ROOT",
         IdempotencyToken="token2",
     )["CertificateAuthorityArn"]
-    
+
     # List all CAs
     response = client.list_certificate_authorities()
-    
+
     # Verify response structure and content
     assert "CertificateAuthorities" in response
     cas = response["CertificateAuthorities"]
     assert len(cas) == 2
-    
+
     # Verify CAs are returned with correct information
     ca_arns = [ca["Arn"] for ca in cas]
     assert ca1_arn in ca_arns
     assert ca2_arn in ca_arns
-    
+
     # Verify CA details
     for ca in cas:
         assert "Arn" in ca
@@ -747,11 +747,17 @@ def test_list_certificate_authorities():
         if ca["Arn"] == ca1_arn:
             assert ca["Type"] == "SUBORDINATE"
             assert ca["Status"] == "PENDING_CERTIFICATE"
-            assert ca["CertificateAuthorityConfiguration"]["Subject"]["CommonName"] == "ca1.test"
+            assert (
+                ca["CertificateAuthorityConfiguration"]["Subject"]["CommonName"]
+                == "ca1.test"
+            )
         else:
             assert ca["Type"] == "ROOT"
             assert ca["Status"] == "PENDING_CERTIFICATE"
-            assert ca["CertificateAuthorityConfiguration"]["Subject"]["CommonName"] == "ca2.test"
+            assert (
+                ca["CertificateAuthorityConfiguration"]["Subject"]["CommonName"]
+                == "ca2.test"
+            )
 
     # Test with MaxResults parameter
     response = client.list_certificate_authorities(MaxResults=1)


### PR DESCRIPTION
This PR implements the [`ListCertificateAuthorities`](https://docs.aws.amazon.com/privateca/latest/APIReference/API_ListCertificateAuthorities.html) API for the ACM-PCA provider.