### PR TITLE
Admin: Improve teardown of SFN tests

### DIFF
--- a/tests/test_stepfunctions/parser/__init__.py
+++ b/tests/test_stepfunctions/parser/__init__.py
@@ -73,20 +73,37 @@ def verify_execution_result(
     for _ in range(30):
         execution = client.describe_execution(executionArn=execution_arn)
         if expected_status is None or execution["status"] == expected_status:
-            result = _verify_result(client, execution, execution_arn)
-            if result is not False:
-                client.delete_state_machine(stateMachineArn=state_machine_arn)
-                iam.delete_role_policy(
-                    RoleName=role_name, PolicyName="allowLambdaInvoke"
-                )
-                iam.delete_role(RoleName=role_name)
-                break
+            try:
+                result = _verify_result(client, execution, execution_arn)
+                if result is not False:
+                    _teardown(client, iam, role_name, state_machine_arn)
+                    break
+            except Exception:
+                _teardown(client, iam, role_name, state_machine_arn)
+                raise
         sleep(10 if allow_aws_request() else 0.1)
     else:
-        client.delete_state_machine(stateMachineArn=state_machine_arn)
-        iam.delete_role_policy(RoleName=role_name, PolicyName="allowLambdaInvoke")
-        iam.delete_role(RoleName=role_name)
+        _teardown(client, iam, role_name, state_machine_arn)
         assert False, "Should have failed already"
+
+
+def _teardown(client, iam, role_name, state_machine_arn):
+    # Stop/Cancel any existing executions, as deletion will only occur after all executions have finished
+    execs = client.list_executions(stateMachineArn=state_machine_arn)["executions"]
+    for exec in execs:
+        if exec["status"] == "RUNNING":
+            try:
+                client.stop_execution(executionArn=exec["executionArn"])
+            except Exception as e:
+                # list_executions sometimes returns an execution as RUNNING,even though it has already failed
+                # Cancelling it again will fail, but we should not stop everything
+                # Just log it for visibility
+                print(f"Unable to stop 'running' execution in {state_machine_arn}")  # noqa
+                print(e)  # noqa
+    # Delete actual resources
+    client.delete_state_machine(stateMachineArn=state_machine_arn)
+    iam.delete_role_policy(RoleName=role_name, PolicyName="allowLambdaInvoke")
+    iam.delete_role(RoleName=role_name)
 
 
 def _start_execution(client, definition, exec_input, sfn_role):

--- a/tests/test_stepfunctions/parser/test_stepfunctions.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions.py
@@ -44,7 +44,9 @@ def test_state_machine_with_simple_failure_state():
         assert len(executions) == 1
         assert executions[0]["executionArn"] == execution_arn
         assert executions[0]["stateMachineArn"] == state_machine_arn
-        assert executions[0]["status"] == "FAILED"
+        # AWS can be a little slow to catch up, and list_executions will still return this as RUNNING
+        # Return False to indicate we should retry this
+        return executions[0]["status"] == "FAILED"
 
     verify_execution_result(_verify_result, "FAILED", "failure")
 


### PR DESCRIPTION
The SFN tests would sometimes fail because of a race condition. More specifically, the `list_executions` would show the status of a particular execution as `RUNNING`, even though `describe_execution` already returns it as `FAILING`.

This is not a problem when mocking, but when running the test against AWS, the 
1) test would fail, **and**
2) all resources would still exist in AWS (StateMachine + IAM role), and I would have to go in manually to delete them

This PR improves the flow a bit so that:
 - If the status is `RUNNING` when it should be `FAILED`, it will retry the operation (30 times in total, 10 secs in between)
 - If an assert still fails after all this, it will delete all resources first, and then rethrow the assertion
 - When deleting resources, we explicitly stop executions before trying to delete the state machine

Note that this is overkill - from what I've seen, the first fix alone should solve the problem. But some belts and braces never hurt anyone.