### PR TITLE
ServiceCatalogAppRegistry - Local CF import

### DIFF
--- a/moto/servicecatalogappregistry/models.py
+++ b/moto/servicecatalogappregistry/models.py
@@ -4,8 +4,6 @@ import datetime
 import re
 from typing import Any, Dict, List
 
-from moto.cloudformation.exceptions import ValidationError
-from moto.cloudformation.models import cloudformation_backends
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
@@ -63,6 +61,9 @@ class AssociatedResource(BaseBackend):
         region_name: str,
     ):
         if resource_type == "CFN_STACK":
+            from moto.cloudformation.exceptions import ValidationError
+            from moto.cloudformation.models import cloudformation_backends
+
             self.resource = resource
             match = re.search(
                 r"^arn:aws:cloudformation:(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d:\d{12}:stack/\w[a-zA-Z0-9\-]{0,127}/[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}$",

--- a/tests/test_servicecatalogappregistry/test_servicecatalogappregistry.py
+++ b/tests/test_servicecatalogappregistry/test_servicecatalogappregistry.py
@@ -50,53 +50,6 @@ def test_associate_resource():
 
 
 @mock_aws
-def test_associate_resource_cloudformation():
-    client = boto3.client("servicecatalog-appregistry", region_name="us-east-1")
-    stack_name = "foo"
-    stack_id = boto3.client("cloudformation", region_name="us-east-1").create_stack(
-        StackName=stack_name,
-        TemplateBody="""
----
-AWSTemplateFormatVersion: '2010-09-09'
-Resources:
-  S3:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: foo
-""",
-    )["StackId"]
-    create = client.create_application(name="testapp", description="blah")
-    resp = client.associate_resource(
-        application=create["application"]["id"],
-        resource=stack_id,
-        resourceType="CFN_STACK",
-        options=["APPLY_APPLICATION_TAG"],
-    )
-
-    assert "applicationArn" in resp
-    assert "resourceArn" in resp
-    assert "options" in resp
-    assert resp["applicationArn"] == create["application"]["arn"]
-
-
-@mock_aws
-def test_associate_resource_cloudformation_validation_error():
-    client = boto3.client("servicecatalog-appregistry", region_name="us-east-1")
-    create = client.create_application(name="testapp", description="blah")
-    stack_name = "foo"
-    with pytest.raises(ClientError) as exc:
-        client.associate_resource(
-            application=create["application"]["id"],
-            resource=stack_name,
-            resourceType="CFN_STACK",
-            options=["APPLY_APPLICATION_TAG"],
-        )
-    err = exc.value.response["Error"]
-    assert err["Code"] == "ResourceNotFoundException"
-    assert err["Message"] == f"No CloudFormation stack called '{stack_name}' found"
-
-
-@mock_aws
 def test_associate_resource_fails_resource_type():
     client = boto3.client("servicecatalog-appregistry", region_name="us-east-1")
     create = client.create_application(name="testapp", description="blah")

--- a/tests/test_servicecatalogappregistry/test_servicecatalogappregistry_cloudformation.py
+++ b/tests/test_servicecatalogappregistry/test_servicecatalogappregistry_cloudformation.py
@@ -1,0 +1,52 @@
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_associate_resource_cloudformation():
+    client = boto3.client("servicecatalog-appregistry", region_name="us-east-1")
+    stack_name = "foo"
+    stack_id = boto3.client("cloudformation", region_name="us-east-1").create_stack(
+        StackName=stack_name,
+        TemplateBody="""
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  S3:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: foo
+""",
+    )["StackId"]
+    create = client.create_application(name="testapp", description="blah")
+    resp = client.associate_resource(
+        application=create["application"]["id"],
+        resource=stack_id,
+        resourceType="CFN_STACK",
+        options=["APPLY_APPLICATION_TAG"],
+    )
+
+    assert "applicationArn" in resp
+    assert "resourceArn" in resp
+    assert "options" in resp
+    assert resp["applicationArn"] == create["application"]["arn"]
+
+
+@mock_aws
+def test_associate_resource_cloudformation_validation_error():
+    client = boto3.client("servicecatalog-appregistry", region_name="us-east-1")
+    create = client.create_application(name="testapp", description="blah")
+    stack_name = "foo"
+    with pytest.raises(ClientError) as exc:
+        client.associate_resource(
+            application=create["application"]["id"],
+            resource=stack_name,
+            resourceType="CFN_STACK",
+            options=["APPLY_APPLICATION_TAG"],
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
+    assert err["Message"] == f"No CloudFormation stack called '{stack_name}' found"


### PR DESCRIPTION
- Move the CF imports to reduce the initial loading time, from 1.6 secs to 0.6 secs. (CloudFormation imports everything, so this is quite an expensive import)
- Move the CF-specific tests to a dedicated file, so this is skipped when verifying the [service-specific dependencies](https://github.com/getmoto/moto/blob/master/.github/workflows/dependency_test.yml)