### PR TITLE
Add tagging for CodeDeploy

### DIFF
--- a/moto/codedeploy/models.py
+++ b/moto/codedeploy/models.py
@@ -199,7 +199,6 @@ class DeploymentInfo(BaseModel):
         self.external_id = ""
         self.related_deployments: Dict[str, Any] = {}
         self.override_alarm_configuration = override_alarm_configuration
-        # Add tags attribute to deployments
         self.tags: List[Dict[str, str]] = []
 
     def to_dict(self) -> Dict[str, Any]:
@@ -444,7 +443,6 @@ class CodeDeployBackend(BaseBackend):
             self.deployment_groups[application_name] = {}
         self.deployment_groups[application_name][dg.deployment_group_name] = dg
 
-        # Tag the deployment group
         if tags:
             dg_arn = f"arn:aws:codedeploy:{self.region_name}:{self.account_id}:deploymentgroup:{application_name}/{deployment_group_name}"
             self.tagger.tag_resource(dg_arn, tags)

--- a/moto/codedeploy/models.py
+++ b/moto/codedeploy/models.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
+from moto.utilities.tagging_service import TaggingService
 
 from .exceptions import (
     ApplicationAlreadyExistsException,
@@ -109,7 +110,7 @@ class DeploymentGroup(BaseModel):
         self.ec2_tag_set = ec2_tag_set or {}
         self.ecs_services = ecs_services or []
         self.on_premises_tag_set = on_premises_tag_set or {}
-        self.tags = tags
+        self.tags = tags or []
         self.termination_hook_enabled = termination_hook_enabled
         self.deployment_group_id = str(uuid.uuid4())
 
@@ -198,6 +199,8 @@ class DeploymentInfo(BaseModel):
         self.external_id = ""
         self.related_deployments: Dict[str, Any] = {}
         self.override_alarm_configuration = override_alarm_configuration
+        # Add tags attribute to deployments
+        self.tags = []
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -242,6 +245,7 @@ class CodeDeployBackend(BaseBackend):
         self.applications: Dict[str, Application] = {}
         self.deployments: Dict[str, DeploymentInfo] = {}
         self.deployment_groups: Dict[str, Dict[str, DeploymentGroup]] = {}
+        self.tagger = TaggingService()
 
     def get_application(self, application_name: str) -> Application:
         if application_name not in self.applications:
@@ -302,6 +306,11 @@ class CodeDeployBackend(BaseBackend):
 
         app = Application(application_name, compute_platform, tags)
         self.applications[app.application_name] = app
+
+        if tags:
+            app_arn = f"arn:aws:codedeploy:{self.region_name}:{self.account_id}:application:{application_name}"
+            self.tagger.tag_resource(app_arn, tags)
+
         return app.id
 
     def create_deployment(
@@ -362,6 +371,14 @@ class CodeDeployBackend(BaseBackend):
         )
 
         self.deployments[deployment.deployment_id] = deployment
+
+        deployment_arn = f"arn:aws:codedeploy:{self.region_name}:{self.account_id}:deployment:{deployment.deployment_id}"
+        if self.deployment_groups[application_name][deployment_group_name].tags:
+            self.tagger.tag_resource(
+                deployment_arn,
+                self.deployment_groups[application_name][deployment_group_name].tags,
+            )
+
         return deployment.deployment_id
 
     # TODO support all optional fields
@@ -427,6 +444,11 @@ class CodeDeployBackend(BaseBackend):
             self.deployment_groups[application_name] = {}
         self.deployment_groups[application_name][dg.deployment_group_name] = dg
 
+        # Tag the deployment group
+        if tags:
+            dg_arn = f"arn:aws:codedeploy:{self.region_name}:{self.account_id}:deploymentgroup:{application_name}/{deployment_group_name}"
+            self.tagger.tag_resource(dg_arn, tags)
+
         return dg.deployment_group_id
 
     # TODO: implement pagination
@@ -491,6 +513,32 @@ class CodeDeployBackend(BaseBackend):
             deployment_group.deployment_group_id
             for deployment_group in self.deployment_groups[application_name].values()
         ]
+
+    def list_tags_for_resource(
+        self, resource_arn: str
+    ) -> Dict[str, List[Dict[str, str]]]:
+        try:
+            return self.tagger.list_tags_for_resource(resource_arn)
+        except Exception:
+            return {"Tags": []}
+
+    def tag_resource(
+        self, resource_arn: str, tags: List[Dict[str, str]]
+    ) -> Dict[str, Any]:
+        try:
+            self.tagger.tag_resource(resource_arn, tags)
+        except Exception:
+            pass
+
+        return {}
+
+    def untag_resource(self, resource_arn: str, tag_keys: List[str]) -> Dict[str, Any]:
+        try:
+            self.tagger.untag_resource_using_names(resource_arn, tag_keys)
+        except Exception:
+            pass
+
+        return {}
 
 
 codedeploy_backends = BackendDict(CodeDeployBackend, "codedeploy")

--- a/moto/codedeploy/models.py
+++ b/moto/codedeploy/models.py
@@ -200,7 +200,7 @@ class DeploymentInfo(BaseModel):
         self.related_deployments: Dict[str, Any] = {}
         self.override_alarm_configuration = override_alarm_configuration
         # Add tags attribute to deployments
-        self.tags = []
+        self.tags: List[Dict[str, str]] = []
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/moto/codedeploy/responses.py
+++ b/moto/codedeploy/responses.py
@@ -185,3 +185,23 @@ class CodeDeployResponse(BaseResponse):
                 nextToken=next_token,
             )
         )
+
+    def list_tags_for_resource(self) -> str:
+        """Handler for list_tags_for_resource API call."""
+        resource_arn = self._get_param("ResourceArn")
+        tags_response = self.codedeploy_backend.list_tags_for_resource(resource_arn)
+        return json.dumps(tags_response)
+
+    def tag_resource(self) -> str:
+        """Handler for tag_resource API call."""
+        resource_arn = self._get_param("ResourceArn")
+        tags = self._get_param("Tags")
+        response = self.codedeploy_backend.tag_resource(resource_arn, tags)
+        return json.dumps(response)
+
+    def untag_resource(self) -> str:
+        """Handler for untag_resource API call."""
+        resource_arn = self._get_param("ResourceArn")
+        tag_keys = self._get_param("TagKeys")
+        response = self.codedeploy_backend.untag_resource(resource_arn, tag_keys)
+        return json.dumps(response)

--- a/moto/codedeploy/urls.py
+++ b/moto/codedeploy/urls.py
@@ -8,4 +8,7 @@ url_bases = [
 
 url_paths = {
     "{0}/$": CodeDeployResponse.dispatch,
+    "{0}/list-tags-for-resource$": CodeDeployResponse.list_tags_for_resource,
+    "{0}/tag-resource$": CodeDeployResponse.tag_resource,
+    "{0}/untag-resource$": CodeDeployResponse.untag_resource,
 }

--- a/tests/test_codedeploy/test_codedeploy.py
+++ b/tests/test_codedeploy/test_codedeploy.py
@@ -553,3 +553,91 @@ def test_list_deployment_groups():
 
     resp = client.list_deployment_groups(applicationName=application_name)
     assert len(resp["deploymentGroups"]) == 2
+
+
+@mock_aws
+def test_application_tagging():
+    client = boto3.client("codedeploy", region_name="us-west-2")
+    app_name = "test-tag-application"
+    initial_tags = [{"Key": "Environment", "Value": "Test"}]
+
+    response = client.create_application(
+        applicationName=app_name, computePlatform="Server", tags=initial_tags
+    )
+
+    app_arn = f"arn:aws:codedeploy:us-west-2:123456789012:application:{app_name}"
+
+    response = client.list_tags_for_resource(ResourceArn=app_arn)
+    assert "Tags" in response
+    assert len(response["Tags"]) == 1
+    assert response["Tags"][0]["Key"] == "Environment"
+    assert response["Tags"][0]["Value"] == "Test"
+
+
+@mock_aws
+def test_deployment_group_tagging():
+    client = boto3.client("codedeploy", region_name="us-west-2")
+    app_name = "test-tag-dg-app"
+    dg_name = "test-tag-deployment-group"
+    service_role_arn = "arn:aws:iam::123456789012:role/CodeDeployDemoRole"
+
+    client.create_application(applicationName=app_name, computePlatform="Server")
+
+    initial_tags = [{"Key": "Team", "Value": "Platform"}]
+    response = client.create_deployment_group(
+        applicationName=app_name,
+        deploymentGroupName=dg_name,
+        serviceRoleArn=service_role_arn,
+        tags=initial_tags,
+    )
+
+    dg_arn = f"arn:aws:codedeploy:us-west-2:123456789012:deploymentgroup:{app_name}/{dg_name}"
+
+    response = client.list_tags_for_resource(ResourceArn=dg_arn)
+    assert "Tags" in response
+    assert len(response["Tags"]) == 1
+    assert response["Tags"][0]["Key"] == "Team"
+    assert response["Tags"][0]["Value"] == "Platform"
+
+
+@mock_aws
+def test_deployment_inherits_tags():
+    """Test that deployments inherit tags from deployment groups."""
+    client = boto3.client("codedeploy", region_name="us-west-2")
+    app_name = "test-tag-inherit-app"
+    dg_name = "test-tag-inherit-group"
+    service_role_arn = "arn:aws:iam::123456789012:role/CodeDeployDemoRole"
+
+    client.create_application(applicationName=app_name, computePlatform="Server")
+
+    dg_tags = [{"Key": "Environment", "Value": "Production"}]
+    client.create_deployment_group(
+        applicationName=app_name,
+        deploymentGroupName=dg_name,
+        serviceRoleArn=service_role_arn,
+        tags=dg_tags,
+    )
+
+    response = client.create_deployment(
+        applicationName=app_name,
+        deploymentGroupName=dg_name,
+        revision={
+            "revisionType": "S3",
+            "s3Location": {
+                "bucket": "my-bucket",
+                "key": "my-key",
+                "bundleType": "zip",
+                "version": "1",
+                "eTag": "my-etag",
+            },
+        },
+    )
+    deployment_id = response["deploymentId"]
+
+    deployment_arn = (
+        f"arn:aws:codedeploy:us-west-2:123456789012:deployment:{deployment_id}"
+    )
+
+    response = client.list_tags_for_resource(ResourceArn=deployment_arn)
+    assert "Tags" in response
+    assert len(response["Tags"]) == 1


### PR DESCRIPTION
This PR implements tagging functionality for AWS CodeDeploy resources. It adds support for:

Creating applications and deployment groups with tags
Automatic tag inheritance from deployment groups to deployments
The list_tags_for_resource, tag_resource, and untag_resource API operations