### PR TITLE
IOTData: update_thing_shadow() should keep empty dicts

### DIFF
--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -331,19 +331,17 @@ def merge_dicts(
     :param dict dict1: the dictionary to be updated.
     :param dict dict2: a dictionary of keys/values to be merged into dict1.
 
-    :param bool remove_nulls: If true, updated values equal to None or an empty dictionary
+    :param bool remove_nulls: If true, updated values equal to None
         will be removed from dict1.
     """
     for key in dict2:
         if isinstance(dict2[key], dict):
-            if key in dict1 and key in dict2:
+            if key in dict1 and isinstance(dict1[key], dict):
                 merge_dicts(dict1[key], dict2[key], remove_nulls)
             else:
                 dict1[key] = dict2[key]
                 if isinstance(dict1[key], dict):
                     remove_null_from_dict(dict1)
-            if dict1[key] == {} and remove_nulls:
-                dict1.pop(key)
         else:
             dict1[key] = dict2[key]
             if dict1[key] is None and remove_nulls:

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -60,13 +60,22 @@ class FakeShadow(BaseModel):
             shadow = FakeShadow(None, None, None, version, deleted=True)
             return shadow
 
+        desired_payload = payload.get("state", {}).get("desired")
+        reported_payload = payload.get("state", {}).get("reported")
+
+        state_document = previous_payload.copy()
+
+        desired = state_document.get("state", {}).get("desired", {})
+        reported = state_document.get("state", {}).get("reported", {})
+
         # Updates affect only the fields specified in the request state document.
         # Any field with a value of None is removed from the device's shadow.
-        state_document = previous_payload.copy()
-        merge_dicts(state_document, payload, remove_nulls=True)
-        desired = state_document.get("state", {}).get("desired")
-        reported = state_document.get("state", {}).get("reported")
-        return FakeShadow(desired, reported, payload, version)
+        if desired_payload:
+            merge_dicts(desired, desired_payload, remove_nulls=True)
+        if reported_payload:
+            merge_dicts(reported, reported_payload, remove_nulls=True)
+
+        return FakeShadow(desired or None, reported or None, payload, version)
 
     @classmethod
     def parse_payload(cls, desired: Any, reported: Any) -> Any:  # type: ignore[misc]


### PR DESCRIPTION
## Motivation

Improves the parity between how `update_thing_shadow()` behaves when sending empty dictionaries. The existing implementation had two problems.

### State treated the same as Attributes

First: when a user calls `update_thing_shadow` with an empty desired or reported state, we should ignore this empty dict.
```json
{
    "state": {
        "reported": {}
    }
}
```

However, if an attribute within the state is empty, we should keep it:
```json
{
    "state": {
        "reported": {
            "attr": {}
        }
    }
}
```

Our implementation treated the two cases the same, and always removed empty dictionaries. With this change, we make it explicit that empty reported/desired states are effectively ignored

### Type changes

The second problem is that we always assumed that types would not change - that is, if a new value for attribute `a` is a dictionary, it was assumed that the original value for `a` was also a dictionary.
This is not the case - a user could update `'a': 3` to `'a': {}`.

#### API change
The `merge_dicts`-method now no longer removes empty dictionaries from the input if `remove_nulls=True`.
This makes sense IMO, as the naming is very specific. It also should not matter, as this method is not used anywhere else (despite being part of `moto.core`)