### PR TITLE
Workspaces Tests: Deprecate EnableWorkDocs-param

### DIFF
--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -937,9 +937,7 @@ def test_get_resources_workspaces():
 
     # Create two tagged Workspaces
     directory_id = create_directory()
-    workspaces.register_workspace_directory(
-        DirectoryId=directory_id, EnableWorkDocs=False
-    )
+    workspaces.register_workspace_directory(DirectoryId=directory_id)
     workspaces.create_workspaces(
         Workspaces=[
             {
@@ -986,10 +984,7 @@ def test_get_resources_workspace_directories():
         directory_id = create_directory()
         workspaces.register_workspace_directory(
             DirectoryId=directory_id,
-            EnableWorkDocs=False,
-            Tags=[
-                {"Key": "Test", "Value": i_str},
-            ],
+            Tags=[{"Key": "Test", "Value": i_str}],
         )
 
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
@@ -1013,9 +1008,7 @@ def test_get_resources_workspace_images():
 
     # Create two tagged Workspace Images
     directory_id = create_directory()
-    workspaces.register_workspace_directory(
-        DirectoryId=directory_id, EnableWorkDocs=False
-    )
+    workspaces.register_workspace_directory(DirectoryId=directory_id)
     resp = workspaces.create_workspaces(
         Workspaces=[
             {


### PR DESCRIPTION
The WorkDocs service is [deprecated as of April 25th 2025](https://www.reddit.com/r/aws/comments/1cd1iqb/workdocsamazon_has_decided_to_end_support_for_the/), and `botocore` has removed support for the `EnableWorkDocs`-parameter in [version 1.38.13](https://github.com/boto/botocore/commit/d996fb2fac60d7413e10272ebad14ea55b344694).

This PR:
 - Removes all references to `EnableWorkDocs` in the regular `Workspaces` tests
 - Adds a new test for older botocore versions to verify that this still behaves correctly in Moto 
 - Removes the `test_register_workspace_directory_with_subnets`, as it was equivalent to `test_register_workspace_directory`.