### PR TITLE
Tests: Add SageMakerClient test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,10 @@ jobs:
     needs: lint
     uses: ./.github/workflows/tests_sdk_cpp.yml
 
+  sagemaker_client_test:
+    needs: lint
+    uses: ./.github/workflows/tests_sdk_sagemaker.yml
+
   javatest:
     needs: lint
     uses: ./.github/workflows/tests_sdk_java.yml

--- a/.github/workflows/tests_sdk_sagemaker.yml
+++ b/.github/workflows/tests_sdk_sagemaker.yml
@@ -1,0 +1,32 @@
+name: SageMaker SDK test
+on: [workflow_call]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install Moto
+      run: |
+        pip install .[sagemaker]
+    - name: Install dependencies
+      run: |
+        pip install boto3 pytest sagemaker
+        # https://github.com/aws/sagemaker-python-sdk/issues/5116
+        pip install graphene
+    - name: Run tests
+      run: |
+        mkdir ~/.aws
+        touch ~/.aws/credentials
+        echo -e "[default]\naws_access_key_id = test\naws_secret_access_key = test" > ~/.aws/credentials
+        touch ~/.aws/config
+        echo -e "[default]\nregion = us-east-1" > ~/.aws/config
+        cd other_langs/tests_sagemaker_client
+        pytest -sv .

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1613,10 +1613,9 @@ class User(CloudFormationModel):
     ) -> "User":
         properties = cloudformation_json.get("Properties", {})
         path = properties.get("Path")
-        user, _ = iam_backends[account_id][get_partition(region_name)].create_user(
+        return iam_backends[account_id][get_partition(region_name)].create_user(
             region_name=region_name, user_name=resource_name, path=path
         )
-        return user
 
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
@@ -2676,7 +2675,7 @@ class IAMBackend(BaseBackend):
         user_name: str,
         path: str = "/",
         tags: Optional[List[Dict[str, str]]] = None,
-    ) -> Tuple[User, Dict[str, List[Dict[str, str]]]]:
+    ) -> User:
         if user_name in self.users:
             raise IAMConflictException(
                 "EntityAlreadyExists", f"User {user_name} already exists"
@@ -2685,7 +2684,7 @@ class IAMBackend(BaseBackend):
         user = User(self.account_id, region_name, user_name, path)
         self.tagger.tag_resource(user.arn, tags or [])
         self.users[user_name] = user
-        return user, self.tagger.list_tags_for_resource(user.arn)
+        return user
 
     def get_user(self, name: str) -> User:
         user = self.users.get(name)

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -540,11 +540,11 @@ class IamResponse(BaseResponse):
         user_name = self._get_param("UserName")
         path = self._get_param("Path")
         tags = self._get_multi_param("Tags.member")
-        user, user_tags = self.backend.create_user(
+        user = self.backend.create_user(
             self.region, user_name=user_name, path=path, tags=tags
         )
         template = self.response_template(USER_TEMPLATE)
-        return template.render(action="Create", user=user, tags=user_tags["Tags"])
+        return template.render(action="Create", user=user, tags=tags)
 
     def get_user(self) -> str:
         user_name = self._get_param("UserName")

--- a/other_langs/tests_sagemaker_client/custom_script.py
+++ b/other_langs/tests_sagemaker_client/custom_script.py
@@ -1,0 +1,22 @@
+import argparse
+import os
+import json
+
+if __name__ =='__main__':
+
+    parser = argparse.ArgumentParser()
+
+    # hyperparameters sent by the client are passed as command-line arguments to the script.
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--batch-size', type=int, default=100)
+    parser.add_argument('--learning-rate', type=float, default=0.1)
+
+    # an alternative way to load hyperparameters via SM_HPS environment variable.
+    parser.add_argument('--sm-hps', type=json.loads, default=os.environ['SM_HPS'])
+
+    # input data and model directories
+    parser.add_argument('--model-dir', type=str, default=os.environ['SM_MODEL_DIR'])
+    parser.add_argument('--train', type=str, default=os.environ['SM_CHANNEL_TRAIN'])
+    parser.add_argument('--test', type=str, default=os.environ['SM_CHANNEL_TEST'])
+
+    args, _ = parser.parse_known_args()

--- a/other_langs/tests_sagemaker_client/test_model_training.py
+++ b/other_langs/tests_sagemaker_client/test_model_training.py
@@ -1,0 +1,43 @@
+from moto import mock_aws
+from sagemaker.modules.train import ModelTrainer
+from sagemaker.modules.configs import SourceCode, InputData
+
+
+@mock_aws
+def test_model_trainer():
+
+    # https://sagemaker.readthedocs.io/en/stable/overview.html#using-modeltrainer
+
+    # Image URI for the training job
+    pytorch_image = "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.0.0-cpu-py310"
+
+    # Define the script to be run
+    source_code = SourceCode(
+        source_dir=".",
+        entry_script="custom_script.py",
+    )
+
+    # Define the ModelTrainer
+    model_trainer = ModelTrainer(
+        # SageMaker always calls `get_caller_identity`
+        # If no role is provided, it will also call `get_role` on the output of `get_caller_identity`
+        # That fails against Moto, because Moto's `get_caller_identity` returns a User, instead of a Role
+        # If we pass a custom role, SageMaker does not explicitly call `get_role`, and therefore does not fail
+        #
+        # TODO
+        # AFAIK, AWS also returns a User when calling `get_caller_identity`
+        # We should investigate why SageMaker behaves like this/what SageMaker expects to happen
+        role=f"arn:aws:sts::000000000000:user/moto",
+        training_image=pytorch_image,
+        source_code=source_code,
+        base_job_name="script-mode",
+    )
+
+    # Pass the input data
+    input_data = InputData(
+        channel_name="train",
+        data_source="s3://some/path",  # S3 path where training data is stored
+    )
+
+    # Start the training job
+    model_trainer.train(input_data_config=[input_data], wait=True)

--- a/other_langs/tests_sagemaker_client/test_pipeline_session.py
+++ b/other_langs/tests_sagemaker_client/test_pipeline_session.py
@@ -1,0 +1,5 @@
+def test_pipeline_session():
+    # TODO:
+    # https://github.com/aws/sagemaker-python-sdk/blob/master/doc/amazon_sagemaker_model_building_pipeline.rst
+    # Need to copy the test here to verify when/if https://github.com/getmoto/moto/issues/7037 is implemented
+    pass


### PR DESCRIPTION
We have an [outstanding feature request](https://github.com/getmoto/moto/issues/7037) to add support for SageMaker PipelineSessions, which is a feature specific to the [Sagemaker client](https://sagemaker.readthedocs.io/en/stable/overview.html).

This PR adds some initial tests for this library to verify that Moto can interact with it.

There is also a minor improvement to `IAM:create_role`, where we don't need to return the tags. Unrelated, just something I noticed while debugging.