### PR TITLE
Update Ruff to 0.11.9 - Drop Pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ lint:
 	@echo "Running ruff..."
 	ruff check moto tests
 	ruff format --check moto tests
-	@echo "Running pylint..."
-	pylint -j 0 moto tests
 	@echo "Running MyPy..."
 	mypy --install-types --non-interactive
 

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -805,7 +805,7 @@ class ApiKey(BaseModel):
         name: Optional[str] = None,
         description: Optional[str] = None,
         enabled: bool = False,
-        generateDistinctId: bool = False,  # pylint: disable=unused-argument
+        generateDistinctId: bool = False,
         value: Optional[str] = None,
         stageKeys: Optional[Any] = None,
         tags: Optional[List[Dict[str, str]]] = None,

--- a/moto/applicationautoscaling/responses.py
+++ b/moto/applicationautoscaling/responses.py
@@ -131,7 +131,7 @@ class ApplicationAutoScalingResponse(BaseResponse):
             message = f"1 validation error detected: {messages[0]}"
         elif len(messages) > 1:
             message = (
-                f'{len(messages)} validation errors detected: {"; ".join(messages)}'
+                f"{len(messages)} validation errors detected: {'; '.join(messages)}"
             )
         if message:
             raise AWSValidationException(message)

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -983,7 +983,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             env_vars["MOTO_HOST"] = settings.moto_server_host()
             moto_port = settings.moto_server_port()
             env_vars["MOTO_PORT"] = moto_port
-            env_vars["MOTO_HTTP_ENDPOINT"] = f'{env_vars["MOTO_HOST"]}:{moto_port}'
+            env_vars["MOTO_HTTP_ENDPOINT"] = f"{env_vars['MOTO_HOST']}:{moto_port}"
 
             if settings.is_test_proxy_mode():
                 env_vars["HTTPS_PROXY"] = env_vars["MOTO_HTTP_ENDPOINT"]
@@ -992,9 +992,10 @@ class LambdaFunction(CloudFormationModel, DockerModel):
             container = exit_code = None
             log_config = docker.types.LogConfig(type=docker.types.LogConfig.types.JSON)
 
-            with _DockerDataVolumeContext(
-                self
-            ) as data_vol, _DockerDataVolumeLayerContext(self) as layer_context:
+            with (
+                _DockerDataVolumeContext(self) as data_vol,
+                _DockerDataVolumeLayerContext(self) as layer_context,
+            ):
                 try:
                     run_kwargs: Dict[str, Any] = dict()
                     network_name = settings.moto_network_name()

--- a/moto/awslambda_simple/models.py
+++ b/moto/awslambda_simple/models.py
@@ -14,7 +14,6 @@ class LambdaSimpleBackend(LambdaBackend):
         super().__init__(region_name, account_id)
         self.lambda_simple_results_queue: List[str] = []
 
-    # pylint: disable=unused-argument
     def invoke(
         self,
         function_name: str,

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -796,7 +796,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
                 environment["MOTO_HOST"] = settings.moto_server_host()
                 environment["MOTO_PORT"] = settings.moto_server_port()
                 environment["MOTO_HTTP_ENDPOINT"] = (
-                    f'{environment["MOTO_HOST"]}:{environment["MOTO_PORT"]}'
+                    f"{environment['MOTO_HOST']}:{environment['MOTO_PORT']}"
                 )
 
                 if network_name:

--- a/moto/cloudformation/custom_model.py
+++ b/moto/cloudformation/custom_model.py
@@ -93,7 +93,7 @@ class CustomModel(CloudFormationModel):
         return custom_resource
 
     @classmethod
-    def has_cfn_attr(cls, attr: str) -> bool:  # pylint: disable=unused-argument
+    def has_cfn_attr(cls, attr: str) -> bool:
         # We don't know which attributes are supported for third-party resources
         return True
 

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import yaml
-from yaml.parser import ParserError  # pylint:disable=c-extension-no-member
-from yaml.scanner import ScannerError  # pylint:disable=c-extension-no-member
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -557,7 +557,7 @@ class FakeStack(CloudFormationModel):
         return "AWS::CloudFormation::Stack"
 
     @classmethod
-    def has_cfn_attr(cls, attr: str) -> bool:  # pylint: disable=unused-argument
+    def has_cfn_attr(cls, attr: str) -> bool:
         return True
 
     @property

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -28,40 +28,40 @@ from typing import (
 # the subclass's module hasn't been imported yet - then that subclass
 # doesn't exist yet, and __subclasses__ won't find it.
 # So we import here to populate the list of subclasses.
-from moto.apigateway import models as apigw_models  # noqa  # pylint: disable=all
-from moto.autoscaling import models as as_models  # noqa  # pylint: disable=all
-from moto.awslambda import models as lambda_models  # noqa  # pylint: disable=all
-from moto.batch import models as batch_models  # noqa  # pylint: disable=all
+from moto.apigateway import models as apigw_models  # noqa
+from moto.autoscaling import models as as_models  # noqa
+from moto.awslambda import models as lambda_models  # noqa
+from moto.batch import models as batch_models  # noqa
 from moto.cloudformation.custom_model import CustomModel
-from moto.cloudwatch import models as cw_models  # noqa  # pylint: disable=all
+from moto.cloudwatch import models as cw_models  # noqa
 from moto.core.common_models import CloudFormationModel
-from moto.datapipeline import models as data_models  # noqa  # pylint: disable=all
-from moto.dynamodb import models as ddb_models  # noqa  # pylint: disable=all
+from moto.datapipeline import models as data_models  # noqa
+from moto.dynamodb import models as ddb_models  # noqa
 from moto.ec2 import models as ec2_models
 from moto.ec2.models.core import TaggedEC2Resource
-from moto.ecr import models as ecr_models  # noqa  # pylint: disable=all
-from moto.ecs import models as ecs_models  # noqa  # pylint: disable=all
-from moto.efs import models as efs_models  # noqa  # pylint: disable=all
-from moto.elb import models as elb_models  # noqa  # pylint: disable=all
-from moto.elbv2 import models as elbv2_models  # noqa  # pylint: disable=all
-from moto.emr import models as emr_models  # noqa  # pylint: disable=all
-from moto.events import models as events_models  # noqa  # pylint: disable=all
-from moto.iam import models as iam_models  # noqa  # pylint: disable=all
-from moto.iot import models as iot_models  # noqa  # pylint: disable=all
-from moto.kinesis import models as kinesis_models  # noqa  # pylint: disable=all
-from moto.kms import models as kms_models  # noqa  # pylint: disable=all
-from moto.rds import models as rds_models  # noqa  # pylint: disable=all
-from moto.redshift import models as redshift_models  # noqa  # pylint: disable=all
-from moto.route53 import models as route53_models  # noqa  # pylint: disable=all
-from moto.s3 import models as s3_models  # noqa  # pylint: disable=all
+from moto.ecr import models as ecr_models  # noqa
+from moto.ecs import models as ecs_models  # noqa
+from moto.efs import models as efs_models  # noqa
+from moto.elb import models as elb_models  # noqa
+from moto.elbv2 import models as elbv2_models  # noqa
+from moto.emr import models as emr_models  # noqa
+from moto.events import models as events_models  # noqa
+from moto.iam import models as iam_models  # noqa
+from moto.iot import models as iot_models  # noqa
+from moto.kinesis import models as kinesis_models  # noqa
+from moto.kms import models as kms_models  # noqa
+from moto.rds import models as rds_models  # noqa
+from moto.redshift import models as redshift_models  # noqa
+from moto.route53 import models as route53_models  # noqa
+from moto.s3 import models as s3_models  # noqa
 from moto.s3.models import s3_backends
 from moto.s3.utils import bucket_and_name_from_url
-from moto.sagemaker import models as sagemaker_models  # noqa  # pylint: disable=all
-from moto.sns import models as sns_models  # noqa  # pylint: disable=all
-from moto.sqs import models as sqs_models  # noqa  # pylint: disable=all
-from moto.ssm import models as ssm_models  # noqa  # pylint: disable=all
+from moto.sagemaker import models as sagemaker_models  # noqa
+from moto.sns import models as sns_models  # noqa
+from moto.sqs import models as sqs_models  # noqa
+from moto.ssm import models as ssm_models  # noqa
 from moto.ssm import ssm_backends
-from moto.stepfunctions import models as sfn_models  # noqa  # pylint: disable=all
+from moto.stepfunctions import models as sfn_models  # noqa
 from moto.utilities.utils import get_partition
 
 # End ugly list of imports

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -3,8 +3,8 @@ import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
-from yaml.parser import ParserError  # pylint:disable=c-extension-no-member
-from yaml.scanner import ScannerError  # pylint:disable=c-extension-no-member
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
 
 from moto.core.responses import BaseResponse
 from moto.s3.exceptions import S3ClientError
@@ -47,7 +47,7 @@ class CloudFormationResponse(BaseResponse):
         return cloudformation_backends[self.current_account][self.region]
 
     @classmethod
-    def cfnresponse(cls, *args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]  # pylint: disable=unused-argument
+    def cfnresponse(cls, *args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
         request, full_url, headers = args
         full_url += "&Action=ProcessCfnResponse"
         return cls.dispatch(request=request, full_url=full_url, headers=headers)

--- a/moto/cloudformation/utils.py
+++ b/moto/cloudformation/utils.py
@@ -46,7 +46,7 @@ def yaml_tag_constructor(loader: Any, tag: Any, node: Any) -> Any:
             if isinstance(node.value, list):
                 return node.value
             return node.value.split(".")
-        elif type(node) == yaml.SequenceNode:
+        elif type(node) is yaml.SequenceNode:
             return loader.construct_sequence(node)
         else:
             return node.value

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -576,7 +576,7 @@ class CloudWatchBackend(BaseBackend):
         for metric_member in metric_data:
             # Preserve "datetime" for get_metric_statistics comparisons
             timestamp = metric_member.get("Timestamp")
-            if timestamp is not None and type(timestamp) != datetime:
+            if timestamp is not None and type(timestamp) is not datetime:
                 timestamp = parser.parse(timestamp)
             metric_name = metric_member["MetricName"]
             dimension = metric_member.get("Dimensions.member", _EMPTY_LIST)
@@ -590,7 +590,7 @@ class CloudWatchBackend(BaseBackend):
                 for i in range(0, len(values)):
                     value = values[i]
                     timestamp = metric_member.get("Timestamp")
-                    if timestamp is not None and type(timestamp) != datetime:
+                    if timestamp is not None and type(timestamp) is not datetime:
                         timestamp = parser.parse(timestamp)
 
                     # add the value count[i] times

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -740,7 +740,7 @@ class ConfigRule(ConfigEmptyDictable):
                 "ConfigRule Arn or Id"
             )
 
-        self.maximum_execution_frequency = None  # keeps pylint happy
+        self.maximum_execution_frequency = None
         self.modify_fields(region, config_rule, tags)
         self.config_rule_id = f"config-rule-{random_string():.6}"
         self.config_rule_arn = f"arn:{get_partition(region)}:config:{region}:{account_id}:config-rule/{self.config_rule_id}"
@@ -782,7 +782,7 @@ class ConfigRule(ConfigEmptyDictable):
                 # are actually needed.
                 self.input_parameters_dict = json.loads(self.input_parameters)
             except ValueError:
-                raise InvalidParameterValueException(  # pylint: disable=raise-missing-from
+                raise InvalidParameterValueException(
                     f"Invalid json {self.input_parameters} passed in the "
                     f"InputParameters field"
                 )

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -128,7 +128,7 @@ class BaseBackend:
     @staticmethod
     def default_vpc_endpoint_service(
         service_region: str,
-        zones: List[str],  # pylint: disable=unused-argument
+        zones: List[str],
     ) -> List[Dict[str, str]]:
         """Invoke the factory method for any VPC endpoint(s) services."""
         return []
@@ -150,7 +150,7 @@ class BaseBackend:
         special_service_name: str = "",
         policy_supported: bool = True,
         base_endpoint_dns_names: Optional[List[str]] = None,
-    ) -> List[Dict[str, Any]]:  # pylint: disable=too-many-arguments
+    ) -> List[Dict[str, Any]]:
         """List of dicts representing default VPC endpoints for this service."""
         if special_service_name:
             service_name = f"com.amazonaws.{service_region}.{special_service_name}"

--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -18,7 +18,7 @@ class MockRawResponse(BytesIO):
             response_input = response_input.encode("utf-8")
         super().__init__(response_input)
 
-    def stream(self, **kwargs: Any) -> Any:  # pylint: disable=unused-argument
+    def stream(self, **kwargs: Any) -> Any:
         contents = self.read()
         while contents:
             yield contents

--- a/moto/core/common_models.py
+++ b/moto/core/common_models.py
@@ -8,7 +8,7 @@ class BaseModel(metaclass=InstanceTrackerMeta):
     def __new__(
         cls,
         *args: Any,
-        **kwargs: Any,  # pylint: disable=unused-argument
+        **kwargs: Any,
     ) -> "BaseModel":
         instance = super(BaseModel, cls).__new__(cls)
         cls.instances.append(instance)  # type: ignore[attr-defined]
@@ -35,7 +35,7 @@ class CloudFormationModel(BaseModel):
 
     @classmethod
     @abstractmethod
-    def has_cfn_attr(cls, attr: str) -> bool:  # pylint: disable=unused-argument
+    def has_cfn_attr(cls, attr: str) -> bool:
         # Used for validation
         # If a template creates an Output for an attribute that does not exist, an error should be thrown
         return True

--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -106,9 +106,7 @@ class CallbackResponse(responses.CallbackResponse):
             return False
 
 
-def not_implemented_callback(
-    request: Any,  # pylint: disable=unused-argument
-) -> TYPE_RESPONSE:
+def not_implemented_callback(request: Any) -> TYPE_RESPONSE:
     status = 400
     headers: Dict[str, str] = {}
     response = "The method is not implemented"

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -121,11 +121,7 @@ class RESTError(HTTPException):
             )
             self.content_type = APP_XML
 
-    def get_headers(
-        self,
-        *args: Any,
-        **kwargs: Any,  # pylint: disable=unused-argument
-    ) -> List[Tuple[str, str]]:
+    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
         return [
             ("X-Amzn-ErrorType", self.relative_error_type or "UnknownError"),
             ("Content-Type", self.content_type),
@@ -135,11 +131,7 @@ class RESTError(HTTPException):
     def relative_error_type(self) -> str:
         return self.error_type
 
-    def get_body(
-        self,
-        *args: Any,
-        **kwargs: Any,  # pylint: disable=unused-argument
-    ) -> str:
+    def get_body(self, *args: Any, **kwargs: Any) -> str:
         return self.description
 
     def to_json(self) -> "JsonRESTError":

--- a/moto/core/responses_custom_registry.py
+++ b/moto/core/responses_custom_registry.py
@@ -92,7 +92,7 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
             #  - Callbacks created by APIGateway to intercept URL requests to *.execute-api.amazonaws.com
             #
             for match in implemented_matches:
-                if type(match) == responses.CallbackResponse:
+                if type(match) is responses.CallbackResponse:
                     return match, match_failed_reasons
             # Return moto.core.custom_responses_mock.CallbackResponse otherwise
             return implemented_matches[0], match_failed_reasons

--- a/moto/databrew/responses.py
+++ b/moto/databrew/responses.py
@@ -57,7 +57,6 @@ class DataBrewResponse(BaseResponse):
             "RecipeVersion", self._get_param("recipeVersion")
         )
 
-        # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
         recipe_list, next_token = self.databrew_backend.list_recipes(
             next_token=next_token,
             max_results=max_results,
@@ -78,7 +77,6 @@ class DataBrewResponse(BaseResponse):
             "MaxResults", self._get_int_param("maxResults")
         )
 
-        # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
         recipe_list, next_token = self.databrew_backend.list_recipe_versions(
             recipe_name=recipe_name, next_token=next_token, max_results=max_results
         )
@@ -170,7 +168,6 @@ class DataBrewResponse(BaseResponse):
             "MaxResults", self._get_int_param("maxResults")
         )
 
-        # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
         ruleset_list, next_token = self.databrew_backend.list_rulesets(
             next_token=next_token, max_results=max_results
         )
@@ -210,7 +207,6 @@ class DataBrewResponse(BaseResponse):
             "MaxResults", self._get_int_param("maxResults")
         )
 
-        # pylint: disable=unexpected-keyword-arg, unbalanced-tuple-unpacking
         dataset_list, next_token = self.databrew_backend.list_datasets(
             next_token=next_token, max_results=max_results
         )

--- a/moto/dax/models.py
+++ b/moto/dax/models.py
@@ -30,7 +30,7 @@ class DaxParameterGroup(BaseModel):
 
 class DaxNode:
     def __init__(self, endpoint: "DaxEndpoint", name: str, index: int):
-        self.node_id = f"{name}-{chr(ord('a')+index)}"  # name-a, name-b, etc
+        self.node_id = f"{name}-{chr(ord('a') + index)}"  # name-a, name-b, etc
         self.node_endpoint = {
             "Address": f"{self.node_id}.{endpoint.cluster_hex}.nodes.dax-clusters.{endpoint.region}.amazonaws.com",
             "Port": endpoint.port,

--- a/moto/directconnect/models.py
+++ b/moto/directconnect/models.py
@@ -343,7 +343,7 @@ class DirectConnectBackend(BaseBackend):
             connection = self.create_connection(
                 location=location,
                 bandwidth=connections_bandwidth,
-                connection_name=f"Requested Connection {i+1} for Lag {lag.lag_id}",
+                connection_name=f"Requested Connection {i + 1} for Lag {lag.lag_id}",
                 lag_id=lag.lag_id,
                 tags=child_connection_tags,
                 request_mac_sec=False,

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -94,7 +94,7 @@ class Trust(BaseModel):
         }
 
 
-class Directory(BaseModel):  # pylint: disable=too-many-instance-attributes
+class Directory(BaseModel):
     """Representation of a Simple AD Directory.
 
     When the "create" API for a Simple AD or a Microsoft AD directory is
@@ -131,7 +131,7 @@ class Directory(BaseModel):  # pylint: disable=too-many-instance-attributes
         short_name: Optional[str] = None,
         description: Optional[str] = None,
         edition: Optional[str] = None,
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.account_id = account_id
         self.region = region
         self.name = name
@@ -340,7 +340,7 @@ class DirectoryServiceBackend(BaseBackend):
         size: str,
         connect_settings: Dict[str, Any],
         tags: List[Dict[str, str]],
-    ) -> str:  # pylint: disable=too-many-arguments
+    ) -> str:
         """Create a fake AD Connector."""
         if len(self.directories) > Directory.CONNECTED_DIRECTORIES_LIMIT:
             raise DirectoryLimitExceededException(
@@ -400,7 +400,7 @@ class DirectoryServiceBackend(BaseBackend):
         size: str,
         vpc_settings: Dict[str, Any],
         tags: List[Dict[str, str]],
-    ) -> str:  # pylint: disable=too-many-arguments
+    ) -> str:
         """Create a fake Simple Ad Directory."""
         if len(self.directories) > Directory.CLOUDONLY_DIRECTORIES_LIMIT:
             raise DirectoryLimitExceededException(
@@ -484,7 +484,7 @@ class DirectoryServiceBackend(BaseBackend):
         vpc_settings: Dict[str, Any],
         edition: str,
         tags: List[Dict[str, str]],
-    ) -> str:  # pylint: disable=too-many-arguments
+    ) -> str:
         """Create a fake Microsoft Ad Directory."""
         if len(self.directories) > Directory.CLOUDONLY_MICROSOFT_AD_LIMIT:
             raise DirectoryLimitExceededException(

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -62,7 +62,7 @@ class DynamoType(object):
     """
 
     def __init__(self, type_as_dict: Union["DynamoType", Dict[str, Any]]):
-        if type(type_as_dict) == DynamoType:
+        if type(type_as_dict) is DynamoType:
             self.type: str = type_as_dict.type
             self.value: Any = type_as_dict.value
         else:
@@ -277,12 +277,12 @@ class LimitedSizeDict(Dict[str, Any]):
     def __setitem__(self, key: str, value: Any) -> None:
         current_item_size = sum(
             [
-                item.size() if type(item) == DynamoType else bytesize(str(item))
+                item.size() if type(item) is DynamoType else bytesize(str(item))
                 for item in (list(self.keys()) + list(self.values()))
             ]
         )
         new_item_size = bytesize(key) + (
-            value.size() if type(value) == DynamoType else bytesize(str(value))
+            value.size() if type(value) is DynamoType else bytesize(str(value))
         )
         # Official limit is set to 400000 (400KB)
         # Manual testing confirms that the actual limit is between 409 and 410KB

--- a/moto/dynamodb/parsing/ast_nodes.py
+++ b/moto/dynamodb/parsing/ast_nodes.py
@@ -241,9 +241,9 @@ class ExpressionSelector(LeafNode):
         try:
             super().__init__(children=[int(selection_index)])
         except ValueError:
-            assert (
-                False
-            ), "Expression selector must be an int, this is a bug in the moto library."
+            assert False, (
+                "Expression selector must be an int, this is a bug in the moto library."
+            )
 
     def get_index(self):
         return self.children[0]

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -1139,7 +1139,7 @@ class DynamoHandler(BaseResponse):
         return values
 
     def _build_updated_new_attributes(self, original: Any, changed: Any) -> Any:
-        if type(changed) != type(original):
+        if type(changed) is not type(original):
             return changed
         else:
             if isinstance(changed, dict):

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -30,7 +30,7 @@ else:
 
 
 class Ami(TaggedEC2Resource):
-    def __init__(  # pylint: disable=dangerous-default-value
+    def __init__(
         self,
         ec2_backend: Any,
         ami_id: str,

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -390,7 +390,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     def delete(
         self,
         account_id: str,
-        region: str,  # pylint: disable=unused-argument
+        region: str,
     ) -> None:
         self.terminate()
 

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -347,7 +347,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
     def delete(
         self,
         account_id: str,
-        region_name: str,  # pylint: disable=unused-argument
+        region_name: str,
     ) -> None:
         """Not exposed as part of the ELB API - used for CloudFormation."""
         self.ec2_backend.delete_security_group(group_id=self.id)
@@ -795,7 +795,7 @@ class SecurityGroupBackend:
         sgrule_tags: Dict[str, str] = {},
         source_groups: Optional[List[Dict[str, str]]] = None,
         prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,  # pylint:disable=unused-argument
+        security_rule_ids: Optional[List[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> Tuple[List[SecurityRule], SecurityGroup]:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
@@ -915,7 +915,7 @@ class SecurityGroupBackend:
         sgrule_tags: Dict[str, str] = {},
         source_groups: Optional[List[Dict[str, Any]]] = None,
         prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,  # pylint:disable=unused-argument
+        security_rule_ids: Optional[List[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> Tuple[List[SecurityRule], SecurityGroup]:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
@@ -1051,7 +1051,7 @@ class SecurityGroupBackend:
         ip_ranges: List[str],
         source_groups: Optional[List[Dict[str, Any]]] = None,
         prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,  # pylint:disable=unused-argument
+        security_rule_ids: Optional[List[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> SecurityGroup:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
@@ -1106,7 +1106,7 @@ class SecurityGroupBackend:
         ip_ranges: List[str],
         source_groups: Optional[List[Dict[str, Any]]] = None,
         prefix_list_ids: Optional[List[Dict[str, str]]] = None,
-        security_rule_ids: Optional[List[str]] = None,  # pylint:disable=unused-argument
+        security_rule_ids: Optional[List[str]] = None,
         vpc_id: Optional[str] = None,
     ) -> SecurityGroup:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)

--- a/moto/ec2/models/spot_requests.py
+++ b/moto/ec2/models/spot_requests.py
@@ -370,7 +370,7 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
 
             if new_fulfilled_capacity - spec.weighted_capacity < self.target_capacity:
                 continue
-            new_fulfilled_capacity -= spec.weighted_capacity  # pylint: disable=W0631
+            new_fulfilled_capacity -= spec.weighted_capacity
             instance_ids.append(instance.id)
 
         self.spot_requests = [

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -1042,7 +1042,7 @@ class VPCBackend:
                 if zone.name.startswith(region)
             ]
 
-            from moto import backends  # pylint: disable=import-outside-toplevel
+            from moto import backends
 
             for implemented_service in IMPLEMENTED_ENDPOINT_SERVICES:
                 _backends = backends.get_backend(implemented_service)  # type: ignore[call-overload]
@@ -1172,7 +1172,7 @@ class VPCBackend:
         max_results: int,
         next_token: Optional[str],
         region: str,
-    ) -> Dict[str, Any]:  # pylint: disable=too-many-arguments
+    ) -> Dict[str, Any]:
         """Return info on services to which you can create a VPC endpoint.
 
         Currently only the default endpoint services are returned.  When

--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -404,9 +404,9 @@ class InstanceResponse(EC2BaseResponse):
         from botocore import __version__ as botocore_version
 
         if "no_device" in device_mapping:
-            assert isinstance(
-                device_mapping["no_device"], str
-            ), f"botocore {botocore_version} isn't limiting NoDevice to str type anymore, it is type:{type(device_mapping['no_device'])}"
+            assert isinstance(device_mapping["no_device"], str), (
+                f"botocore {botocore_version} isn't limiting NoDevice to str type anymore, it is type:{type(device_mapping['no_device'])}"
+            )
             if device_mapping["no_device"] == "":
                 # the only legit value it can have is empty string
                 # and none of the other checks here matter if NoDevice

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -272,7 +272,7 @@ class Image(BaseModel):
             )
         else:
             random_sha = hashlib.sha256(
-                f"{random.randint(0,100)}".encode("utf-8")
+                f"{random.randint(0, 100)}".encode("utf-8")
             ).hexdigest()
             self._image_digest = f"sha256:{random_sha}"
 

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -108,7 +108,7 @@ def create_s3_destination_config(
     return destination
 
 
-class DeliveryStream(BaseModel):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+class DeliveryStream(BaseModel):
     """Represents a delivery stream, its source and destination configs."""
 
     STATES = {"CREATING", "ACTIVE", "CREATING_FAILED"}
@@ -132,7 +132,7 @@ class DeliveryStream(BaseModel):  # pylint: disable=too-few-public-methods,too-m
         kinesis_stream_source_configuration: Dict[str, Any],
         destination_name: str,
         destination_config: Dict[str, Any],
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.delivery_stream_status = "CREATING"
         self.delivery_stream_name = delivery_stream_name
         self.delivery_stream_type = (
@@ -188,7 +188,7 @@ class FirehoseBackend(BaseBackend):
             service_region, zones, "firehose", special_service_name="kinesis-firehose"
         )
 
-    def create_delivery_stream(  # pylint: disable=unused-argument
+    def create_delivery_stream(
         self,
         region: str,
         delivery_stream_name: str,
@@ -590,7 +590,7 @@ class FirehoseBackend(BaseBackend):
 
         delivery_stream.delivery_stream_encryption_configuration["Status"] = "DISABLED"
 
-    def update_destination(  # pylint: disable=unused-argument
+    def update_destination(
         self,
         delivery_stream_name: str,
         current_delivery_stream_version_id: str,

--- a/moto/guardduty/exceptions.py
+++ b/moto/guardduty/exceptions.py
@@ -16,7 +16,7 @@ class DetectorNotFoundException(GuardDutyException):
             "The request is rejected because the input detectorId is not owned by the current account.",
         )
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:  # pylint: disable=unused-argument
+    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
         return [("X-Amzn-ErrorType", "BadRequestException")]
 
 
@@ -29,5 +29,5 @@ class FilterNotFoundException(GuardDutyException):
             "The request is rejected since no such resource found.",
         )
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:  # pylint: disable=unused-argument
+    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
         return [("X-Amzn-ErrorType", "BadRequestException")]

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -1092,7 +1092,7 @@ class InstanceProfile(CloudFormationModel):
             "path": self.path,
             "instanceProfileName": self.name,
             "instanceProfileId": self.id,
-            "arn": f"arn:{self.partition}:iam::{self.account_id}:instance-profile/{role.name}",  # pylint: disable=W0631
+            "arn": f"arn:{self.partition}:iam::{self.account_id}:instance-profile/{role.name}",
             "createDate": str(self.create_date),
             "roles": roles,
         }

--- a/moto/instance_metadata/responses.py
+++ b/moto/instance_metadata/responses.py
@@ -17,7 +17,7 @@ class InstanceMetadataResponse(BaseResponse):
 
     @staticmethod
     def metadata_response(  # type: ignore
-        request: Any,  # pylint: disable=unused-argument
+        request: Any,
         full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:

--- a/moto/kinesisanalyticsv2/models.py
+++ b/moto/kinesisanalyticsv2/models.py
@@ -56,7 +56,7 @@ class Application(BaseModel):
         self, cloud_watch_logging_options: Optional[List[Dict[str, str]]]
     ) -> List[Dict[str, str]] | None:
         cloud_watch_logging_option_descriptions = []
-        option_id = f"{str(random.randint(1,100))}.1"
+        option_id = f"{str(random.randint(1, 100))}.1"
 
         # Leaving out RoleARN since it is provided only sometimes for backwards
         # compatibility. Current API versions do not have the resource-level

--- a/moto/kms/policy_validator.py
+++ b/moto/kms/policy_validator.py
@@ -45,7 +45,7 @@ def action_matches(applicable_actions: List[str], action: str) -> bool:
 
 def resource_matches(
     applicable_resources: str,
-    resource: str,  # pylint: disable=unused-argument
+    resource: str,
 ) -> bool:
     if applicable_resources == "*":
         return True

--- a/moto/lakeformation/models.py
+++ b/moto/lakeformation/models.py
@@ -577,7 +577,7 @@ class LakeFormationBackend(BaseBackend):
 
     def get_resource_lf_tags(
         self,
-        catalog_id: str,  # pylint: disable=unused-argument
+        catalog_id: str,
         resource: Dict[str, Any],
     ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]]]:
         database_tags = []

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1451,7 +1451,7 @@ class LogsBackend(BaseBackend):
                 )
                 raw_logs = "\n".join(
                     [
-                        f"{datetime.fromtimestamp(log['timestamp']/1000).strftime('%Y-%m-%dT%H:%M:%S.000Z')} {log['message']}"
+                        f"{datetime.fromtimestamp(log['timestamp'] / 1000).strftime('%Y-%m-%dT%H:%M:%S.000Z')} {log['message']}"
                         for log in logs
                     ]
                 )

--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -115,15 +115,15 @@ class LogsResponse(BaseResponse):
 
         if metric_name and not metric_namespace:
             raise InvalidParameterException(
-                constraint=f'{"If you include the metricName parameter in your request, "}'
-                f'{"you must also include the metricNamespace parameter."}',
+                constraint=f"{'If you include the metricName parameter in your request, '}"
+                f"{'you must also include the metricNamespace parameter.'}",
                 parameter="metricNamespace",
                 value=metric_namespace,
             )
         if metric_namespace and not metric_name:
             raise InvalidParameterException(
-                constraint=f'{"If you include the metricNamespace parameter in your request, "}'
-                f'{"you must also include the metricName parameter."}',
+                constraint=f"{'If you include the metricNamespace parameter in your request, '}"
+                f"{'you must also include the metricName parameter.'}",
                 parameter="metricName",
                 value=metric_name,
             )

--- a/moto/logs/utils.py
+++ b/moto/logs/utils.py
@@ -35,7 +35,7 @@ class SingleTermFilterPattern(FilterPattern):
 
 
 class UnsupportedFilterPattern(FilterPattern):
-    def matches(self, message: str) -> bool:  # pylint: disable=unused-argument
+    def matches(self, message: str) -> bool:
         return True
 
 

--- a/moto/managedblockchain/exceptions.py
+++ b/moto/managedblockchain/exceptions.py
@@ -11,13 +11,13 @@ class ManagedBlockchainClientError(JsonRESTError):
         self.message = message
         self.description = json.dumps({"message": self.message})
 
-    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:  # pylint: disable=unused-argument
+    def get_headers(self, *args: Any, **kwargs: Any) -> List[Tuple[str, str]]:
         return [
             ("Content-Type", "application/json"),
             ("x-amzn-ErrorType", self.error_type),
         ]
 
-    def get_body(self, *args: Any, **kwargs: Any) -> str:  # pylint: disable=unused-argument
+    def get_body(self, *args: Any, **kwargs: Any) -> str:
         return self.description
 
 

--- a/moto/memorydb/models.py
+++ b/moto/memorydb/models.py
@@ -116,12 +116,12 @@ class MemoryDBCluster(BaseModel):
     def get_shard_details(self) -> List[Dict[str, Any]]:
         shards = []
         for i in range(self.num_shards):
-            shard_name = f"{i+1:04}"
+            shard_name = f"{i + 1:04}"
             num_nodes = self.num_replicas_per_shard + 1
             nodes = []
             azs = ["a", "b", "c", "d"]
             for n in range(num_nodes):
-                node_name = f"{self.cluster_name}-{shard_name}-{n+1:03}"
+                node_name = f"{self.cluster_name}-{shard_name}-{n + 1:03}"
                 node = {
                     "Name": node_name,
                     "Status": "available",
@@ -140,7 +140,7 @@ class MemoryDBCluster(BaseModel):
                 "Name": shard_name,
                 # Set to 'available', other options are 'creating', 'modifying' , 'deleting'.
                 "Status": "available",
-                "Slots": f"0-{str(random.randint(10000,99999))}",
+                "Slots": f"0-{str(random.randint(10000, 99999))}",
                 "Nodes": nodes,
                 "NumberOfNodes": num_nodes,
             }

--- a/moto/moto_api/_internal/recorder/responses.py
+++ b/moto/moto_api/_internal/recorder/responses.py
@@ -11,7 +11,7 @@ class RecorderResponse(BaseResponse):
         self,
         req: Any,
         url: str,
-        headers: Any,  # pylint: disable=unused-argument
+        headers: Any,
     ) -> TYPE_RESPONSE:
         recorder.reset_recording()
         return 200, {}, ""
@@ -20,7 +20,7 @@ class RecorderResponse(BaseResponse):
         self,
         req: Any,
         url: str,
-        headers: Any,  # pylint: disable=unused-argument
+        headers: Any,
     ) -> TYPE_RESPONSE:
         recorder.start_recording()
         return 200, {}, "Recording is set to True"
@@ -29,7 +29,7 @@ class RecorderResponse(BaseResponse):
         self,
         req: Any,
         url: str,
-        headers: Any,  # pylint: disable=unused-argument
+        headers: Any,
     ) -> TYPE_RESPONSE:
         recorder.stop_recording()
         return 200, {}, "Recording is set to False"
@@ -38,7 +38,7 @@ class RecorderResponse(BaseResponse):
         self,
         req: Any,
         url: str,
-        headers: Any,  # pylint: disable=unused-argument
+        headers: Any,
     ) -> TYPE_RESPONSE:
         data = req.data
         recorder.upload_recording(data)
@@ -48,7 +48,7 @@ class RecorderResponse(BaseResponse):
         self,
         req: Any,
         url: str,
-        headers: Any,  # pylint: disable=unused-argument
+        headers: Any,
     ) -> TYPE_RESPONSE:
         data = recorder.download_recording()
         return 200, {}, data
@@ -59,7 +59,7 @@ class RecorderResponse(BaseResponse):
         self,
         req: Any,
         url: str,
-        headers: Any,  # pylint: disable=unused-argument
+        headers: Any,
     ) -> TYPE_RESPONSE:
         recorder.replay_recording(target_host=url)
         return 200, {}, ""

--- a/moto/moto_api/_internal/responses.py
+++ b/moto/moto_api/_internal/responses.py
@@ -13,8 +13,8 @@ class MotoAPIResponse(BaseResponse):
     def reset_response(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
-        headers: Any,  # pylint: disable=unused-argument
+        full_url: str,
+        headers: Any,
     ) -> TYPE_RESPONSE:
         if request.method == "POST":
             from .models import moto_api_backend
@@ -26,8 +26,8 @@ class MotoAPIResponse(BaseResponse):
     def reset_auth_response(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
-        headers: Any,  # pylint: disable=unused-argument
+        full_url: str,
+        headers: Any,
     ) -> TYPE_RESPONSE:
         if request.method == "POST":
             previous_initial_no_auth_action_count = (
@@ -51,9 +51,9 @@ class MotoAPIResponse(BaseResponse):
 
     def model_data(
         self,
-        request: Any,  # pylint: disable=unused-argument
-        full_url: str,  # pylint: disable=unused-argument
-        headers: Any,  # pylint: disable=unused-argument
+        request: Any,
+        full_url: str,
+        headers: Any,
     ) -> TYPE_RESPONSE:
         from moto.core.model_instances import model_data
 
@@ -79,9 +79,9 @@ class MotoAPIResponse(BaseResponse):
 
     def dashboard(
         self,
-        request: Any,  # pylint: disable=unused-argument
-        full_url: str,  # pylint: disable=unused-argument
-        headers: Any,  # pylint: disable=unused-argument
+        request: Any,
+        full_url: str,
+        headers: Any,
     ) -> str:
         from flask import render_template
 
@@ -90,8 +90,8 @@ class MotoAPIResponse(BaseResponse):
     def get_transition(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
-        headers: Any,  # pylint: disable=unused-argument
+        full_url: str,
+        headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
 
@@ -107,7 +107,7 @@ class MotoAPIResponse(BaseResponse):
     def set_transition(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -122,7 +122,7 @@ class MotoAPIResponse(BaseResponse):
     def unset_transition(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -144,7 +144,7 @@ class MotoAPIResponse(BaseResponse):
     def set_athena_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -167,7 +167,7 @@ class MotoAPIResponse(BaseResponse):
     def set_ce_cost_usage_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -182,7 +182,7 @@ class MotoAPIResponse(BaseResponse):
     def set_lambda_simple_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -200,7 +200,7 @@ class MotoAPIResponse(BaseResponse):
     def set_resilience_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -218,7 +218,7 @@ class MotoAPIResponse(BaseResponse):
     def set_sagemaker_async_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -241,7 +241,7 @@ class MotoAPIResponse(BaseResponse):
     def set_sagemaker_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -268,7 +268,7 @@ class MotoAPIResponse(BaseResponse):
     def set_rds_data_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -297,7 +297,7 @@ class MotoAPIResponse(BaseResponse):
     def set_ecr_scan_finding_results(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -317,7 +317,7 @@ class MotoAPIResponse(BaseResponse):
     def set_inspector2_findings_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -337,7 +337,7 @@ class MotoAPIResponse(BaseResponse):
     def set_timestream_result(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -359,7 +359,7 @@ class MotoAPIResponse(BaseResponse):
     def set_proxy_passthrough(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend
@@ -381,7 +381,7 @@ class MotoAPIResponse(BaseResponse):
     def config(
         self,
         request: Any,
-        full_url: str,  # pylint: disable=unused-argument
+        full_url: str,
         headers: Any,
     ) -> TYPE_RESPONSE:
         from .models import moto_api_backend

--- a/moto/opensearchserverless/models.py
+++ b/moto/opensearchserverless/models.py
@@ -139,7 +139,7 @@ class OSEndpoint(BaseModel):
         self.security_group_ids = security_group_ids
         self.subnet_ids = subnet_ids
         self.vpc_id = vpc_id
-        self.id = f"vpce-0{mock_random.get_random_string(length=16,lower_case=True)}"
+        self.id = f"vpce-0{mock_random.get_random_string(length=16, lower_case=True)}"
         self.status = "ACTIVE"
 
     def to_dict(self) -> Dict[str, Any]:

--- a/moto/proxy.py
+++ b/moto/proxy.py
@@ -10,7 +10,7 @@ from moto.moto_proxy import logger
 from moto.moto_proxy.proxy3 import CertificateCreator, ProxyRequestHandler, with_color
 
 
-def signal_handler(signum: Any, frame: Any) -> None:  # pylint: disable=unused-argument
+def signal_handler(signum: Any, frame: Any) -> None:
     sys.exit(0)
 
 

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -929,7 +929,7 @@ class Route53Backend(BaseBackend):
         # logging doesn't grant Route 53 sufficient permission to create
         # a log stream in the specified log group."
 
-        from moto.logs import logs_backends  # pylint: disable=import-outside-toplevel
+        from moto.logs import logs_backends
 
         log_groups = logs_backends[self.account_id][
             LOGS_GROUP_REGION

--- a/moto/route53/responses.py
+++ b/moto/route53/responses.py
@@ -414,8 +414,6 @@ class Route53(BaseResponse):
         next_token = self._get_param("nexttoken")
         max_results = self._get_int_param("maxresults")
 
-        # The paginator picks up named arguments, returns tuple.
-        # pylint: disable=unbalanced-tuple-unpacking
         all_configs, next_token = self.backend.list_query_logging_configs(
             hosted_zone_id=hosted_zone_id,
             next_token=next_token,

--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -29,7 +29,7 @@ from moto.utilities.utils import get_partition
 CAMEL_TO_SNAKE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
 
 
-class ResolverRuleAssociation(BaseModel):  # pylint: disable=too-few-public-methods
+class ResolverRuleAssociation(BaseModel):
     """Representation of a fake Route53 Resolver Rules Association."""
 
     MAX_TAGS_PER_RESOLVER_ENDPOINT = 200
@@ -51,14 +51,14 @@ class ResolverRuleAssociation(BaseModel):  # pylint: disable=too-few-public-meth
         resolver_rule_id: str,
         vpc_id: str,
         name: str,
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.region = region
         self.resolver_rule_id = resolver_rule_id
         self.name = name
         self.vpc_id = vpc_id
 
         # Constructed members.
-        self.id = resolver_rule_association_id  # pylint: disable=invalid-name
+        self.id = resolver_rule_association_id
         self.status = "COMPLETE"
         self.status_message = ""
 
@@ -74,7 +74,7 @@ class ResolverRuleAssociation(BaseModel):  # pylint: disable=too-few-public-meth
         }
 
 
-class ResolverRule(BaseModel):  # pylint: disable=too-many-instance-attributes
+class ResolverRule(BaseModel):
     """Representation of a fake Route53 Resolver Rule."""
 
     MAX_TAGS_PER_RESOLVER_RULE = 200
@@ -102,7 +102,7 @@ class ResolverRule(BaseModel):  # pylint: disable=too-many-instance-attributes
         target_ips: Optional[List[Dict[str, Any]]],
         resolver_endpoint_id: Optional[str],
         name: str,
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.account_id = account_id
         self.region = region
         self.creator_request_id = creator_request_id
@@ -114,7 +114,7 @@ class ResolverRule(BaseModel):  # pylint: disable=too-many-instance-attributes
         self.resolver_endpoint_id = resolver_endpoint_id
 
         # Constructed members.
-        self.id = rule_id  # pylint: disable=invalid-name
+        self.id = rule_id
         self.status = "COMPLETE"
 
         # The status message should contain a trace Id which is the value
@@ -152,7 +152,7 @@ class ResolverRule(BaseModel):  # pylint: disable=too-many-instance-attributes
         }
 
 
-class ResolverEndpoint(BaseModel):  # pylint: disable=too-many-instance-attributes
+class ResolverEndpoint(BaseModel):
     """Representation of a fake Route53 Resolver Endpoint."""
 
     MAX_TAGS_PER_RESOLVER_ENDPOINT = 200
@@ -180,7 +180,7 @@ class ResolverEndpoint(BaseModel):  # pylint: disable=too-many-instance-attribut
         direction: str,
         ip_addresses: List[Dict[str, Any]],
         name: str,
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.account_id = account_id
         self.region = region
         self.creator_request_id = creator_request_id
@@ -191,7 +191,7 @@ class ResolverEndpoint(BaseModel):  # pylint: disable=too-many-instance-attribut
         self.ec2_backend = ec2_backends[self.account_id][self.region]
 
         # Constructed members.
-        self.id = endpoint_id  # pylint: disable=invalid-name
+        self.id = endpoint_id
 
         # NOTE; This currently doesn't reflect IPv6 addresses.
         self.subnets = self._build_subnet_info()
@@ -568,7 +568,7 @@ class Route53ResolverBackend(BaseBackend):
         direction: str,
         ip_addresses: List[Dict[str, Any]],
         tags: List[Dict[str, str]],
-    ) -> ResolverEndpoint:  # pylint: disable=too-many-arguments
+    ) -> ResolverEndpoint:
         """
         Return description for a newly created resolver endpoint.
 
@@ -640,7 +640,7 @@ class Route53ResolverBackend(BaseBackend):
         target_ips: List[Dict[str, Any]],
         resolver_endpoint_id: str,
         tags: List[Dict[str, str]],
-    ) -> ResolverRule:  # pylint: disable=too-many-arguments
+    ) -> ResolverRule:
         """Return description for a newly created resolver rule."""
         validate_args(
             [

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2151,7 +2151,7 @@ class S3Response(BaseResponse):
                     if part_number > 1:
                         raise RangeNotSatisfiable
                     response_headers["content-range"] = (
-                        f"bytes 0-{full_key.size -1}/{full_key.size}"  # type: ignore
+                        f"bytes 0-{full_key.size - 1}/{full_key.size}"  # type: ignore
                     )
                     return 206, response_headers, ""
 

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -1185,7 +1185,7 @@ class FeatureGroup(BaseObject):
         self.feature_definitions = feature_definitions
 
         table_name = (
-            f"{feature_group_name.replace('-','_')}_{int(datetime.now().timestamp())}"
+            f"{feature_group_name.replace('-', '_')}_{int(datetime.now().timestamp())}"
         )
         offline_store_config["DataCatalogConfig"] = {
             "TableName": table_name,
@@ -1193,7 +1193,7 @@ class FeatureGroup(BaseObject):
             "Database": "sagemaker_featurestore",
         }
         offline_store_config["S3StorageConfig"]["ResolvedOutputS3Uri"] = (
-            f'{offline_store_config["S3StorageConfig"]["S3Uri"]}/{account_id}/{region_name}/offline-store/{feature_group_name}-{int(datetime.now().timestamp())}/data'
+            f"{offline_store_config['S3StorageConfig']['S3Uri']}/{account_id}/{region_name}/offline-store/{feature_group_name}-{int(datetime.now().timestamp())}/data"
         )
 
         self.offline_store_config = offline_store_config

--- a/moto/server.py
+++ b/moto/server.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional
 from werkzeug.serving import run_simple
 
 # Expose ThreadedMotoServer as a public symbol according to PEP-561
-from moto.moto_server.threaded_moto_server import (  # pylint: disable=unused-import
+from moto.moto_server.threaded_moto_server import (
     ThreadedMotoServer as ThreadedMotoServer,
 )
 from moto.moto_server.werkzeug_app import (
@@ -16,7 +16,7 @@ from moto.moto_server.werkzeug_app import (
 )
 
 
-def signal_handler(signum: Any, frame: Any) -> None:  # pylint: disable=unused-argument
+def signal_handler(signum: Any, frame: Any) -> None:
     sys.exit(0)
 
 

--- a/moto/ses/template.py
+++ b/moto/ses/template.py
@@ -51,7 +51,7 @@ class EachBlockProcessor(BlockProcessor):
                     )
                     # If we've reached the end, we should stop processing
                     # Our parent will continue with whatever comes after {{/each}}
-                    if type(_processor) == EachEndBlockProcessor:
+                    if type(_processor) is EachEndBlockProcessor:
                         break
                     # If we've encountered another processor, they can continue
                     parsed += _processor.parse()
@@ -97,9 +97,9 @@ class IfBlockProcessor(BlockProcessor):
                 _processor = get_processor(self.tokenizer)(
                     self.template, self.template_data, self.tokenizer
                 )
-                if type(_processor) == IfEndBlockProcessor:
+                if type(_processor) is IfEndBlockProcessor:
                     break
-                elif type(_processor) == ElseBlockProcessor:
+                elif type(_processor) is ElseBlockProcessor:
                     self.parse_contents = not self.parse_contents
                     continue
                 if self.parse_contents:

--- a/moto/stepfunctions/parser/asl/component/intrinsic/functionname/state_function_name_types.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/functionname/state_function_name_types.py
@@ -25,5 +25,5 @@ class StatesFunctionNameType(Enum):
     StringSplit = ASLIntrinsicLexer.StringSplit
     UUID = ASLIntrinsicLexer.UUID
 
-    def name(self) -> str:  # pylint: disable=function-redefined
+    def name(self) -> str:
         return ASLIntrinsicLexer.symbolicNames[self.value][1:-1]

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_aws_sdk.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_aws_sdk.py
@@ -97,7 +97,7 @@ class StateTaskServiceAwsSdk(StateTaskServiceCallback):
             ]
             if "HostId" in ex.response["ResponseMetadata"]:
                 cause_details.append(
-                    f'Extended Request ID: {ex.response["ResponseMetadata"]["HostId"]}'
+                    f"Extended Request ID: {ex.response['ResponseMetadata']['HostId']}"
                 )
 
             cause: str = f"{error_message} ({', '.join(cause_details)})"

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sfn.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sfn.py
@@ -68,7 +68,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
             ]
             if "HostId" in ex.response["ResponseMetadata"]:
                 error_cause_details.append(
-                    f'Extended Request ID: {ex.response["ResponseMetadata"]["HostId"]}'
+                    f"Extended Request ID: {ex.response['ResponseMetadata']['HostId']}"
                 )
             error_cause: str = (
                 f"{ex.response['Error']['Message']} ({'; '.join(error_cause_details)})"

--- a/moto/stepfunctions/parser/asl/eval/test_state/environment.py
+++ b/moto/stepfunctions/parser/asl/eval/test_state/environment.py
@@ -44,7 +44,7 @@ class TestStateEnvironment(Environment):
         )
         self.inspection_data = InspectionData()
 
-    def as_frame_of(  # pylint: disable=arguments-renamed
+    def as_frame_of(
         cls,
         env: TestStateEnvironment,
         event_history_frame_cache: Optional[EventHistoryContext] = None,
@@ -55,7 +55,7 @@ class TestStateEnvironment(Environment):
         frame.inspection_data = env.inspection_data
         return frame
 
-    def as_inner_frame_of(  # pylint: disable=arguments-renamed
+    def as_inner_frame_of(
         cls,
         env: TestStateEnvironment,
         variable_store: VariableStore,

--- a/moto/stepfunctions/parser/asl/parse/asl_parser.py
+++ b/moto/stepfunctions/parser/asl/parse/asl_parser.py
@@ -17,7 +17,7 @@ class SyntaxErrorListener(ErrorListener):
         super().__init__()
         self.errors = list()
 
-    def syntaxError(  # pylint: disable=arguments-renamed
+    def syntaxError(
         self, recognizer, offending_symbol, line, column, message, exception
     ):
         log_parts = [f"line {line}:{column}"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -e .[all,server]
 -r requirements-tests.txt
 
-ruff==0.3.3
+ruff==0.11.9
 click
 inflection
 lxml

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,5 +5,4 @@ pytest-cov
 pytest-order
 pytest-xdist
 freezegun
-pylint
 pyotp

--- a/setup.cfg
+++ b/setup.cfg
@@ -258,13 +258,6 @@ markers =
 [coverage:run]
 relative_files = True
 
-[pylint.MASTER]
-ignore-paths=moto/packages
-
-[pylint.'MESSAGES CONTROL']
-disable = W,C,R,E
-enable = arguments-renamed, deprecated-module, function-redefined, redefined-outer-name, signature-differs
-
 [mypy]
 files= moto, tests/test_core, tests/test_batch_simple, tests/test_iotdata/
 exclude = moto/stepfunctions/parser

--- a/tests/test_appconfig/test_appconfig_hosted_config_versions.py
+++ b/tests/test_appconfig/test_appconfig_hosted_config_versions.py
@@ -7,7 +7,7 @@ from moto import mock_aws
 
 @mock_aws
 class TestHostedConfigurationVersions:
-    def setup_method(self, *args):  # pylint: disable=unused-argument
+    def setup_method(self, *args):
         self.client = boto3.client("appconfig", region_name="us-west-1")
         self.app_id = self.client.create_application(Name="testapp")["Id"]
         self.config_profile_id = self.client.create_configuration_profile(

--- a/tests/test_awslambda/test_lambda.py
+++ b/tests/test_awslambda/test_lambda.py
@@ -454,7 +454,7 @@ def test_create_function_from_stubbed_ecr():
 @mock_aws
 def test_create_function_from_mocked_ecr_image_tag(
     with_ecr_mock,
-):  # pylint: disable=unused-argument
+):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
         raise SkipTest("Parameters only available in newer versions")
     if not settings.TEST_DECORATOR_MODE:
@@ -498,7 +498,7 @@ def test_create_function_from_mocked_ecr_image_tag(
 @mock_aws
 def test_create_function_from_mocked_ecr_image_digest(
     with_ecr_mock,
-):  # pylint: disable=unused-argument
+):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
         raise SkipTest("Parameters only available in newer versions")
     if not settings.TEST_DECORATOR_MODE:
@@ -527,7 +527,7 @@ def test_create_function_from_mocked_ecr_image_digest(
 @mock_aws
 def test_create_function_from_mocked_ecr_missing_image(
     with_ecr_mock,
-):  # pylint: disable=unused-argument
+):
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
         raise SkipTest("Parameters only available in newer versions")
     if not settings.TEST_DECORATOR_MODE:

--- a/tests/test_awslambda/test_lambda_eventsourcemapping.py
+++ b/tests/test_awslambda/test_lambda_eventsourcemapping.py
@@ -278,9 +278,9 @@ def test_invoke_function_from_dynamodb_update():
         expected_msg + " was not found after updating DDB. All logs: " + str(all_logs)
     )
     assert "Nr_of_records(1)" in all_logs, "Only one item should be updated"
-    assert (
-        "Nr_of_records(2)" not in all_logs
-    ), "The inserted item should not show up again"
+    assert "Nr_of_records(2)" not in all_logs, (
+        "The inserted item should not show up again"
+    )
 
 
 @pytest.mark.network

--- a/tests/test_batch/test_batch_jobs.py
+++ b/tests/test_batch/test_batch_jobs.py
@@ -726,12 +726,12 @@ def test_failed_dependencies():
         assert resp["jobs"][1]["status"] != "SUCCEEDED", "Job 3 cannot succeed"
 
         if resp["jobs"][1]["status"] == "FAILED":
-            assert (
-                "logStreamName" in resp["jobs"][0]["container"]
-            ), "Job 2 should have logStreamName because it FAILED but was in RUNNING state"
-            assert (
-                "logStreamName" not in resp["jobs"][1]["container"]
-            ), "Job 3 shouldn't have logStreamName because it was never in RUNNING state"
+            assert "logStreamName" in resp["jobs"][0]["container"], (
+                "Job 2 should have logStreamName because it FAILED but was in RUNNING state"
+            )
+            assert "logStreamName" not in resp["jobs"][1]["container"], (
+                "Job 3 shouldn't have logStreamName because it was never in RUNNING state"
+            )
 
             break
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1578,9 +1578,9 @@ def test_describe_change_set(stack_template, change_template):
     assert change_set["Status"] == "CREATE_COMPLETE"
     assert change_set["ExecutionStatus"] == "AVAILABLE"
     two_secs_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=2)
-    assert (
-        two_secs_ago < change_set["CreationTime"] < datetime.now(tz=timezone.utc)
-    ), "Change set should have been created recently"
+    assert two_secs_ago < change_set["CreationTime"] < datetime.now(tz=timezone.utc), (
+        "Change set should have been created recently"
+    )
     assert len(change_set["Changes"]) == 1
     assert change_set["Changes"][0] == {
         "Type": "Resource",
@@ -1732,9 +1732,9 @@ def test_describe_stack_by_name():
     stack = cf.describe_stacks(StackName=TEST_STACK_NAME)["Stacks"][0]
     assert stack["StackName"] == TEST_STACK_NAME
     two_secs_ago = datetime.now(tz=timezone.utc) - timedelta(seconds=2)
-    assert (
-        two_secs_ago < stack["CreationTime"] < datetime.now(tz=timezone.utc)
-    ), "Stack should have been created recently"
+    assert two_secs_ago < stack["CreationTime"] < datetime.now(tz=timezone.utc), (
+        "Stack should have been created recently"
+    )
 
 
 @mock_aws

--- a/tests/test_config/test_config_rules.py
+++ b/tests/test_config/test_config_rules.py
@@ -112,7 +112,7 @@ def test_put_config_rule_update_errors():
 
 
 @mock_aws
-def test_config_rule_errors():  # pylint: disable=too-many-statements
+def test_config_rule_errors():
     """Test various error conditions in ConfigRule instantiation."""
     client = boto3.client("config", region_name=TEST_REGION)
 
@@ -237,7 +237,7 @@ def test_aws_managed_rule_errors():
 
 
 @mock_aws
-def test_config_rules_scope_errors():  # pylint: disable=too-many-statements
+def test_config_rules_scope_errors():
     """Test various error conditions in ConfigRule.Scope instantiation."""
     client = boto3.client("config", region_name=TEST_REGION)
 

--- a/tests/test_config/test_config_rules_integration.py
+++ b/tests/test_config/test_config_rules_integration.py
@@ -226,7 +226,7 @@ def test_valid_put_config_custom_rule():
 
 
 @mock_aws
-def test_config_rules_source_errors():  # pylint: disable=too-many-statements
+def test_config_rules_source_errors():
     """Test various error conditions in ConfigRule.Source instantiation."""
     client = boto3.client("config", region_name=TEST_REGION)
 
@@ -288,7 +288,7 @@ def test_config_rules_source_errors():  # pylint: disable=too-many-statements
     err = exc.value.response["Error"]
     assert err["Code"] == "InsufficientPermissionsException"
     assert (
-        f'The AWS Lambda function {custom_rule["Source"]["SourceIdentifier"]} '
+        f"The AWS Lambda function {custom_rule['Source']['SourceIdentifier']} "
         f"cannot be invoked. Check the specified function ARN, and check the "
         f"function's permissions" in err["Message"]
     )

--- a/tests/test_core/test_backenddict.py
+++ b/tests/test_core/test_backenddict.py
@@ -36,7 +36,7 @@ def test_backend_dict_does_not_contain_unknown_regions() -> None:
 def test_backend_dict_fails_when_retrieving_unknown_regions() -> None:
     backend_dict = BackendDict(ExampleBackend, "ec2")
     with pytest.raises(KeyError):
-        backend_dict["account"]["mars-south-1"]  # pylint: disable=pointless-statement
+        backend_dict["account"]["mars-south-1"]
 
 
 def test_backend_dict_can_retrieve_for_specific_account() -> None:
@@ -157,26 +157,26 @@ def _create_asb(
 def test_multiple_backends_cache_behaviour() -> None:
     ec2 = BackendDict(EC2Backend, "ec2")
     ec2_useast1 = ec2[DEFAULT_ACCOUNT_ID]["us-east-1"]
-    assert type(ec2_useast1) == EC2Backend
+    assert type(ec2_useast1) is EC2Backend
 
     autoscaling = BackendDict(AutoScalingBackend, "autoscaling")
     as_1 = autoscaling[DEFAULT_ACCOUNT_ID]["us-east-1"]
-    assert type(as_1) == AutoScalingBackend
+    assert type(as_1) is AutoScalingBackend
 
     from moto.elbv2 import elbv2_backends
 
     elbv2_useast = elbv2_backends["00000000"]["us-east-1"]
-    assert type(elbv2_useast) == ELBv2Backend
+    assert type(elbv2_useast) is ELBv2Backend
     elbv2_useast2 = elbv2_backends[DEFAULT_ACCOUNT_ID]["us-east-2"]
-    assert type(elbv2_useast2) == ELBv2Backend
+    assert type(elbv2_useast2) is ELBv2Backend
 
     ec2_useast1 = ec2[DEFAULT_ACCOUNT_ID]["us-east-1"]
-    assert type(ec2_useast1) == EC2Backend
+    assert type(ec2_useast1) is EC2Backend
     ec2_useast2 = ec2[DEFAULT_ACCOUNT_ID]["us-east-2"]
-    assert type(ec2_useast2) == EC2Backend
+    assert type(ec2_useast2) is EC2Backend
 
     as_1 = autoscaling[DEFAULT_ACCOUNT_ID]["us-east-1"]
-    assert type(as_1) == AutoScalingBackend
+    assert type(as_1) is AutoScalingBackend
 
 
 def test_global_region_defaults_to_aws() -> None:

--- a/tests/test_core/test_decorator_calls.py
+++ b/tests/test_core/test_decorator_calls.py
@@ -32,7 +32,7 @@ def fixture_aws_credentials(monkeypatch: Any) -> None:  # type: ignore[misc]
 
 
 @pytest.mark.network
-def test_context_manager(aws_credentials: Any) -> None:  # type: ignore[misc]  # pylint: disable=unused-argument
+def test_context_manager(aws_credentials: Any) -> None:  # type: ignore[misc]
     client = boto3.client("ec2", region_name="us-west-1")
     with pytest.raises(ClientError) as exc:
         client.describe_addresses()
@@ -144,7 +144,7 @@ class TestWithSetup_UppercaseU(unittest.TestCase):
 
 @mock_aws
 class TestWithSetup_LowercaseU:
-    def setup_method(self, *args: Any) -> None:  # pylint: disable=unused-argument
+    def setup_method(self, *args: Any) -> None:
         # This method will be executed automatically using pytest
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="mybucket")
@@ -161,7 +161,7 @@ class TestWithSetup_LowercaseU:
 
 @mock_aws
 class TestWithSetupMethod:
-    def setup_method(self, *args: Any) -> None:  # pylint: disable=unused-argument
+    def setup_method(self, *args: Any) -> None:
         # This method will be executed automatically using pytest
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="mybucket")
@@ -178,7 +178,7 @@ class TestWithSetupMethod:
 
 @mock_aws
 class TestKinesisUsingSetupMethod:
-    def setup_method(self, *args: Any) -> None:  # pylint: disable=unused-argument
+    def setup_method(self, *args: Any) -> None:
         self.stream_name = "test_stream"
         self.boto3_kinesis_client = boto3.client("kinesis", region_name="us-east-1")
         self.boto3_kinesis_client.create_stream(

--- a/tests/test_core/test_docker.py
+++ b/tests/test_core/test_docker.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.order(0)
 def test_docker_package_is_available() -> None:
     try:
-        import docker  # noqa: F401   # pylint: disable=unused-import
+        import docker  # noqa: F401
     except ImportError as err:
         logger.error("error running docker: %s", err)
         assert False, (

--- a/tests/test_core/test_importorder.py
+++ b/tests/test_core/test_importorder.py
@@ -23,7 +23,7 @@ def fixture_aws_credentials(monkeypatch: Any) -> None:  # type: ignore[misc]
 
 
 def test_mock_works_with_client_created_inside(
-    aws_credentials: Any,  # pylint: disable=unused-argument
+    aws_credentials: Any,
 ) -> None:
     m = mock_aws()
     m.start()
@@ -35,7 +35,7 @@ def test_mock_works_with_client_created_inside(
 
 
 def test_mock_works_with_client_created_outside(
-    aws_credentials: Any,  # pylint: disable=unused-argument
+    aws_credentials: Any,
 ) -> None:
     # Create the boto3 client first
     outside_client = boto3.client("s3", region_name="us-east-1")
@@ -55,7 +55,7 @@ def test_mock_works_with_client_created_outside(
 
 
 def test_mock_works_with_resource_created_outside(
-    aws_credentials: Any,  # pylint: disable=unused-argument
+    aws_credentials: Any,
 ) -> None:
     # Create the boto3 client first
     outside_resource = boto3.resource("s3", region_name="us-east-1")
@@ -122,7 +122,7 @@ class ImportantBusinessLogic:
 
 
 def test_mock_works_when_replacing_client(
-    aws_credentials: Any,  # pylint: disable=unused-argument
+    aws_credentials: Any,
 ) -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
         raise SkipTest("Error handling is different in newer versions")

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -45,6 +45,6 @@ def moto_server() -> Iterable[str]:
     server.stop()
 
 
-def test_s3_using_moto_fixture(moto_server: str) -> None:  # pylint: disable=redefined-outer-name
+def test_s3_using_moto_fixture(moto_server: str) -> None:
     client = boto3.client("s3", endpoint_url=moto_server)
     client.list_buckets()

--- a/tests/test_ds/test_ds_ad_connect.py
+++ b/tests/test_ds/test_ds_ad_connect.py
@@ -23,7 +23,7 @@ def create_test_ad_connector(
     customer_dns_ips=None,
     customer_user_name="Admin",
     tags=None,
-):  # pylint: disable=too-many-arguments
+):
     """Return ID of a newly created valid directory."""
     if not vpc_settings:
         good_vpc_id = create_vpc(ec2_client)

--- a/tests/test_dynamodb/conftest.py
+++ b/tests/test_dynamodb/conftest.py
@@ -8,7 +8,6 @@ from moto.core import DEFAULT_ACCOUNT_ID
 from moto.dynamodb.models import Table
 
 
-# pylint: disable=redefined-outer-name
 @pytest.fixture(scope="function")
 def aws_credentials():
     """Mocked AWS Credentials for moto."""

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -4912,7 +4912,7 @@ def test_query_with_gsi_reverse_paginated():
             TableName=table_name,
             Item={
                 "pri": {"S": f"pri_{i}"},
-                "alt": {"S": f"alt_{i//4}"},
+                "alt": {"S": f"alt_{i // 4}"},
             },
         )
 

--- a/tests/test_dynamodb/test_dynamodb_scan.py
+++ b/tests/test_dynamodb/test_dynamodb_scan.py
@@ -515,7 +515,7 @@ def test_scan_gsi_order_range_key(table_name=None):
         table.put_item(Item={"pk": f"{i}", "gsi_pk": "john", "gsi_sk": f"{i}"})
 
     for i in range(3, 5):
-        table.put_item(Item={"pk": f"{i}", "gsi_pk": "john", "gsi_sk": f"{7-i}"})
+        table.put_item(Item={"pk": f"{i}", "gsi_pk": "john", "gsi_sk": f"{7 - i}"})
 
     page = table.scan(IndexName="test_gsi")
     items = page["Items"]
@@ -534,7 +534,7 @@ def test_scan_gsi_exlusive_start_key(table_name=None):
     table = dynamodb.Table(table_name)
 
     for i in range(1, 5):
-        table.put_item(Item={"pk": f"{i}", "gsi_pk": "john", "gsi_sk": f"{5-i}"})
+        table.put_item(Item={"pk": f"{i}", "gsi_pk": "john", "gsi_sk": f"{5 - i}"})
 
     page = table.scan(IndexName="test_gsi", Limit=3)
     assert len(page["Items"]) == 3
@@ -780,7 +780,7 @@ class TestFilterExpression:
 @pytest.mark.aws_verified
 class TestParallelScan(BaseTest):
     @staticmethod
-    def setup_class(cls):  # pylint: disable=arguments-renamed
+    def setup_class(cls):
         super().setup_class(add_range=True)
 
     def test_segment_only(self):

--- a/tests/test_ec2/test_amis.py
+++ b/tests/test_ec2/test_amis.py
@@ -26,9 +26,9 @@ def test_snapshots_for_initial_amis():
     snapshot_descs = [s["Description"] for s in snapshots]
     initial_ami_count = len(AMIS)
 
-    assert (
-        len(snapshots) >= initial_ami_count
-    ), "Should have at least as many snapshots as AMIs"
+    assert len(snapshots) >= initial_ami_count, (
+        "Should have at least as many snapshots as AMIs"
+    )
 
     for ami in AMIS:
         ami_id = ami["ami_id"]
@@ -434,9 +434,9 @@ def test_ami_filters():
         Filters=[{"Name": "architecture", "Values": ["x86_64"]}]
     )["Images"]
     assert imageB_id in [ami["ImageId"] for ami in amis_by_architecture]
-    assert (
-        len(amis_by_architecture) >= 40
-    ), "Should have at least 40 AMI's of type x86_64"
+    assert len(amis_by_architecture) >= 40, (
+        "Should have at least 40 AMI's of type x86_64"
+    )
 
     amis_by_kernel = ec2.describe_images(
         Filters=[{"Name": "kernel-id", "Values": [kernel_value_B]}]

--- a/tests/test_ec2/test_customer_gateways.py
+++ b/tests/test_ec2/test_customer_gateways.py
@@ -66,9 +66,9 @@ def test_describe_customer_gateways():
     assert cgw["Type"] == "ipsec.1"
 
     all_cgws = ec2.describe_customer_gateways()["CustomerGateways"]
-    assert (
-        len(all_cgws) >= 1
-    ), "Should have at least the one CustomerGateway we just created"
+    assert len(all_cgws) >= 1, (
+        "Should have at least the one CustomerGateway we just created"
+    )
 
 
 @mock_aws

--- a/tests/test_ec2/test_dhcp_options.py
+++ b/tests/test_ec2/test_dhcp_options.py
@@ -458,9 +458,9 @@ def test_dhcp_options_get_by_key_filter():
 
     filters = [{"Name": "key", "Values": ["domain-name"]}]
     dhcp_options_sets = list(ec2.dhcp_options_sets.filter(Filters=filters))
-    assert (
-        len(dhcp_options_sets) >= 3
-    ), "Should have at least 3 DHCP options just created"
+    assert len(dhcp_options_sets) >= 3, (
+        "Should have at least 3 DHCP options just created"
+    )
 
     configs = []
     for d in dhcp_options_sets:

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -547,9 +547,9 @@ def test_modify_snapshot_attribute():
     attributes = ec2_client.describe_snapshot_attribute(
         SnapshotId=snapshot.id, Attribute="createVolumePermission"
     )
-    assert not attributes[
-        "CreateVolumePermissions"
-    ], "Snapshot should have no permissions."
+    assert not attributes["CreateVolumePermissions"], (
+        "Snapshot should have no permissions."
+    )
 
     ADD_GROUP_ARGS = {
         "SnapshotId": snapshot.id,
@@ -578,15 +578,15 @@ def test_modify_snapshot_attribute():
     attributes = ec2_client.describe_snapshot_attribute(
         SnapshotId=snapshot.id, Attribute="createVolumePermission"
     )
-    assert attributes["CreateVolumePermissions"] == [
-        {"Group": "all"}
-    ], "This snapshot should have public group permissions."
+    assert attributes["CreateVolumePermissions"] == [{"Group": "all"}], (
+        "This snapshot should have public group permissions."
+    )
 
     # Add is idempotent
     ec2_client.modify_snapshot_attribute(**ADD_GROUP_ARGS)
-    assert attributes["CreateVolumePermissions"] == [
-        {"Group": "all"}
-    ], "This snapshot should have public group permissions."
+    assert attributes["CreateVolumePermissions"] == [{"Group": "all"}], (
+        "This snapshot should have public group permissions."
+    )
 
     # Remove 'all' group and confirm
     with pytest.raises(ClientError):
@@ -602,15 +602,15 @@ def test_modify_snapshot_attribute():
     attributes = ec2_client.describe_snapshot_attribute(
         SnapshotId=snapshot.id, Attribute="createVolumePermission"
     )
-    assert not attributes[
-        "CreateVolumePermissions"
-    ], "This snapshot should have no permissions."
+    assert not attributes["CreateVolumePermissions"], (
+        "This snapshot should have no permissions."
+    )
 
     # Remove is idempotent
     ec2_client.modify_snapshot_attribute(**REMOVE_GROUP_ARGS)
-    assert not attributes[
-        "CreateVolumePermissions"
-    ], "This snapshot should have no permissions."
+    assert not attributes["CreateVolumePermissions"], (
+        "This snapshot should have no permissions."
+    )
 
     # Error: Add with group != 'all'
     with pytest.raises(ClientError) as cm:

--- a/tests/test_ec2/test_elastic_network_interfaces.py
+++ b/tests/test_ec2/test_elastic_network_interfaces.py
@@ -1051,7 +1051,7 @@ def test_recreate_instance_with_same_ip_address():
         ec2_client.get_waiter("instance_terminated").wait(InstanceIds=[instance_id])
 
 
-def setup_vpc(boto3):  # pylint: disable=W0621
+def setup_vpc(boto3):
     ec2resource = boto3.resource("ec2", region_name="us-east-1")
     ec2client = boto3.client("ec2", "us-east-1")
 

--- a/tests/test_ec2/test_flow_logs.py
+++ b/tests/test_ec2/test_flow_logs.py
@@ -748,7 +748,7 @@ def test_flow_logs_by_ids():
     assert fl3 not in all_ids
 
 
-def retrieve_all_logs(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_logs(client, filters=[]):
     resp = client.describe_flow_logs(Filters=filters)
     all_logs = resp["FlowLogs"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -2803,7 +2803,7 @@ def test_instance_iam_instance_profile():
     assert retrieve_all_instances(ec2_client, filters) == []
 
 
-def retrieve_all_reservations(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_reservations(client, filters=[]):
     resp = client.describe_instances(Filters=filters)
     all_reservations = resp["Reservations"]
     next_token = resp.get("NextToken")
@@ -2814,7 +2814,7 @@ def retrieve_all_reservations(client, filters=[]):  # pylint: disable=W0102
     return all_reservations
 
 
-def retrieve_all_instances(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_instances(client, filters=[]):
     reservations = retrieve_all_reservations(client, filters)
     return [i for r in reservations for i in r["Instances"]]
 

--- a/tests/test_ec2/test_internet_gateways.py
+++ b/tests/test_ec2/test_internet_gateways.py
@@ -311,7 +311,7 @@ def test_create_internet_gateway_with_tags():
     assert igw.tags == [{"Key": "test", "Value": "TestRouteTable"}]
 
 
-def retrieve_all(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all(client, filters=[]):
     resp = client.describe_internet_gateways(Filters=filters)
     all_igws = resp["InternetGateways"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_launch_templates.py
+++ b/tests/test_ec2/test_launch_templates.py
@@ -670,7 +670,7 @@ def test_delete_launch_template__by_id():
     )
 
 
-def retrieve_all_templates(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_templates(client, filters=[]):
     resp = client.describe_launch_templates(Filters=filters)
     all_templates = resp["LaunchTemplates"]
     next_token = resp.get("NextToken")

--- a/tests/test_ec2/test_nat_gateway.py
+++ b/tests/test_ec2/test_nat_gateway.py
@@ -260,7 +260,7 @@ def test_describe_nat_gateway_filter_vpc_id():
     )
 
 
-def retrieve_all_gateways(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_gateways(client, filters=[]):
     resp = client.describe_nat_gateways(Filters=filters)
     all_gws = resp["NatGateways"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -1068,7 +1068,7 @@ def test_security_group_filter_ip_permission():
     assert describe[0]["GroupName"] == sg_name
 
 
-def retrieve_all_sgs(conn, filters=[]):  # pylint: disable=W0102
+def retrieve_all_sgs(conn, filters=[]):
     res = conn.describe_security_groups(Filters=filters)
     all_groups = res["SecurityGroups"]
     next_token = res.get("NextToken")

--- a/tests/test_ec2/test_tags.py
+++ b/tests/test_ec2/test_tags.py
@@ -125,7 +125,7 @@ def test_tag_limit_exceeded():
     instance = ec2.create_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)[0]
     tag_list = []
     for i in range(51):
-        tag_list.append({"Key": f"{i+1:02d}", "Value": ""})
+        tag_list.append({"Key": f"{i + 1:02d}", "Value": ""})
 
     with pytest.raises(ClientError) as ex:
         client.create_tags(Resources=[instance.id], Tags=tag_list)
@@ -539,7 +539,7 @@ def get_filter(tag_val):
     ]
 
 
-def retrieve_all_tagged(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_tagged(client, filters=[]):
     resp = client.describe_tags(Filters=filters)
     tags = resp["Tags"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_transit_gateway_peering_attachments.py
+++ b/tests/test_ec2/test_transit_gateway_peering_attachments.py
@@ -266,7 +266,7 @@ def create_peering_attachment(
     )["TransitGatewayPeeringAttachment"]["TransitGatewayAttachmentId"]
 
 
-def retrieve_all_attachments(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_attachments(client, filters=[]):
     resp = client.describe_transit_gateway_peering_attachments(Filters=filters)
     attmnts = resp["TransitGatewayPeeringAttachments"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_virtual_private_gateways.py
+++ b/tests/test_ec2/test_virtual_private_gateways.py
@@ -289,7 +289,7 @@ def test_detach_vpn_gateway_boto3():
     assert attachments == [{"State": "detached", "VpcId": vpc.id}]
 
 
-def retrieve_all(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all(client, filters=[]):
     resp = client.describe_vpn_gateways(Filters=filters)
     all_gateways = resp["VpnGateways"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_vpc_endpoint_services_integration.py
+++ b/tests/test_ec2/test_vpc_endpoint_services_integration.py
@@ -102,14 +102,13 @@ def validate_s3_service_endpoint_interface(details):
 @mock_aws
 def test_describe_vpc_endpoint_services_filters():
     """Verify that different type of filters return the expected results."""
-    from moto.ec2.models import ec2_backends  # pylint: disable=import-outside-toplevel
+    from moto.ec2.models import ec2_backends
 
     ec2_backend = ec2_backends[ACCOUNT_ID]["us-west-1"]
     test_data = fake_endpoint_services()
 
     # Allow access to _filter_endpoint_services as it provides the best
     # means of testing this logic.
-    # pylint: disable=protected-access
 
     # Test a service name filter, using s3 as the service name.
     filtered_services = ec2_backend._filter_endpoint_services(

--- a/tests/test_ec2/test_vpcs.py
+++ b/tests/test_ec2/test_vpcs.py
@@ -160,7 +160,7 @@ def test_vpc_state_available_filter():
     assert vpc2.id in [v["VpcId"] for v in available]
 
 
-def retrieve_all_vpcs(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_vpcs(client, filters=[]):
     resp = client.describe_vpcs(Filters=filters)
     all_vpcs = resp["Vpcs"]
     token = resp.get("NextToken")

--- a/tests/test_ec2/test_vpn_connections.py
+++ b/tests/test_ec2/test_vpn_connections.py
@@ -109,7 +109,7 @@ def test_describe_vpn_connections_unknown():
     assert err["Code"] == "InvalidVpnConnectionID.NotFound"
 
 
-def retrieve_all_vpncs(client, filters=[]):  # pylint: disable=W0102
+def retrieve_all_vpncs(client, filters=[]):
     resp = client.describe_vpn_connections(Filters=filters)
     all_vpncs = resp["VpnConnections"]
     token = resp.get("NextToken")

--- a/tests/test_ecr/test_ecr_helpers.py
+++ b/tests/test_ecr/test_ecr_helpers.py
@@ -5,7 +5,7 @@ import random
 
 
 def _generate_random_sha():
-    random_sha = hashlib.sha256(f"{random.randint(0,100)}".encode("utf-8")).hexdigest()
+    random_sha = hashlib.sha256(f"{random.randint(0, 100)}".encode("utf-8")).hexdigest()
     return f"sha256:{random_sha}"
 
 

--- a/tests/test_efs/test_access_point_tagging.py
+++ b/tests/test_efs/test_access_point_tagging.py
@@ -1,6 +1,6 @@
 import pytest
 
-from . import fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_efs  # noqa
 
 
 @pytest.fixture(scope="function", name="file_system")

--- a/tests/test_efs/test_access_points.py
+++ b/tests/test_efs/test_access_points.py
@@ -3,7 +3,7 @@ from botocore.exceptions import ClientError
 
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
-from . import fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_efs  # noqa
 
 
 @pytest.fixture(scope="function", name="file_system")

--- a/tests/test_efs/test_file_system.py
+++ b/tests/test_efs/test_file_system.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 
 from tests.test_efs.junk_drawer import has_status_code
 
-from . import fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_efs  # noqa
 
 ARN_PATT = r"^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$"
 STRICT_ARN_PATT = r"^arn:aws:[a-z]+:[a-z]{2}-[a-z]+-[0-9]:[0-9]+:[a-z-]+\/[a-z0-9-]+$"

--- a/tests/test_efs/test_filesystem_policy.py
+++ b/tests/test_efs/test_filesystem_policy.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import ClientError
 
-from . import fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_efs  # noqa
 
 
 def test_describe_file_system_policy__initial(efs):

--- a/tests/test_efs/test_filesystem_tagging.py
+++ b/tests/test_efs/test_filesystem_tagging.py
@@ -1,4 +1,4 @@
-from . import fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_efs  # noqa
 
 
 def test_list_tags_for_resource__without_tags(efs):

--- a/tests/test_efs/test_lifecycle_config.py
+++ b/tests/test_efs/test_lifecycle_config.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import ClientError
 
-from . import fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_efs  # noqa
 
 
 def test_describe_filesystem_config__unknown(efs):

--- a/tests/test_efs/test_mount_target.py
+++ b/tests/test_efs/test_mount_target.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from tests.test_efs.junk_drawer import has_status_code
 
-from . import fixture_ec2, fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_ec2, fixture_efs  # noqa
 
 
 @pytest.fixture(scope="function", name="file_system")
@@ -66,9 +66,9 @@ def test_create_mount_target_aws_sample_2(efs, ec2, file_system, subnet):
         ip_addr = ip_addr_obj.exploded
         break
     else:
-        assert (
-            False
-        ), f"Could not generate an IP address from CIDR block: {subnet['CidrBlock']}"
+        assert False, (
+            f"Could not generate an IP address from CIDR block: {subnet['CidrBlock']}"
+        )
     desc_sg_resp = ec2.describe_security_groups()
     security_group = desc_sg_resp["SecurityGroups"][0]
     security_group_id = security_group["GroupId"]
@@ -206,7 +206,7 @@ def test_create_mount_target_too_many_security_groups(efs, ec2, file_system, sub
     assert "SecurityGroupLimitExceeded" == resp["Error"]["Code"]
 
 
-def test_delete_file_system_mount_targets_attached(efs, ec2, file_system, subnet):  # pylint: disable=unused-argument
+def test_delete_file_system_mount_targets_attached(efs, ec2, file_system, subnet):
     efs.create_mount_target(
         FileSystemId=file_system["FileSystemId"], SubnetId=subnet["SubnetId"]
     )
@@ -217,7 +217,7 @@ def test_delete_file_system_mount_targets_attached(efs, ec2, file_system, subnet
     assert "FileSystemInUse" == resp["Error"]["Code"]
 
 
-def test_describe_mount_targets_minimal_case(efs, ec2, file_system, subnet):  # pylint: disable=unused-argument
+def test_describe_mount_targets_minimal_case(efs, ec2, file_system, subnet):
     create_resp = efs.create_mount_target(
         FileSystemId=file_system["FileSystemId"], SubnetId=subnet["SubnetId"]
     )
@@ -238,7 +238,7 @@ def test_describe_mount_targets_minimal_case(efs, ec2, file_system, subnet):  # 
     assert mount_target == create_resp
 
 
-def test_describe_mount_targets__by_access_point_id(efs, ec2, file_system, subnet):  # pylint: disable=unused-argument
+def test_describe_mount_targets__by_access_point_id(efs, ec2, file_system, subnet):
     create_resp = efs.create_mount_target(
         FileSystemId=file_system["FileSystemId"], SubnetId=subnet["SubnetId"]
     )

--- a/tests/test_efs/test_mount_target_security_groups.py
+++ b/tests/test_efs/test_mount_target_security_groups.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import ClientError
 
-from . import fixture_ec2, fixture_efs  # noqa # pylint: disable=unused-import
+from . import fixture_ec2, fixture_efs  # noqa
 
 
 @pytest.fixture(scope="function", name="file_system")

--- a/tests/test_efs/test_server.py
+++ b/tests/test_efs/test_server.py
@@ -20,7 +20,7 @@ def fixture_aws_credentials(monkeypatch):
 
 
 @pytest.fixture(scope="function", name="efs_client")
-def fixture_efs_client(aws_credentials):  # pylint: disable=unused-argument
+def fixture_efs_client(aws_credentials):
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("Using server directly - no point in testing ServerMode")
 
@@ -29,7 +29,7 @@ def fixture_efs_client(aws_credentials):  # pylint: disable=unused-argument
 
 
 @pytest.fixture(scope="function", name="subnet_id")
-def fixture_subnet_id(aws_credentials):  # pylint: disable=unused-argument
+def fixture_subnet_id(aws_credentials):
     with mock_aws():
         ec2_client = server.create_backend_app("ec2").test_client()
         resp = ec2_client.get("/?Action=DescribeSubnets")

--- a/tests/test_emrcontainers/test_emrcontainers.py
+++ b/tests/test_emrcontainers/test_emrcontainers.py
@@ -204,7 +204,7 @@ class TestListVirtualClusters:
     tomorrow = today + timedelta(days=1)
 
     @pytest.fixture(autouse=True)
-    def _setup_environment(self, client, virtual_cluster_factory):  # pylint: disable=unused-argument
+    def _setup_environment(self, client, virtual_cluster_factory):
         self.client = client
 
     @pytest.mark.parametrize(
@@ -417,7 +417,7 @@ class TestListJobRuns:
     tomorrow = today + timedelta(days=1)
 
     @pytest.fixture(autouse=True)
-    def _setup_environment(self, client, virtual_cluster_factory, job_factory):  # pylint: disable=unused-argument
+    def _setup_environment(self, client, virtual_cluster_factory, job_factory):
         self.client = client
         self.virtual_cluster_id = virtual_cluster_factory[0]
 

--- a/tests/test_firehose/test_firehose.py
+++ b/tests/test_firehose/test_firehose.py
@@ -368,7 +368,7 @@ def test_list_delivery_streams():
         )
     for idx in range(5):
         client.create_delivery_stream(
-            DeliveryStreamName=f"{stream_name}-{idx+5}",
+            DeliveryStreamName=f"{stream_name}-{idx + 5}",
             DeliveryStreamType="KinesisStreamAsSource",
             S3DestinationConfiguration=s3_dest_config,
         )
@@ -392,7 +392,7 @@ def test_list_delivery_streams():
 
     hoses = client.list_delivery_streams(DeliveryStreamType="KinesisStreamAsSource")
     assert len(hoses["DeliveryStreamNames"]) == 5
-    expected_kinesis_stream_list = [f"{stream_name}-{x+5}" for x in range(5)]
+    expected_kinesis_stream_list = [f"{stream_name}-{x + 5}" for x in range(5)]
     assert hoses["DeliveryStreamNames"] == expected_kinesis_stream_list
     assert hoses["HasMoreDeliveryStreams"] is False
 
@@ -401,7 +401,7 @@ def test_list_delivery_streams():
         ExclusiveStartDeliveryStreamName=f"{stream_name}-5"
     )
     assert len(hoses["DeliveryStreamNames"]) == 4
-    expected_stream_list = [f"{stream_name}-{x+5}" for x in range(1, 5)]
+    expected_stream_list = [f"{stream_name}-{x + 5}" for x in range(1, 5)]
     assert hoses["DeliveryStreamNames"] == expected_stream_list
     assert hoses["HasMoreDeliveryStreams"] is False
 
@@ -509,9 +509,7 @@ def test_lookup_name_from_arn():
         DeliveryStreamName=stream_name, S3DestinationConfiguration=s3_dest_config
     )["DeliveryStreamARN"]
 
-    from moto.firehose.models import (  # pylint: disable=import-outside-toplevel
-        firehose_backends,
-    )
+    from moto.firehose.models import firehose_backends
 
     delivery_stream = firehose_backends[ACCOUNT_ID][TEST_REGION].lookup_name_from_arn(
         arn

--- a/tests/test_kms/test_kms_policy_enforcement.py
+++ b/tests/test_kms/test_kms_policy_enforcement.py
@@ -14,7 +14,7 @@ from moto.kms.policy_validator import validate_policy
 
 @mock_aws
 class TestKMSPolicyEnforcement:
-    def setup_method(self, *args) -> None:  # pylint: disable=unused-argument
+    def setup_method(self, *args) -> None:
         self.client = boto3.client("kms", "us-east-1")
 
         # The key-value is irrelevant, so let's mock the expensive cryptographic key-generation

--- a/tests/test_kms/test_utils.py
+++ b/tests/test_kms/test_utils.py
@@ -26,11 +26,11 @@ from moto.kms.utils import (
 ENCRYPTION_CONTEXT_VECTORS = [
     (
         {"this": "is", "an": "encryption", "context": "example"},
-        b"an" b"encryption" b"context" b"example" b"this" b"is",
+        b"anencryptioncontextexamplethisis",
     ),
     (
         {"a_this": "one", "b_is": "actually", "c_in": "order"},
-        b"a_this" b"one" b"b_is" b"actually" b"c_in" b"order",
+        b"a_thisoneb_isactuallyc_inorder",
     ),
 ]
 CIPHERTEXT_BLOB_VECTORS = [
@@ -214,9 +214,7 @@ def test_decrypt_invalid_ciphertext():
     master_key = Key("nop", "nop", "nop", "nop", "nop", "nop")
     master_key_map = {master_key.id: master_key}
     ciphertext_blob = (
-        master_key.id.encode("utf-8") + b"123456789012"
-        b"1234567890123456"
-        b"some ciphertext"
+        master_key.id.encode("utf-8") + b"1234567890121234567890123456some ciphertext"
     )
 
     with pytest.raises(InvalidCiphertextException):

--- a/tests/test_lakeformation/test_resource_tags_integration.py
+++ b/tests/test_lakeformation/test_resource_tags_integration.py
@@ -9,10 +9,10 @@ from . import lakeformation_aws_verified
 @pytest.mark.aws_verified
 @lakeformation_aws_verified
 def test_add_unknown_lf_tags(
-    bucket_name=None,  # pylint: disable=unused-argument
+    bucket_name=None,
     db_name=None,
-    table_name=None,  # pylint: disable=unused-argument
-    column_name=None,  # pylint: disable=unused-argument
+    table_name=None,
+    column_name=None,
 ):
     client = boto3.client("lakeformation", region_name="eu-west-2")
     sts = boto3.client("sts", "eu-west-2")
@@ -37,10 +37,10 @@ def test_add_unknown_lf_tags(
 @pytest.mark.aws_verified
 @lakeformation_aws_verified
 def test_tag_lakeformation_database(
-    bucket_name=None,  # pylint: disable=unused-argument
+    bucket_name=None,
     db_name=None,
-    table_name=None,  # pylint: disable=unused-argument
-    column_name=None,  # pylint: disable=unused-argument
+    table_name=None,
+    column_name=None,
 ):
     client = boto3.client("lakeformation", region_name="eu-west-2")
     sts = boto3.client("sts", "eu-west-2")
@@ -121,10 +121,10 @@ def test_tag_lakeformation_database(
 @pytest.mark.aws_verified
 @lakeformation_aws_verified
 def test_tag_lakeformation_table(
-    bucket_name=None,  # pylint: disable=unused-argument
+    bucket_name=None,
     db_name=None,
     table_name=None,
-    column_name=None,  # pylint: disable=unused-argument
+    column_name=None,
 ):
     client = boto3.client("lakeformation", region_name="eu-west-2")
     sts = boto3.client("sts", "eu-west-2")
@@ -205,7 +205,7 @@ def test_tag_lakeformation_table(
 @pytest.mark.aws_verified
 @lakeformation_aws_verified
 def test_tag_lakeformation_columns(
-    bucket_name=None,  # pylint: disable=unused-argument
+    bucket_name=None,
     db_name=None,
     table_name=None,
     column_name=None,
@@ -368,7 +368,7 @@ def test_tag_lakeformation_columns(
 
 @pytest.mark.aws_verified
 @lakeformation_aws_verified
-def test_lf_tags(bucket_name=None, db_name=None, table_name=None, column_name=None):  # pylint: disable=unused-argument
+def test_lf_tags(bucket_name=None, db_name=None, table_name=None, column_name=None):
     client = boto3.client("lakeformation", region_name="eu-west-2")
     sts = boto3.client("sts", "eu-west-2")
     account_id = sts.get_caller_identity()["Account"]

--- a/tests/test_logs/test_export_tasks.py
+++ b/tests/test_logs/test_export_tasks.py
@@ -60,7 +60,7 @@ def s3():
 
 
 @pytest.fixture(scope="function")
-def log_group_name(logs):  # pylint: disable=redefined-outer-name
+def log_group_name(logs):
     name = "/moto/logs_test/" + str(uuid4())[0:5]
     logs.create_log_group(logGroupName=name)
     yield name
@@ -68,7 +68,7 @@ def log_group_name(logs):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture()
-def bucket_name(s3, account_id):  # pylint: disable=redefined-outer-name
+def bucket_name(s3, account_id):
     name = f"moto-logs-test-{str(uuid4())[0:6]}"
     s3.create_bucket(Bucket=name)
     policy = copy.copy(S3_POLICY)
@@ -103,7 +103,7 @@ def bucket_name(s3, account_id):  # pylint: disable=redefined-outer-name
 
 
 @pytest.mark.aws_verified
-def test_create_export_task_happy_path(logs, s3, log_group_name, bucket_name):  # pylint: disable=redefined-outer-name
+def test_create_export_task_happy_path(logs, s3, log_group_name, bucket_name):
     fromTime = 1611316574
     to = 1642852574
     resp = logs.create_export_task(
@@ -140,7 +140,7 @@ def test_create_export_task_happy_path(logs, s3, log_group_name, bucket_name):  
 
 
 @pytest.mark.aws_verified
-def test_cancel_unknown_export_task(logs):  # pylint: disable=redefined-outer-name
+def test_cancel_unknown_export_task(logs):
     with pytest.raises(ClientError) as exc:
         logs.cancel_export_task(taskId=str(uuid4()))
     err = exc.value.response["Error"]
@@ -152,7 +152,7 @@ def test_cancel_unknown_export_task(logs):  # pylint: disable=redefined-outer-na
 def test_create_export_task_raises_ClientError_when_bucket_not_found(
     logs,
     log_group_name,
-):  # pylint: disable=redefined-outer-name
+):
     destination = "368a7022dea3dd621"
     fromTime = 1611316574
     to = 1642852574
@@ -175,7 +175,7 @@ def test_create_export_task_raises_ClientError_when_bucket_not_found(
 def test_create_export_raises_ResourceNotFoundException_log_group_not_found(
     logs,
     bucket_name,
-):  # pylint: disable=redefined-outer-name
+):
     with pytest.raises(logs.exceptions.ResourceNotFoundException) as exc:
         logs.create_export_task(
             logGroupName=f"/aws/nonexisting/{str(uuid4())[0:6]}",
@@ -189,7 +189,7 @@ def test_create_export_raises_ResourceNotFoundException_log_group_not_found(
 
 
 @pytest.mark.aws_verified
-def test_create_export_executes_export_task(logs, s3, log_group_name, bucket_name):  # pylint: disable=redefined-outer-name
+def test_create_export_executes_export_task(logs, s3, log_group_name, bucket_name):
     fromTime = int(unix_time_millis(datetime.now() - timedelta(days=1)))
     to = int(unix_time_millis(datetime.now() + timedelta(days=1)))
 
@@ -223,7 +223,7 @@ def test_create_export_executes_export_task(logs, s3, log_group_name, bucket_nam
     assert "aws-logs-write-test" in key_names
 
 
-def test_describe_export_tasks_happy_path(logs, s3, log_group_name):  # pylint: disable=redefined-outer-name
+def test_describe_export_tasks_happy_path(logs, s3, log_group_name):
     destination = "mybucket"
     fromTime = 1611316574
     to = 1642852574
@@ -244,7 +244,7 @@ def test_describe_export_tasks_happy_path(logs, s3, log_group_name):  # pylint: 
     assert resp["exportTasks"][0]["status"]["message"] == "Completed successfully"
 
 
-def test_describe_export_tasks_out_of_order_timestamps(logs, s3, log_group_name):  # pylint: disable=redefined-outer-name
+def test_describe_export_tasks_out_of_order_timestamps(logs, s3, log_group_name):
     destination = "mybucket"
     fromTime = 1000
     to = 500
@@ -265,7 +265,7 @@ def test_describe_export_tasks_out_of_order_timestamps(logs, s3, log_group_name)
     assert resp["exportTasks"][0]["status"]["message"] == "Task is active"
 
 
-def test_describe_export_tasks_task_id(logs, log_group_name, bucket_name):  # pylint: disable=redefined-outer-name
+def test_describe_export_tasks_task_id(logs, log_group_name, bucket_name):
     fromTime = 1611316574
     to = 1642852574
     resp = logs.create_export_task(
@@ -287,6 +287,6 @@ def test_describe_export_tasks_task_id(logs, log_group_name, bucket_name):  # py
 
 def test_describe_export_tasks_raises_ResourceNotFoundException_task_id_not_found(
     logs,
-):  # pylint: disable=redefined-outer-name
+):
     with pytest.raises(logs.exceptions.ResourceNotFoundException):
         logs.describe_export_tasks(taskId="368a7022dea3dd621")

--- a/tests/test_logs/test_integration.py
+++ b/tests/test_logs/test_integration.py
@@ -163,9 +163,9 @@ def test_put_subscription_filter_with_lambda():
     msg_showed_up, received_message = _wait_for_log_msg(
         client_logs, "/aws/lambda/test", "awslogs"
     )
-    assert (
-        msg_showed_up
-    ), f"CloudWatch log event was not found. All logs: {received_message}"
+    assert msg_showed_up, (
+        f"CloudWatch log event was not found. All logs: {received_message}"
+    )
 
     data = json.loads(received_message)["awslogs"]["data"]
     response = json.loads(
@@ -234,9 +234,9 @@ def test_subscription_filter_applies_to_new_streams():
     msg_showed_up, received_message = _wait_for_log_msg(
         client_logs, "/aws/lambda/test", "awslogs"
     )
-    assert (
-        msg_showed_up
-    ), f"CloudWatch log event was not found. All logs: {received_message}"
+    assert msg_showed_up, (
+        f"CloudWatch log event was not found. All logs: {received_message}"
+    )
 
     data = json.loads(received_message)["awslogs"]["data"]
     response = json.loads(

--- a/tests/test_organizations/test_organizations_boto3.py
+++ b/tests/test_organizations/test_organizations_boto3.py
@@ -920,22 +920,22 @@ def test_detach_policy():
     # Attach/List/Detach policy
     for name, target in [("OU", ou_id), ("Root", root_id), ("Account", account_id)]:
         #
-        assert (
-            len(get_nonaws_policies(target, client)) == 0
-        ), "We should start with 0 policies"
+        assert len(get_nonaws_policies(target, client)) == 0, (
+            "We should start with 0 policies"
+        )
 
         #
         client.attach_policy(PolicyId=policy_id, TargetId=target)
-        assert (
-            len(get_nonaws_policies(target, client)) == 1
-        ), f"Expecting 1 policy after creation of target={name}"
+        assert len(get_nonaws_policies(target, client)) == 1, (
+            f"Expecting 1 policy after creation of target={name}"
+        )
 
         #
         response = client.detach_policy(PolicyId=policy_id, TargetId=target)
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        assert (
-            len(get_nonaws_policies(target, client)) == 0
-        ), f"Expecting 0 policies after deletion of target={name}"
+        assert len(get_nonaws_policies(target, client)) == 0, (
+            f"Expecting 0 policies after deletion of target={name}"
+        )
 
 
 def get_nonaws_policies(account_id, client):

--- a/tests/test_rds/test_rds_proxy_target_groups.py
+++ b/tests/test_rds/test_rds_proxy_target_groups.py
@@ -45,7 +45,7 @@ def secrets_arn():
 
 
 @pytest.fixture(scope="module")
-def vpc_id(mockaws):  # pylint: disable=redefined-outer-name
+def vpc_id(mockaws):
     ec2_client = boto3.client("ec2", region_name=DEFAULT_REGION)
     _vpc_id = None
     try:
@@ -56,7 +56,7 @@ def vpc_id(mockaws):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture(scope="module")
-def subnet_id1(vpc_id):  # pylint: disable=redefined-outer-name
+def subnet_id1(vpc_id):
     ec2_client = boto3.client("ec2", region_name=DEFAULT_REGION)
     try:
         subnet = ec2_client.create_subnet(
@@ -69,7 +69,7 @@ def subnet_id1(vpc_id):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture(scope="module")
-def subnet_id2(vpc_id):  # pylint: disable=redefined-outer-name
+def subnet_id2(vpc_id):
     ec2_client = boto3.client("ec2", region_name=DEFAULT_REGION)
     try:
         subnet = ec2_client.create_subnet(
@@ -82,7 +82,7 @@ def subnet_id2(vpc_id):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture(scope="module")
-def role_arn(mockaws):  # pylint: disable=redefined-outer-name
+def role_arn(mockaws):
     role_name = f"moto-test-{str(uuid4())[0:6]}"
     iam = boto3.client("iam", region_name=DEFAULT_REGION)
     try:
@@ -96,7 +96,7 @@ def role_arn(mockaws):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture(scope="module")
-def proxy_name(subnet_id1, subnet_id2, role_arn, secrets_arn):  # pylint: disable=redefined-outer-name
+def proxy_name(subnet_id1, subnet_id2, role_arn, secrets_arn):
     name = f"moto-test-{str(uuid4())[0:6]}"
     rds_client = boto3.client("rds", region_name=DEFAULT_REGION)
     proxy_creation_succeeded = False
@@ -137,7 +137,7 @@ def proxy_name(subnet_id1, subnet_id2, role_arn, secrets_arn):  # pylint: disabl
 
 
 @pytest.fixture(scope="module")
-def db_cluster_id(mockaws):  # pylint: disable=redefined-outer-name
+def db_cluster_id(mockaws):
     cluster_name = f"moto-test-{str(uuid4())[0:6]}"
     rds_client = boto3.client("rds", region_name=DEFAULT_REGION)
     cluster_creation_succeeded = False
@@ -160,7 +160,7 @@ def db_cluster_id(mockaws):  # pylint: disable=redefined-outer-name
             )
 
 
-def test_default_proxy_targets(account_id, proxy_name):  # pylint: disable=redefined-outer-name
+def test_default_proxy_targets(account_id, proxy_name):
     rds_client = boto3.client("rds", region_name=DEFAULT_REGION)
     resp = rds_client.describe_db_proxy_targets(DBProxyName=proxy_name)
 
@@ -191,7 +191,7 @@ def test_default_proxy_targets(account_id, proxy_name):  # pylint: disable=redef
     }
 
 
-def test_register_db_proxy(account_id, proxy_name, db_cluster_id):  # pylint: disable=redefined-outer-name
+def test_register_db_proxy(account_id, proxy_name, db_cluster_id):
     rds_client = boto3.client("rds", region_name=DEFAULT_REGION)
 
     resp = rds_client.register_db_proxy_targets(
@@ -224,7 +224,7 @@ def test_register_db_proxy(account_id, proxy_name, db_cluster_id):  # pylint: di
     assert resp["Targets"] == []
 
 
-def test_modify_group(proxy_name):  # pylint: disable=redefined-outer-name
+def test_modify_group(proxy_name):
     rds_client = boto3.client("rds", region_name=DEFAULT_REGION)
 
     rds_client.modify_db_proxy_target_group(

--- a/tests/test_route53/test_route53_query_logging_config.py
+++ b/tests/test_route53/test_route53_query_logging_config.py
@@ -132,7 +132,7 @@ def test_create_query_logging_config_bad_args():
 
 @mock_aws
 @pytest.mark.parametrize("route53_region", ["us-west-1", TEST_REGION])
-def test_create_query_logging_config_good_args(moto_server, route53_region):  # pylint: disable=redefined-outer-name
+def test_create_query_logging_config_good_args(moto_server, route53_region):
     """Test a valid create_logging_config() request."""
     client_kwargs = {"region_name": route53_region}
     if route53_region != TEST_REGION:

--- a/tests/test_route53domains/test_route53domains_domain.py
+++ b/tests/test_route53domains/test_route53domains_domain.py
@@ -77,9 +77,9 @@ def test_register_domain(domain_parameters: Dict):
         if operation["OperationId"] == operation_id:
             return
 
-    assert (
-        operation_id in [operation["OperationId"] for operation in operations]
-    ), "Could not find expected operation id returned from `register_domain` in operation list"
+    assert operation_id in [operation["OperationId"] for operation in operations], (
+        "Could not find expected operation id returned from `register_domain` in operation list"
+    )
 
 
 @mock_aws
@@ -92,9 +92,9 @@ def test_register_domain_creates_hosted_zone(
     route53domains_client.register_domain(**domain_parameters)
 
     res = route53_client.list_hosted_zones()
-    assert "domain.com" in [
-        zone["Name"] for zone in res["HostedZones"]
-    ], "`register_domain` did not create a new hosted zone with the same name"
+    assert "domain.com" in [zone["Name"] for zone in res["HostedZones"]], (
+        "`register_domain` did not create a new hosted zone with the same name"
+    )
 
 
 @mock_aws

--- a/tests/test_route53resolver/test_route53resolver.py
+++ b/tests/test_route53resolver/test_route53resolver.py
@@ -86,9 +86,9 @@ def test_associate_resolver_query_log_config_with_nonexistent_vpc():
         client.associate_resolver_query_log_config(
             ResolverQueryLogConfigId=config_id, ResourceId="vpc-nonexistent"
         )
-        assert (
-            False
-        ), "Expected an InvalidParameterException but no exception was raised"
+        assert False, (
+            "Expected an InvalidParameterException but no exception was raised"
+        )
     except client.exceptions.InvalidParameterException as e:
         assert "vpc ID 'vpc-nonexistent' does not exist" in str(e)
 

--- a/tests/test_route53resolver/test_route53resolver_endpoint.py
+++ b/tests/test_route53resolver/test_route53resolver_endpoint.py
@@ -296,7 +296,7 @@ def test_route53resolver_bad_create_endpoint_security_groups():
 
 
 @mock_aws
-def test_route53resolver_create_resolver_endpoint():  # pylint: disable=too-many-locals
+def test_route53resolver_create_resolver_endpoint():
     """Test good create_resolver_endpoint API calls."""
     client = boto3.client("route53resolver", region_name=TEST_REGION)
     ec2_client = boto3.client("ec2", region_name=TEST_REGION)

--- a/tests/test_route53resolver/test_route53resolver_rule.py
+++ b/tests/test_route53resolver/test_route53resolver_rule.py
@@ -120,7 +120,7 @@ def test_route53resolver_invalid_create_rule_args():
 
 
 @mock_aws
-def test_route53resolver_create_resolver_rule():  # pylint: disable=too-many-locals
+def test_route53resolver_create_resolver_rule():
     """Test good create_resolver_rule API calls."""
     client = boto3.client("route53resolver", region_name=TEST_REGION)
     ec2_client = boto3.client("ec2", region_name=TEST_REGION)

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1690,7 +1690,7 @@ def test_head_object(size, bucket_name=None):
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 206
     assert (
         resp["ResponseMetadata"]["HTTPHeaders"]["content-range"]
-        == f"bytes 0-{size-1}/{size}"
+        == f"bytes 0-{size - 1}/{size}"
     )
     assert resp["ContentLength"] == size
     assert resp["AcceptRanges"] == "bytes"

--- a/tests/test_s3/test_s3_logging.py
+++ b/tests/test_s3/test_s3_logging.py
@@ -284,10 +284,14 @@ def test_invalid_bucket_logging_when_permissions_are_false():
     log_bucket = "logbucket"
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.create_bucket(Bucket=log_bucket)
-    with patch(
-        "moto.s3.models.FakeBucket._log_permissions_enabled_policy", return_value=False
-    ), patch(
-        "moto.s3.models.FakeBucket._log_permissions_enabled_acl", return_value=False
+    with (
+        patch(
+            "moto.s3.models.FakeBucket._log_permissions_enabled_policy",
+            return_value=False,
+        ),
+        patch(
+            "moto.s3.models.FakeBucket._log_permissions_enabled_acl", return_value=False
+        ),
     ):
         with pytest.raises(ClientError) as err:
             s3_client.put_bucket_logging(
@@ -310,10 +314,14 @@ def test_valid_bucket_logging_when_permissions_are_true():
     log_bucket = "logbucket"
     s3_client.create_bucket(Bucket=bucket_name)
     s3_client.create_bucket(Bucket=log_bucket)
-    with patch(
-        "moto.s3.models.FakeBucket._log_permissions_enabled_policy", return_value=True
-    ), patch(
-        "moto.s3.models.FakeBucket._log_permissions_enabled_acl", return_value=True
+    with (
+        patch(
+            "moto.s3.models.FakeBucket._log_permissions_enabled_policy",
+            return_value=True,
+        ),
+        patch(
+            "moto.s3.models.FakeBucket._log_permissions_enabled_acl", return_value=True
+        ),
     ):
         s3_client.put_bucket_logging(
             Bucket=bucket_name,

--- a/tests/test_s3/test_s3_object_attributes.py
+++ b/tests/test_s3/test_s3_object_attributes.py
@@ -8,7 +8,7 @@ from moto import mock_aws
 
 @mock_aws
 class TestS3ObjectAttributes:
-    def setup_method(self, *args) -> None:  # pylint: disable=unused-argument
+    def setup_method(self, *args) -> None:
         self.bucket_name = str(uuid4())
         self.s3_resource = boto3.resource("s3", region_name="us-east-1")
         self.client = boto3.client("s3", region_name="us-east-1")

--- a/tests/test_s3/test_s3_utils.py
+++ b/tests/test_s3/test_s3_utils.py
@@ -107,8 +107,6 @@ def test_checksum_crc32():
 
 def test_checksum_crc32c():
     try:
-        import crc32c  # noqa # pylint: disable=unused-import
-
         assert compute_checksum(b"somedata", "CRC32C") == b"dB9qBQ=="
     except:  # noqa: E722 Do not use bare except
         # Optional library Can't be found - just revert to CRC32

--- a/tests/test_sagemaker/test_sagemaker_model_cards.py
+++ b/tests/test_sagemaker/test_sagemaker_model_cards.py
@@ -129,16 +129,16 @@ def test_list_model_cards_basic():
     resp = client.list_model_cards().get("ModelCardSummaries")
     assert len(resp) == 3
     for i, r in enumerate(resp):
-        assert (
-            r["ModelCardName"] == f"my-{cards_to_create[i]}-model-card"
-        ), "model card name didn't match expected"
+        assert r["ModelCardName"] == f"my-{cards_to_create[i]}-model-card", (
+            "model card name didn't match expected"
+        )
         assert (
             r["ModelCardArn"]
             == f"arn:aws:sagemaker:us-east-1:{ACCOUNT_ID}:model-card/my-{cards_to_create[i]}-model-card"
         ), "model_card_arn didn't match expected"
-        assert (
-            r["ModelCardStatus"] == "Draft"
-        ), "model card status didn't match expected"
+        assert r["ModelCardStatus"] == "Draft", (
+            "model card status didn't match expected"
+        )
 
 
 @mock_aws

--- a/tests/test_scheduler/__init__.py
+++ b/tests/test_scheduler/__init__.py
@@ -4,9 +4,9 @@ from typing import List, Tuple
 from moto.core.utils import utcnow
 
 
-def pytest_parametrize_test_create_get_schedule__with_start_date() -> (
-    List[Tuple[datetime, datetime]]
-):
+def pytest_parametrize_test_create_get_schedule__with_start_date() -> List[
+    Tuple[datetime, datetime]
+]:
     now = utcnow()
     timedelta_kwargs = {"days": 1, "hours": 1, "weeks": 1}
     return_ = []
@@ -19,9 +19,9 @@ def pytest_parametrize_test_create_get_schedule__with_start_date() -> (
     return return_
 
 
-def pytest_parametrize_test_create_schedule__exception_with_start_date() -> (
-    List[datetime]
-):
+def pytest_parametrize_test_create_schedule__exception_with_start_date() -> List[
+    datetime
+]:
     now = utcnow()
     timedelta_kwargs = {"days": 1, "minutes": 6, "hours": 1, "weeks": 1}
     return_ = []

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -1193,8 +1193,7 @@ def test_create_ses_template():
         Template={
             "TemplateName": "MyTemplate",
             "SubjectPart": "Greetings, {{name}}!",
-            "TextPart": "Dear {{name}},"
-            "\r\nYour favorite animal is {{favoriteanimal}}.",
+            "TextPart": "Dear {{name}},\r\nYour favorite animal is {{favoriteanimal}}.",
             "HtmlPart": "<h1>Hello {{name}},"
             "</h1><p>Your favorite animal is {{favoriteanimal}}.</p>",
         }
@@ -1247,8 +1246,7 @@ def test_render_template():
         Template={
             "TemplateName": "MyTestTemplate",
             "SubjectPart": "Greetings, {{name}}!",
-            "TextPart": "Dear {{name}},"
-            "\r\nYour favorite animal is {{favoriteanimal}}.",
+            "TextPart": "Dear {{name}},\r\nYour favorite animal is {{favoriteanimal}}.",
             "HtmlPart": "<h1>Hello {{name}},"
             "</h1><p>Your favorite animal is {{favoriteanimal}}.</p>",
         }
@@ -1268,8 +1266,7 @@ def test_render_template():
         Template={
             "TemplateName": "MyTestTemplate1",
             "SubjectPart": "Greetings, {{name}}!",
-            "TextPart": "Dear {{name}},"
-            "\r\nYour favorite animal is {{favoriteanimal}}.",
+            "TextPart": "Dear {{name}},\r\nYour favorite animal is {{favoriteanimal}}.",
             "HtmlPart": "<h1>Hello {{name}},"
             "</h1><p>Your favorite animal is {{favoriteanimal  }}.</p>",
         }
@@ -1334,7 +1331,7 @@ def test_update_ses_template():
     template = {
         "TemplateName": "MyTemplateToUpdate",
         "SubjectPart": "Greetings, {{name}}!",
-        "TextPart": "Dear {{name}}," "\r\nYour favorite animal is {{favoriteanimal}}.",
+        "TextPart": "Dear {{name}},\r\nYour favorite animal is {{favoriteanimal}}.",
         "HtmlPart": "<h1>Hello {{name}},"
         "</h1><p>Your favorite animal is {{favoriteanimal}}.</p>",
     }

--- a/tests/test_sesv2/test_sesv2.py
+++ b/tests/test_sesv2/test_sesv2.py
@@ -19,7 +19,7 @@ def ses_v1():
 
 
 @mock_aws
-def test_send_email(ses_v1):  # pylint: disable=redefined-outer-name
+def test_send_email(ses_v1):
     # Setup
     conn = boto3.client("sesv2", region_name="us-east-1")
     kwargs = dict(
@@ -60,7 +60,7 @@ def test_send_email(ses_v1):  # pylint: disable=redefined-outer-name
 
 
 @mock_aws
-def test_send_html_email(ses_v1):  # pylint: disable=redefined-outer-name
+def test_send_html_email(ses_v1):
     # Setup
     conn = boto3.client("sesv2", region_name="us-east-1")
     ses_v1.verify_domain_identity(Domain="example.com")
@@ -93,7 +93,7 @@ def test_send_html_email(ses_v1):  # pylint: disable=redefined-outer-name
 
 
 @mock_aws
-def test_send_raw_email(ses_v1):  # pylint: disable=redefined-outer-name
+def test_send_raw_email(ses_v1):
     # Setup
     conn = boto3.client("sesv2", region_name="us-east-1")
     message = get_raw_email()
@@ -119,7 +119,7 @@ def test_send_raw_email(ses_v1):  # pylint: disable=redefined-outer-name
 @mock_aws
 def test_send_raw_email__with_specific_message(
     ses_v1,
-):  # pylint: disable=redefined-outer-name
+):
     # Setup
     conn = boto3.client("sesv2", region_name="us-east-1")
     message = get_raw_email()
@@ -150,7 +150,7 @@ def test_send_raw_email__with_specific_message(
 @mock_aws
 def test_send_raw_email__with_to_address_display_name(
     ses_v1,
-):  # pylint: disable=redefined-outer-name
+):
     # Setup
     conn = boto3.client("sesv2", region_name="us-east-1")
     message = get_raw_email()

--- a/tests/test_sns/test_application_boto3.py
+++ b/tests/test_sns/test_application_boto3.py
@@ -348,7 +348,7 @@ def test_get_endpoint_attributes():
 @sns_aws_verified
 def test_get_non_existent_endpoint_attributes(
     api_key=None,
-):  # pylint: disable=unused-argument
+):
     identity = boto3.client("sts", region_name="us-east-1").get_caller_identity()
     account_id = identity["Account"]
 

--- a/tests/test_sns/test_http_message_verification.py
+++ b/tests/test_sns/test_http_message_verification.py
@@ -114,15 +114,15 @@ class TestHTTPMessageVerification:
         msg = TestHTTPMessageVerification.MESSAGES_RECEIVED[topic_arn]
 
         string_to_sign = f"""Message
-{msg['Message']}
+{msg["Message"]}
 MessageId
-{msg['MessageId']}
+{msg["MessageId"]}
 Timestamp
-{msg['Timestamp']}
+{msg["Timestamp"]}
 TopicArn
-{msg['TopicArn']}
+{msg["TopicArn"]}
 Type
-{msg['Type']}
+{msg["Type"]}
 """
 
         signature = base64.b64decode(msg["Signature"])

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1946,9 +1946,9 @@ def test_delete_message_batch_with_invalid_receipt_id():
     ]
     response = client.delete_message_batch(QueueUrl=queue_url, Entries=entries)
 
-    assert response["Successful"] == [
-        {"Id": messages[0]["MessageId"]}
-    ], "delete ok for real message"
+    assert response["Successful"] == [{"Id": messages[0]["MessageId"]}], (
+        "delete ok for real message"
+    )
 
     assert response["Failed"] == [
         {
@@ -2102,8 +2102,7 @@ def test_send_message_batch_errors(queue_name=None, queue_url=None):
             QueueUrl=queue_url, Entries=[{"Id": "id_1", "MessageBody": "b" * 262145}]
         )
     assert client_error.value.response["Error"]["Message"] == (
-        "Batch requests cannot be longer than 262144 bytes. "
-        "You have sent 262145 bytes."
+        "Batch requests cannot be longer than 262144 bytes. You have sent 262145 bytes."
     )
 
     with pytest.raises(ClientError) as client_error:

--- a/tests/test_ssm/test_ssm_boto3.py
+++ b/tests/test_ssm/test_ssm_boto3.py
@@ -2145,7 +2145,7 @@ def test_parameter_version_limit():
     for i in range(PARAMETER_VERSION_LIMIT + 1):
         client.put_parameter(
             Name=parameter_name,
-            Value=f"value-{(i+1)}",
+            Value=f"value-{(i + 1)}",
             Type="String",
             Overwrite=True,
         )
@@ -2170,7 +2170,7 @@ def test_parameter_overwrite_fails_when_limit_reached_and_oldest_version_has_lab
     for i in range(PARAMETER_VERSION_LIMIT):
         client.put_parameter(
             Name=parameter_name,
-            Value=f"value-{(i+1)}",
+            Value=f"value-{(i + 1)}",
             Type="String",
             Overwrite=True,
         )
@@ -2205,7 +2205,7 @@ def test_get_parameters_includes_invalid_parameter_when_requesting_invalid_versi
     for i in range(versions_to_create):
         client.put_parameter(
             Name=parameter_name,
-            Value=f"value-{(i+1)}",
+            Value=f"value-{(i + 1)}",
             Type="String",
             Overwrite=True,
         )
@@ -2235,7 +2235,7 @@ def test_get_parameters_includes_invalid_parameter_when_requesting_invalid_label
     for i in range(versions_to_create):
         client.put_parameter(
             Name=parameter_name,
-            Value=f"value-{(i+1)}",
+            Value=f"value-{(i + 1)}",
             Type="String",
             Overwrite=True,
         )

--- a/tests/test_ssoadmin/test_ssoadmin.py
+++ b/tests/test_ssoadmin/test_ssoadmin.py
@@ -443,8 +443,7 @@ def test_update_permission_set_unknown():
         client.update_permission_set(
             InstanceArn="arn:aws:sso:::instance/ins-aaaabbbbccccdddd",
             PermissionSetArn=(
-                "arn:aws:sso:::permissionSet/ins-eeeeffffgggghhhh/"
-                "ps-hhhhkkkkppppoooo"
+                "arn:aws:sso:::permissionSet/ins-eeeeffffgggghhhh/ps-hhhhkkkkppppoooo"
             ),
             Description="New description",
             SessionDuration="PT2H",

--- a/tests/test_workspacesweb/test_workspacesweb.py
+++ b/tests/test_workspacesweb/test_workspacesweb.py
@@ -183,15 +183,15 @@ def test_get_portal():
     )["portalArn"]
     resp = client.get_portal(portalArn=arn)["portal"]
     assert resp["portalArn"] == arn, f"Expected ARN {arn} in response"
-    assert (
-        resp["authenticationType"] == "Standard"
-    ), "Expected authentication type in response"
-    assert (
-        resp["instanceType"] == "TestInstanceType"
-    ), "Expected instance type in response"
-    assert (
-        resp["maxConcurrentSessions"] == 5
-    ), "Expected max concurrent sessions in response"
+    assert resp["authenticationType"] == "Standard", (
+        "Expected authentication type in response"
+    )
+    assert resp["instanceType"] == "TestInstanceType", (
+        "Expected instance type in response"
+    )
+    assert resp["maxConcurrentSessions"] == 5, (
+        "Expected max concurrent sessions in response"
+    )
 
 
 @mock_aws

--- a/tests/test_xray/test_xray_client.py
+++ b/tests/test_xray/test_xray_client.py
@@ -7,7 +7,7 @@ import aws_xray_sdk.core.patcher as xray_core_patcher
 import boto3
 import botocore.client
 import botocore.endpoint
-import requests  # noqa # pylint: disable=all
+import requests
 
 from moto import mock_aws
 from moto.utilities.distutils_version import LooseVersion


### PR DESCRIPTION
The `ruff` formatter is not yet stable, but it makes sense (IMO) to update to the latest version as much as possible, to reduce the amount of changes we'll have to make when `ruff` 1.0 releases.

The latest version of `ruff` supports a ton more of `pylint`'s rules. The ones that are not covered yet, but that we had enabled:
 - arguments-renamed
 - deprecated-module
 - redefined-outer-name
 - signature-differs

I'm sure that thse rules will be part of `ruff` at some point, but in the mean time, I propose we drop `pylint` altogether. Validation of these 4 rules is nice, but it's not worth the time it takes `pylint` to run (again, IMHO).

@bpandola What do you think - any objections to this?