### PR TITLE
EventBridge: Update describe_event_bus schema

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1573,12 +1573,14 @@ class EventsBackend(BaseBackend):
         return self.event_buses[name]
 
     def list_event_buses(self, name_prefix: Optional[str]) -> List[EventBus]:
-        return [
-            event_bus
-            for event_bus in self.event_buses.values()
-            if event_bus.name != "default"
-            and (name_prefix is None or event_bus.name.startswith(name_prefix))
-        ]
+        if name_prefix:
+            return [
+                event_bus
+                for event_bus in self.event_buses.values()
+                if event_bus.name.startswith(name_prefix)
+            ]
+
+        return list(self.event_buses.values())
 
     def delete_event_bus(self, name: str) -> None:
         if name == "default":

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -376,6 +376,9 @@ class EventBus(CloudFormationModel):
         account_id: str,
         region_name: str,
         name: str,
+        description: Optional[str] = None,
+        kms_key_identifier: Optional[str] = None,
+        dead_letter_config: Optional[Dict[str, str]] = None,
         tags: Optional[List[Dict[str, str]]] = None,
     ):
         self.account_id = account_id
@@ -384,11 +387,12 @@ class EventBus(CloudFormationModel):
         self.arn = f"arn:{get_partition(self.region)}:events:{self.region}:{account_id}:event-bus/{name}"
         self.tags = tags or []
 
+        self.description = description
+        self.kms_key_identifier = kms_key_identifier
+        self.dead_letter_config = dead_letter_config
+
         self.creation_time = unix_time()
         self.last_modified_time = self.creation_time
-        self.description = None
-        self.kms_key_identifier = None
-        self.dead_letter_config = None
 
         self._statements: Dict[str, EventBusPolicyStatement] = {}
         self.rules: Dict[str, Rule] = OrderedDict()
@@ -1532,6 +1536,9 @@ class EventsBackend(BaseBackend):
         self,
         name: str,
         event_source_name: Optional[str] = None,
+        description: Optional[str] = None,
+        kms_key_identifier: Optional[str] = None,
+        dead_letter_config: Optional[Dict[str, str]] = None,
         tags: Optional[List[Dict[str, str]]] = None,
     ) -> EventBus:
         if name in self.event_buses:
@@ -1550,7 +1557,15 @@ class EventsBackend(BaseBackend):
                 f"Event source {event_source_name} does not exist.",
             )
 
-        event_bus = EventBus(self.account_id, self.region_name, name, tags=tags)
+        event_bus = EventBus(
+            self.account_id,
+            self.region_name,
+            name,
+            description=description,
+            kms_key_identifier=kms_key_identifier,
+            dead_letter_config=dead_letter_config,
+            tags=tags,
+        )
         self.event_buses[name] = event_bus
         if tags:
             self.tagger.tag_resource(event_bus.arn, tags)

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -384,6 +384,12 @@ class EventBus(CloudFormationModel):
         self.arn = f"arn:{get_partition(self.region)}:events:{self.region}:{account_id}:event-bus/{name}"
         self.tags = tags or []
 
+        self.creation_time = unix_time()
+        self.last_modified_time = self.creation_time
+        self.description = None
+        self.kms_key_identifier = None
+        self.dead_letter_config = None
+
         self._statements: Dict[str, EventBusPolicyStatement] = {}
         self.rules: Dict[str, Rule] = OrderedDict()
 
@@ -1552,14 +1558,12 @@ class EventsBackend(BaseBackend):
         return self.event_buses[name]
 
     def list_event_buses(self, name_prefix: Optional[str]) -> List[EventBus]:
-        if name_prefix:
-            return [
-                event_bus
-                for event_bus in self.event_buses.values()
-                if event_bus.name.startswith(name_prefix)
-            ]
-
-        return list(self.event_buses.values())
+        return [
+            event_bus
+            for event_bus in self.event_buses.values()
+            if event_bus.name != "default"
+            and (name_prefix is None or event_bus.name.startswith(name_prefix))
+        ]
 
     def delete_event_bus(self, name: str) -> None:
         if name == "default":

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -239,7 +239,21 @@ class EventsHandler(BaseResponse):
         name = self._get_param("Name")
 
         event_bus = self.events_backend.describe_event_bus(name)
-        response = {"Name": event_bus.name, "Arn": event_bus.arn}
+        response = {
+            "Arn": event_bus.arn,
+            "CreationTime": event_bus.creation_time,
+            "Name": event_bus.name,
+            "LastModifiedTime": event_bus.last_modified_time,
+        }
+
+        if event_bus.dead_letter_config:
+            response["DeadLetterConfig"] = event_bus.dead_letter_config
+
+        if event_bus.description:
+            response["Description"] = event_bus.description
+
+        if event_bus.kms_key_identifier:
+            response["KmsKeyIdentifier"] = event_bus.kms_key_identifier
 
         if event_bus.policy:
             response["Policy"] = event_bus.policy

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -263,9 +263,19 @@ class EventsHandler(BaseResponse):
     def create_event_bus(self) -> Tuple[str, Dict[str, Any]]:
         name = self._get_param("Name")
         event_source_name = self._get_param("EventSourceName")
+        description = self._get_param("Description")
+        kms_key_identifier = self._get_param("KmsKeyIdentifier")
+        dead_letter_config = self._get_param("DeadLetterConfig")
         tags = self._get_param("Tags")
 
-        event_bus = self.events_backend.create_event_bus(name, event_source_name, tags)
+        event_bus = self.events_backend.create_event_bus(
+            name=name,
+            event_source_name=event_source_name,
+            description=description,
+            kms_key_identifier=kms_key_identifier,
+            dead_letter_config=dead_letter_config,
+            tags=tags,
+        )
         return json.dumps({"EventBusArn": event_bus.arn}), self.response_headers
 
     def list_event_buses(self) -> Tuple[str, Dict[str, Any]]:

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -922,9 +922,12 @@ def test_list_event_buses():
 
     response = client.list_event_buses()
 
-    assert len(response["EventBuses"]) == 4
-
+    assert len(response["EventBuses"]) == 5
     assert sorted(response["EventBuses"], key=lambda i: i["Name"]) == [
+        {
+            "Name": "default",
+            "Arn": f"arn:aws:events:us-east-1:{ACCOUNT_ID}:event-bus/default",
+        },
         {
             "Name": "other-bus-1",
             "Arn": f"arn:aws:events:us-east-1:{ACCOUNT_ID}:event-bus/other-bus-1",
@@ -964,20 +967,20 @@ def test_delete_event_bus():
     client.create_event_bus(Name="test-bus")
 
     response = client.list_event_buses()
-    assert len(response["EventBuses"]) == 1
-    assert response["EventBuses"][0]["Name"] == "test-bus"
+    assert len(response["EventBuses"]) == 2
 
     client.delete_event_bus(Name="test-bus")
 
     response = client.list_event_buses()
-    assert len(response["EventBuses"]) == 0
+    assert len(response["EventBuses"]) == 1
+    assert response["EventBuses"] == [
+        {
+            "Name": "default",
+            "Arn": f"arn:aws:events:us-east-1:{ACCOUNT_ID}:event-bus/default",
+        }
+    ]
 
-    default_bus = client.describe_event_bus()
-    assert default_bus["Name"] == "default"
-    assert (
-        default_bus["Arn"] == f"arn:aws:events:us-east-1:{ACCOUNT_ID}:event-bus/default"
-    )
-
+    # deleting non existing event bus should be successful
     client.delete_event_bus(Name="non-existing")
 
 


### PR DESCRIPTION
1. Updated the event bus schema to match boto3 API for describe_event_bus and create_event_bus: https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeEventBus.html
- Added timestamp fields (CreationTime and LastModifiedTime) to the EventBus class
- Added support for optional fields (DeadLetterConfig, Description, and KmsKeyIdentifier) to match the full AWS API schema