### PR TITLE
Added the ability to use tags in batch compute environment

### DIFF
--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -1219,6 +1219,7 @@ class BatchBackend(BaseBackend):
                 "type": environment.env_type,
                 "status": "VALID",
                 "statusReason": "Compute environment is available",
+                "tags": self.list_tags_for_resource(arn),
             }
             if environment.env_type == "MANAGED":
                 json_part["computeResources"] = environment.compute_resources
@@ -1234,6 +1235,7 @@ class BatchBackend(BaseBackend):
         state: str,
         compute_resources: Dict[str, Any],
         service_role: str,
+        tags: Optional[Dict[str, str]] = None,
     ) -> ComputeEnvironment:
         # Validate
         if COMPUTE_ENVIRONMENT_NAME_REGEX.match(compute_environment_name) is None:
@@ -1288,6 +1290,9 @@ class BatchBackend(BaseBackend):
             region_name=self.region_name,
         )
         self._compute_environments[new_comp_env.arn] = new_comp_env
+
+        if tags:
+            self.tag_resource(new_comp_env.arn, tags)
 
         # Ok by this point, everything is legit, so if its Managed then start some instances
         if _type == "MANAGED" and "FARGATE" not in compute_resources["type"]:

--- a/moto/batch/responses.py
+++ b/moto/batch/responses.py
@@ -30,6 +30,7 @@ class BatchResponse(BaseResponse):
         service_role = self._get_param("serviceRole")
         state = self._get_param("state")
         _type = self._get_param("type")
+        tags = self._get_param("tags")
 
         env = self.batch_backend.create_compute_environment(
             compute_environment_name=compute_env_name,
@@ -37,6 +38,7 @@ class BatchResponse(BaseResponse):
             state=state,
             compute_resources=compute_resource,
             service_role=service_role,
+            tags=tags,
         )
 
         result = {"computeEnvironmentArn": env.arn, "computeEnvironmentName": env.name}

--- a/tests/test_batch/test_batch_compute_envs.py
+++ b/tests/test_batch/test_batch_compute_envs.py
@@ -61,6 +61,62 @@ def test_create_managed_compute_environment(use_arn_for_instance_role):
 
 
 @mock_aws
+@pytest.mark.parametrize("use_arn_for_instance_role", [True, False])
+def test_create_managed_compute_environment_with_tags(use_arn_for_instance_role):
+    ec2_client, iam_client, ecs_client, _, batch_client = _get_clients()
+    _, subnet_id, sg_id, iam_arn = _setup(ec2_client, iam_client)
+
+    instance_role = (
+        iam_arn.replace("role", "instance-profile")
+        if use_arn_for_instance_role
+        else iam_arn.split("/")[-1]
+    )
+    compute_name = str(uuid4())
+    resp = batch_client.create_compute_environment(
+        computeEnvironmentName=compute_name,
+        type="MANAGED",
+        state="ENABLED",
+        computeResources={
+            "type": "EC2",
+            "minvCpus": 5,
+            "maxvCpus": 10,
+            "desiredvCpus": 5,
+            "instanceTypes": ["t2.small", "t2.medium"],
+            "imageId": "some_image_id",
+            "subnets": [subnet_id],
+            "securityGroupIds": [sg_id],
+            "ec2KeyPair": "string",
+            "instanceRole": instance_role,
+            "tags": {"string": "string"},
+            "bidPercentage": 123,
+            "spotIamFleetRole": "string",
+        },
+        serviceRole=iam_arn,
+        tags={"name": "compute-environment-1"},
+    )
+    assert "computeEnvironmentArn" in resp
+    assert resp["computeEnvironmentName"] == compute_name
+
+    our_env = batch_client.describe_compute_environments(
+        computeEnvironments=[compute_name]
+    )["computeEnvironments"][0]
+
+    # Given a t2.medium is 2 vcpu and t2.small is 1, therefore 2 mediums and 1 small should be created
+    if not settings.TEST_SERVER_MODE:
+        # Can't verify this in ServerMode, as other tests may have created instances
+        resp = ec2_client.describe_instances()
+        assert "Reservations" in resp
+        assert len(resp["Reservations"]) == 3
+
+    # Should have created 1 ECS cluster
+    all_clusters = ecs_client.list_clusters()["clusterArns"]
+    assert our_env["ecsClusterArn"] in all_clusters
+
+    assert "tags" in our_env
+    assert len(our_env["tags"]) == 1
+
+
+@mock_aws
 def test_create_managed_compute_environment_with_instance_family():
     """
     The InstanceType parameter can have multiple values:


### PR DESCRIPTION
Added the ability to use tags in the batch compute environment for the following two functions:

**1. create_compute_environment
2. describe_compute_environment**

Fixes: https://github.com/getmoto/moto/issues/8895