### PR TITLE
SQS: Return MessageGroupId (and similar attributes) on receive_messages

### DIFF
--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -643,9 +643,9 @@ class SQSResponse(BaseResponse):
                         message.approximate_first_receive_timestamp
                     )
                 if attributes["message_deduplication_id"]:
-                    msg["Attributes"][
-                        "MessageDeduplicationId"
-                    ] = message.deduplication_id
+                    msg["Attributes"]["MessageDeduplicationId"] = (
+                        message.deduplication_id
+                    )
                 if attributes["message_group_id"] and message.group_id is not None:
                     msg["Attributes"]["MessageGroupId"] = message.group_id
                 if message.system_attributes and message.system_attributes.get(

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -537,6 +537,8 @@ class SQSResponse(BaseResponse):
             message_system_attributes = self._get_multi_param(
                 "message_system_attributes"
             )
+        if not message_system_attributes:
+            message_system_attributes = set()
 
         if self.is_json():
             attribute_names = self._get_param("AttributeNames", [])

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -531,6 +531,8 @@ class SQSResponse(BaseResponse):
             message_attributes = self._get_multi_param("message_attributes")
         if not message_attributes:
             message_attributes = extract_input_message_attributes(self.querystring)
+        if self.is_json():
+            message_system_attributes = self._get_param("MessageSystemAttributeNames")
 
         if self.is_json():
             attribute_names = self._get_param("AttributeNames", [])
@@ -587,14 +589,28 @@ class SQSResponse(BaseResponse):
         )
 
         attributes = {
-            "approximate_first_receive_timestamp": False,
-            "approximate_receive_count": False,
-            "message_deduplication_id": False,
-            "message_group_id": False,
-            "sender_id": False,
-            "sent_timestamp": False,
-            "sequence_number": False,
+            "approximate_first_receive_timestamp": "ApproximateFirstReceiveTimestamp"
+            in message_system_attributes,
+            "approximate_receive_count": "ApproximateReceiveCount"
+            in message_system_attributes,
+            "message_deduplication_id": "MessageDeduplicationId"
+            in message_system_attributes,
+            "message_group_id": "MessageGroupId" in message_system_attributes,
+            "sender_id": "SenderId" in message_system_attributes,
+            "sent_timestamp": "SentTimestamp" in message_system_attributes,
+            "sequence_number": "SequenceNumber" in message_system_attributes,
         }
+
+        if "All" in message_system_attributes:
+            attributes = {
+                "approximate_first_receive_timestamp": True,
+                "approximate_receive_count": True,
+                "message_deduplication_id": True,
+                "message_group_id": True,
+                "sender_id": True,
+                "sent_timestamp": True,
+                "sequence_number": True,
+            }
 
         for attribute in attributes:
             pascalcase_name = camelcase_to_pascal(underscores_to_camelcase(attribute))
@@ -627,9 +643,9 @@ class SQSResponse(BaseResponse):
                         message.approximate_first_receive_timestamp
                     )
                 if attributes["message_deduplication_id"]:
-                    msg["Attributes"]["MessageDeduplicationId"] = (
-                        message.deduplication_id
-                    )
+                    msg["Attributes"][
+                        "MessageDeduplicationId"
+                    ] = message.deduplication_id
                 if attributes["message_group_id"] and message.group_id is not None:
                     msg["Attributes"]["MessageGroupId"] = message.group_id
                 if message.system_attributes and message.system_attributes.get(

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -533,6 +533,10 @@ class SQSResponse(BaseResponse):
             message_attributes = extract_input_message_attributes(self.querystring)
         if self.is_json():
             message_system_attributes = self._get_param("MessageSystemAttributeNames")
+        else:
+            message_system_attributes = self._get_multi_param(
+                "message_system_attributes"
+            )
 
         if self.is_json():
             attribute_names = self._get_param("AttributeNames", [])

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1946,9 +1946,9 @@ def test_delete_message_batch_with_invalid_receipt_id():
     ]
     response = client.delete_message_batch(QueueUrl=queue_url, Entries=entries)
 
-    assert response["Successful"] == [
-        {"Id": messages[0]["MessageId"]}
-    ], "delete ok for real message"
+    assert response["Successful"] == [{"Id": messages[0]["MessageId"]}], (
+        "delete ok for real message"
+    )
 
     assert response["Failed"] == [
         {

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from mailbox import Message
 import os
 import re
 import sys
@@ -1946,9 +1947,9 @@ def test_delete_message_batch_with_invalid_receipt_id():
     ]
     response = client.delete_message_batch(QueueUrl=queue_url, Entries=entries)
 
-    assert response["Successful"] == [{"Id": messages[0]["MessageId"]}], (
-        "delete ok for real message"
-    )
+    assert response["Successful"] == [
+        {"Id": messages[0]["MessageId"]}
+    ], "delete ok for real message"
 
     assert response["Failed"] == [
         {
@@ -3136,6 +3137,84 @@ def test_message_attributes_contains_trace_header():
         messages[0]["Attributes"]["AWSTraceHeader"]
         == "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
     )
+
+
+@mock_aws
+@pytest.mark.parametrize(
+    "attribute",
+    [
+        "MessageGroupId",
+        "MessageDeduplicationId",
+        "ApproximateFirstReceiveTimestamp",
+        "ApproximateReceiveCount",
+        "SenderId",
+        "SentTimestamp",
+        "SequenceNumber",
+    ],
+)
+def test_message_system_attributes_contains_system_attribute(attribute):
+    sqs = boto3.resource("sqs", region_name=REGION)
+    conn = boto3.client("sqs", region_name=REGION)
+    q_name = str(uuid4())[0:6] + ".fifo"
+    q_resp = conn.create_queue(
+        QueueName=q_name,
+        Attributes={
+            "FifoQueue": "true",
+            "ContentBasedDeduplication": "true",
+        },
+    )
+    queue = sqs.Queue(q_resp["QueueUrl"])
+    body_one = "this is a test message"
+
+    queue.send_message(
+        MessageBody=body_one,
+        MessageGroupId="group1",
+        MessageDeduplicationId="dedup1",
+    )
+
+    messages = conn.receive_message(
+        QueueUrl=queue.url,
+        MaxNumberOfMessages=2,
+        MessageSystemAttributeNames=[attribute],
+    )["Messages"]
+
+    assert messages[0]["Attributes"].get(attribute) is not None
+
+
+@mock_aws
+def test_message_system_attributes_contains_all_attributes():
+    sqs = boto3.resource("sqs", region_name=REGION)
+    conn = boto3.client("sqs", region_name=REGION)
+    q_name = str(uuid4())[0:6] + ".fifo"
+    q_resp = conn.create_queue(
+        QueueName=q_name,
+        Attributes={
+            "FifoQueue": "true",
+            "ContentBasedDeduplication": "true",
+        },
+    )
+    queue = sqs.Queue(q_resp["QueueUrl"])
+    body_one = "this is a test message"
+
+    queue.send_message(
+        MessageBody=body_one,
+        MessageGroupId="group1",
+        MessageDeduplicationId="dedup1",
+    )
+
+    messages = conn.receive_message(
+        QueueUrl=queue.url,
+        MaxNumberOfMessages=2,
+        MessageSystemAttributeNames=["All"],
+    )["Messages"]
+
+    assert messages[0]["Attributes"]["MessageGroupId"] == "group1"
+    assert messages[0]["Attributes"]["MessageDeduplicationId"] == "dedup1"
+    assert messages[0]["Attributes"]["ApproximateFirstReceiveTimestamp"] is not None
+    assert messages[0]["Attributes"]["ApproximateReceiveCount"] == "1"
+    assert messages[0]["Attributes"]["SenderId"] is not None
+    assert messages[0]["Attributes"]["SentTimestamp"] is not None
+    assert messages[0]["Attributes"]["SequenceNumber"] is not None
 
 
 @mock_aws

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-from mailbox import Message
 import os
 import re
 import sys


### PR DESCRIPTION
In our tests we were missing the MessageGroupId which AWS SQS returns when specified in the `MessageSystemAttributeNames` parameters of `receive_message`. See [boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs/client/receive_message.html).

We added support for returning the MessageGroupId and several other system attributes and added tests for those as well.