### PR TITLE
[APIGateway] Add ApiKeyNotFoundException for update/delete_api_key

### DIFF
--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -2198,6 +2198,8 @@ class APIGatewayBackend(BaseBackend):
         return self.keys[api_key_id]
 
     def update_api_key(self, api_key_id: str, patch_operations: Any) -> ApiKey:
+        if api_key_id not in self.keys:
+            raise ApiKeyNotFoundException()
         key = self.keys[api_key_id]
         return key.update_operations(patch_operations)
 

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -2204,6 +2204,8 @@ class APIGatewayBackend(BaseBackend):
         return key.update_operations(patch_operations)
 
     def delete_api_key(self, api_key_id: str) -> None:
+        if api_key_id not in self.keys:
+            raise ApiKeyNotFoundException()
         self.keys.pop(api_key_id)
 
     def create_usage_plan(self, payload: Any) -> UsagePlan:

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1965,6 +1965,16 @@ def test_update_api_key_unknown_apikey():
 
 
 @mock_aws
+def test_delete_api_key_unknown_apikey():
+    client = boto3.client("apigateway", region_name="us-east-1")
+    with pytest.raises(ClientError) as ex:
+        client.delete_api_key(apiKey="unknown")
+    err = ex.value.response["Error"]
+    assert err["Message"] == "Invalid API Key identifier specified"
+    assert err["Code"] == "NotFoundException"
+
+
+@mock_aws
 def test_get_rest_api_without_id():
     client = boto3.client("apigateway", region_name="us-east-1")
     resp = client.get_rest_api(restApiId="")

--- a/tests/test_apigateway/test_apigateway.py
+++ b/tests/test_apigateway/test_apigateway.py
@@ -1954,6 +1954,17 @@ def test_get_api_key_unknown_apikey():
 
 
 @mock_aws
+def test_update_api_key_unknown_apikey():
+    client = boto3.client("apigateway", region_name="us-east-1")
+    patch_operations = [{"op": "replace", "path": "/name", "value": "test"}]
+    with pytest.raises(ClientError) as ex:
+        client.update_api_key(apiKey="unknown", patchOperations=patch_operations)
+    err = ex.value.response["Error"]
+    assert err["Message"] == "Invalid API Key identifier specified"
+    assert err["Code"] == "NotFoundException"
+
+
+@mock_aws
 def test_get_rest_api_without_id():
     client = boto3.client("apigateway", region_name="us-east-1")
     resp = client.get_rest_api(restApiId="")


### PR DESCRIPTION
This PR:
- Raises `ApiKeyNotFoundException` for `update_api_key` when the key is not found
- Raises `ApiKeyNotFoundException` for `delete_api_key` when the key is not found
- Adds test cases for both functions

Previously these functions would raise `KeyError` instead of what AWS would raise in this case.