### PR TITLE
Allow duplicated Sids in ECR policies

### DIFF
--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -816,6 +816,8 @@ class ECRBackend(BaseBackend):
             iam_policy_document_validator._validate_resource_exist = lambda: None  # type: ignore
             # the repository policy can have the old version 2008-10-17
             iam_policy_document_validator._validate_version = lambda: None  # type: ignore
+            # ECR does not have uniqueness requirements on Sids
+            iam_policy_document_validator._validate_sid_uniqueness = lambda: None  # type: ignore
             iam_policy_document_validator.validate()
         except MalformedPolicyDocument:
             raise InvalidParameterException(


### PR DESCRIPTION
## Motivation
A recent customer request in LocalStack hinted towards validation errors of an ECR policy.
After some investigation, it turns out that the ECR repository policy had duplicated Sids in different statements.
While this is discouraged, it works with ECR on AWS, so it should work with moto as well.

## Changes
* Remove requirement for sid uniqueness on ECR repository policies
* Add test to validate the special cases of ECR policy validation