### PR TITLE
Stable cognito user pool client

### DIFF
--- a/moto/settings.py
+++ b/moto/settings.py
@@ -183,6 +183,10 @@ def get_cognito_idp_user_pool_id_strategy() -> Optional[str]:
     return os.environ.get("MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY")
 
 
+def get_cognito_idp_user_pool_client_id_strategy() -> Optional[str]:
+    return os.environ.get("MOTO_COGNITO_IDP_USER_POOL_CLIENT_ID_STRATEGY")
+
+
 def enable_iso_regions() -> bool:
     return os.environ.get("MOTO_ENABLE_ISO_REGIONS", "false").lower() == "true"
 


### PR DESCRIPTION
Same as #5194 , but for user pool client.

My use case is: 
I have a frontend which uses cognito for login and i want to connect to moto server for testing and developing. Every time I run the compose file, it creates a new user pool client with a different id, and the frontend breaks.
