### PR TITLE
S3Tables: Support new URL for botocore 1.38.32

### DIFF
--- a/moto/s3tables/responses.py
+++ b/moto/s3tables/responses.py
@@ -181,8 +181,9 @@ class S3TablesResponse(BaseResponse):
         )
 
     def get_table(self) -> TYPE_RESPONSE:
-        _, table_bucket_arn, namespace, name = self.raw_path.lstrip("/").split("/")
-        table_bucket_arn = unquote(table_bucket_arn)
+        table_bucket_arn = unquote(self._get_param("tableBucketARN"))
+        namespace = self._get_param("namespace")
+        name = self._get_param("name")
         table = self.s3tables_backend.get_table(
             table_bucket_arn=table_bucket_arn,
             namespace=namespace,

--- a/moto/s3tables/urls.py
+++ b/moto/s3tables/urls.py
@@ -10,6 +10,7 @@ url_paths = {
     "{0}/buckets$": S3TablesResponse.dispatch,
     "{0}/buckets/(?P<tableBucketARN>.+)$": S3TablesResponse.dispatch,
     "{0}/buckets/(?P<tableBucketARN_pt_1>[^/]+)/(?P<tableBucketARN_pt_2>[^/]+)$": S3TablesResponse.dispatch,
+    "{0}/get-table$": S3TablesResponse.dispatch,
     "{0}/namespaces/(?P<tableBucketARN>.+)$": S3TablesResponse.dispatch,
     "{0}/tables/(?P<tableBucketARN>[^/]+)/(?P<namespace>[^/]+)$": S3TablesResponse.dispatch,
     "{0}/tables/(?P<tableBucketARN>[^/]+)/(?P<namespace>[^/]+)/(?P<name>[^/]+)$": S3TablesResponse.dispatch,

--- a/tests/test_s3tables/test_server.py
+++ b/tests/test_s3tables/test_server.py
@@ -116,13 +116,13 @@ def test_s3tables_get_table(bucket_name: str):
     arn = resp.get_json()["arn"]
 
     quoted_arn = quote(arn, safe="")
-    resp = test_client.put(f"/namespaces/{quoted_arn}", json={"namespace": ["bar"]})
+    test_client.put(f"/namespaces/{quoted_arn}", json={"namespace": ["bar"]})
 
-    resp = test_client.put(
+    test_client.put(
         f"/tables/{quoted_arn}/bar", json={"name": "baz", "format": "ICEBERG"}
     )
 
-    resp = test_client.get(f"/tables/{quoted_arn}/bar/baz")
+    resp = test_client.get(f"/get-table?tableBucketARN={arn}&namespace=bar&name=baz")
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
See changeset: https://github.com/boto/botocore/commit/75060cf32da8ba035e74362a2558bdf8edfbb99d#diff-3f3b0b087fa041bc9956863e5c76ee5b7f44d31a5a581182850e2f9bc7fe975b

The URL for the `GetTable`-command changed from `/tables/{tableBucketARN}/{namespace}/{name}` to `/get-table`.