### PR TITLE
SNS: Allow sending messages from standard topic to FIFO queue

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -24,7 +24,8 @@ from moto.core.utils import (
 )
 from moto.moto_api._internal import mock_random
 from moto.sqs import sqs_backends
-from moto.sqs.exceptions import MissingParameter
+from moto.sqs.exceptions import MissingParameter, QueueDoesNotExist
+from moto.sqs.models import SQSBackend
 from moto.utilities.arns import parse_arn
 from moto.utilities.utils import get_partition
 
@@ -245,8 +246,10 @@ class Subscription(BaseModel):
             queue_name = self.endpoint.split(":")[-1]
             region = self.endpoint.split(":")[3]
 
+            backend: SQSBackend = sqs_backends[self.account_id][region]
+
             if self.attributes.get("RawMessageDelivery") != "true":
-                sqs_backends[self.account_id][region].send_message(
+                backend.send_message(
                     queue_name,
                     json.dumps(
                         self.get_post_data(
@@ -261,6 +264,7 @@ class Subscription(BaseModel):
                     ),
                     deduplication_id=deduplication_id,
                     group_id=group_id,
+                    validate_group_id=False,
                 )
             else:
                 raw_message_attributes = {}
@@ -277,12 +281,13 @@ class Subscription(BaseModel):
                         attr_type: type_value,
                     }
 
-                sqs_backends[self.account_id][region].send_message(
+                backend.send_message(
                     queue_name,
                     message,
                     message_attributes=raw_message_attributes,
                     deduplication_id=deduplication_id,
                     group_id=group_id,
+                    validate_group_id=False,
                 )
         elif self.protocol in ["http", "https"]:
             post_data = self.get_post_data(message, message_id, subject)
@@ -608,6 +613,7 @@ class SNSBackend(BaseBackend):
         setattr(topic, attribute_name, attribute_value)
 
     def subscribe(self, topic_arn: str, endpoint: str, protocol: str) -> Subscription:
+        topic = self.get_topic(topic_arn)
         if protocol == "sms":
             if re.search(r"[./-]{2,}", endpoint) or re.search(
                 r"(^[./-]|[./-]$)", endpoint
@@ -618,6 +624,24 @@ class SNSBackend(BaseBackend):
 
             if not is_e164(reduced_endpoint):
                 raise SNSInvalidParameter(f"Invalid SMS endpoint: {endpoint}")
+
+        if protocol == "sqs":
+            try:
+                arn = parse_arn(endpoint)
+            except ValueError:
+                raise SNSInvalidParameter("Invalid parameter: SQS endpoint ARN")
+
+            backend: SQSBackend = sqs_backends[arn.account][arn.region]
+            topic = self.get_topic(topic_arn)
+            try:
+                queue = backend.get_queue(arn.resource_id)
+                if topic.fifo_topic == "false" and queue.fifo_queue:
+                    raise SNSInvalidParameter(
+                        "Invalid parameter: Invalid parameter: Endpoint Reason: FIFO SQS Queues can not be subscribed to standard SNS topics"
+                    )
+            except QueueDoesNotExist:
+                # Subscribing to an unknown queue is apparently not a problem
+                pass
 
         # AWS doesn't create duplicates
         old_subscription = self._find_subscription(topic_arn, endpoint, protocol)
@@ -635,7 +659,6 @@ class SNSBackend(BaseBackend):
                     f"Invalid parameter: Endpoint Reason: Endpoint does not exist for endpoint arn{endpoint}"
                 )
 
-        topic = self.get_topic(topic_arn)
         subscription = Subscription(self.account_id, topic, endpoint, protocol)
         attributes = {
             "PendingConfirmation": "false",

--- a/tests/test_sns/__init__.py
+++ b/tests/test_sns/__init__.py
@@ -1,11 +1,14 @@
+import json
 import os
 from functools import wraps
 from unittest import SkipTest
+from uuid import uuid4
 
 import boto3
 import botocore
 
 from moto import mock_aws
+from tests import allow_aws_request
 
 
 def sns_aws_verified(func):
@@ -48,3 +51,79 @@ def sns_aws_verified(func):
         return resp
 
     return pagination_wrapper
+
+
+def sns_sqs_aws_verified():
+    """
+    Function that is verified to work against AWS.
+    Can be run against AWS at any time by setting:
+      MOTO_TEST_ALLOW_AWS_REQUEST=true
+
+    If this environment variable is not set, the function runs in a `mock_aws` context.
+
+    This decorator will:
+      - Create an SNS topic + SQS queue
+      - Run the test, passing both names as an argument
+      - Delete both resources
+    """
+
+    def inner(func):
+        @wraps(func)
+        def pagination_wrapper(**kwargs):
+            topic_name = f"test_topic_{str(uuid4())[0:6]}"
+            kwargs["topic_name"] = topic_name
+            queue_name = f"test_queue_{str(uuid4())[0:6]}"
+            kwargs["queue_name"] = queue_name
+
+            def create_resources_and_test():
+                client = boto3.client("sns", region_name="us-east-1")
+                sqs_client = boto3.resource("sqs", region_name="us-east-1")
+
+                topic_arn = client.create_topic(Name=topic_name)["TopicArn"]
+                kwargs["topic_arn"] = topic_arn
+
+                queue = sqs_client.create_queue(QueueName=queue_name)
+
+                identity = boto3.client("sts", "us-east-1").get_caller_identity()
+                queue_arn = f"arn:aws:sqs:us-east-1:{identity['Account']}:{queue_name}"
+
+                # Give permissions to the queue
+                policy = {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "sns.amazonaws.com"},
+                            "Action": "sqs:SendMessage",
+                            "Resource": queue_arn,
+                            "Condition": {"ArnEquals": {"aws:SourceArn": topic_arn}},
+                        }
+                    ],
+                }
+                queue.set_attributes(Attributes={"Policy": json.dumps(policy)})
+
+                # Subscribe the Queue to the Topic
+                subscription_arn = client.subscribe(
+                    TopicArn=topic_arn,
+                    Protocol="sqs",
+                    Endpoint=queue_arn,
+                )["SubscriptionArn"]
+
+                try:
+                    resp = func(**kwargs)
+                finally:
+                    client.unsubscribe(SubscriptionArn=subscription_arn)
+                    client.delete_topic(TopicArn=topic_arn)
+                    queue.delete()
+
+                return resp
+
+            if allow_aws_request():
+                return create_resources_and_test()
+            else:
+                with mock_aws():
+                    return create_resources_and_test()
+
+        return pagination_wrapper
+
+    return inner

--- a/tests/test_sns/__init__.py
+++ b/tests/test_sns/__init__.py
@@ -53,7 +53,7 @@ def sns_aws_verified(func):
     return pagination_wrapper
 
 
-def sns_sqs_aws_verified():
+def sns_sqs_aws_verified(fifo_topic: bool = False, fifo_queue: bool = False):
     """
     Function that is verified to work against AWS.
     Can be run against AWS at any time by setting:
@@ -70,22 +70,42 @@ def sns_sqs_aws_verified():
     def inner(func):
         @wraps(func)
         def pagination_wrapper(**kwargs):
-            topic_name = f"test_topic_{str(uuid4())[0:6]}"
+            topic_name = f"test_topic_{str(uuid4())[0:6]}" + (
+                ".fifo" if fifo_topic else ""
+            )
             kwargs["topic_name"] = topic_name
-            queue_name = f"test_queue_{str(uuid4())[0:6]}"
+            queue_name = f"test_queue_{str(uuid4())[0:6]}" + (
+                ".fifo" if fifo_queue else ""
+            )
             kwargs["queue_name"] = queue_name
 
             def create_resources_and_test():
                 client = boto3.client("sns", region_name="us-east-1")
                 sqs_client = boto3.resource("sqs", region_name="us-east-1")
 
-                topic_arn = client.create_topic(Name=topic_name)["TopicArn"]
+                topic_args = {}
+                if fifo_topic:
+                    topic_args["Attributes"] = {
+                        "FifoTopic": "true",
+                        "ContentBasedDeduplication": "true",
+                    }
+                topic_arn = client.create_topic(Name=topic_name, **topic_args)[
+                    "TopicArn"
+                ]
                 kwargs["topic_arn"] = topic_arn
 
-                queue = sqs_client.create_queue(QueueName=queue_name)
+                queue_args = {}
+                if fifo_queue:
+                    queue_args["Attributes"] = {
+                        "FifoQueue": "true",
+                        "ContentBasedDeduplication": "true",
+                    }
+                queue = sqs_client.create_queue(QueueName=queue_name, **queue_args)
 
                 identity = boto3.client("sts", "us-east-1").get_caller_identity()
-                queue_arn = f"arn:aws:sqs:us-east-1:{identity['Account']}:{queue_name}"
+                kwargs["queue_arn"] = (
+                    f"arn:aws:sqs:us-east-1:{identity['Account']}:{queue_name}"
+                )
 
                 # Give permissions to the queue
                 policy = {
@@ -95,24 +115,25 @@ def sns_sqs_aws_verified():
                             "Effect": "Allow",
                             "Principal": {"Service": "sns.amazonaws.com"},
                             "Action": "sqs:SendMessage",
-                            "Resource": queue_arn,
+                            "Resource": kwargs["queue_arn"],
                             "Condition": {"ArnEquals": {"aws:SourceArn": topic_arn}},
                         }
                     ],
                 }
                 queue.set_attributes(Attributes={"Policy": json.dumps(policy)})
 
-                # Subscribe the Queue to the Topic
-                subscription_arn = client.subscribe(
-                    TopicArn=topic_arn,
-                    Protocol="sqs",
-                    Endpoint=queue_arn,
-                )["SubscriptionArn"]
-
+                subscription_arn = None
                 try:
+                    subscription_arn = client.subscribe(
+                        TopicArn=topic_arn,
+                        Protocol="sqs",
+                        Endpoint=kwargs["queue_arn"],
+                    )["SubscriptionArn"]
+
                     resp = func(**kwargs)
                 finally:
-                    client.unsubscribe(SubscriptionArn=subscription_arn)
+                    if subscription_arn:
+                        client.unsubscribe(SubscriptionArn=subscription_arn)
                     client.delete_topic(TopicArn=topic_arn)
                     queue.delete()
 

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -6,12 +6,12 @@ import boto3
 import pytest
 import requests
 from botocore.exceptions import ClientError
-from freezegun import freeze_time
 
 from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.core.models import responses_mock
 from moto.sns import sns_backends
+from tests.test_sns import sns_sqs_aws_verified
 
 
 def to_comparable_dicts(list_entry: list):
@@ -22,31 +22,21 @@ def to_comparable_dicts(list_entry: list):
     return set(list_entry)
 
 
-@mock_aws
-def test_publish_to_sqs():
+@pytest.mark.aws_verified
+@sns_sqs_aws_verified()
+def test_publish_to_sqs(topic_name=None, topic_arn=None, queue_name=None):
     conn = boto3.client("sns", region_name="us-east-1")
-    conn.create_topic(Name="some-topic")
-    response = conn.list_topics()
-    topic_arn = response["Topics"][0]["TopicArn"]
 
     sqs_conn = boto3.resource("sqs", region_name="us-east-1")
-    sqs_conn.create_queue(QueueName="test-queue")
 
-    conn.subscribe(
-        TopicArn=topic_arn,
-        Protocol="sqs",
-        Endpoint=f"arn:aws:sqs:us-east-1:{ACCOUNT_ID}:test-queue",
-    )
     message = "my message"
-    with freeze_time("2015-01-01 12:00:00"):
-        published_message = conn.publish(
-            TopicArn=topic_arn, Message=message, Subject="my subject"
-        )
+    published_message = conn.publish(
+        TopicArn=topic_arn, Message=message, Subject="my subject"
+    )
     published_message_id = published_message["MessageId"]
 
-    queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(MaxNumberOfMessages=1)
+    queue = sqs_conn.get_queue_by_name(QueueName=queue_name)
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
     acquired_message = json.loads(messages[0].body)
 
     assert acquired_message["Message"] == "my message"
@@ -73,11 +63,9 @@ def test_publish_to_sqs_raw():
     )
 
     message = "my message"
-    with freeze_time("2015-01-01 12:00:00"):
-        topic.publish(Message=message)
+    topic.publish(Message=message)
 
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(MaxNumberOfMessages=1)
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
     assert messages[0].body == message
 
 
@@ -120,18 +108,16 @@ def test_publish_to_sqs_fifo_with_deduplication_id():
     )
 
     message = '{"msg": "hello"}'
-    with freeze_time("2015-01-01 12:00:00"):
-        topic.publish(
-            Message=message,
-            MessageGroupId="message_group_id",
-            MessageDeduplicationId="message_deduplication_id",
-        )
+    topic.publish(
+        Message=message,
+        MessageGroupId="message_group_id",
+        MessageDeduplicationId="message_deduplication_id",
+    )
 
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(
-            MaxNumberOfMessages=1,
-            AttributeNames=["MessageDeduplicationId", "MessageGroupId"],
-        )
+    messages = queue.receive_messages(
+        MaxNumberOfMessages=1,
+        AttributeNames=["MessageDeduplicationId", "MessageGroupId"],
+    )
     assert messages[0].attributes["MessageGroupId"] == "message_group_id"
     assert (
         messages[0].attributes["MessageDeduplicationId"] == "message_deduplication_id"
@@ -160,18 +146,16 @@ def test_publish_to_sqs_fifo_raw_with_deduplication_id():
     )
 
     message = "my message"
-    with freeze_time("2015-01-01 12:00:00"):
-        topic.publish(
-            Message=message,
-            MessageGroupId="message_group_id",
-            MessageDeduplicationId="message_deduplication_id",
-        )
+    topic.publish(
+        Message=message,
+        MessageGroupId="message_group_id",
+        MessageDeduplicationId="message_deduplication_id",
+    )
 
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(
-            MaxNumberOfMessages=1,
-            AttributeNames=["MessageDeduplicationId", "MessageGroupId"],
-        )
+    messages = queue.receive_messages(
+        MaxNumberOfMessages=1,
+        AttributeNames=["MessageDeduplicationId", "MessageGroupId"],
+    )
     assert messages[0].attributes["MessageGroupId"] == "message_group_id"
     assert (
         messages[0].attributes["MessageDeduplicationId"] == "message_deduplication_id"
@@ -412,15 +396,13 @@ def test_publish_to_sqs_dump_json():
         },
         sort_keys=True,
     )
-    with freeze_time("2015-01-01 12:00:00"):
-        published_message = conn.publish(
-            TopicArn=topic_arn, Message=message, Subject="my subject"
-        )
+    published_message = conn.publish(
+        TopicArn=topic_arn, Message=message, Subject="my subject"
+    )
     published_message_id = published_message["MessageId"]
 
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(MaxNumberOfMessages=1)
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
 
     acquired_message = json.loads(messages[0].body)
     assert json.loads(acquired_message["Message"]) == json.loads(message)
@@ -447,15 +429,13 @@ def test_publish_to_sqs_in_different_region():
     )
 
     message = "my message"
-    with freeze_time("2015-01-01 12:00:00"):
-        published_message = conn.publish(
-            TopicArn=topic_arn, Message=message, Subject="my subject"
-        )
+    published_message = conn.publish(
+        TopicArn=topic_arn, Message=message, Subject="my subject"
+    )
     published_message_id = published_message["MessageId"]
 
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(MaxNumberOfMessages=1)
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
 
     acquired_message = json.loads(messages[0].body)
     assert acquired_message["MessageId"] == published_message_id
@@ -465,7 +445,6 @@ def test_publish_to_sqs_in_different_region():
     assert acquired_message["Subject"] == "my subject"
 
 
-@freeze_time("2013-01-01")
 @mock_aws
 def test_publish_to_http():
     if settings.TEST_SERVER_MODE:
@@ -519,18 +498,23 @@ def test_publish_subject():
     )
     message = "my message"
     subject1 = "test subject"
-    subject2 = "test subject" * 20
-    with freeze_time("2015-01-01 12:00:00"):
-        conn.publish(TopicArn=topic_arn, Message=message, Subject=subject1)
+    conn.publish(TopicArn=topic_arn, Message=message, Subject=subject1)
 
-    # Just that it doesnt error is a pass
-    try:
-        with freeze_time("2015-01-01 12:00:00"):
-            conn.publish(TopicArn=topic_arn, Message=message, Subject=subject2)
-    except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameter"
-    else:
-        raise RuntimeError("Should have raised an InvalidParameter exception")
+
+@mock_aws
+def test_publish_large_subject():
+    conn = boto3.client("sns", region_name="us-east-1")
+    conn.create_topic(Name="some-topic")
+    response = conn.list_topics()
+    topic_arn = response["Topics"][0]["TopicArn"]
+
+    large_subject = "test subject" * 20
+
+    with pytest.raises(ClientError) as exc:
+        conn.publish(TopicArn=topic_arn, Message="message", Subject=large_subject)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidParameter"
+    assert err["Message"] == "Subject must be less than 100 characters"
 
 
 @mock_aws
@@ -549,12 +533,10 @@ def test_publish_null_subject():
         Endpoint=f"arn:aws:sqs:us-east-1:{ACCOUNT_ID}:test-queue",
     )
     message = "my message"
-    with freeze_time("2015-01-01 12:00:00"):
-        conn.publish(TopicArn=topic_arn, Message=message)
+    conn.publish(TopicArn=topic_arn, Message=message)
 
     queue = sqs_conn.get_queue_by_name(QueueName="test-queue")
-    with freeze_time("2015-01-01 12:00:01"):
-        messages = queue.receive_messages(MaxNumberOfMessages=1)
+    messages = queue.receive_messages(MaxNumberOfMessages=1)
 
     acquired_message = json.loads(messages[0].body)
     assert acquired_message["Message"] == message


### PR DESCRIPTION
Fixes #8899 

- Enables sending messages from a FIFO topic to a standard Queue
- Adds validation when subscribing from a standard topic to a FIFO queue
- Adds validation when subscribing to SQS without specifying an ARN
- Adds AWS-validated tests for all