### PR TITLE
EC2: VPC: Fix typo in referenced group

### DIFF
--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -808,7 +808,7 @@ class SecurityGroupBackend:
             cidr_ipv4 = new_rule.get("CidrIpv4")
             cidr_ipv6 = new_rule.get("CidrIpv6")
             prefix_list_id = new_rule.get("PrefixListId")
-            reference_group_id = new_rule.get("ReferenceGroupId")
+            reference_group_id = new_rule.get("ReferencedGroupId")
 
             set_param_count = sum(
                 item is not None

--- a/tests/test_ec2/test_security_groups.py
+++ b/tests/test_ec2/test_security_groups.py
@@ -1018,6 +1018,59 @@ def test_modify_security_group_rules(ec2_client=None, vpc_id=None, sg_id=None):
     assert response["SecurityGroupRules"][0]["Description"] == "first modification"
 
 
+@ec2_aws_verified(create_vpc=True, create_sg=True)
+@pytest.mark.aws_verified
+def test_modify_security_group_rules_with_referenced_group_id(
+    ec2_client=None, vpc_id=None, sg_id=None
+):
+    client = ec2_client
+    group_id = sg_id
+
+    ip_permissions = [
+        {
+            "IpProtocol": "tcp",
+            "FromPort": 30900,
+            "ToPort": 31000,
+            "UserIdGroupPairs": [
+                {
+                    "GroupId": group_id,
+                }
+            ],
+        }
+    ]
+    rule_id = client.authorize_security_group_ingress(
+        GroupId=group_id, IpPermissions=ip_permissions
+    )["SecurityGroupRules"][0]["SecurityGroupRuleId"]
+
+    client.modify_security_group_rules(
+        GroupId=group_id,
+        SecurityGroupRules=[
+            {
+                "SecurityGroupRuleId": rule_id,
+                "SecurityGroupRule": {
+                    "IpProtocol": "tcp",
+                    "FromPort": 39900,
+                    "ToPort": 40000,
+                    "ReferencedGroupId": group_id,
+                },
+            }
+        ],
+    )
+    response = client.describe_security_group_rules(
+        Filters=[
+            {"Name": "group-id", "Values": [group_id]},
+            {"Name": "security-group-rule-id", "Values": [rule_id]},
+        ]
+    )
+    assert len(response["SecurityGroupRules"]) == 1
+    assert response["SecurityGroupRules"][0]["IpProtocol"] == "tcp"
+    assert response["SecurityGroupRules"][0]["FromPort"] == 39900
+    assert response["SecurityGroupRules"][0]["ToPort"] == 40000
+    assert (
+        response["SecurityGroupRules"][0]["ReferencedGroupInfo"]["GroupId"] == group_id
+    )
+
+
 @mock_aws
 @pytest.mark.parametrize("use_vpc", [True, False], ids=["Use VPC", "Without VPC"])
 def test_sec_group_rule_limit(use_vpc):


### PR DESCRIPTION
## Motivation

This pr fixes a typo in `ModifySecurityGroupRule`. Attempting to modify a security group rule with a security group association would fail as `ReferencedGroupId` was misspelled.