### PR TITLE
Serialization: Refactor Attribute Access

### DIFF
--- a/moto/core/constants.py
+++ b/moto/core/constants.py
@@ -1,0 +1,20 @@
+from typing import Final
+
+
+class _Missing:
+    """A singleton class to represent a sentinel for a missing value."""
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __copy__(self):  # type: ignore[no-untyped-def]
+        return self
+
+    def __deepcopy__(self, _):  # type: ignore[no-untyped-def]
+        return self
+
+    def __repr__(self) -> str:
+        return "<moto.MISSING>"
+
+
+MISSING: Final = _Missing()


### PR DESCRIPTION
There is often a mismatch between the attribute names in the botocore model data (which are typically `camelCase` or `PascalCase`) and the Python objects in the moto backend (which are `snake_case`). The serializer attempts to pluck values from a backend object by checking various "aliases" for a given attribute name.  This PR refactors the alias list into a generator based on discrete `AliasProvider` classes, which properly encapsulate the logic behind each alias and speeds things up by only calculating them as needed.