### PR TITLE
AWSLambda: TF compatibility

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -1286,7 +1286,12 @@ class EventSourceMapping(CloudFormationModel):
 
         # optional
         self.batch_size = spec.get("BatchSize")  # type: ignore[assignment]
-        self.starting_position = spec.get("StartingPosition", "TRIM_HORIZON")
+        self.starting_position = spec.get("StartingPosition")
+        if (
+            not self.starting_position
+            and "sqs" not in self._get_service_source_from_arn()
+        ):
+            self.starting_position = "TRIM_HORIZON"
         self.enabled = spec.get("Enabled", True)
         self.starting_position_timestamp = spec.get("StartingPositionTimestamp")
         self.kafka_config = spec.get("AmazonManagedKafkaEventSourceConfig")
@@ -1316,16 +1321,14 @@ class EventSourceMapping(CloudFormationModel):
         self.function_arn: str = spec["FunctionArn"]
         self.last_modified = time.mktime(utcnow().timetuple())
 
-    def _get_service_source_from_arn(self, event_source_arn: str) -> str:
-        service = event_source_arn.split(":")[2].lower()
-        if service == "sqs" and event_source_arn.endswith(".fifo"):
+    def _get_service_source_from_arn(
+        self, event_source_arn: Optional[str] = None
+    ) -> str:
+        arn = event_source_arn or self.event_source_arn
+        service = arn.split(":")[2].lower()
+        if service == "sqs" and arn.endswith(".fifo"):
             return "sqs-fifo"
         return service
-
-    def _validate_event_source(self, event_source_arn: str) -> bool:
-        valid_services = ("dynamodb", "kinesis", "sqs", "sqs-fifo")
-        service = self._get_service_source_from_arn(event_source_arn)
-        return service in valid_services
 
     @property
     def event_source_arn(self) -> str:
@@ -1333,7 +1336,8 @@ class EventSourceMapping(CloudFormationModel):
 
     @event_source_arn.setter
     def event_source_arn(self, event_source_arn: str) -> None:
-        if not self._validate_event_source(event_source_arn):
+        service = self._get_service_source_from_arn(event_source_arn)
+        if service not in ("dynamodb", "kinesis", "sqs", "sqs-fifo"):
             raise ValueError(
                 "InvalidParameterValueException", "Unsupported event source type"
             )
@@ -1344,7 +1348,7 @@ class EventSourceMapping(CloudFormationModel):
         return self._batch_size
 
     @batch_size.setter
-    def batch_size(self, batch_size: Optional[int]) -> None:
+    def batch_size(self, new_batch_size: Optional[int]) -> None:
         batch_size_service_map = {
             "kinesis": (100, 10000),
             "dynamodb": (100, 10000),
@@ -1352,18 +1356,16 @@ class EventSourceMapping(CloudFormationModel):
             "sqs-fifo": (10, 10),
         }
 
-        source_type = self._get_service_source_from_arn(self.event_source_arn)
+        source_type = self._get_service_source_from_arn()
         batch_size_for_source = batch_size_service_map[source_type]
 
-        if batch_size is None:
+        if new_batch_size is None:
             self._batch_size = batch_size_for_source[0]
-        elif batch_size > batch_size_for_source[1]:
-            error_message = (
-                f"BatchSize {batch_size} exceeds the max of {batch_size_for_source[1]}"
-            )
+        elif new_batch_size > batch_size_for_source[1]:
+            error_message = f"BatchSize {new_batch_size} exceeds the max of {batch_size_for_source[1]}"
             raise ValueError("InvalidParameterValueException", error_message)
         else:
-            self._batch_size = int(batch_size)
+            self._batch_size = int(new_batch_size)
 
     def get_configuration(self) -> Dict[str, Any]:
         response_dict = {

--- a/other_langs/terraform/awslambda/event_source_mapping.tf
+++ b/other_langs/terraform/awslambda/event_source_mapping.tf
@@ -17,49 +17,6 @@ resource "aws_kinesis_stream" "test_stream" {
   }
 }
 
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-
-    actions = ["sts:AssumeRole"]
-  }
-}
-
-resource "aws_iam_role" "iam_for_lambda" {
-  name               = "iam_for_lambda"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-}
-
-data "archive_file" "lambda" {
-  type        = "zip"
-  source_file = "lambda.js"
-  output_path = "lambda_function_payload.zip"
-}
-
-resource "aws_lambda_function" "test_lambda" {
-  # If the file is not in the current working directory you will need to include a
-  # path.module in the filename.
-  filename      = "lambda_function_payload.zip"
-  function_name = "lambda_function_name"
-  role          = aws_iam_role.iam_for_lambda.arn
-  handler       = "index.test"
-
-  source_code_hash = data.archive_file.lambda.output_base64sha256
-
-  runtime = "nodejs18.x"
-
-  environment {
-    variables = {
-      foo = "bar"
-    }
-  }
-}
-
 resource "aws_lambda_event_source_mapping" "kinesis_to_sqs" {
   event_source_arn  = aws_kinesis_stream.test_stream.arn
   function_name     = aws_lambda_function.test_lambda.arn

--- a/other_langs/terraform/awslambda/event_source_mapping_common.tf
+++ b/other_langs/terraform/awslambda/event_source_mapping_common.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name               = "iam_for_lambda"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_file = "lambda.js"
+  output_path = "lambda_function_payload.zip"
+}
+
+resource "aws_lambda_function" "test_lambda" {
+  # If the file is not in the current working directory you will need to include a
+  # path.module in the filename.
+  filename      = "lambda_function_payload.zip"
+  function_name = "lambda_function_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "index.test"
+
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+
+  runtime = "nodejs18.x"
+
+  environment {
+    variables = {
+      foo = "bar"
+    }
+  }
+}

--- a/other_langs/terraform/awslambda/event_source_mapping_sqs.tf
+++ b/other_langs/terraform/awslambda/event_source_mapping_sqs.tf
@@ -1,0 +1,10 @@
+resource "aws_sqs_queue" "esm_queue" {
+  name                        = "test-queue"
+}
+
+
+resource "aws_lambda_event_source_mapping" "esm_to_sqs_queue" {
+  event_source_arn = aws_sqs_queue.esm_queue.arn
+  function_name    = aws_lambda_function.test_lambda.arn
+  batch_size       = 1000
+}

--- a/other_langs/terraform/awslambda/event_source_mapping_sqs_fifo.tf
+++ b/other_langs/terraform/awslambda/event_source_mapping_sqs_fifo.tf
@@ -1,0 +1,11 @@
+resource "aws_sqs_queue" "esm_fifo_queue" {
+  name                        = "testfifoqueue.fifo"
+  fifo_queue                  = true
+}
+
+
+resource "aws_lambda_event_source_mapping" "esm_to_sqs_fifo_queue" {
+  event_source_arn = aws_sqs_queue.esm_fifo_queue.arn
+  function_name    = aws_lambda_function.test_lambda.arn
+  batch_size       = 10
+}


### PR DESCRIPTION
Follow up # #8972

`StartingPosition` now only defaults to `TRIM_HORIZON` when the source is not SQS. (Based on [the TF docs](https://registry.terraform.io/providers/hashicorp/aws/4.58.0/docs/resources/lambda_event_source_mapping#starting_position-1).)
This ensures that ESM's are only updated when something changes, and are not destroyed and recreated with every `terraform apply`.

Includes some minor refactorings to make things more readable (like removing the `_validate_event_source`-method, and making the `event_source_arn`-parameter to `_get_service_source_from_arn` optional

New Terraform scripts are now included to verify that we can create/manage/delete ESM's without problems.