### PR TITLE
Proxy: Test passthrough with local server

### DIFF
--- a/moto/moto_proxy/proxy3.py
+++ b/moto/moto_proxy/proxy3.py
@@ -151,7 +151,10 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
 
         if f"{host}{path}" in moto_api_backend.proxy_urls_to_passthrough:
             parsed = urlparse(host)
-            self.passthrough_http((parsed.netloc, 80))
+            target_host, target_port = parsed.netloc, "80"
+            if ":" in target_host:
+                target_host, target_port = target_host.split(":")
+            self.passthrough_http((target_host, int(target_port)))
             return
 
         req_body = b""

--- a/tests/test_core/utilities.py
+++ b/tests/test_core/utilities.py
@@ -1,0 +1,35 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Event, Thread
+from typing import Optional, Tuple
+
+
+class SimpleServer:
+    def __init__(self, handler: type[BaseHTTPRequestHandler]) -> None:
+        self._port = 0
+        self._handler = handler
+
+        self._thread: Optional[Thread] = None
+        self._ip_address = "0.0.0.0"
+        self._server: Optional[HTTPServer] = None
+        self._server_ready_event = Event()
+
+    def _server_entry(self) -> None:
+        self._server = HTTPServer(("0.0.0.0", 0), self._handler)
+        self._server_ready_event.set()
+        self._server.serve_forever()
+
+    def start(self) -> None:
+        self._thread = Thread(target=self._server_entry, daemon=True)
+        self._thread.start()
+        self._server_ready_event.wait()
+
+    def get_host_and_port(self) -> Tuple[str, int]:
+        assert self._server
+        host, port = self._server.server_address
+        return str(host), port
+
+    def stop(self) -> None:
+        if self._server:
+            self._server.shutdown()
+        if self._thread:
+            self._thread.join()


### PR DESCRIPTION
The proxy tests time out regularly, as they try to reach out to `httpbin.org` which appears to be unreliable

## Changes
- Allow requests to a host on a custom port to be passed through (i.e. `http://localhost:8080`)
- Change test to pass through to a local server for HTTP requests
- Disable test that passes through HTTPS request, as there's no need to run this every time
- Refactor the `SimpleServer` concept, as the same class is used in multiple places