### PR TITLE
RAM - Implementing ListResourceTypes

### DIFF
--- a/docs/docs/services/ram.rst
+++ b/docs/docs/services/ram.rst
@@ -38,7 +38,7 @@ ram
 - [ ] list_principals
 - [ ] list_replace_permission_associations_work
 - [ ] list_resource_share_permissions
-- [ ] list_resource_types
+- [X] list_resource_types
 - [ ] list_resources
 - [ ] promote_permission_created_from_policy
 - [ ] promote_resource_share_created_from_policy

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -37,7 +37,10 @@ class ResourceShare(BaseModel):
         "report-group",  # AWS CodeBuild report group
         "resolver-rule",  # Amazon Route 53 forwarding rule
         "subnet",  # Amazon EC2 subnet
-        "transit-gateway",  # Amazon EC2 transit gateway
+        "transit-gateway",  # Amazon EC2 transit gateway,
+        "database",  # Amazon Glue database
+        "table",  # Amazon Glue table
+        "catalog",  # Amazon Glue catalog
     ]
 
     def __init__(self, account_id: str, region: str, **kwargs: Any):

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -156,6 +156,94 @@ class ResourceShare(BaseModel):
 
 
 class ResourceAccessManagerBackend(BaseBackend):
+    RESOURCE_TYPES = [  # List of resource types based on SHAREABLE_RESOURCES
+        {
+            "resourceType": "rds:Cluster",
+            "serviceName": "rds",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "imagebuilder:Component",
+            "serviceName": "imagebuilder",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "networkmanager:CoreNetwork",
+            "serviceName": "networkmanager",
+            "resourceRegionScope": "GLOBAL"
+        },
+        {
+            "resourceType": "resource-groups:Group",
+            "serviceName": "resource-groups",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "imagebuilder:Image",
+            "serviceName": "imagebuilder",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "imagebuilder:ImageRecipe",
+            "serviceName": "imagebuilder",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "license-manager:LicenseConfiguration",
+            "serviceName": "license-manager",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "appmesh:Mesh",
+            "serviceName": "appmesh",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "ec2:PrefixList",
+            "serviceName": "ec2",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "codebuild:Project",
+            "serviceName": "codebuild",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "codebuild:ReportGroup",
+            "serviceName": "codebuild",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "route53resolver:ResolverRule",
+            "serviceName": "route53resolver",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "ec2:Subnet",
+            "serviceName": "ec2",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "ec2:TransitGatewayMulticastDomain",
+            "serviceName": "ec2",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "glue:Database",
+            "serviceName": "glue",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "glue:Table",
+            "serviceName": "glue",
+            "resourceRegionScope": "REGIONAL"
+        },
+        {
+            "resourceType": "glue:Catalog",
+            "serviceName": "glue",
+            "resourceRegionScope": "REGIONAL"
+        },
+    ]
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.resource_shares: List[ResourceShare] = []
@@ -304,6 +392,26 @@ class ResourceAccessManagerBackend(BaseBackend):
                     )
 
         return dict(resourceShareAssociations=associations)
+
+    def list_resource_types(self, **kwargs: Any) -> Dict[str, Any]:
+        resource_region_scope = kwargs.get("resourceRegionScope", "ALL")
+
+        if resource_region_scope not in ["ALL", "REGIONAL", "GLOBAL"]:
+            raise InvalidParameterException(
+                f"{resource_region_scope} is not a valid resource region "
+                "scope value. Specify a valid value and try again."
+            )
+        
+        if resource_region_scope == "ALL":
+            resource_types = self.RESOURCE_TYPES
+        else:
+            resource_types = [
+                resource_type
+                for resource_type in self.RESOURCE_TYPES
+                if resource_type["resourceRegionScope"] == resource_region_scope
+            ]
+
+        return dict(resourceTypes=resource_types)
 
 
 ram_backends = BackendDict(ResourceAccessManagerBackend, "ram")

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -160,87 +160,87 @@ class ResourceAccessManagerBackend(BaseBackend):
         {
             "resourceType": "rds:Cluster",
             "serviceName": "rds",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "imagebuilder:Component",
             "serviceName": "imagebuilder",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "networkmanager:CoreNetwork",
             "serviceName": "networkmanager",
-            "resourceRegionScope": "GLOBAL"
+            "resourceRegionScope": "GLOBAL",
         },
         {
             "resourceType": "resource-groups:Group",
             "serviceName": "resource-groups",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "imagebuilder:Image",
             "serviceName": "imagebuilder",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "imagebuilder:ImageRecipe",
             "serviceName": "imagebuilder",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "license-manager:LicenseConfiguration",
             "serviceName": "license-manager",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "appmesh:Mesh",
             "serviceName": "appmesh",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "ec2:PrefixList",
             "serviceName": "ec2",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "codebuild:Project",
             "serviceName": "codebuild",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "codebuild:ReportGroup",
             "serviceName": "codebuild",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "route53resolver:ResolverRule",
             "serviceName": "route53resolver",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "ec2:Subnet",
             "serviceName": "ec2",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "ec2:TransitGatewayMulticastDomain",
             "serviceName": "ec2",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "glue:Database",
             "serviceName": "glue",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "glue:Table",
             "serviceName": "glue",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
         {
             "resourceType": "glue:Catalog",
             "serviceName": "glue",
-            "resourceRegionScope": "REGIONAL"
+            "resourceRegionScope": "REGIONAL",
         },
     ]
 
@@ -401,7 +401,7 @@ class ResourceAccessManagerBackend(BaseBackend):
                 f"{resource_region_scope} is not a valid resource region "
                 "scope value. Specify a valid value and try again."
             )
-        
+
         if resource_region_scope == "ALL":
             resource_types = self.RESOURCE_TYPES
         else:

--- a/moto/ram/responses.py
+++ b/moto/ram/responses.py
@@ -41,6 +41,6 @@ class ResourceAccessManagerResponse(BaseResponse):
         return json.dumps(
             self.ram_backend.get_resource_share_associations(**self.request_params)
         )
-    
+
     def list_resource_types(self) -> str:
         return json.dumps(self.ram_backend.list_resource_types(**self.request_params))

--- a/moto/ram/responses.py
+++ b/moto/ram/responses.py
@@ -41,3 +41,6 @@ class ResourceAccessManagerResponse(BaseResponse):
         return json.dumps(
             self.ram_backend.get_resource_share_associations(**self.request_params)
         )
+    
+    def list_resource_types(self) -> str:
+        return json.dumps(self.ram_backend.list_resource_types(**self.request_params))

--- a/moto/ram/urls.py
+++ b/moto/ram/urls.py
@@ -9,4 +9,5 @@ url_paths = {
     "{0}/getresourceshares$": ResourceAccessManagerResponse.dispatch,
     "{0}/getresourceshareassociations$": ResourceAccessManagerResponse.dispatch,
     "{0}/updateresourceshare$": ResourceAccessManagerResponse.dispatch,
+    "{0}/listresourcetypes$": ResourceAccessManagerResponse.dispatch,
 }

--- a/tests/test_ram/test_ram.py
+++ b/tests/test_ram/test_ram.py
@@ -541,7 +541,11 @@ def test_get_resource_share_associations_errors():
         ({"resourceRegionScope": "ALL"}, False, None),
         ({"resourceRegionScope": "GLOBAL"}, False, None),
         ({"resourceRegionScope": "REGIONAL"}, False, None),
-        ({"resourceRegionScope": "INVALID"}, True, "INVALID is not a valid resource region scope value. Specify a valid value and try again."),
+        (
+            {"resourceRegionScope": "INVALID"},
+            True,
+            "INVALID is not a valid resource region scope value. Specify a valid value and try again.",
+        ),
     ],
     ids=[
         "default_region_scope",
@@ -568,9 +572,13 @@ def test_list_resource_types(resource_region_scope, expect_error, error_message)
         response = client.list_resource_types(**kwargs)
         expected_types = ResourceAccessManagerBackend.RESOURCE_TYPES
         if kwargs["resourceRegionScope"] == "GLOBAL":
-            expected_types = [rt for rt in expected_types if rt["resourceRegionScope"] == "GLOBAL"]
+            expected_types = [
+                rt for rt in expected_types if rt["resourceRegionScope"] == "GLOBAL"
+            ]
         elif kwargs["resourceRegionScope"] == "REGIONAL":
-            expected_types = [rt for rt in expected_types if rt["resourceRegionScope"] == "REGIONAL"]
+            expected_types = [
+                rt for rt in expected_types if rt["resourceRegionScope"] == "REGIONAL"
+            ]
 
         assert "resourceTypes" in response
         assert response["resourceTypes"] == expected_types

--- a/tests/test_ram/test_ram.py
+++ b/tests/test_ram/test_ram.py
@@ -8,6 +8,7 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+from moto.ram.models import ResourceAccessManagerBackend
 
 
 @mock_aws
@@ -530,3 +531,46 @@ def test_get_resource_share_associations_errors():
         "You cannot specify a principal when the association type is RESOURCE"
         in ex.response["Error"]["Message"]
     )
+
+
+@mock_aws
+@pytest.mark.parametrize(
+    "resource_region_scope, expect_error, error_message",
+    [
+        ({}, False, None),  # default value is "ALL"
+        ({"resourceRegionScope": "ALL"}, False, None),
+        ({"resourceRegionScope": "GLOBAL"}, False, None),
+        ({"resourceRegionScope": "REGIONAL"}, False, None),
+        ({"resourceRegionScope": "INVALID"}, True, "INVALID is not a valid resource region scope value. Specify a valid value and try again."),
+    ],
+    ids=[
+        "default_region_scope",
+        "all_region_scope",
+        "global_region_scope",
+        "regional_region_scope",
+        "invalid_region_scope",
+    ],
+)
+def test_list_resource_types(resource_region_scope, expect_error, error_message):
+    client = boto3.client("ram", region_name="us-east-1")
+    kwargs = dict(resource_region_scope)
+    if "resourceRegionScope" not in kwargs:
+        kwargs["resourceRegionScope"] = "ALL"
+
+    if expect_error:
+        with pytest.raises(ClientError) as e:
+            client.list_resource_types(**kwargs)
+        ex = e.value
+        assert ex.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+        assert "InvalidParameterException" in ex.response["Error"]["Code"]
+        assert ex.response["Error"]["Message"] == error_message
+    else:
+        response = client.list_resource_types(**kwargs)
+        expected_types = ResourceAccessManagerBackend.RESOURCE_TYPES
+        if kwargs["resourceRegionScope"] == "GLOBAL":
+            expected_types = [rt for rt in expected_types if rt["resourceRegionScope"] == "GLOBAL"]
+        elif kwargs["resourceRegionScope"] == "REGIONAL":
+            expected_types = [rt for rt in expected_types if rt["resourceRegionScope"] == "REGIONAL"]
+
+        assert "resourceTypes" in response
+        assert response["resourceTypes"] == expected_types

--- a/tests/test_ram/test_ram.py
+++ b/tests/test_ram/test_ram.py
@@ -557,25 +557,23 @@ def test_get_resource_share_associations_errors():
 )
 def test_list_resource_types(resource_region_scope, expect_error, error_message):
     client = boto3.client("ram", region_name="us-east-1")
-    kwargs = dict(resource_region_scope)
-    if "resourceRegionScope" not in kwargs:
-        kwargs["resourceRegionScope"] = "ALL"
+    region_scope = resource_region_scope.get("resourceRegionScope")
 
     if expect_error:
         with pytest.raises(ClientError) as e:
-            client.list_resource_types(**kwargs)
+            client.list_resource_types(**resource_region_scope)
         ex = e.value
         assert ex.response["ResponseMetadata"]["HTTPStatusCode"] == 400
         assert "InvalidParameterException" in ex.response["Error"]["Code"]
         assert ex.response["Error"]["Message"] == error_message
     else:
-        response = client.list_resource_types(**kwargs)
+        response = client.list_resource_types(**resource_region_scope)
         expected_types = ResourceAccessManagerBackend.RESOURCE_TYPES
-        if kwargs["resourceRegionScope"] == "GLOBAL":
+        if region_scope == "GLOBAL":
             expected_types = [
                 rt for rt in expected_types if rt["resourceRegionScope"] == "GLOBAL"
             ]
-        elif kwargs["resourceRegionScope"] == "REGIONAL":
+        elif region_scope == "REGIONAL":
             expected_types = [
                 rt for rt in expected_types if rt["resourceRegionScope"] == "REGIONAL"
             ]


### PR DESCRIPTION
Greetings.

Recently, I'm working with the RAM methods and I noticed that we don't have some API methods for this service implemented here. So, I commited some changes in the lib:
- I'm adding the AWS Glue `database`, `table` and `catalog` shared resource types to enable these resources for the currently available API implementations;
- I'm implementing the `list_resource_types()` API, just to pavimentate the next implementations I'm willing to code.

I've been thinking about implementing the permissions methods in another PR, such as:
- `create_permission()`;
- `get_permission()`;
- `list_permissions()`;
- `list_permission_associations()`;
- `list_resource_share_permissions()`

I'm new here, so, feel free to recomend any design pattern for the implementations I added and to guide me with any recomendations for the code and the contributions :)