### PR TITLE
Implement ECS `delete_task_definition` and `status` filter for `list_task_definitions`

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3371,7 +3371,7 @@
 
 ## ecs
 <details>
-<summary>73% implemented</summary>
+<summary>75% implemented</summary>
 
 - [X] create_capacity_provider
 - [X] create_cluster
@@ -3382,7 +3382,7 @@
 - [X] delete_capacity_provider
 - [X] delete_cluster
 - [X] delete_service
-- [ ] delete_task_definitions
+- [X] delete_task_definitions
 - [X] delete_task_set
 - [X] deregister_container_instance
 - [X] deregister_task_definition

--- a/docs/docs/services/ecs.rst
+++ b/docs/docs/services/ecs.rst
@@ -25,7 +25,7 @@ ecs
 - [X] delete_capacity_provider
 - [X] delete_cluster
 - [X] delete_service
-- [ ] delete_task_definitions
+- [X] delete_task_definitions
 - [X] delete_task_set
   
         The Force-parameter is not yet implemented

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1321,14 +1321,19 @@ class EC2ContainerServiceBackend(BaseBackend):
             ):
                 raise TaskDefinitionMemoryError(cd["name"])
 
-    def list_task_definitions(self, family_prefix: str) -> List[str]:
+    def list_task_definitions(
+        self, family_prefix: str, status: str = "ACTIVE"
+    ) -> List[str]:
         task_arns = []
         for task_definition_list in self.task_definitions.values():
             task_arns.extend(
                 [
                     task_definition.arn
                     for task_definition in task_definition_list.values()
-                    if family_prefix is None or task_definition.family == family_prefix
+                    if (
+                        family_prefix is None or task_definition.family == family_prefix
+                    )
+                    and task_definition.status == status
                 ]
             )
         return task_arns

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -347,6 +347,19 @@ class TaskDefinition(BaseObject, CloudFormationModel):
             return original_resource
 
 
+class DeleteTaskDefinitionFailure(BaseObject):
+    def __init__(self, reason: str, name: str, account_id: str, region_name: str):
+        self.reason = reason
+        self.arn = name
+
+    @property
+    def response_object(self) -> Dict[str, Any]:  # type: ignore[misc]
+        response_object = self.gen_response_object()
+        response_object["reason"] = self.reason
+        response_object["arn"] = self.arn
+        return response_object
+
+
 class Task(BaseObject, ManagedState):
     def __init__(
         self,
@@ -2449,6 +2462,67 @@ class EC2ContainerServiceBackend(BaseBackend):
         if account and account.value == "disabled":
             return False
         return settings.ecs_new_arn_format()
+
+    def delete_task_definitions(
+        self, task_definitions: List[str]
+    ) -> Tuple[List[TaskDefinition], List[DeleteTaskDefinitionFailure]]:
+        if not task_definitions:
+            raise InvalidParameterException(
+                "size of TaskDefinition references list must be greater than 0"
+            )
+
+        if len(task_definitions) > 10:
+            raise InvalidParameterException(
+                "Size of TaskDefinition references list cannot exceed 10"
+            )
+
+        deleted_task_definitions = []
+        failures = []
+        for task_def in task_definitions:
+            task_definition_name = task_def.split("/")[-1]
+            if ":" in task_definition_name:
+                family, rev = task_definition_name.split(":")
+                revision = int(rev)
+            else:
+                failures.append(
+                    DeleteTaskDefinitionFailure(
+                        "The specified task definition identifier is invalid. Specify a valid name or ARN and try again.",
+                        task_def,
+                        self.account_id,
+                        self.region_name,
+                    )
+                )
+                continue
+
+            try:
+                resolved_task_def = self.task_definitions[family][revision]
+            except KeyError:
+                failures.append(
+                    DeleteTaskDefinitionFailure(
+                        "The specified task definition does not exist. Specify a valid account, family, revision and try again.",
+                        task_def,
+                        self.account_id,
+                        self.region_name,
+                    )
+                )
+                continue
+
+            if resolved_task_def.status == "ACTIVE":
+                failures.append(
+                    DeleteTaskDefinitionFailure(
+                        "The specified task definition is still in ACTIVE status. Please deregister the target and try again.",
+                        task_def,
+                        self.account_id,
+                        self.region_name,
+                    )
+                )
+                continue
+
+            del self.task_definitions[family][revision]
+            resolved_task_def.status = "DELETE_IN_PROGRESS"
+            deleted_task_definitions.append(resolved_task_def)
+
+        return deleted_task_definitions, failures
 
 
 ecs_backends = BackendDict(EC2ContainerServiceBackend, "ecs")

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -543,3 +543,18 @@ class EC2ContainerServiceResponse(BaseResponse):
         name = self._get_param("name")
         self.ecs_backend.delete_account_setting(name)
         return "{}"
+
+    def delete_task_definitions(self) -> str:
+        task_definitions = self._get_param("taskDefinitions")
+        deleted_task_definitions, failures = self.ecs_backend.delete_task_definitions(
+            task_definitions=task_definitions,
+        )
+        return json.dumps(
+            {
+                "taskDefinitions": [
+                    td.response_object["taskDefinition"]
+                    for td in deleted_task_definitions
+                ],
+                "failures": [f.response_object for f in failures],
+            }
+        )

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -152,7 +152,10 @@ class EC2ContainerServiceResponse(BaseResponse):
 
     def list_task_definitions(self) -> str:
         family_prefix = self._get_param("familyPrefix")
-        task_definition_arns = self.ecs_backend.list_task_definitions(family_prefix)
+        status = self._get_param("status", "ACTIVE")
+        task_definition_arns = self.ecs_backend.list_task_definitions(
+            family_prefix, status
+        )
         return json.dumps({"taskDefinitionArns": task_definition_arns})
 
     def describe_task_definition(self) -> str:

--- a/tests/test_ecs/test_ecs_boto3.py
+++ b/tests/test_ecs/test_ecs_boto3.py
@@ -507,6 +507,58 @@ def test_list_task_definitions_with_family_prefix():
 
 
 @mock_aws
+def test_list_task_definitions_with_status_filter():
+    client = boto3.client("ecs", region_name=ECS_REGION)
+    client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+                "essential": True,
+                "environment": [
+                    {"name": "AWS_ACCESS_KEY_ID", "value": "SOME_ACCESS_KEY"}
+                ],
+                "logConfiguration": {"logDriver": "json-file"},
+            }
+        ],
+    )
+    td2_response = client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world2",
+                "image": "docker/hello-world2:latest",
+                "cpu": 1024,
+                "memory": 400,
+                "essential": True,
+                "environment": [
+                    {"name": "AWS_ACCESS_KEY_ID", "value": "SOME_ACCESS_KEY2"}
+                ],
+                "logConfiguration": {"logDriver": "json-file"},
+            }
+        ],
+    )
+    client.deregister_task_definition(
+        taskDefinition=td2_response["taskDefinition"]["taskDefinitionArn"]
+    )
+    response = client.list_task_definitions(status="ACTIVE")
+    assert len(response["taskDefinitionArns"]) == 1
+    assert (
+        response["taskDefinitionArns"][0]
+        == f"arn:aws:ecs:us-east-1:{ACCOUNT_ID}:task-definition/test_ecs_task:1"
+    )
+    response = client.list_task_definitions(status="INACTIVE")
+    assert len(response["taskDefinitionArns"]) == 1
+    assert (
+        response["taskDefinitionArns"][0]
+        == f"arn:aws:ecs:us-east-1:{ACCOUNT_ID}:task-definition/test_ecs_task:2"
+    )
+
+
+@mock_aws
 def test_describe_task_definitions():
     client = boto3.client("ecs", region_name=ECS_REGION)
     client.register_task_definition(

--- a/tests/test_ecs/test_ecs_task_definitions.py
+++ b/tests/test_ecs/test_ecs_task_definitions.py
@@ -99,15 +99,15 @@ def test_delete_task_definitions_invalid_identifier():
     client = boto3.client("ecs", region_name="us-east-2")
     resp = client.delete_task_definitions(
         taskDefinitions=[
-            "nonexistent-task-definition:1",
+            "invalid-task-definition-name",
         ]
     )
 
     assert resp["taskDefinitions"] == []
     assert resp["failures"] == [
         {
-            "arn": "nonexistent-task-definition:1",
-            "reason": "The specified task definition does not exist. Specify a valid account, family, revision and try again.",
+            "arn": "invalid-task-definition-name",
+            "reason": "The specified task definition identifier is invalid. Specify a valid name or ARN and try again.",
         }
     ]
 

--- a/tests/test_ecs/test_ecs_task_definitions.py
+++ b/tests/test_ecs/test_ecs_task_definitions.py
@@ -1,0 +1,130 @@
+"""Unit tests for ecs-supported APIs."""
+
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_delete_task_definitions():
+    client = boto3.client("ecs", region_name="us-east-2")
+    client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+                "essential": True,
+                "environment": [
+                    {"name": "AWS_ACCESS_KEY_ID", "value": "SOME_ACCESS_KEY"}
+                ],
+                "logConfiguration": {"logDriver": "json-file"},
+            }
+        ],
+    )
+
+    client.deregister_task_definition(taskDefinition="test_ecs_task:1")
+    resp = client.delete_task_definitions(taskDefinitions=["test_ecs_task:1"])
+
+    assert resp["taskDefinitions"] == [
+        {
+            "family": "test_ecs_task",
+            "revision": 1,
+            "volumes": [],
+            "compatibilities": ["EC2"],
+            "status": "DELETE_IN_PROGRESS",
+            "containerDefinitions": [
+                {
+                    "cpu": 1024,
+                    "portMappings": [],
+                    "essential": True,
+                    "environment": [
+                        {"name": "AWS_ACCESS_KEY_ID", "value": "SOME_ACCESS_KEY"}
+                    ],
+                    "mountPoints": [],
+                    "volumesFrom": [],
+                    "name": "hello_world",
+                    "image": "docker/hello-world:latest",
+                    "memory": 400,
+                    "logConfiguration": {"logDriver": "json-file"},
+                }
+            ],
+            "networkMode": "bridge",
+            "placementConstraints": [],
+            "taskDefinitionArn": "arn:aws:ecs:us-east-2:123456789012:task-definition/test_ecs_task:1",
+        }
+    ]
+    assert resp["failures"] == []
+
+
+@mock_aws
+def test_delete_task_definitions_cannot_delete_active():
+    client = boto3.client("ecs", region_name="us-east-2")
+    task_def_1 = client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+                "essential": True,
+                "environment": [
+                    {"name": "AWS_ACCESS_KEY_ID", "value": "SOME_ACCESS_KEY"}
+                ],
+                "logConfiguration": {"logDriver": "json-file"},
+            }
+        ],
+    )
+
+    resp = client.delete_task_definitions(
+        taskDefinitions=[
+            task_def_1["taskDefinition"]["taskDefinitionArn"],
+        ]
+    )
+
+    assert resp["taskDefinitions"] == []
+    assert resp["failures"] == [
+        {
+            "arn": task_def_1["taskDefinition"]["taskDefinitionArn"],
+            "reason": "The specified task definition is still in ACTIVE status. Please deregister the target and try again.",
+        }
+    ]
+
+
+@mock_aws
+def test_delete_task_definitions_invalid_identifier():
+    client = boto3.client("ecs", region_name="us-east-2")
+    resp = client.delete_task_definitions(
+        taskDefinitions=[
+            "nonexistent-task-definition:1",
+        ]
+    )
+
+    assert resp["taskDefinitions"] == []
+    assert resp["failures"] == [
+        {
+            "arn": "nonexistent-task-definition:1",
+            "reason": "The specified task definition does not exist. Specify a valid account, family, revision and try again.",
+        }
+    ]
+
+
+@mock_aws
+def test_delete_task_definitions_nonexistent():
+    client = boto3.client("ecs", region_name="us-east-2")
+    resp = client.delete_task_definitions(
+        taskDefinitions=[
+            "nonexistent-task-definition:1",
+        ]
+    )
+
+    assert resp["taskDefinitions"] == []
+    assert resp["failures"] == [
+        {
+            "arn": "nonexistent-task-definition:1",
+            "reason": "The specified task definition does not exist. Specify a valid account, family, revision and try again.",
+        }
+    ]


### PR DESCRIPTION
While I'm working on my personal project, I found there are some features missing in ECS that I need. So I implemented:

- I found that current `list_task_definitions` does not support `status` filter. I implement it added tests for it.
-The `delete_task_definitions` feature is not implemented, so I implemented it.

I have some questions:

- Because I thought `test_ecs_boto3.py` file quite big, I added tests for `delete_task_definitions` in new file, `test_ecs_task_definitions.py`. If I should merge the file, please let me know.

Thank you for maintaining this library. Please feel free to suggest any changes!