### PR TITLE
Athena: Add more keys to `AthenaResponse.get_query_execution()` dictionary

### DIFF
--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -117,6 +117,7 @@ class Execution(BaseModel):
         self.workgroup = workgroup
         self.execution_parameters = execution_parameters
         self.start_time = time.time()
+        self.end_time = time.time()
         self.status = "SUCCEEDED"
 
         if self.config is not None and "OutputLocation" in self.config:

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -76,18 +76,24 @@ class AthenaResponse(BaseResponse):
                 "Query": execution.query,
                 "StatementType": statement_type,
                 "ResultConfiguration": execution.config,
+                "ResultReuseConfiguration": {
+                    "ResultReuseByAgeConfiguration": {"Enabled": False}
+                },
                 "QueryExecutionContext": execution.context,
                 "Status": {
                     "State": execution.status,
                     "SubmissionDateTime": execution.start_time,
+                    "CompletionDateTime": execution.end_time,
                 },
                 "Statistics": {
                     "EngineExecutionTimeInMillis": 0,
                     "DataScannedInBytes": 0,
                     "TotalExecutionTimeInMillis": 0,
                     "QueryQueueTimeInMillis": 0,
+                    "ServicePreProcessingTimeInMillis": 0,
                     "QueryPlanningTimeInMillis": 0,
                     "ServiceProcessingTimeInMillis": 0,
+                    "ResultReuseInformation": {"ReusedPreviousResult": False},
                 },
                 "WorkGroup": execution.workgroup.name if execution.workgroup else None,
             }


### PR DESCRIPTION
This PR adds keys to the dictionary returned by the `moto.athena.responses.AthenaResponse.get_query_execution` method to more closely match [real responses from Amazon Athena](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/athena/client/get_query_execution.html).

- Added `ResultReuseConfiguration`
   - Added `ResultReuseByAgeConfiguration`
      - Added `Enabled`: `False`
- Edited `Status`
   - Added `CompletionDateTime`: New `Execution.end_time` property
- Edited `Statistics`
   - Added `ServicePreProcessingTimeInMillis`: 0
   - Added `ResultReuseInformation`
      - Added `ReusedPreviousResult`: `False`

Run the unit tests:

```shell
pytest ./tests/test_athena/test_athena.py
```

Fixes #8624 