### PR TITLE
RDS: Add rds bluegreen deployment api implementations

### DIFF
--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -303,7 +303,7 @@ class BlueGreenDeploymentAlreadyExistsFault(RDSClientError):
     def __init__(self, bg_name: str):
         super().__init__(
             "BlueGreenDeploymentAlreadyExistsFault",
-            f"Cannot create Bluegreen Deployment because a Bluegreen Deployment with the name {bg_name} already exists.",
+            f"A blue/green deployment with the specified name {bg_name} already exists.",
         )
 
 
@@ -311,5 +311,13 @@ class BlueGreenDeploymentNotFoundFault(RDSClientError):
     def __init__(self, bg_identifier: str):
         super().__init__(
             "BlueGreenDeploymentNotFoundFault",
-            f"Bluegreen Deployment {bg_identifier} not found.",
+            f"BlueGreenDeploymentIdentifier {bg_identifier} doesn't refer to an existing blue/green deployment.",
+        )
+
+
+class InvalidBlueGreenDeploymentStateFault(RDSClientError):
+    def __init__(self, bg_identifier: str):
+        super().__init__(
+            "InvalidBlueGreenDeploymentStateFault",
+            f"The blue/green deployment {bg_identifier} can't be switched over or deleted because there is an invalid configuration in the green environment.",
         )

--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -321,3 +321,11 @@ class InvalidBlueGreenDeploymentStateFault(RDSClientError):
             "InvalidBlueGreenDeploymentStateFault",
             f"The blue/green deployment {bg_identifier} can't be switched over or deleted because there is an invalid configuration in the green environment.",
         )
+
+
+class SourceDatabaseNotSupportedFault(RDSClientError):
+    def __init__(self, source_arn: str):
+        super().__init__(
+            "SourceDatabaseNotSupportedFault",
+            f"The source DB instance {source_arn} isn't supported for a blue/green deployment.",
+        )

--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -297,3 +297,19 @@ class DBProxyNotFoundFault(RDSClientError):
             "DBProxyNotFoundFault",
             f"The specified proxy name {db_proxy_identifier} doesn't correspond to a proxy owned by your Amazon Web Services account in the specified Amazon Web Services Region.",
         )
+
+
+class BlueGreenDeploymentAlreadyExistsFault(RDSClientError):
+    def __init__(self, bg_name: str):
+        super().__init__(
+            "BlueGreenDeploymentAlreadyExistsFault",
+            f"Cannot create Bluegreen Deployment because a Bluegreen Deployment with the name {bg_name} already exists.",
+        )
+
+
+class BlueGreenDeploymentNotFoundFault(RDSClientError):
+    def __init__(self, bg_identifier: str):
+        super().__init__(
+            "BlueGreenDeploymentNotFoundFault",
+            f"Bluegreen Deployment {bg_identifier} not found.",
+        )

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -3944,6 +3944,9 @@ class RDSBackend(BaseBackend):
             raise DBInstanceNotFoundError(db_instance_identifier)
         database = self.databases[db_instance_identifier]
         return database.log_file_manager.files
+    
+    def create_blue_green_deployment(self, bg_kwargs: Dict[str, Any]) -> BlueGreenDeployment:
+        return BlueGreenDeployment(**bg_kwargs)
 
 
 class OptionGroup(RDSBaseModel):
@@ -4153,6 +4156,34 @@ class Event:
         self.event_categories = event_metadata["Categories"]
         self.source_arn = resource.arn
         self.date = utcnow()
+
+class BlueGreenDeployment:
+    def __init__(
+        self,
+        blue_green_deployment_name: str,
+        source: str,
+        target_engine_version: str | None = None,
+        target_db_parameter_group_name: str | None = None,
+        target_cluster_db_parameter_group_name: str | None = None,
+        target_db_instance_class: str | None = None,
+        target_iops: int | None = None,
+        target_storage_type: str | None = None,
+        target_allocated_storage: int | None = None,
+        target_storage_throughput: int | None = None,
+        tags: List[Dict[str, str]] | None = None,
+        upgrade_target_storage_config: bool = False
+        ) -> None:
+        self.blue_green_deployment_identifier = "foo"
+        self.blue_green_deployment_name = blue_green_deployment_name
+        self.source = source
+        self.target = "foobarBaz" # ToDo: Create Instance with targetblob
+        self.switchover_details = [{}] # ToDo: Setup SwitchoverDetails
+        self.tasks = [{}] # ToDo: Setup Tasks
+        self.status = "AVAILABLE"
+        self.status_details = "None"
+        self.create_time = utcnow()
+        self.deletion_time = None
+        self.tag_list = tags
 
 
 rds_backends = BackendDict(RDSBackend, "rds")

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -4036,10 +4036,10 @@ class RDSBackend(BaseBackend):
 
         bg_deployment_before_switch = copy.copy(bg_deployment)
 
-        bg_deployment._switchover()
+        bg_deployment.switchover()
         self.bluegreen_deployments[blue_green_deployment_identifier] = bg_deployment
 
-        bg_deployment_before_switch._set_status(
+        bg_deployment_before_switch.set_status(
             bg_deployment.SupportedStates.SWITCHOVER_IN_PROGRESS
         )
 
@@ -4074,7 +4074,7 @@ class RDSBackend(BaseBackend):
                     db_instance_identifier=instance.db_instance_identifier
                 )
 
-        bg_deployment._set_status(bg_deployment.SupportedStates.DELETING)
+        bg_deployment.set_status(bg_deployment.SupportedStates.DELETING)
         bg_deployment.deletion_time = utcnow()
         return bg_deployment
 
@@ -4350,7 +4350,7 @@ class BlueGreenDeployment(RDSBaseModel):
                 BlueGreenDeploymentTask.SupportedStates.COMPLETED.name,
             ),
         ]
-        self._set_status(self.SupportedStates.AVAILABLE)
+        self.set_status(self.SupportedStates.AVAILABLE)
         self.status_details: str | None = None
         self.create_time = utcnow()
         self.deletion_time: datetime | None = None
@@ -4360,7 +4360,7 @@ class BlueGreenDeployment(RDSBaseModel):
     def resource_id(self) -> str:
         return self.blue_green_deployment_identifier
 
-    def _set_status(self, value: SupportedStates) -> None:
+    def set_status(self, value: SupportedStates) -> None:
         self.status = value.name
         self.switchover_details = [
             SwitchoverDetails(self.source, self.target, self.status)
@@ -4505,7 +4505,7 @@ class BlueGreenDeployment(RDSBaseModel):
         else:
             return self.backend.describe_db_instances(db_instance_identifier=arn)[0]
 
-    def _switchover(self) -> None:
+    def switchover(self) -> None:
         source = self._get_instance(self.source)
         target = self._get_instance(self.target)
         source_result: DBCluster | DBInstance
@@ -4542,7 +4542,7 @@ class BlueGreenDeployment(RDSBaseModel):
             )
         self.source = source_result.arn
         self.target = target_result.arn
-        self._set_status(self.SupportedStates.SWITCHOVER_COMPLETED)
+        self.set_status(self.SupportedStates.SWITCHOVER_COMPLETED)
         self.status_details = "Switchover completed"
 
 

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -3994,7 +3994,7 @@ class RDSBackend(BaseBackend):
         )
         # update states only for the response of create command
         bg_copy = copy.copy(bg_deployment)
-        bg_copy._set_status(bg_deployment.SupportedStates.PROVISIONING)  # type: ignore
+        bg_copy.set_status(bg_deployment.SupportedStates.PROVISIONING)  # type: ignore
 
         return bg_copy  # type: ignore
 
@@ -4389,7 +4389,6 @@ class BlueGreenDeployment(RDSBaseModel):
     ) -> str:
         source_instance: DBInstance | DBCluster = self._get_instance(self.source)
         green_instance: DBInstance | DBCluster
-
         if source_instance.manage_master_user_password:
             raise SourceDatabaseNotSupportedFault(source_instance.arn)
 

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -787,6 +787,17 @@ class RDSResponse(BaseResponse):
         result = {"BlueGreenDeployment": bg_deployment}
         return ActionResult(result)
 
+    def describe_blue_green_deployments(self) -> ActionResult:
+        filters = self.parameters.get("Filters", [])
+        filter_dict = {f["Name"]: f["Values"] for f in filters}
+        self.parameters["filters"] = filter_dict
+        all_bg_deployments = self.backend.describe_blue_green_deployments(
+            **self.parameters
+        )
+        bg_deployments, _ = self._paginate(all_bg_deployments)
+        result = {"BlueGreenDeployments": bg_deployments}
+        return ActionResult(result)
+
     def _paginate(self, resources: List[Any]) -> Tuple[List[Any], Optional[str]]:
         from moto.rds.exceptions import InvalidParameterValue
 

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -780,6 +780,12 @@ class RDSResponse(BaseResponse):
         log_files = self.backend.describe_db_log_files(**self.parameters)
         result = {"DescribeDBLogFiles": log_files}
         return ActionResult(result)
+    
+    def create_blue_green_deployment(self) -> ActionResult:
+        bg_kwargs = self.parameters
+        bg_deployment = self.backend.create_blue_green_deployment(bg_kwargs)
+        result = {"BlueGreenDeployment": bg_deployment}
+        return ActionResult(result)
 
     def _paginate(self, resources: List[Any]) -> Tuple[List[Any], Optional[str]]:
         from moto.rds.exceptions import InvalidParameterValue

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -798,6 +798,11 @@ class RDSResponse(BaseResponse):
         result = {"BlueGreenDeployments": bg_deployments}
         return ActionResult(result)
 
+    def switchover_blue_green_deployment(self) -> ActionResult:
+        bg_deployment = self.backend.switchover_blue_green_deployment(**self.parameters)
+        result = {"BlueGreenDeployment": bg_deployment}
+        return ActionResult(result)
+
     def _paginate(self, resources: List[Any]) -> Tuple[List[Any], Optional[str]]:
         from moto.rds.exceptions import InvalidParameterValue
 

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -803,6 +803,11 @@ class RDSResponse(BaseResponse):
         result = {"BlueGreenDeployment": bg_deployment}
         return ActionResult(result)
 
+    def delete_blue_green_deployment(self) -> ActionResult:
+        bg_deployment = self.backend.delete_blue_green_deployment(**self.parameters)
+        result = {"BlueGreenDeployment": bg_deployment}
+        return ActionResult(result)
+
     def _paginate(self, resources: List[Any]) -> Tuple[List[Any], Optional[str]]:
         from moto.rds.exceptions import InvalidParameterValue
 

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -780,7 +780,7 @@ class RDSResponse(BaseResponse):
         log_files = self.backend.describe_db_log_files(**self.parameters)
         result = {"DescribeDBLogFiles": log_files}
         return ActionResult(result)
-    
+
     def create_blue_green_deployment(self) -> ActionResult:
         bg_kwargs = self.parameters
         bg_deployment = self.backend.create_blue_green_deployment(bg_kwargs)

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -3659,3 +3659,20 @@ def test_db_instance_identifier_is_case_insensitive(client):
 
     response = client.describe_db_instances()
     assert len(response["DBInstances"]) == 0
+
+@mock_aws
+def test_create_bluegreen_deployment_creates_a_new_instance(client):
+    instance = create_db_instance(DBInstanceIdentifier="FooBar")
+
+    response = client.create_blue_green_deployment(
+        BlueGreenDeploymentName="FooBarBlueGreen",
+        Source=instance["DBInstanceArn"]
+    )
+
+    bluegreen_deployment_response = response["BlueGreenDeployment"]
+    assert bluegreen_deployment_response != None
+    assert bluegreen_deployment_response["BlueGreenDeploymentName"] == "FooBarBlueGreen"
+    assert bluegreen_deployment_response["Source"] == instance["DBInstanceArn"]
+    assert bluegreen_deployment_response["Target"] != None
+    assert bluegreen_deployment_response["Status"] == "AVAILABLE"
+

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -3845,4 +3845,21 @@ def test_describe_bluegreen_deployments_with_filters(client):
 
 @mock_aws
 def test_describe_bluegreen_deployments_with_no_hits(client):
-    assert False
+    with pytest.raises(ClientError) as ex:
+        client.describe_blue_green_deployments(
+            BlueGreenDeploymentIdentifier="red-yellow"
+        )
+
+    filter_response = client.describe_blue_green_deployments(
+        Filters=[
+            {
+                "Name": "source",
+                "Values": ["no-real-arn"]
+            }
+        ]
+    )
+
+    error = ex.value.response["Error"]
+
+    assert error["Code"] == "BlueGreenDeploymentNotFoundFault"
+    assert len(filter_response["BlueGreenDeployments"]) == 0

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -3773,9 +3773,7 @@ def test_create_blue_green_deployment_error_if_source_not_found(client):
         )
 
     err = ex.value.response["Error"]
-    assert (
-        err["Code"] == "DBInstanceNotFound"
-    )  # ToDo: Determine the correct exception thrown
+    assert err["Code"] == "DBInstanceNotFound"
     assert err["Message"] == "DBInstance arn:rds:123456789012:db:not_an_arn not found."
 
 

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -3670,9 +3670,16 @@ def test_create_bluegreen_deployment_creates_a_new_instance(client):
     )
 
     bluegreen_deployment_response = response["BlueGreenDeployment"]
+
+    db_describe_response = client.describe_db_instances(
+        DBInstanceIdentifier=bluegreen_deployment_response["Target"]
+    )
+
     assert bluegreen_deployment_response != None
+    assert "bgd-" in bluegreen_deployment_response["BlueGreenDeploymentIdentifier"]
     assert bluegreen_deployment_response["BlueGreenDeploymentName"] == "FooBarBlueGreen"
     assert bluegreen_deployment_response["Source"] == instance["DBInstanceArn"]
     assert bluegreen_deployment_response["Target"] != None
     assert bluegreen_deployment_response["Status"] == "AVAILABLE"
 
+    assert len(db_describe_response["DBInstances"]) > 0

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -2111,6 +2111,19 @@ def test_create_bluegreen_deployment_creates_a_green_db_cluster(client):
         )
 
 
+@mock_aws
+def test_create_blue_green_deployment_error_if_source_not_found(client):
+    with pytest.raises(ClientError) as ex:
+        client.create_blue_green_deployment(
+            BlueGreenDeploymentName="FooBarBlueGreen",
+            Source="not_an_arn",
+        )
+
+    err = ex.value.response["Error"]
+    assert err["Code"] == "DBClusterNotFoundFault"
+    assert err["Message"] == "DBCluster not_an_arn not found."
+
+
 def create_subnet() -> str:
     ec2_client = boto3.client("ec2", DEFAULT_REGION)
     vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -8,7 +8,11 @@ from moto import mock_aws, settings
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 
 from . import DEFAULT_REGION
-from .test_rds import create_db_instance, update_status_from_create_blue_green_response
+from .test_rds import (
+    create_db_instance,
+    create_subnet,
+    update_status_from_create_blue_green_response,
+)
 
 test_tags = [
     {
@@ -2347,10 +2351,3 @@ def test_delete_blue_green_deployment_with_source_db_cluster(client, options):
         assert len(describe_target_cluster["DBClusters"]) == 0
     else:
         assert len(describe_target_cluster["DBClusters"]) == 1
-
-
-def create_subnet() -> str:
-    ec2_client = boto3.client("ec2", DEFAULT_REGION)
-    vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
-    response = ec2_client.create_subnet(VpcId=vpc["VpcId"], CidrBlock="10.0.1.0/24")
-    return response["Subnet"]["SubnetId"]

--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -2262,7 +2262,7 @@ def test_switchover_blue_green_deployment(client):
     assert (
         describe_target_instance["DBClusters"][0]["Endpoint"].split(".")[0]
         == cluster["Endpoint"].split(".")[0]
-    )  # ToDo: Maybe copy whole instance so endpoints stay the same?
+    )
 
 
 @mock_aws


### PR DESCRIPTION
Hi there,

I was not quite sure how you guys handle new implementations of AWS Features, so it started to implement the apis for rds blue green deployments by myself. This PR contains the following changes:

create_blue_green_deployment:
- adds the BlueGreenDeployment resource to the backend
- adds a green rds instance or cluster to the backend

switchover_blue_green_deployment:
- modifies the source rds instance or cluster and renames it with the "old"-suffix
- modifies the target rds instance or cluster and renames it to the source name

delete_blue_green_deployment:
- deletes the BlueGreenDeployment
- if specified, deletes the green rds instance or cluster

describe_blue_green_deployments:
- get a filterable list of existing BlueGreenDeployment resources

minor changes:
- adds storage_throughput property to DBInstance to be able to update this property with BlueGreenDeployments

Feedback would be highly appreciated!
