### PR TITLE
IAM: Omit role tags field from response when not set

### DIFF
--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -2186,7 +2186,7 @@ class IAMBackend(BaseBackend):
             path=path,
             permissions_boundary=permissions_boundary,
             description=description,
-            tags=[clean_tags[tag] for tag in clean_tags] or None,
+            tags=[clean_tags[tag] for tag in clean_tags],
             max_session_duration=max_session_duration,
             linked_service=linked_service,
         )

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -2177,6 +2177,10 @@ class IAMBackend(BaseBackend):
             raise EntityAlreadyExists(f"Role with name {role_name} already exists.")
 
         clean_tags = self._tag_verification(tags)
+        tags = None
+        if clean_tags:
+            tags = [clean_tags[tag] for tag in clean_tags]
+
         role = Role(
             account_id=self.account_id,
             partition=self.partition,
@@ -2186,7 +2190,7 @@ class IAMBackend(BaseBackend):
             path=path,
             permissions_boundary=permissions_boundary,
             description=description,
-            tags=[clean_tags[tag] for tag in clean_tags],
+            tags=tags,
             max_session_duration=max_session_duration,
             linked_service=linked_service,
         )

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -2177,10 +2177,6 @@ class IAMBackend(BaseBackend):
             raise EntityAlreadyExists(f"Role with name {role_name} already exists.")
 
         clean_tags = self._tag_verification(tags)
-        tags = None
-        if clean_tags:
-            tags = [clean_tags[tag] for tag in clean_tags]
-
         role = Role(
             account_id=self.account_id,
             partition=self.partition,
@@ -2190,7 +2186,7 @@ class IAMBackend(BaseBackend):
             path=path,
             permissions_boundary=permissions_boundary,
             description=description,
-            tags=tags,
+            tags=[clean_tags[tag] for tag in clean_tags] or None,
             max_session_duration=max_session_duration,
             linked_service=linked_service,
         )

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -252,6 +252,8 @@ class IamResponse(BaseResponse):
         role_name = self._get_param("RoleName")
         role = self.backend.get_role(role_name)
         role = copy(role)
+        if not role.tags:
+            role.tags = None  # type: ignore[assignment]  # empty tag-list should not be serialized
         setattr(
             role, "AssumeRolePolicyDocument", quote(role.assume_role_policy_document)
         )

--- a/tests/test_iam/__init__.py
+++ b/tests/test_iam/__init__.py
@@ -1,3 +1,4 @@
+import json
 from functools import wraps
 from uuid import uuid4
 
@@ -6,8 +7,17 @@ import boto3
 from moto import mock_aws
 from tests import allow_aws_request
 
+assume_role_policy_document = {
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Principal": {"AWS": "*"},
+        "Action": "sts:AssumeRole",
+    },
+}
 
-def iam_aws_verified(create_user: bool = False):
+
+def iam_aws_verified(create_user: bool = False, create_role: bool = False, tags=None):
     """
     Function that is verified to work against AWS.
     Can be run against AWS at any time by setting:
@@ -17,13 +27,27 @@ def iam_aws_verified(create_user: bool = False):
     """
 
     def inner(func):
-        def create_user_and_invoke_test():
+        def create_user_and_invoke_test(**kwargs):
             client = boto3.client("iam", "us-east-1")
             user_name = f"testuser_{str(uuid4())[0:6]}"
+            role_name = f"testrole_{str(uuid4())[0:6]}"
+            iam_kwargs = {}
+            if tags is not None:
+                iam_kwargs["Tags"] = tags
             try:
                 if create_user:
                     client.create_user(UserName=user_name)
-                return func(user_name=user_name)
+                    kwargs["user_name"] = user_name
+                if create_role:
+                    client.create_role(
+                        RoleName=role_name,
+                        AssumeRolePolicyDocument=json.dumps(
+                            assume_role_policy_document
+                        ),
+                        **iam_kwargs,
+                    )
+                    kwargs["role_name"] = role_name
+                return func(**kwargs)
             finally:
                 if create_user:
                     certificates = client.list_signing_certificates(UserName=user_name)[
@@ -35,6 +59,8 @@ def iam_aws_verified(create_user: bool = False):
                             UserName=user_name, CertificateId=cert["CertificateId"]
                         )
                     client.delete_user(UserName=user_name)
+                if create_role:
+                    client.delete_role(RoleName=role_name)
 
         @wraps(func)
         def pagination_wrapper():

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2748,7 +2748,7 @@ def test_create_role_with_tags():
     )
     # Ensure the tags field is not present in the response
     role = conn.get_role(RoleName="your-role")["Role"]
-    assert 'Tags' not in role
+    assert "Tags" not in role
 
     conn.create_role(
         RoleName="my-role",

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -2738,6 +2738,18 @@ def test_create_role_defaults():
 def test_create_role_with_tags():
     """Tests both the tag_role and get_role_tags capability"""
     conn = boto3.client("iam", region_name="us-east-1")
+
+    # Create a role without tags
+    conn.create_role(
+        RoleName="your-role",
+        AssumeRolePolicyDocument="{}",
+        Tags=[],
+        Description="testing",
+    )
+    # Ensure the tags field is not present in the response
+    role = conn.get_role(RoleName="your-role")["Role"]
+    assert 'Tags' not in role
+
     conn.create_role(
         RoleName="my-role",
         AssumeRolePolicyDocument="{}",


### PR DESCRIPTION
This PR fixes a small cosmetic bug which popped up in LocalStack snapshot tests.

Moto IAM CreateRole always returns the `Tags` field.

```
$ aws --endpoint-url=http://localhost:5000 iam create-role \
    --role-name hello0 \
    --assume-role-policy-document '{"Version": "2012-10-17", "Statement": [{"Action": "sts:AssumeRole", "Principal": {"AWS": "123456789012"}, "Effect": "Allow"}]}'
{
    "Role": {
        "Path": "/",
        "RoleName": "hello0",
        "RoleId": "AROARZPUZDIKGYSLBPCKW",
        "Arn": "arn:aws:iam::123456789012:role/hello0",
        "CreateDate": "2025-06-19T12:42:46.393417Z",
        "AssumeRolePolicyDocument": {
            "Version": "2012-10-17",
            "Statement": [
                {
                    "Action": "sts:AssumeRole",
                    "Principal": {
                        "AWS": "123456789012"
                    },
                    "Effect": "Allow"
                }
            ]
        },
        "MaxSessionDuration": 3600,
        "Tags": [],
        "RoleLastUsed": {}
    }
}
```

AWS IAM CreateRole only returns the `Tags` field when specified in the request.

```
# Without tags
$ aws iam create-role \
    --role-name hello1 \
    --assume-role-policy-document '{"Version": "2012-10-17", "Statement": [{"Action": "sts:AssumeRole", "Principal": {"AWS": "123456789012"}, "Effect": "Allow"}]}'                                                                                                    
{                               
    "Role": {                 
        "Path": "/",
        "RoleName": "hello1",
        "RoleId": "AROAZCRR4CRXXXXXXXXXX",
        "Arn": "arn:aws:iam::123456789012:role/hello1",
        "CreateDate": "2025-06-19T12:28:18Z",
        "AssumeRolePolicyDocument": {                                                                    
            "Version": "2012-10-17",                                                                                                                                                                              
            "Statement": [
                {
                    "Action": "sts:AssumeRole",
                    "Principal": {
                        "AWS": "123456789012"
                    },
                    "Effect": "Allow"
                }
            ]
        }
    }
}
```
```
# With tags
$ aws iam create-role \
    --role-name hello2 \
    --assume-role-policy-document '{"Version": "2012-10-17", "Statement": [{"Action": "sts:AssumeRole", "Principal": {"AWS": "123456789012"}, "Effect": "Allow"}]}' --tags Key=colour,Value=red
{
    "Role": {
        "Path": "/",
        "RoleName": "hello2",
        "RoleId": "AROAZCRR4CRXXXXXXXXXX",
        "Arn": "arn:aws:iam::123456789012:role/hello2",
        "CreateDate": "2025-06-19T12:28:42Z",
        "AssumeRolePolicyDocument": {
            "Version": "2012-10-17",
            "Statement": [
                {
                    "Action": "sts:AssumeRole",
                    "Principal": {
                        "AWS": "123456789012"
                    },
                    "Effect": "Allow"
                }
            ]
        },
        "Tags": [
            {
                "Key": "colour",
                "Value": "red"
            }
        ]
    }
}
```

See https://github.com/getmoto/moto/pull/8970 and https://github.com/getmoto/moto/issues/5092