### PR TITLE
S3: get_object() should not return ContentEncoding=aws-chunked

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -229,6 +229,14 @@ class FakeKey(BaseModel, ManagedState):
     def set_metadata(self, metadata: Any, replace: bool = False) -> None:
         if replace:
             self._metadata = {}  # type: ignore
+        # Remove AWS-specific Content-Encoding
+        if encoding := metadata.pop("Content-Encoding", None):
+            # Remove 'aws-chunked', but keep any other (user-provided) content encoding
+            encoding = ",".join(
+                [enc for enc in encoding.split(",") if enc != "aws-chunked"]
+            )
+            if encoding:
+                metadata["Content-Encoding"] = encoding
         self._metadata.update(metadata)
 
     def set_storage_class(self, storage: Optional[str]) -> None:

--- a/tests/test_s3/test_s3_content_encoding.py
+++ b/tests/test_s3/test_s3_content_encoding.py
@@ -1,0 +1,30 @@
+import os
+from tempfile import TemporaryFile
+
+import boto3
+import pytest
+
+from . import s3_aws_verified
+
+
+@pytest.mark.aws_verified
+@s3_aws_verified
+@pytest.mark.parametrize("encoding", [None, "gzip", "unknown"])
+def test_content_encoding_is_returned(encoding, bucket_name=None):
+    client = boto3.client("s3", region_name="us-east-1")
+    s3_file = "some.file"
+
+    attrs = {
+        "ContentType": "application/octet-stream",
+        "ACL": "bucket-owner-full-control",
+    }
+    if encoding:
+        attrs["ContentEncoding"] = encoding
+
+    with TemporaryFile() as f:
+        f.write(os.urandom(1024))
+        f.flush()
+        client.upload_fileobj(f, bucket_name, s3_file, ExtraArgs=attrs)
+
+    res = client.get_object(Bucket=bucket_name, Key=s3_file)
+    assert res.get("ContentEncoding") == encoding


### PR DESCRIPTION
Fixes #9007 

## Background
`botocore` sometimes adds the Content-Encoding header `aws-chunked` (since https://github.com/boto/botocore/pull/2859)

Moto receives the headers, and returns it as-is. But: AWS: removes the `aws-chunked` part, and only returns whatever the user explicitly provided.

Note that in `botocore==1.35.0` this did not happen - the `aws-chunked` encoding is not added. My assumption is that this changed with https://github.com/boto/boto3/issues/4392 (fixed on our side with https://github.com/getmoto/moto/pull/8495), which would align with the observation from the user that this started around February. I haven't done any deepdive into the root cause though.

This PR explicitly removes the `aws-chunked` value (if provided), improving parity with AWS.