### PR TITLE
feat: Add ID field to CORS rule

### DIFF
--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -845,6 +845,7 @@ class CorsRule(BaseModel):
         allowed_headers: Any = None,
         expose_headers: Any = None,
         max_age_seconds: Any = None,
+        id_: Any = None,
     ):
         self.allowed_methods = (
             [allowed_methods] if isinstance(allowed_methods, str) else allowed_methods
@@ -859,6 +860,7 @@ class CorsRule(BaseModel):
             [expose_headers] if isinstance(expose_headers, str) else expose_headers
         )
         self.max_age_seconds = max_age_seconds
+        self.id_ = id_
 
 
 class Notification(BaseModel):
@@ -1264,6 +1266,7 @@ class FakeBucket(CloudFormationModel):
                 rule.get("ExposeHeader", ""), str
             )
             assert isinstance(rule.get("MaxAgeSeconds", "0"), str)
+            assert isinstance(rule.get("ID", ""), str)
 
             if isinstance(rule["AllowedMethod"], str):
                 methods = [rule["AllowedMethod"]]
@@ -1281,6 +1284,7 @@ class FakeBucket(CloudFormationModel):
                     rule.get("AllowedHeader"),
                     rule.get("ExposeHeader"),
                     rule.get("MaxAgeSeconds"),
+                    rule.get("ID"),
                 )
             )
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -3075,6 +3075,9 @@ S3_BUCKET_CORS_RESPONSE = """<?xml version="1.0" encoding="UTF-8"?>
       <AllowedHeader>{{ header }}</AllowedHeader>
       {% endfor %}
     {% endif %}
+    {% if cors.id_ is not none %}
+    <ID>{{ cors.id_ }}</ID>
+    {% endif %}
     {% if cors.exposed_headers is not none %}
       {% for header in cors.exposed_headers %}
       <ExposeHeader>{{ header }}</ExposeHeader>

--- a/tests/test_s3/test_s3.py
+++ b/tests/test_s3/test_s3.py
@@ -1994,6 +1994,7 @@ def test_put_bucket_cors():
                     "AllowedHeaders": ["Authorization"],
                     "ExposeHeaders": ["x-amz-request-id"],
                     "MaxAgeSeconds": 123,
+                    "ID": "some-id",
                 },
                 {
                     "AllowedOrigins": ["*"],
@@ -2067,6 +2068,7 @@ def test_get_bucket_cors():
                     "AllowedHeaders": ["Authorization"],
                     "ExposeHeaders": ["x-amz-request-id"],
                     "MaxAgeSeconds": 123,
+                    "ID": "some-id",
                 },
                 {
                     "AllowedOrigins": ["*"],
@@ -2087,6 +2089,9 @@ def test_get_bucket_cors():
         assert rules["AllowedHeaders"] == ["Authorization"]
         assert rules["ExposeHeaders"] == ["x-amz-request-id"]
         assert rules["MaxAgeSeconds"] == 123
+
+    assert sum(1 for rule in resp["CORSRules"] if rule.get("ID") == "some-id") == 1
+    assert sum(1 for rule in resp["CORSRules"] if rule.get("ID") is None) == 1
 
 
 @pytest.mark.aws_verified


### PR DESCRIPTION
According to the AWS S3 documentation, the [`PutBucketCors` operation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html#API_PutBucketCors_RequestSyntax) can have an optional field `ID` for every rule with an arbitrary string for later identification. These IDs are stored with the rule and can be retrieved with the [`GetBucketCors` operation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html#API_GetBucketCors_ResponseSyntax).

This PR adds this field to the internal CORS rule representation and adds test statements in the appropriate tests to ensure they are retrieved correctly by `boto3`.