### PR TITLE
EMR: integrate with core AWS response serializer

### DIFF
--- a/moto/emr/exceptions.py
+++ b/moto/emr/exceptions.py
@@ -1,16 +1,16 @@
-from moto.core.exceptions import JsonRESTError
+from moto.core.exceptions import ServiceException
 
 
-class InvalidRequestException(JsonRESTError):
+class InvalidRequestException(ServiceException):
     def __init__(self, message: str):
         super().__init__("InvalidRequestException", message)
 
 
-class ValidationException(JsonRESTError):
+class ValidationException(ServiceException):
     def __init__(self, message: str):
         super().__init__("ValidationException", message)
 
 
-class ResourceNotFoundException(JsonRESTError):
+class ResourceNotFoundException(ServiceException):
     def __init__(self, message: str):
         super().__init__("ResourceNotFoundException", message)

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -100,7 +100,7 @@ class Instance(BaseModel):
         return ebs_volumes
 
     @property
-    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+    def status(self) -> dict[str, Any]:
         status_dict = {
             "State": self.instance_group.state,
             "StateChangeReason": {
@@ -158,7 +158,7 @@ class InstanceGroup(CloudFormationModel):
         self.num_instances = instance_count
 
     @property
-    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+    def status(self) -> dict[str, Any]:
         status_dict = {
             "State": self.state,
             "StateChangeReason": {
@@ -174,7 +174,7 @@ class InstanceGroup(CloudFormationModel):
         return status_dict
 
     @property
-    def ebs_block_devices(self) -> list[dict[str, Any]]:  # type: ignore[misc]
+    def ebs_block_devices(self) -> list[dict[str, Any]]:
         ebs_block_devices = []
         if self.ebs_configuration is not None:
             for ebs_block_device in self.ebs_configuration.get(
@@ -214,7 +214,7 @@ class InstanceGroup(CloudFormationModel):
         return self.num_instances
 
     @property
-    def auto_scaling_policy(self) -> Any:  # type: ignore[misc]
+    def auto_scaling_policy(self) -> Any:
         return self._auto_scaling_policy
 
     @auto_scaling_policy.setter
@@ -250,7 +250,7 @@ class InstanceGroup(CloudFormationModel):
         return "AWS::EMR::InstanceGroupConfig"
 
     @classmethod
-    def create_from_cloudformation_json(  # type: ignore[misc]
+    def create_from_cloudformation_json(
         cls,
         resource_name: str,
         cloudformation_json: Any,
@@ -305,7 +305,7 @@ class Step(BaseModel):
         self.state = state
 
     @property
-    def config(self) -> dict[str, Any]:  # type: ignore[misc]
+    def config(self) -> dict[str, Any]:
         config = {
             "ActionOnFailure": self.action_on_failure,
             "HadoopJarStep": {
@@ -323,7 +323,7 @@ class Step(BaseModel):
         return config
 
     @property
-    def execution_status_detail(self) -> dict[str, Any]:  # type: ignore[misc]
+    def execution_status_detail(self) -> dict[str, Any]:
         status_dict = {
             "CreationDateTime": self.creation_date_time,
             "StartDateTime": self.start_date_time,
@@ -335,7 +335,7 @@ class Step(BaseModel):
         return status_dict
 
     @property
-    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+    def status(self) -> dict[str, Any]:
         status_dict = {
             "State": self.state,
             "StateChangeReason": {
@@ -514,7 +514,7 @@ class Cluster(CloudFormationModel):
         return not self.keep_job_flow_alive_when_no_steps
 
     @property
-    def bootstrap_action_detail_list(self) -> list[dict[str, Any]]:  # type: ignore[misc]
+    def bootstrap_action_detail_list(self) -> list[dict[str, Any]]:
         details = []
         for bootstrap_action in self.bootstrap_actions:
             member = {
@@ -534,7 +534,7 @@ class Cluster(CloudFormationModel):
         return Ec2InstanceAttributes(self)
 
     @property
-    def job_flow_instances_detail(self) -> dict[str, Any]:  # type: ignore[misc]
+    def job_flow_instances_detail(self) -> dict[str, Any]:
         instances_detail = {
             "Ec2KeyName": self.ec2_key_name,
             "Ec2SubnetId": self.ec2_subnet_id,
@@ -553,7 +553,7 @@ class Cluster(CloudFormationModel):
         return instances_detail
 
     @property
-    def execution_status_detail(self) -> dict[str, Any]:  # type: ignore[misc]
+    def execution_status_detail(self) -> dict[str, Any]:
         status_dict = {
             "State": self.state,
             "CreationDateTime": self.creation_datetime,
@@ -578,7 +578,7 @@ class Cluster(CloudFormationModel):
         return "ec2-184-0-0-1.us-west-1.compute.amazonaws.com"
 
     @property
-    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+    def status(self) -> dict[str, Any]:
         status_dict = {
             "State": self.state,
             "StateChangeReason": {
@@ -719,7 +719,7 @@ class Cluster(CloudFormationModel):
         raise UnformattedGetAttTemplateException()
 
     @classmethod
-    def create_from_cloudformation_json(  # type: ignore[misc]
+    def create_from_cloudformation_json(
         cls,
         resource_name: str,
         cloudformation_json: Any,
@@ -764,7 +764,7 @@ class Cluster(CloudFormationModel):
         return cluster
 
     @classmethod
-    def delete_from_cloudformation_json(  # type: ignore[misc]
+    def delete_from_cloudformation_json(
         cls,
         resource_name: str,
         cloudformation_json: Dict[str, Any],
@@ -791,7 +791,7 @@ class SecurityConfiguration(CloudFormationModel):
         return "AWS::EMR::SecurityConfiguration"
 
     @classmethod
-    def create_from_cloudformation_json(  # type: ignore[misc]
+    def create_from_cloudformation_json(
         cls,
         resource_name: str,
         cloudformation_json: Any,
@@ -808,7 +808,7 @@ class SecurityConfiguration(CloudFormationModel):
         )
 
     @classmethod
-    def delete_from_cloudformation_json(  # type: ignore[misc]
+    def delete_from_cloudformation_json(
         cls,
         resource_name: str,
         cloudformation_json: Dict[str, Any],
@@ -831,7 +831,7 @@ class ElasticMapReduceBackend(BaseBackend):
         self.block_public_access_configuration: Dict[str, Any] = {}
 
     @property
-    def ec2_backend(self) -> Any:  # type: ignore[misc]
+    def ec2_backend(self) -> Any:
         """
         :return: EC2 Backend
         :rtype: moto.ec2.models.EC2Backend

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -1,10 +1,14 @@
-from datetime import datetime, timedelta, timezone
+from __future__ import annotations
+
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from dateutil.parser import parse as dtparse
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.utils import utcnow
+from moto.ec2.models.instances import Instance as EC2Instance
 from moto.emr.exceptions import (
     InvalidRequestException,
     ResourceNotFoundException,
@@ -22,38 +26,96 @@ from .utils import (
 EXAMPLE_AMI_ID = "ami-12c6146b"
 
 
-class FakeApplication(BaseModel):
+class Application(BaseModel):
     def __init__(
         self, name: str, version: str, args: List[str], additional_info: Dict[str, str]
     ):
         self.additional_info = additional_info or {}
         self.args = args or []
-        self.name = name
-        self.version = version
+        self.name = name or None
+        self.version = version or None
 
 
-class FakeBootstrapAction(BaseModel):
+class BootstrapAction(BaseModel):
     def __init__(self, args: List[str], name: str, script_path: str):
         self.args = args or []
         self.name = name
         self.script_path = script_path
 
 
-class FakeInstance(BaseModel):
+class Instance(BaseModel):
     def __init__(
         self,
-        ec2_instance_id: str,
-        instance_group: "FakeInstanceGroup",
+        ec2_instance: EC2Instance,
+        instance_group: InstanceGroup,
         instance_fleet_id: Optional[str] = None,
         instance_id: Optional[str] = None,
     ):
         self.id = instance_id or random_instance_group_id()
-        self.ec2_instance_id = ec2_instance_id
+        self.ec2_instance = ec2_instance
         self.instance_group = instance_group
-        self.instance_fleet_id = instance_fleet_id
+        self.instance_fleet_id = instance_fleet_id or ""
+
+    @property
+    def ec2_instance_id(self) -> str:
+        return self.ec2_instance.id
+
+    @property
+    def public_dns_name(self) -> str | None:
+        return self.ec2_instance.public_dns
+
+    @property
+    def public_ip_address(self) -> str | None:
+        return self.ec2_instance.public_ip
+
+    @property
+    def private_ip_address(self) -> str | None:
+        return self.ec2_instance.private_ip
+
+    @property
+    def private_dns_name(self) -> str:
+        return self.ec2_instance.private_dns
+
+    @property
+    def instance_group_id(self) -> str:
+        return self.instance_group.id
+
+    @property
+    def market(self) -> str:
+        return self.instance_group.market
+
+    @property
+    def instance_type(self) -> str:
+        return self.ec2_instance.instance_type
+
+    @property
+    def ebs_volumes(self) -> list[dict[str, str]]:
+        ebs_volumes = []
+        for volume in self.ec2_instance.block_device_mapping:
+            member = {
+                "Device": volume,
+                "VolumeId": self.ec2_instance.block_device_mapping[volume].volume_id,
+            }
+            ebs_volumes.append(member)
+        return ebs_volumes
+
+    @property
+    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+        status_dict = {
+            "State": self.instance_group.state,
+            "StateChangeReason": {
+                "Message": getattr(self, "state_change_reason", None),
+            },
+            "Timeline": {
+                "CreationDateTime": self.instance_group.creation_date_time,
+                "EndDateTime": self.instance_group.end_date_time,
+                "ReadyDateTime": self.instance_group.ready_date_time,
+            },
+        }
+        return status_dict
 
 
-class FakeInstanceGroup(CloudFormationModel):
+class InstanceGroup(CloudFormationModel):
     def __init__(
         self,
         cluster_id: str,
@@ -66,7 +128,7 @@ class FakeInstanceGroup(CloudFormationModel):
         bid_price: Optional[str] = None,
         ebs_configuration: Optional[Dict[str, Any]] = None,
         auto_scaling_policy: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> None:
         self.id = instance_group_id or random_instance_group_id()
         self.cluster_id = cluster_id
 
@@ -82,17 +144,74 @@ class FakeInstanceGroup(CloudFormationModel):
         self.name = name
         self.num_instances = instance_count
         self.role = instance_role
+        self.instance_group_type = self.role
         self.instance_type = instance_type
         self.ebs_configuration = ebs_configuration
         self.auto_scaling_policy = auto_scaling_policy
-        self.creation_datetime = datetime.now(timezone.utc)
-        self.start_datetime = datetime.now(timezone.utc)
-        self.ready_datetime = datetime.now(timezone.utc)
-        self.end_datetime = None
-        self.state = "RUNNING"
+        self.creation_date_time: datetime = utcnow()
+        self.start_date_time: datetime = utcnow()
+        self.ready_date_time: datetime = utcnow()
+        self.end_date_time: Optional[datetime] = None
+        self.state: str = "RUNNING"
 
     def set_instance_count(self, instance_count: int) -> None:
         self.num_instances = instance_count
+
+    @property
+    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+        status_dict = {
+            "State": self.state,
+            "StateChangeReason": {
+                "Message": getattr(self, "state_change_reason", None),
+                "Code": "USER_REQUEST",
+            },
+            "Timeline": {
+                "CreationDateTime": self.creation_date_time,
+                "EndDateTime": self.end_date_time,
+                "ReadyDateTime": self.ready_date_time,
+            },
+        }
+        return status_dict
+
+    @property
+    def ebs_block_devices(self) -> list[dict[str, Any]]:  # type: ignore[misc]
+        ebs_block_devices = []
+        if self.ebs_configuration is not None:
+            for ebs_block_device in self.ebs_configuration.get(
+                "ebs_block_device_configs", []
+            ):
+                for i in range(ebs_block_device.get("volumes_per_instance", 0)):
+                    volume_spec = ebs_block_device["volume_specification"]
+                    member = {
+                        "VolumeSpecification": {
+                            "VolumeType": volume_spec.get("volume_type"),
+                            "Iops": volume_spec.get("iops"),
+                            "SizeInGB": volume_spec.get("size_in_gb"),
+                        },
+                        "Device": f"/dev/sd{i}",
+                    }
+                    ebs_block_devices.append(member)
+        return ebs_block_devices
+
+    @property
+    def instance_request_count(self) -> int:
+        return self.num_instances
+
+    @property
+    def instance_role(self) -> str:
+        return self.role
+
+    @property
+    def instance_running_count(self) -> int:
+        return self.num_instances
+
+    @property
+    def requested_instance_count(self) -> int:
+        return self.num_instances
+
+    @property
+    def running_instance_count(self) -> int:
+        return self.num_instances
 
     @property
     def auto_scaling_policy(self) -> Any:  # type: ignore[misc]
@@ -138,7 +257,7 @@ class FakeInstanceGroup(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeInstanceGroup":
+    ) -> InstanceGroup:
         properties = cloudformation_json["Properties"]
         job_flow_id = properties["JobFlowId"]
         ebs_config = properties.get("EbsConfiguration")
@@ -161,7 +280,7 @@ class FakeInstanceGroup(CloudFormationModel):
         )[0]
 
 
-class FakeStep(BaseModel):
+class Step(BaseModel):
     def __init__(
         self,
         state: str,
@@ -179,20 +298,81 @@ class FakeStep(BaseModel):
         self.jar = jar
         self.properties = properties or {}
 
-        self.creation_datetime = datetime.now(timezone.utc)
-        self.end_datetime = None
-        self.ready_datetime = None
-        self.start_datetime: Optional[datetime] = None
+        self.creation_date_time = utcnow()
+        self.end_date_time = None
+        self.ready_date_time = None
+        self.start_date_time: Optional[datetime] = None
         self.state = state
 
+    @property
+    def config(self) -> dict[str, Any]:  # type: ignore[misc]
+        config = {
+            "ActionOnFailure": self.action_on_failure,
+            "HadoopJarStep": {
+                "Jar": self.jar,
+                "Args": self.args,
+                "Properties": [
+                    {"Key": k, "Value": v} for k, v in self.properties.items()
+                ],
+            },
+            "Name": self.name,
+            "Jar": self.jar,
+            "Args": self.args,
+            "Properties": self.properties,
+        }
+        return config
+
+    @property
+    def execution_status_detail(self) -> dict[str, Any]:  # type: ignore[misc]
+        status_dict = {
+            "CreationDateTime": self.creation_date_time,
+            "StartDateTime": self.start_date_time,
+            "ReadyDateTime": self.ready_date_time,
+            "EndDateTime": self.end_date_time,
+            "LastStateChangeReason": getattr(self, "last_state_change_reason", None),
+            "State": self.state,
+        }
+        return status_dict
+
+    @property
+    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+        status_dict = {
+            "State": self.state,
+            "StateChangeReason": {
+                "Message": getattr(self, "last_state_change_reason", None)
+            },
+            "Timeline": {
+                "CreationDateTime": self.creation_date_time,
+                "EndDateTime": self.end_date_time,
+                "StartDateTime": self.start_date_time,
+            },
+        }
+        return status_dict
+
     def start(self) -> None:
-        self.start_datetime = datetime.now(timezone.utc)
+        self.start_date_time = utcnow()
 
 
-class FakeCluster(CloudFormationModel):
+class Ec2InstanceAttributes:
+    def __init__(self, cluster: Cluster) -> None:
+        self.cluster = cluster
+        self.additional_master_security_groups = (
+            cluster.additional_master_security_groups
+        )
+        self.additional_slave_security_groups = cluster.additional_slave_security_groups
+        self.ec2_availability_zone = cluster.availability_zone
+        self.ec2_key_name = cluster.ec2_key_name
+        self.ec2_subnet_id = cluster.ec2_subnet_id
+        self.iam_instance_profile = cluster.role
+        self.emr_managed_master_security_group = cluster.master_security_group
+        self.emr_managed_slave_security_group = cluster.slave_security_group
+        self.service_access_security_group = cluster.service_access_security_group
+
+
+class Cluster(CloudFormationModel):
     def __init__(
         self,
-        emr_backend: "ElasticMapReduceBackend",
+        emr_backend: ElasticMapReduceBackend,
         name: str,
         log_uri: str,
         job_flow_role: str,
@@ -202,7 +382,7 @@ class FakeCluster(CloudFormationModel):
         bootstrap_actions: Optional[List[Dict[str, Any]]] = None,
         configurations: Optional[List[Dict[str, Any]]] = None,
         cluster_id: Optional[str] = None,
-        visible_to_all_users: str = "false",
+        visible_to_all_users: bool = False,
         release_label: Optional[str] = None,
         requested_ami_version: Optional[str] = None,
         running_ami_version: Optional[str] = None,
@@ -216,27 +396,27 @@ class FakeCluster(CloudFormationModel):
         emr_backend.clusters[self.id] = self
         self.emr_backend = emr_backend
 
-        self.applications: List[FakeApplication] = []
+        self.applications: List[Application] = []
 
-        self.bootstrap_actions: List[FakeBootstrapAction] = []
+        self.bootstrap_actions: List[BootstrapAction] = []
         for bootstrap_action in bootstrap_actions or []:
             self.add_bootstrap_action(bootstrap_action)
 
         self.configurations = configurations or []
 
-        self.tags: Dict[str, str] = {}
+        self._tags: Dict[str, str] = {}
 
         self.log_uri = log_uri
         self.name = name
         self.normalized_instance_hours = 0
 
-        self.steps: List[FakeStep] = []
+        self.steps: List[Step] = []
         self.add_steps(steps)
 
         self.set_visibility(visible_to_all_users)
 
         self.instance_group_ids: List[str] = []
-        self.instances: List[FakeInstance] = []
+        self.ec2_instances: List[Instance] = []
         self.master_instance_group_id: Optional[str] = None
         self.core_instance_group_id: Optional[str] = None
         if (
@@ -304,7 +484,7 @@ class FakeCluster(CloudFormationModel):
         self.service_role = service_role
         self.step_concurrency_level = step_concurrency_level
 
-        self.creation_datetime = datetime.now(timezone.utc)
+        self.creation_datetime = utcnow()
         self.start_datetime: Optional[datetime] = None
         self.ready_datetime: Optional[datetime] = None
         self.end_datetime: Optional[datetime] = None
@@ -319,13 +499,106 @@ class FakeCluster(CloudFormationModel):
         )
         self.kerberos_attributes = kerberos_attributes
         self.auto_scaling_role = auto_scaling_role
+        self.supported_products: list[str] = []
 
     @property
     def arn(self) -> str:
         return f"arn:{get_partition(self.emr_backend.region_name)}:elasticmapreduce:{self.emr_backend.region_name}:{self.emr_backend.account_id}:cluster/{self.id}"
 
     @property
-    def instance_groups(self) -> List[FakeInstanceGroup]:
+    def ami_version(self) -> str | None:
+        return self.running_ami_version
+
+    @property
+    def auto_terminate(self) -> bool:
+        return not self.keep_job_flow_alive_when_no_steps
+
+    @property
+    def bootstrap_action_detail_list(self) -> list[dict[str, Any]]:  # type: ignore[misc]
+        details = []
+        for bootstrap_action in self.bootstrap_actions:
+            member = {
+                "BootstrapActionConfig": {
+                    "Name": bootstrap_action.name,
+                    "ScriptBootstrapAction": {
+                        "Args": bootstrap_action.args,
+                        "Path": bootstrap_action.script_path,
+                    },
+                }
+            }
+            details.append(member)
+        return details
+
+    @property
+    def ec2_instance_attributes(self) -> Ec2InstanceAttributes:
+        return Ec2InstanceAttributes(self)
+
+    @property
+    def job_flow_instances_detail(self) -> dict[str, Any]:  # type: ignore[misc]
+        instances_detail = {
+            "Ec2KeyName": self.ec2_key_name,
+            "Ec2SubnetId": self.ec2_subnet_id,
+            "HadoopVersion": self.hadoop_version,
+            "InstanceCount": self.instance_count,
+            "InstanceGroups": self.instance_groups,
+            "KeepJobFlowAliveWhenNoSteps": self.keep_job_flow_alive_when_no_steps,
+            "MasterInstanceId": getattr(self, "master_instance_id", None),
+            "MasterInstanceType": self.master_instance_type,
+            "MasterPublicDnsName": f"ec2-184-0-0-1.{self.emr_backend.region_name}.compute.amazonaws.com",
+            "NormalizedInstanceHours": self.normalized_instance_hours,
+            "Placement": {"AvailabilityZone": self.availability_zone},
+            "SlaveInstanceType": self.slave_instance_type,
+            "TerminationProtected": self.termination_protected,
+        }
+        return instances_detail
+
+    @property
+    def execution_status_detail(self) -> dict[str, Any]:  # type: ignore[misc]
+        status_dict = {
+            "State": self.state,
+            "CreationDateTime": self.creation_datetime,
+            "StartDateTime": self.start_datetime,
+            "ReadyDateTime": self.ready_datetime,
+            "EndDateTime": self.end_datetime,
+            "LastStateChangeReason": getattr(self, "last_state_change_reason", None),
+        }
+        return status_dict
+
+    @property
+    def job_flow_id(self) -> str:
+        return self.id
+
+    @property
+    def job_flow_role(self) -> str:
+        return self.role
+
+    @property
+    def master_public_dns_name(self) -> str:
+        # FIXME: This was hardcoded in the original XML template.
+        return "ec2-184-0-0-1.us-west-1.compute.amazonaws.com"
+
+    @property
+    def status(self) -> dict[str, Any]:  # type: ignore[misc]
+        status_dict = {
+            "State": self.state,
+            "StateChangeReason": {
+                "Message": getattr(self, "last_state_change_reason", None)
+            },
+            "Timeline": {
+                "CreationDateTime": self.creation_datetime,
+                "EndDateTime": self.end_datetime,
+                "ReadyDateTime": self.ready_datetime,
+            },
+        }
+        return status_dict
+
+    @property
+    def tags(self) -> list[dict[str, str]]:
+        tags = [{"Key": k, "Value": v} for k, v in self._tags.items()]
+        return tags
+
+    @property
+    def instance_groups(self) -> List[InstanceGroup]:
         return self.emr_backend.get_instance_groups(self.instance_group_ids)
 
     @property
@@ -346,11 +619,11 @@ class FakeCluster(CloudFormationModel):
 
     def start_cluster(self) -> None:
         self.state = "STARTING"
-        self.start_datetime = datetime.now(timezone.utc)
+        self.start_datetime = utcnow()
 
     def run_bootstrap_actions(self) -> None:
         self.state = "BOOTSTRAPPING"
-        self.ready_datetime = datetime.now(timezone.utc)
+        self.ready_datetime = utcnow()
         self.state = "WAITING"
         if not self.steps:
             if not self.keep_job_flow_alive_when_no_steps:
@@ -358,13 +631,13 @@ class FakeCluster(CloudFormationModel):
 
     def terminate(self) -> None:
         self.state = "TERMINATING"
-        self.end_datetime = datetime.now(timezone.utc)
+        self.end_datetime = utcnow()
         self.state = "TERMINATED"
 
     def add_applications(self, applications: List[Dict[str, Any]]) -> None:
         self.applications.extend(
             [
-                FakeApplication(
+                Application(
                     name=app.get("name", ""),
                     version=app.get("version", ""),
                     args=app.get("args", []),
@@ -375,9 +648,9 @@ class FakeCluster(CloudFormationModel):
         )
 
     def add_bootstrap_action(self, bootstrap_action: Dict[str, Any]) -> None:
-        self.bootstrap_actions.append(FakeBootstrapAction(**bootstrap_action))
+        self.bootstrap_actions.append(BootstrapAction(**bootstrap_action))
 
-    def add_instance_group(self, instance_group: FakeInstanceGroup) -> None:
+    def add_instance_group(self, instance_group: InstanceGroup) -> None:
         if instance_group.role == "MASTER":
             if self.master_instance_group_id:
                 raise Exception("Cannot add another master instance group")
@@ -397,33 +670,33 @@ class FakeCluster(CloudFormationModel):
             self.core_instance_group_id = instance_group.id
         self.instance_group_ids.append(instance_group.id)
 
-    def add_instance(self, instance: FakeInstance) -> None:
-        self.instances.append(instance)
+    def add_instance(self, instance: Instance) -> None:
+        self.ec2_instances.append(instance)
 
-    def add_steps(self, steps: List[Dict[str, Any]]) -> List[FakeStep]:
+    def add_steps(self, steps: List[Dict[str, Any]]) -> List[Step]:
         added_steps = []
         for step in steps:
             if self.steps:
                 # If we already have other steps, this one is pending
-                fake = FakeStep(state="PENDING", **step)
+                fake = Step(state="PENDING", **step)
             else:
-                fake = FakeStep(state="RUNNING", **step)
+                fake = Step(state="RUNNING", **step)
             self.steps.append(fake)
             added_steps.append(fake)
         self.state = "RUNNING"
         return added_steps
 
     def add_tags(self, tags: Dict[str, str]) -> None:
-        self.tags.update(tags)
+        self._tags.update(tags)
 
     def remove_tags(self, tag_keys: List[str]) -> None:
         for key in tag_keys:
-            self.tags.pop(key, None)
+            self._tags.pop(key, None)
 
     def set_termination_protection(self, value: bool) -> None:
         self.termination_protected = value
 
-    def set_visibility(self, visibility: str) -> None:
+    def set_visibility(self, visibility: bool) -> None:
         self.visible_to_all_users = visibility
 
     @property
@@ -453,7 +726,7 @@ class FakeCluster(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeCluster":
+    ) -> Cluster:
         properties = cloudformation_json["Properties"]
 
         instance_attrs = properties.get("Instances", {})
@@ -503,11 +776,11 @@ class FakeCluster(CloudFormationModel):
         emr_backend.terminate_job_flows([resource_name])
 
 
-class FakeSecurityConfiguration(CloudFormationModel):
+class SecurityConfiguration(CloudFormationModel):
     def __init__(self, name: str, security_configuration: str):
         self.name = name
         self.security_configuration = security_configuration
-        self.creation_date_time = datetime.now(timezone.utc)
+        self.creation_date_time = utcnow()
 
     @property
     def physical_resource_id(self) -> str:
@@ -525,7 +798,7 @@ class FakeSecurityConfiguration(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeSecurityConfiguration":
+    ) -> SecurityConfiguration:
         emr_backend: ElasticMapReduceBackend = emr_backends[account_id][region_name]
 
         properties = cloudformation_json["Properties"]
@@ -552,9 +825,9 @@ class FakeSecurityConfiguration(CloudFormationModel):
 class ElasticMapReduceBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.clusters: Dict[str, FakeCluster] = {}
-        self.instance_groups: Dict[str, FakeInstanceGroup] = {}
-        self.security_configurations: Dict[str, FakeSecurityConfiguration] = {}
+        self.clusters: Dict[str, Cluster] = {}
+        self.instance_groups: Dict[str, InstanceGroup] = {}
+        self.security_configurations: Dict[str, SecurityConfiguration] = {}
         self.block_public_access_configuration: Dict[str, Any] = {}
 
     @property
@@ -575,11 +848,11 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def add_instance_groups(
         self, cluster_id: str, instance_groups: List[Dict[str, Any]]
-    ) -> List[FakeInstanceGroup]:
+    ) -> List[InstanceGroup]:
         cluster = self.clusters[cluster_id]
         result_groups = []
         for instance_group in instance_groups:
-            group = FakeInstanceGroup(cluster_id=cluster_id, **instance_group)
+            group = InstanceGroup(cluster_id=cluster_id, **instance_group)
             self.instance_groups[group.id] = group
             cluster.add_instance_group(group)
             result_groups.append(group)
@@ -589,7 +862,7 @@ class ElasticMapReduceBackend(BaseBackend):
         self,
         cluster_id: str,
         instances: Dict[str, Any],
-        instance_group: FakeInstanceGroup,
+        instance_group: InstanceGroup,
     ) -> None:
         cluster = self.clusters[cluster_id]
         instances["is_instance_type_default"] = not instances.get("instance_type")
@@ -597,14 +870,12 @@ class ElasticMapReduceBackend(BaseBackend):
             EXAMPLE_AMI_ID, instances["instance_count"], "", [], **instances
         )
         for instance in response.instances:
-            instance = FakeInstance(
-                ec2_instance_id=instance.id, instance_group=instance_group
-            )
+            instance = Instance(ec2_instance=instance, instance_group=instance_group)
             cluster.add_instance(instance)
 
     def add_job_flow_steps(
         self, job_flow_id: str, steps: List[Dict[str, Any]]
-    ) -> List[FakeStep]:
+    ) -> List[Step]:
         cluster = self.clusters[job_flow_id]
         return cluster.add_steps(steps)
 
@@ -618,10 +889,10 @@ class ElasticMapReduceBackend(BaseBackend):
         job_flow_states: Optional[List[str]] = None,
         created_after: Optional[str] = None,
         created_before: Optional[str] = None,
-    ) -> List[FakeCluster]:
+    ) -> List[Cluster]:
         clusters = list(self.clusters.values())
 
-        within_two_month = datetime.now(timezone.utc) - timedelta(days=60)
+        within_two_month = utcnow() - timedelta(days=60)
         clusters = [c for c in clusters if c.creation_datetime >= within_two_month]
 
         if job_flow_ids:
@@ -630,31 +901,33 @@ class ElasticMapReduceBackend(BaseBackend):
             clusters = [c for c in clusters if c.state in job_flow_states]
         if created_after:
             clusters = [
-                c for c in clusters if c.creation_datetime > dtparse(created_after)
+                c
+                for c in clusters
+                if c.creation_datetime > dtparse(created_after).replace(tzinfo=None)
             ]
         if created_before:
             clusters = [
-                c for c in clusters if c.creation_datetime < dtparse(created_before)
+                c
+                for c in clusters
+                if c.creation_datetime < dtparse(created_before).replace(tzinfo=None)
             ]
 
         # Amazon EMR can return a maximum of 512 job flow descriptions
         return sorted(clusters, key=lambda x: x.id)[:512]
 
-    def describe_step(self, cluster_id: str, step_id: str) -> Optional[FakeStep]:
+    def describe_step(self, cluster_id: str, step_id: str) -> Optional[Step]:
         cluster = self.clusters[cluster_id]
         for step in cluster.steps:
             if step.id == step_id:
                 return step
         return None
 
-    def describe_cluster(self, cluster_id: str) -> FakeCluster:
+    def describe_cluster(self, cluster_id: str) -> Cluster:
         if cluster_id in self.clusters:
             return self.clusters[cluster_id]
         raise ResourceNotFoundException("")
 
-    def get_instance_groups(
-        self, instance_group_ids: List[str]
-    ) -> List[FakeInstanceGroup]:
+    def get_instance_groups(self, instance_group_ids: List[str]) -> List[InstanceGroup]:
         return [
             group
             for group_id, group in self.instance_groups.items()
@@ -663,7 +936,7 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_bootstrap_actions(
         self, cluster_id: str, marker: Optional[str] = None
-    ) -> Tuple[List[FakeBootstrapAction], Optional[str]]:
+    ) -> Tuple[List[BootstrapAction], Optional[str]]:
         max_items = 50
         actions = self.clusters[cluster_id].bootstrap_actions
         start_idx = 0 if marker is None else int(marker)
@@ -680,18 +953,22 @@ class ElasticMapReduceBackend(BaseBackend):
         created_after: Optional[str] = None,
         created_before: Optional[str] = None,
         marker: Optional[str] = None,
-    ) -> Tuple[List[FakeCluster], Optional[str]]:
+    ) -> Tuple[List[Cluster], Optional[str]]:
         max_items = 50
         clusters = list(self.clusters.values())
         if cluster_states:
             clusters = [c for c in clusters if c.state in cluster_states]
         if created_after:
             clusters = [
-                c for c in clusters if c.creation_datetime > dtparse(created_after)
+                c
+                for c in clusters
+                if c.creation_datetime > dtparse(created_after).replace(tzinfo=None)
             ]
         if created_before:
             clusters = [
-                c for c in clusters if c.creation_datetime < dtparse(created_before)
+                c
+                for c in clusters
+                if c.creation_datetime < dtparse(created_before).replace(tzinfo=None)
             ]
         clusters = sorted(clusters, key=lambda x: x.id)
         start_idx = 0 if marker is None else int(marker)
@@ -704,7 +981,7 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_instance_groups(
         self, cluster_id: str, marker: Optional[str] = None
-    ) -> Tuple[List[FakeInstanceGroup], Optional[str]]:
+    ) -> Tuple[List[InstanceGroup], Optional[str]]:
         max_items = 50
         groups = sorted(self.clusters[cluster_id].instance_groups, key=lambda x: x.id)
         start_idx = 0 if marker is None else int(marker)
@@ -719,9 +996,9 @@ class ElasticMapReduceBackend(BaseBackend):
         marker: Optional[str] = None,
         instance_group_id: Optional[str] = None,
         instance_group_types: Optional[List[str]] = None,
-    ) -> Tuple[List[FakeInstance], Optional[str]]:
+    ) -> Tuple[List[Instance], Optional[str]]:
         max_items = 50
-        groups = sorted(self.clusters[cluster_id].instances, key=lambda x: x.id)
+        groups = sorted(self.clusters[cluster_id].ec2_instances, key=lambda x: x.id)
         start_idx = 0 if marker is None else int(marker)
         marker = (
             None if len(groups) <= start_idx + max_items else str(start_idx + max_items)
@@ -732,8 +1009,6 @@ class ElasticMapReduceBackend(BaseBackend):
             groups = [
                 g for g in groups if g.instance_group.role in instance_group_types
             ]
-        for g in groups:
-            g.details = self.ec2_backend.get_instance(g.ec2_instance_id)  # type: ignore
         return groups[start_idx : start_idx + max_items], marker
 
     def list_steps(
@@ -742,11 +1017,11 @@ class ElasticMapReduceBackend(BaseBackend):
         marker: Optional[str] = None,
         step_ids: Optional[List[str]] = None,
         step_states: Optional[List[str]] = None,
-    ) -> Tuple[List[FakeStep], Optional[str]]:
+    ) -> Tuple[List[Step], Optional[str]]:
         max_items = 50
         steps = sorted(
             self.clusters[cluster_id].steps,
-            key=lambda o: o.creation_datetime,
+            key=lambda o: o.creation_date_time,
             reverse=True,
         )
         if step_ids:
@@ -759,9 +1034,7 @@ class ElasticMapReduceBackend(BaseBackend):
         )
         return steps[start_idx : start_idx + max_items], marker
 
-    def modify_cluster(
-        self, cluster_id: str, step_concurrency_level: int
-    ) -> FakeCluster:
+    def modify_cluster(self, cluster_id: str, step_concurrency_level: int) -> Cluster:
         cluster = self.clusters[cluster_id]
         cluster.step_concurrency_level = step_concurrency_level
         return cluster
@@ -807,16 +1080,16 @@ class ElasticMapReduceBackend(BaseBackend):
         )
         return master.id, slave.id, service.id
 
-    def run_job_flow(self, **kwargs: Any) -> FakeCluster:
+    def run_job_flow(self, **kwargs: Any) -> Cluster:
         (
             kwargs["instance_attrs"]["emr_managed_master_security_group"],
             kwargs["instance_attrs"]["emr_managed_slave_security_group"],
             kwargs["instance_attrs"]["service_access_security_group"],
         ) = self._manage_security_groups(**kwargs["instance_attrs"])
-        return FakeCluster(self, **kwargs)
+        return Cluster(self, **kwargs)
 
     def set_visible_to_all_users(
-        self, job_flow_ids: List[str], visible_to_all_users: str
+        self, job_flow_ids: List[str], visible_to_all_users: bool
     ) -> None:
         for job_flow_id in job_flow_ids:
             cluster = self.clusters[job_flow_id]
@@ -827,7 +1100,7 @@ class ElasticMapReduceBackend(BaseBackend):
             cluster = self.clusters[job_flow_id]
             cluster.set_termination_protection(value)
 
-    def terminate_job_flows(self, job_flow_ids: List[str]) -> List[FakeCluster]:
+    def terminate_job_flows(self, job_flow_ids: List[str]) -> List[Cluster]:
         clusters_terminated = []
         clusters_protected = []
         for job_flow_id in job_flow_ids:
@@ -845,7 +1118,7 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def put_auto_scaling_policy(
         self, instance_group_id: str, auto_scaling_policy: Optional[Dict[str, Any]]
-    ) -> Optional[FakeInstanceGroup]:
+    ) -> Optional[InstanceGroup]:
         instance_groups = self.get_instance_groups(
             instance_group_ids=[instance_group_id]
         )
@@ -860,18 +1133,18 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def create_security_configuration(
         self, name: str, security_configuration: str
-    ) -> FakeSecurityConfiguration:
+    ) -> SecurityConfiguration:
         if name in self.security_configurations:
             raise InvalidRequestException(
                 message=f"SecurityConfiguration with name '{name}' already exists."
             )
-        config = FakeSecurityConfiguration(
+        config = SecurityConfiguration(
             name=name, security_configuration=security_configuration
         )
         self.security_configurations[name] = config
         return config
 
-    def get_security_configuration(self, name: str) -> FakeSecurityConfiguration:
+    def get_security_configuration(self, name: str) -> SecurityConfiguration:
         if name not in self.security_configurations:
             raise InvalidRequestException(
                 message=f"Security configuration with name '{name}' does not exist."
@@ -913,7 +1186,7 @@ class ElasticMapReduceBackend(BaseBackend):
                 ],
             },
             "block_public_access_configuration_metadata": {
-                "creation_date_time": datetime.now(),
+                "creation_date_time": utcnow(),
                 "created_by_arn": user_arn,
             },
         }

--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -1,51 +1,12 @@
-import json
 import re
-from datetime import datetime, timezone
-from functools import wraps
-from typing import Any, Callable, Dict, List, Pattern
+from typing import Any, Dict, List, Pattern
 
-from moto.core.responses import AWSServiceSpec, BaseResponse, xml_to_json_response
+from moto.core.responses import ActionResult, AWSServiceSpec, BaseResponse
 from moto.core.utils import tags_from_query_string
 
 from .exceptions import ValidationException
 from .models import ElasticMapReduceBackend, emr_backends
 from .utils import ReleaseLabel, Unflattener, steps_from_query_string
-
-
-def generate_boto3_response(
-    operation: str,
-) -> Callable[
-    [Callable[["ElasticMapReduceResponse"], str]],
-    Callable[["ElasticMapReduceResponse"], str],
-]:
-    """The decorator to convert an XML response to JSON, if the request is
-    determined to be from boto3. Pass the API action as a parameter.
-
-    """
-
-    def _boto3_request(
-        method: Callable[["ElasticMapReduceResponse"], str],
-    ) -> Callable[["ElasticMapReduceResponse"], str]:
-        @wraps(method)
-        def f(self: "ElasticMapReduceResponse") -> str:
-            rendered = method(self)
-            if "json" in self.headers.get("Content-Type", []):
-                self.response_headers.update(
-                    {
-                        "x-amzn-requestid": "2690d7eb-ed86-11dd-9877-6fad448a8419",
-                        "date": datetime.now(timezone.utc).strftime(
-                            "%a, %d %b %Y %H:%M:%S %Z"
-                        ),
-                        "content-type": "application/x-amz-json-1.1",
-                    }
-                )
-                resp = xml_to_json_response(self.aws_service_spec, operation, rendered)
-                return "" if resp is None else json.dumps(resp)
-            return rendered
-
-        return f
-
-    return _boto3_request
 
 
 class ElasticMapReduceResponse(BaseResponse):
@@ -72,8 +33,7 @@ class ElasticMapReduceResponse(BaseResponse):
     def backend(self) -> ElasticMapReduceBackend:
         return emr_backends[self.current_account][self.region]
 
-    @generate_boto3_response("AddInstanceGroups")
-    def add_instance_groups(self) -> str:
+    def add_instance_groups(self) -> ActionResult:
         jobflow_id = self._get_param("JobFlowId")
         instance_groups = self._get_list_prefix("InstanceGroups.member")
         for item in instance_groups:
@@ -83,59 +43,48 @@ class ElasticMapReduceResponse(BaseResponse):
             # Adding support for auto_scaling_policy
             Unflattener.unflatten_complex_params(item, "auto_scaling_policy")
         fake_groups = self.backend.add_instance_groups(jobflow_id, instance_groups)
-        template = self.response_template(ADD_INSTANCE_GROUPS_TEMPLATE)
-        return template.render(instance_groups=fake_groups)
+        result = {"InstanceGroups": fake_groups}
+        return ActionResult(result)
 
-    @generate_boto3_response("AddJobFlowSteps")
-    def add_job_flow_steps(self) -> str:
+    def add_job_flow_steps(self) -> ActionResult:
         job_flow_id = self._get_param("JobFlowId")
         steps = self.backend.add_job_flow_steps(
             job_flow_id, steps_from_query_string(self._get_list_prefix("Steps.member"))
         )
-        template = self.response_template(ADD_JOB_FLOW_STEPS_TEMPLATE)
-        return template.render(steps=steps)
+        result = {"StepIds": [step.id for step in steps]}
+        return ActionResult(result)
 
-    @generate_boto3_response("AddTags")
-    def add_tags(self) -> str:
+    def add_tags(self) -> ActionResult:
         cluster_id = self._get_param("ResourceId")
         tags = tags_from_query_string(self.querystring, prefix="Tags")
         self.backend.add_tags(cluster_id, tags)
-        template = self.response_template(ADD_TAGS_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("CreateSecurityConfiguration")
-    def create_security_configuration(self) -> str:
+    def create_security_configuration(self) -> ActionResult:
         name = self._get_param("Name")
         security_configuration = self._get_param("SecurityConfiguration")
-        resp = self.backend.create_security_configuration(
+        security_configuration = self.backend.create_security_configuration(
             name=name, security_configuration=security_configuration
         )
-        template = self.response_template(CREATE_SECURITY_CONFIGURATION_TEMPLATE)
-        return template.render(name=name, creation_date_time=resp.creation_date_time)
+        return ActionResult(security_configuration)
 
-    @generate_boto3_response("DescribeSecurityConfiguration")
-    def describe_security_configuration(self) -> str:
+    def describe_security_configuration(self) -> ActionResult:
         name = self._get_param("Name")
         security_configuration = self.backend.get_security_configuration(name=name)
-        template = self.response_template(DESCRIBE_SECURITY_CONFIGURATION_TEMPLATE)
-        return template.render(security_configuration=security_configuration)
+        return ActionResult(security_configuration)
 
-    @generate_boto3_response("DeleteSecurityConfiguration")
-    def delete_security_configuration(self) -> str:
+    def delete_security_configuration(self) -> ActionResult:
         name = self._get_param("Name")
         self.backend.delete_security_configuration(name=name)
-        template = self.response_template(DELETE_SECURITY_CONFIGURATION_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("DescribeCluster")
-    def describe_cluster(self) -> str:
+    def describe_cluster(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         cluster = self.backend.describe_cluster(cluster_id)
-        template = self.response_template(DESCRIBE_CLUSTER_TEMPLATE)
-        return template.render(cluster=cluster)
+        result = {"Cluster": cluster}
+        return ActionResult(result)
 
-    @generate_boto3_response("DescribeJobFlows")
-    def describe_job_flows(self) -> str:
+    def describe_job_flows(self) -> ActionResult:
         created_after = self._get_param("CreatedAfter")
         created_before = self._get_param("CreatedBefore")
         job_flow_ids = self._get_multi_param("JobFlowIds.member")
@@ -143,29 +92,26 @@ class ElasticMapReduceResponse(BaseResponse):
         clusters = self.backend.describe_job_flows(
             job_flow_ids, job_flow_states, created_after, created_before
         )
-        template = self.response_template(DESCRIBE_JOB_FLOWS_TEMPLATE)
-        return template.render(clusters=clusters)
+        result = {"JobFlows": clusters}
+        return ActionResult(result)
 
-    @generate_boto3_response("DescribeStep")
-    def describe_step(self) -> str:
+    def describe_step(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         step_id = self._get_param("StepId")
         step = self.backend.describe_step(cluster_id, step_id)
-        template = self.response_template(DESCRIBE_STEP_TEMPLATE)
-        return template.render(step=step)
+        result = {"Step": step}
+        return ActionResult(result)
 
-    @generate_boto3_response("ListBootstrapActions")
-    def list_bootstrap_actions(self) -> str:
+    def list_bootstrap_actions(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         marker = self._get_param("Marker")
         bootstrap_actions, marker = self.backend.list_bootstrap_actions(
             cluster_id, marker
         )
-        template = self.response_template(LIST_BOOTSTRAP_ACTIONS_TEMPLATE)
-        return template.render(bootstrap_actions=bootstrap_actions, marker=marker)
+        result = {"BootstrapActions": bootstrap_actions, "Marker": marker}
+        return ActionResult(result)
 
-    @generate_boto3_response("ListClusters")
-    def list_clusters(self) -> str:
+    def list_clusters(self) -> ActionResult:
         cluster_states = self._get_multi_param("ClusterStates.member")
         created_after = self._get_param("CreatedAfter")
         created_before = self._get_param("CreatedBefore")
@@ -173,21 +119,19 @@ class ElasticMapReduceResponse(BaseResponse):
         clusters, marker = self.backend.list_clusters(
             cluster_states, created_after, created_before, marker
         )
-        template = self.response_template(LIST_CLUSTERS_TEMPLATE)
-        return template.render(clusters=clusters, marker=marker)
+        result = {"Clusters": clusters, "Marker": marker}
+        return ActionResult(result)
 
-    @generate_boto3_response("ListInstanceGroups")
-    def list_instance_groups(self) -> str:
+    def list_instance_groups(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         marker = self._get_param("Marker")
         instance_groups, marker = self.backend.list_instance_groups(
             cluster_id, marker=marker
         )
-        template = self.response_template(LIST_INSTANCE_GROUPS_TEMPLATE)
-        return template.render(instance_groups=instance_groups, marker=marker)
+        result = {"InstanceGroups": instance_groups, "Marker": marker}
+        return ActionResult(result)
 
-    @generate_boto3_response("ListInstances")
-    def list_instances(self) -> str:
+    def list_instances(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         marker = self._get_param("Marker")
         instance_group_id = self._get_param("InstanceGroupId")
@@ -198,11 +142,10 @@ class ElasticMapReduceResponse(BaseResponse):
             instance_group_id=instance_group_id,
             instance_group_types=instance_group_types,
         )
-        template = self.response_template(LIST_INSTANCES_TEMPLATE)
-        return template.render(instances=instances, marker=marker)
+        result = {"Instances": instances, "Marker": marker}
+        return ActionResult(result)
 
-    @generate_boto3_response("ListSteps")
-    def list_steps(self) -> str:
+    def list_steps(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         marker = self._get_param("Marker")
         step_ids = self._get_multi_param("StepIds.member")
@@ -210,36 +153,30 @@ class ElasticMapReduceResponse(BaseResponse):
         steps, marker = self.backend.list_steps(
             cluster_id, marker=marker, step_ids=step_ids, step_states=step_states
         )
-        template = self.response_template(LIST_STEPS_TEMPLATE)
-        return template.render(steps=steps, marker=marker)
+        result = {"Steps": steps, "Marker": marker}
+        return ActionResult(result)
 
-    @generate_boto3_response("ModifyCluster")
-    def modify_cluster(self) -> str:
+    def modify_cluster(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         step_concurrency_level = self._get_param("StepConcurrencyLevel")
         cluster = self.backend.modify_cluster(cluster_id, step_concurrency_level)
-        template = self.response_template(MODIFY_CLUSTER_TEMPLATE)
-        return template.render(cluster=cluster)
+        result = {"StepConcurrencyLevel": cluster.step_concurrency_level}
+        return ActionResult(result)
 
-    @generate_boto3_response("ModifyInstanceGroups")
-    def modify_instance_groups(self) -> str:
+    def modify_instance_groups(self) -> ActionResult:
         instance_groups = self._get_list_prefix("InstanceGroups.member")
         for item in instance_groups:
             item["instance_count"] = int(item["instance_count"])
         self.backend.modify_instance_groups(instance_groups)
-        template = self.response_template(MODIFY_INSTANCE_GROUPS_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("RemoveTags")
-    def remove_tags(self) -> str:
+    def remove_tags(self) -> ActionResult:
         cluster_id = self._get_param("ResourceId")
         tag_keys = self._get_multi_param("TagKeys.member")
         self.backend.remove_tags(cluster_id, tag_keys)
-        template = self.response_template(REMOVE_TAGS_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("RunJobFlow")
-    def run_job_flow(self) -> str:
+    def run_job_flow(self) -> ActionResult:
         instance_attrs = dict(
             master_instance_type=self._get_param("Instances.MasterInstanceType"),
             slave_instance_type=self._get_param("Instances.SlaveInstanceType"),
@@ -410,9 +347,11 @@ class ElasticMapReduceResponse(BaseResponse):
             self.backend.add_tags(
                 cluster.id, dict((d["key"], d["value"]) for d in tags)
             )
-
-        template = self.response_template(RUN_JOB_FLOW_TEMPLATE)
-        return template.render(cluster=cluster)
+        result = {
+            "JobFlowId": cluster.job_flow_id,
+            "ClusterArn": cluster.arn,
+        }
+        return ActionResult(result)
 
     def _has_key_prefix(self, key_prefix: str, value: Dict[str, Any]) -> bool:
         for key in value:  # iter on both keys and values
@@ -491,31 +430,24 @@ class ElasticMapReduceResponse(BaseResponse):
                 ebs_configuration[ebs_block_device_configs] = ebs_blocks
             instance_group[key_ebs_config] = ebs_configuration
 
-    @generate_boto3_response("SetTerminationProtection")
-    def set_termination_protection(self) -> str:
+    def set_termination_protection(self) -> ActionResult:
         termination_protection = self._get_bool_param("TerminationProtected")
         job_ids = self._get_multi_param("JobFlowIds.member")
         self.backend.set_termination_protection(job_ids, termination_protection)
-        template = self.response_template(SET_TERMINATION_PROTECTION_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("SetVisibleToAllUsers")
-    def set_visible_to_all_users(self) -> str:
-        visible_to_all_users = self._get_param("VisibleToAllUsers")
+    def set_visible_to_all_users(self) -> ActionResult:
+        visible_to_all_users = self._get_bool_param("VisibleToAllUsers", False)
         job_ids = self._get_multi_param("JobFlowIds.member")
         self.backend.set_visible_to_all_users(job_ids, visible_to_all_users)
-        template = self.response_template(SET_VISIBLE_TO_ALL_USERS_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("TerminateJobFlows")
-    def terminate_job_flows(self) -> str:
+    def terminate_job_flows(self) -> ActionResult:
         job_ids = self._get_multi_param("JobFlowIds.member.")
         self.backend.terminate_job_flows(job_ids)
-        template = self.response_template(TERMINATE_JOB_FLOWS_TEMPLATE)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("PutAutoScalingPolicy")
-    def put_auto_scaling_policy(self) -> str:
+    def put_auto_scaling_policy(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
         cluster = self.backend.describe_cluster(cluster_id)
         instance_group_id = self._get_param("InstanceGroupId")
@@ -523,39 +455,31 @@ class ElasticMapReduceResponse(BaseResponse):
         instance_group = self.backend.put_auto_scaling_policy(
             instance_group_id, auto_scaling_policy
         )
-        template = self.response_template(PUT_AUTO_SCALING_POLICY)
-        return template.render(
-            cluster_id=cluster_id, cluster=cluster, instance_group=instance_group
-        )
+        assert instance_group is not None
+        result = {
+            "ClusterId": cluster.id,
+            "InstanceGroupId": instance_group.id,
+            "AutoScalingPolicy": instance_group.auto_scaling_policy,
+            "ClusterArn": cluster.arn,
+        }
+        return ActionResult(result)
 
-    @generate_boto3_response("RemoveAutoScalingPolicy")
-    def remove_auto_scaling_policy(self) -> str:
+    def remove_auto_scaling_policy(self) -> ActionResult:
         instance_group_id = self._get_param("InstanceGroupId")
         self.backend.remove_auto_scaling_policy(instance_group_id)
-        template = self.response_template(REMOVE_AUTO_SCALING_POLICY)
-        return template.render()
+        return ActionResult({})
 
-    @generate_boto3_response("GetBlockPublicAccessConfiguration")
-    def get_block_public_access_configuration(self) -> str:
+    def get_block_public_access_configuration(self) -> ActionResult:
         configuration = self.backend.get_block_public_access_configuration()
         config = configuration.get("block_public_access_configuration") or {}
         metadata = configuration.get("block_public_access_configuration_metadata") or {}
-        template = self.response_template(
-            GET_BLOCK_PUBLIC_ACCESS_CONFIGURATION_TEMPLATE
-        )
-        return template.render(
-            block_public_security_group_rules=config.get(
-                "block_public_security_group_rules"
-            ),
-            permitted_public_security_group_rule_ranges=config.get(
-                "permitted_public_security_group_rule_ranges"
-            ),
-            creation_date_time=metadata.get("creation_date_time"),
-            created_by_arn=metadata.get("created_by_arn"),
-        )
+        result = {
+            "BlockPublicAccessConfiguration": config,
+            "BlockPublicAccessConfigurationMetadata": metadata,
+        }
+        return ActionResult(result)
 
-    @generate_boto3_response("PutBlockPublicAccessConfiguration")
-    def put_block_public_access_configuration(self) -> str:
+    def put_block_public_access_configuration(self) -> ActionResult:
         params = self._get_params()
         block_public_access_configuration = (
             params.get("BlockPublicAccessConfiguration") or {}
@@ -569,924 +493,4 @@ class ElasticMapReduceResponse(BaseResponse):
                 "PermittedPublicSecurityGroupRuleRanges"
             ),
         )
-        template = self.response_template(
-            PUT_BLOCK_PUBLIC_ACCESS_CONFIGURATION_TEMPLATE
-        )
-        return template.render()
-
-
-ADD_INSTANCE_GROUPS_TEMPLATE = """<AddInstanceGroupsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <AddInstanceGroupsResult>
-    <InstanceGroupIds>
-      {% for instance_group in instance_groups %}
-      <member>{{ instance_group.id }}</member>
-      {% endfor %}
-    </InstanceGroupIds>
-  </AddInstanceGroupsResult>
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</AddInstanceGroupsResponse>"""
-
-ADD_JOB_FLOW_STEPS_TEMPLATE = """<AddJobFlowStepsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <AddJobFlowStepsResult>
-    <StepIds>
-      {% for step in steps %}
-      <member>{{ step.id }}</member>
-      {% endfor %}
-    </StepIds>
-  </AddJobFlowStepsResult>
-  <ResponseMetadata>
-    <RequestId>df6f4f4a-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</AddJobFlowStepsResponse>"""
-
-ADD_TAGS_TEMPLATE = """<AddTagsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</AddTagsResponse>"""
-
-DESCRIBE_CLUSTER_TEMPLATE = """<DescribeClusterResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <DescribeClusterResult>
-    <Cluster>
-      <Applications>
-        {% for application in cluster.applications %}
-        <member>
-          <Name>{{ application.name }}</Name>
-          <Version>{{ application.version }}</Version>
-        </member>
-        {% endfor %}
-      </Applications>
-      <AutoTerminate>{{ (not cluster.keep_job_flow_alive_when_no_steps)|lower }}</AutoTerminate>
-      <Configurations>
-        {% for configuration in cluster.configurations %}
-        <member>
-          <Classification>{{ configuration['classification'] }}</Classification>
-          <Properties>
-            {% for key, value in configuration['properties'].items() %}
-            <entry>
-              <key>{{ key }}</key>
-              <value>{{ value }}</value>
-            </entry>
-            {% endfor %}
-          </Properties>
-        </member>
-        {% endfor %}
-      </Configurations>
-      {% if cluster.custom_ami_id is not none %}
-      <CustomAmiId>{{ cluster.custom_ami_id }}</CustomAmiId>
-      {% endif %}
-      <Ec2InstanceAttributes>
-        <AdditionalMasterSecurityGroups>
-        {% for each in cluster.additional_master_security_groups %}
-          <member>{{ each }}</member>
-        {% endfor %}
-        </AdditionalMasterSecurityGroups>
-        <AdditionalSlaveSecurityGroups>
-        {% for each in cluster.additional_slave_security_groups %}
-          <member>{{ each }}</member>
-        {% endfor %}
-        </AdditionalSlaveSecurityGroups>
-        <Ec2AvailabilityZone>{{ cluster.availability_zone }}</Ec2AvailabilityZone>
-        <Ec2KeyName>{{ cluster.ec2_key_name }}</Ec2KeyName>
-        <Ec2SubnetId>{{ cluster.ec2_subnet_id }}</Ec2SubnetId>
-        <IamInstanceProfile>{{ cluster.role }}</IamInstanceProfile>
-        <EmrManagedMasterSecurityGroup>{{ cluster.master_security_group }}</EmrManagedMasterSecurityGroup>
-        <EmrManagedSlaveSecurityGroup>{{ cluster.slave_security_group }}</EmrManagedSlaveSecurityGroup>
-        <ServiceAccessSecurityGroup>{{ cluster.service_access_security_group }}</ServiceAccessSecurityGroup>
-      </Ec2InstanceAttributes>
-      <Id>{{ cluster.id }}</Id>
-      <KerberosAttributes>
-        {% if 'Realm' in cluster.kerberos_attributes%}
-        <Realm>{{ cluster.kerberos_attributes['Realm'] }}</Realm>
-        {% endif %}
-        {% if 'KdcAdminPassword' in cluster.kerberos_attributes%}
-        <KdcAdminPassword>{{ cluster.kerberos_attributes['KdcAdminPassword'] }}</KdcAdminPassword>
-        {% endif %}
-        {% if 'CrossRealmTrustPrincipalPassword' in cluster.kerberos_attributes%}
-        <CrossRealmTrustPrincipalPassword>{{ cluster.kerberos_attributes['CrossRealmTrustPrincipalPassword'] }}</CrossRealmTrustPrincipalPassword>
-        {% endif %}
-        {% if 'ADDomainJoinUser' in cluster.kerberos_attributes%}
-        <ADDomainJoinUser>{{ cluster.kerberos_attributes['ADDomainJoinUser'] }}</ADDomainJoinUser>
-        {% endif %}
-        {% if 'ADDomainJoinPassword' in cluster.kerberos_attributes%}
-        <ADDomainJoinPassword>{{ cluster.kerberos_attributes['ADDomainJoinPassword'] }}</ADDomainJoinPassword>
-        {% endif %}
-      </KerberosAttributes>
-      <LogUri>{{ cluster.log_uri }}</LogUri>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
-      <Name>{{ cluster.name }}</Name>
-      <NormalizedInstanceHours>{{ cluster.normalized_instance_hours }}</NormalizedInstanceHours>
-      {% if cluster.release_label is not none %}
-      <ReleaseLabel>{{ cluster.release_label }}</ReleaseLabel>
-      {% endif %}
-      {% if cluster.requested_ami_version is not none %}
-      <RequestedAmiVersion>{{ cluster.requested_ami_version }}</RequestedAmiVersion>
-      {% endif %}
-      {% if cluster.running_ami_version is not none %}
-      <RunningAmiVersion>{{ cluster.running_ami_version }}</RunningAmiVersion>
-      {% endif %}
-      {% if cluster.security_configuration is not none %}
-      <SecurityConfiguration>{{ cluster.security_configuration }}</SecurityConfiguration>
-      {% endif %}
-      <ServiceRole>{{ cluster.service_role }}</ServiceRole>
-      <AutoScalingRole>{{ cluster.auto_scaling_role }}</AutoScalingRole>
-      <Status>
-        <State>{{ cluster.state }}</State>
-        <StateChangeReason>
-          {% if cluster.last_state_change_reason is not none %}
-          <Message>{{ cluster.last_state_change_reason }}</Message>
-          {% endif %}
-          <Code>USER_REQUEST</Code>
-        </StateChangeReason>
-        <Timeline>
-          <CreationDateTime>{{ cluster.creation_datetime.isoformat() }}</CreationDateTime>
-          {% if cluster.end_datetime is not none %}
-          <EndDateTime>{{ cluster.end_datetime.isoformat() }}</EndDateTime>
-          {% endif %}
-          {% if cluster.ready_datetime is not none %}
-          <ReadyDateTime>{{ cluster.ready_datetime.isoformat() }}</ReadyDateTime>
-          {% endif %}
-        </Timeline>
-      </Status>
-      <Tags>
-        {% for tag_key, tag_value in cluster.tags.items() %}
-        <member>
-          <Key>{{ tag_key }}</Key>
-          <Value>{{ tag_value }}</Value>
-        </member>
-        {% endfor %}
-      </Tags>
-      <TerminationProtected>{{ cluster.termination_protected|lower }}</TerminationProtected>
-      <VisibleToAllUsers>{{ cluster.visible_to_all_users|lower }}</VisibleToAllUsers>
-      <StepConcurrencyLevel>{{ cluster.step_concurrency_level }}</StepConcurrencyLevel>
-      <ClusterArn>{{ cluster.arn }}</ClusterArn>
-    </Cluster>
-  </DescribeClusterResult>
-  <ResponseMetadata>
-    <RequestId>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</RequestId>
-  </ResponseMetadata>
-</DescribeClusterResponse>"""
-
-DESCRIBE_JOB_FLOWS_TEMPLATE = """<DescribeJobFlowsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <DescribeJobFlowsResult>
-    <JobFlows>
-      {% for cluster in clusters %}
-      <member>
-        {% if cluster.running_ami_version is not none %}
-        <AmiVersion>{{ cluster.running_ami_version }}</AmiVersion>
-        {% endif %}
-        {% if cluster.bootstrap_actions %}
-        <BootstrapActions>
-          {% for bootstrap_action in cluster.bootstrap_actions %}
-          <member>
-            <BootstrapActionConfig>
-              <Name>{{ bootstrap_action.name }}</Name>
-              <ScriptBootstrapAction>
-                <Args>
-                  {% for arg in bootstrap_action.args %}
-                  <member>{{ arg | escape }}</member>
-                  {% endfor %}
-                </Args>
-                <Path>{{ bootstrap_action.script_path | escape }}</Path>
-              </ScriptBootstrapAction>
-            </BootstrapActionConfig>
-          </member>
-          {% endfor %}
-        </BootstrapActions>
-        {% endif %}
-        <ExecutionStatusDetail>
-          <CreationDateTime>{{ cluster.creation_datetime.isoformat() }}</CreationDateTime>
-          {% if cluster.end_datetime is not none %}
-          <EndDateTime>{{ cluster.end_datetime.isoformat() }}</EndDateTime>
-          {% endif %}
-          {% if cluster.last_state_change_reason is not none %}
-          <LastStateChangeReason>{{ cluster.last_state_change_reason }}</LastStateChangeReason>
-          {% endif %}
-          {% if cluster.ready_datetime is not none %}
-          <ReadyDateTime>{{ cluster.ready_datetime.isoformat() }}</ReadyDateTime>
-          {% endif %}
-          {% if cluster.start_datetime is not none %}
-          <StartDateTime>{{ cluster.start_datetime.isoformat() }}</StartDateTime>
-          {% endif %}
-          <State>{{ cluster.state }}</State>
-        </ExecutionStatusDetail>
-        <Instances>
-          {% if cluster.ec2_key_name is not none %}
-          <Ec2KeyName>{{ cluster.ec2_key_name }}</Ec2KeyName>
-          {% endif %}
-          {% if cluster.ec2_subnet_id is not none %}
-          <Ec2SubnetId>{{ cluster.ec2_subnet_id }}</Ec2SubnetId>
-          {% endif %}
-          <HadoopVersion>{{ cluster.hadoop_version }}</HadoopVersion>
-          <InstanceCount>{{ cluster.instance_count }}</InstanceCount>
-          <InstanceGroups>
-            {% for instance_group in cluster.instance_groups %}
-            <member>
-              {% if instance_group.bid_price is not none %}
-              <BidPrice>{{ instance_group.bid_price }}</BidPrice>
-              {% endif %}
-              <CreationDateTime>{{ instance_group.creation_datetime.isoformat() }}</CreationDateTime>
-              {% if instance_group.end_datetime is not none %}
-              <EndDateTime>{{ instance_group.end_datetime.isoformat() }}</EndDateTime>
-              {% endif %}
-
-              <InstanceGroupId>{{ instance_group.id }}</InstanceGroupId>
-              <InstanceRequestCount>{{ instance_group.num_instances }}</InstanceRequestCount>
-              <InstanceRole>{{ instance_group.role }}</InstanceRole>
-              <InstanceRunningCount>{{ instance_group.num_instances }}</InstanceRunningCount>
-              <InstanceType>{{ instance_group.instance_type }}</InstanceType>
-              <LastStateChangeReason/>
-              <Market>{{ instance_group.market }}</Market>
-              <Name>{{ instance_group.name }}</Name>
-              {% if instance_group.ready_datetime is not none %}
-              <ReadyDateTime>{{ instance_group.ready_datetime.isoformat() }}</ReadyDateTime>
-              {% endif %}
-              {% if instance_group.start_datetime is not none %}
-              <StartDateTime>{{ instance_group.start_datetime.isoformat() }}</StartDateTime>
-              {% endif %}
-              <State>{{ instance_group.state }}</State>
-            </member>
-            {% endfor %}
-          </InstanceGroups>
-          <KeepJobFlowAliveWhenNoSteps>{{ cluster.keep_job_flow_alive_when_no_steps|lower }}</KeepJobFlowAliveWhenNoSteps>
-          <MasterInstanceId>{{ cluster.master_instance_id }}</MasterInstanceId>
-          <MasterInstanceType>{{ cluster.master_instance_type }}</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-0-0-1.{{ cluster.region }}.compute.amazonaws.com</MasterPublicDnsName>
-          <NormalizedInstanceHours>{{ cluster.normalized_instance_hours }}</NormalizedInstanceHours>
-          <Placement>
-            <AvailabilityZone>{{ cluster.availability_zone }}</AvailabilityZone>
-          </Placement>
-          <SlaveInstanceType>{{ cluster.slave_instance_type }}</SlaveInstanceType>
-          <TerminationProtected>{{ cluster.termination_protected|lower }}</TerminationProtected>
-        </Instances>
-        <JobFlowId>{{ cluster.id }}</JobFlowId>
-        <JobFlowRole>{{ cluster.role }}</JobFlowRole>
-        <LogUri>{{ cluster.log_uri }}</LogUri>
-        <Name>{{ cluster.name }}</Name>
-        <ServiceRole>{{ cluster.service_role }}</ServiceRole>
-        <Steps>
-          {% for step in cluster.steps %}
-          <member>
-            <ExecutionStatusDetail>
-              <CreationDateTime>{{ step.creation_datetime.isoformat() }}</CreationDateTime>
-              {% if step.end_datetime is not none %}
-              <EndDateTime>{{ step.end_datetime.isoformat() }}</EndDateTime>
-              {% endif %}
-              {% if step.last_state_change_reason is not none %}
-              <LastStateChangeReason>{{ step.last_state_change_reason }}</LastStateChangeReason>
-              {% endif %}
-              {% if step.ready_datetime is not none %}
-              <ReadyDateTime>{{ step.ready_datetime.isoformat() }}</ReadyDateTime>
-              {% endif %}
-              {% if step.start_datetime is not none %}
-              <StartDateTime>{{ step.start_datetime.isoformat() }}</StartDateTime>
-              {% endif %}
-              <State>{{ step.state }}</State>
-            </ExecutionStatusDetail>
-            <StepConfig>
-              <ActionOnFailure>{{ step.action_on_failure }}</ActionOnFailure>
-              <HadoopJarStep>
-                <Jar>{{ step.jar }}</Jar>
-                <MainClass>{{ step.main_class }}</MainClass>
-                <Args>
-                  {% for arg in step.args %}
-                  <member>{{ arg | escape }}</member>
-                  {% endfor %}
-                </Args>
-                <Properties>
-                {% for key, val in step.properties.items() %}
-                  <member>
-                    <Key>{{ key }}</Key>
-                    <Value>{{ val | escape }}</Value>
-                  </member>
-                {% endfor %}
-                </Properties>
-              </HadoopJarStep>
-              <Name>{{ step.name | escape }}</Name>
-            </StepConfig>
-          </member>
-          {% endfor %}
-        </Steps>
-        <SupportedProducts/>
-        <VisibleToAllUsers>{{ cluster.visible_to_all_users|lower }}</VisibleToAllUsers>
-      </member>
-      {% endfor %}
-    </JobFlows>
-  </DescribeJobFlowsResult>
-  <ResponseMetadata>
-    <RequestId>9cea3229-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</DescribeJobFlowsResponse>"""
-
-DESCRIBE_STEP_TEMPLATE = """<DescribeStepResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <DescribeStepResult>
-    <Step>
-      <ActionOnFailure>{{ step.action_on_failure }}</ActionOnFailure>
-      <Config>
-        <Args>
-          {% for arg in step.args %}
-          <member>{{ arg | escape }}</member>
-          {% endfor %}
-        </Args>
-        <Jar>{{ step.jar }}</Jar>
-        <MainClass/>
-        <Properties>
-          {% for key, val in step.properties.items() %}
-          <entry>
-            <key>{{ key }}</key>
-            <value>{{ val | escape }}</value>
-          </entry>
-          {% endfor %}
-        </Properties>
-      </Config>
-      <Id>{{ step.id }}</Id>
-      <Name>{{ step.name | escape }}</Name>
-      <Status>
-        <FailureDetails>
-          <Reason/>
-          <Message/>
-          <LogFile/>
-        </FailureDetails>
-        <State>{{ step.state }}</State>
-        <StateChangeReason>{{ step.state_change_reason }}</StateChangeReason>
-        <Timeline>
-          <CreationDateTime>{{ step.creation_datetime.isoformat() }}</CreationDateTime>
-          {% if step.end_datetime is not none %}
-          <EndDateTime>{{ step.end_datetime.isoformat() }}</EndDateTime>
-          {% endif %}
-          {% if step.ready_datetime is not none %}
-          <StartDateTime>{{ step.start_datetime.isoformat() }}</StartDateTime>
-          {% endif %}
-        </Timeline>
-      </Status>
-    </Step>
-  </DescribeStepResult>
-  <ResponseMetadata>
-    <RequestId>df6f4f4a-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</DescribeStepResponse>"""
-
-LIST_BOOTSTRAP_ACTIONS_TEMPLATE = """<ListBootstrapActionsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ListBootstrapActionsResult>
-    <BootstrapActions>
-      {% for bootstrap_action in bootstrap_actions %}
-      <member>
-        <Args>
-          {% for arg in bootstrap_action.args %}
-          <member>{{ arg | escape }}</member>
-          {% endfor %}
-        </Args>
-        <Name>{{ bootstrap_action.name }}</Name>
-        <ScriptPath>{{ bootstrap_action.script_path }}</ScriptPath>
-      </member>
-      {% endfor %}
-    </BootstrapActions>
-    {% if marker is not none %}
-    <Marker>{{ marker }}</Marker>
-    {% endif %}
-  </ListBootstrapActionsResult>
-  <ResponseMetadata>
-    <RequestId>df6f4f4a-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</ListBootstrapActionsResponse>"""
-
-LIST_CLUSTERS_TEMPLATE = """<ListClustersResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ListClustersResult>
-    <Clusters>
-      {% for cluster in clusters %}
-      <member>
-        <Id>{{ cluster.id }}</Id>
-        <Name>{{ cluster.name }}</Name>
-        <NormalizedInstanceHours>{{ cluster.normalized_instance_hours }}</NormalizedInstanceHours>
-        <Status>
-          <State>{{ cluster.state }}</State>
-          <StateChangeReason>
-            <Code>USER_REQUEST</Code>
-            {% if cluster.last_state_change_reason is not none %}
-            <Message>{{ cluster.last_state_change_reason }}</Message>
-            {% endif %}
-          </StateChangeReason>
-          <Timeline>
-            <CreationDateTime>{{ cluster.creation_datetime.isoformat() }}</CreationDateTime>
-            {% if cluster.end_datetime is not none %}
-            <EndDateTime>{{ cluster.end_datetime.isoformat() }}</EndDateTime>
-            {% endif %}
-            {% if cluster.ready_datetime is not none %}
-            <ReadyDateTime>{{ cluster.ready_datetime.isoformat() }}</ReadyDateTime>
-            {% endif %}
-          </Timeline>
-        </Status>
-        <ClusterArn>{{ cluster.arn }}</ClusterArn>
-      </member>
-      {% endfor %}
-    </Clusters>
-    {% if marker is not none %}
-    <Marker>{{ marker }}</Marker>
-    {% endif %}
-  </ListClustersResult>
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8418</RequestId>
-  </ResponseMetadata>
-</ListClustersResponse>"""
-
-LIST_INSTANCE_GROUPS_TEMPLATE = """<ListInstanceGroupsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ListInstanceGroupsResult>
-    <InstanceGroups>
-      {% for instance_group in instance_groups %}
-      <member>
-        {% if instance_group.bid_price is not none %}
-        <BidPrice>{{ instance_group.bid_price }}</BidPrice>
-        {% endif %}
-        <Configurations/>
-        {% if instance_group.ebs_configuration is not none %}
-        <EbsBlockDevices>
-            {% for ebs_block_device in instance_group.ebs_configuration.ebs_block_device_configs %}
-              {% for i in range(ebs_block_device.volumes_per_instance) %}
-          <member>
-            <VolumeSpecification>
-              <VolumeType>{{ebs_block_device.volume_specification.volume_type}}</VolumeType>
-              <Iops>{{ebs_block_device.volume_specification.iops}}</Iops>
-              <SizeInGB>{{ebs_block_device.volume_specification.size_in_gb}}</SizeInGB>
-            </VolumeSpecification>
-            <Device>/dev/sd{{i}}</Device>
-          </member>
-              {% endfor %}
-            {% endfor %}
-        </EbsBlockDevices>
-        {% endif %}
-        {% if instance_group.auto_scaling_policy is not none %}
-        <AutoScalingPolicy>
-            {% if instance_group.auto_scaling_policy.constraints is not none %}
-            <Constraints>
-                {% if instance_group.auto_scaling_policy.constraints.min_capacity is not none %}
-                <MinCapacity>{{instance_group.auto_scaling_policy.constraints.min_capacity}}</MinCapacity>
-                {% endif %}
-                {% if instance_group.auto_scaling_policy.constraints.max_capacity is not none %}
-                <MaxCapacity>{{instance_group.auto_scaling_policy.constraints.max_capacity}}</MaxCapacity>
-                {% endif %}
-            </Constraints>
-            {% endif %}
-            {% if instance_group.auto_scaling_policy.rules is not none %}
-            <Rules>
-                {% for rule in instance_group.auto_scaling_policy.rules %}
-                <member>
-                    {% if 'name' in rule %}
-                    <Name>{{rule['name']}}</Name>
-                    {% endif %}
-                    {% if 'description' in rule %}
-                    <Description>{{rule['description']}}</Description>
-                    {% endif %}
-                    {% if 'action' in rule %}
-                    <Action>
-                        {% if 'market' in rule['action'] %}
-                        <Market>{{rule['action']['market']}}</Market>
-                        {% endif %}
-                        {% if 'simple_scaling_policy_configuration' in rule['action'] %}
-                        <SimpleScalingPolicyConfiguration>
-                            {% if 'adjustment_type' in rule['action']['simple_scaling_policy_configuration'] %}
-                            <AdjustmentType>{{rule['action']['simple_scaling_policy_configuration']['adjustment_type']}}</AdjustmentType>
-                            {% endif %}
-                            {% if 'scaling_adjustment' in rule['action']['simple_scaling_policy_configuration'] %}
-                            <ScalingAdjustment>{{rule['action']['simple_scaling_policy_configuration']['scaling_adjustment']}}</ScalingAdjustment>
-                            {% endif %}
-                            {% if 'cool_down' in rule['action']['simple_scaling_policy_configuration'] %}
-                            <CoolDown>{{rule['action']['simple_scaling_policy_configuration']['cool_down']}}</CoolDown>
-                            {% endif %}
-                        </SimpleScalingPolicyConfiguration>
-                        {% endif %}
-                    </Action>
-                    {% endif %}
-                    {% if 'trigger' in rule %}
-                    <Trigger>
-                        {% if 'cloud_watch_alarm_definition' in rule['trigger'] %}
-                        <CloudWatchAlarmDefinition>
-                            {% if 'comparison_operator' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <ComparisonOperator>{{rule['trigger']['cloud_watch_alarm_definition']['comparison_operator']}}</ComparisonOperator>
-                            {% endif %}
-                            {% if 'evaluation_periods' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <EvaluationPeriods>{{rule['trigger']['cloud_watch_alarm_definition']['evaluation_periods']}}</EvaluationPeriods>
-                            {% endif %}
-                            {% if 'metric_name' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <MetricName>{{rule['trigger']['cloud_watch_alarm_definition']['metric_name']}}</MetricName>
-                            {% endif %}
-                            {% if 'namespace' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <Namespace>{{rule['trigger']['cloud_watch_alarm_definition']['namespace']}}</Namespace>
-                            {% endif %}
-                            {% if 'period' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <Period>{{rule['trigger']['cloud_watch_alarm_definition']['period']}}</Period>
-                            {% endif %}
-                            {% if 'statistic' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <Statistic>{{rule['trigger']['cloud_watch_alarm_definition']['statistic']}}</Statistic>
-                            {% endif %}
-                            {% if 'threshold' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <Threshold>{{rule['trigger']['cloud_watch_alarm_definition']['threshold']}}</Threshold>
-                            {% endif %}
-                            {% if 'unit' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <Unit>{{rule['trigger']['cloud_watch_alarm_definition']['unit']}}</Unit>
-                            {% endif %}
-                            {% if 'dimensions' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                            <Dimensions>
-                                {% for dimension in rule['trigger']['cloud_watch_alarm_definition']['dimensions'] %}
-                                <member>
-                                    {% if 'key' in dimension %}
-                                    <Key>{{dimension['key']}}</Key>
-                                    {% endif %}
-                                    {% if 'value' in dimension %}
-                                    <Value>{{dimension['value']}}</Value>
-                                    {% endif %}
-                                </member>
-                                {% endfor %}
-                            </Dimensions>
-                            {% endif %}
-                        </CloudWatchAlarmDefinition>
-                        {% endif %}
-                    </Trigger>
-                    {% endif %}
-                </member>
-                {% endfor %}
-            </Rules>
-            {% endif %}
-            {% if instance_group.auto_scaling_policy.status is not none %}
-            <Status>
-                {% if 'state' in instance_group.auto_scaling_policy.status %}
-                <State>{{instance_group.auto_scaling_policy.status['state']}}</State>
-                {% endif %}
-            </Status>
-            {% endif %}
-        </AutoScalingPolicy>
-        {% endif %}
-        {% if instance_group.ebs_optimized is not none %}
-        <EbsOptimized>{{ instance_group.ebs_optimized }}</EbsOptimized>
-        {% endif %}
-        <Id>{{ instance_group.id }}</Id>
-        <InstanceGroupType>{{ instance_group.role }}</InstanceGroupType>
-        <InstanceType>{{ instance_group.instance_type }}</InstanceType>
-        <Market>{{ instance_group.market }}</Market>
-        <Name>{{ instance_group.name }}</Name>
-        <RequestedInstanceCount>{{ instance_group.num_instances }}</RequestedInstanceCount>
-        <RunningInstanceCount>{{ instance_group.num_instances }}</RunningInstanceCount>
-        <Status>
-          <State>{{ instance_group.state }}</State>
-          <StateChangeReason>
-            {% if instance_group.state_change_reason is not none %}
-            <Message>{{ instance_group.state_change_reason }}</Message>
-            {% endif %}
-            <Code>USER_REQUEST</Code>
-          </StateChangeReason>
-          <Timeline>
-            <CreationDateTime>{{ instance_group.creation_datetime.isoformat() }}</CreationDateTime>
-            {% if instance_group.end_datetime is not none %}
-            <EndDateTime>{{ instance_group.end_datetime.isoformat() }}</EndDateTime>
-            {% endif %}
-            {% if instance_group.ready_datetime is not none %}
-            <ReadyDateTime>{{ instance_group.ready_datetime.isoformat() }}</ReadyDateTime>
-            {% endif %}
-          </Timeline>
-        </Status>
-      </member>
-      {% endfor %}
-    </InstanceGroups>
-    {% if marker is not none %}
-    <Marker>{{ marker }}</Marker>
-    {% endif %}
-  </ListInstanceGroupsResult>
-  <ResponseMetadata>
-    <RequestId>8296d8b8-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</ListInstanceGroupsResponse>"""
-
-LIST_INSTANCES_TEMPLATE = """<ListInstancesResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ListInstancesResult>
-    <Instances>
-     {% for instance in instances %}
-      <member>
-        <Id>{{ instance.id }}</Id>
-        <Ec2InstanceId>{{ instance.ec2_instance_id }}</Ec2InstanceId>
-        <PublicDnsName>{{ instance.details.public_dns }}</PublicDnsName>
-        <PublicIpAddress>{{ instance.details.public_ip }}</PublicIpAddress>
-        <PrivateDnsName>{{ instance.details.private_dns }}</PrivateDnsName>
-        <PrivateIpAddress>{{ instance.details.private_ip }}</PrivateIpAddress>
-        <InstanceGroupId>{{ instance.instance_group.id }}</InstanceGroupId>
-        <InstanceFleetId>{{ instance.instance_fleet_id }}</InstanceFleetId>
-        <Market>{{ instance.instance_group.market }}</Market>
-        <InstanceType>{{ instance.details.instance_type }}</InstanceType>
-         <EbsVolumes>
-              {% for volume in instance.details.block_device_mapping %}
-          <member>
-              <Device>{{ volume }}</Device>
-              <VolumeId>{{ instance.details.block_device_mapping[volume].volume_id }}</VolumeId>
-          </member>
-              {% endfor %}
-        </EbsVolumes>
-       <Status>
-          <State>{{ instance.instance_group.state }}</State>
-          <StateChangeReason>
-            {% if instance.state_change_reason is not none %}
-            <Message>{{ instance.state_change_reason }}</Message>
-            {% endif %}
-          </StateChangeReason>
-          <Timeline>
-            <CreationDateTime>{{ instance.instance_group.creation_datetime.isoformat() }}</CreationDateTime>
-            {% if instance.instance_group.end_datetime is not none %}
-            <EndDateTime>{{ instance.instance_group.end_datetime.isoformat() }}</EndDateTime>
-            {% endif %}
-            {% if instance.instance_group.ready_datetime is not none %}
-            <ReadyDateTime>{{ instance.instance_group.ready_datetime.isoformat() }}</ReadyDateTime>
-            {% endif %}
-          </Timeline>
-        </Status>
-      </member>
-    {% endfor %}
-    </Instances>
- </ListInstancesResult>
- <ResponseMetadata>
-    <RequestId>4248c46c-71c0-4772-b155-0e992dc30027</RequestId>
-  </ResponseMetadata>
-</ListInstancesResponse>"""
-
-LIST_STEPS_TEMPLATE = """<ListStepsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ListStepsResult>
-    <Steps>
-      {% for step in steps %}
-      <member>
-        <ActionOnFailure>{{ step.action_on_failure }}</ActionOnFailure>
-        <Config>
-          <Args>
-            {% for arg in step.args %}
-            <member>{{ arg | escape }}</member>
-            {% endfor %}
-          </Args>
-          <Jar>{{ step.jar | escape }}</Jar>
-          <MainClass/>
-          <Properties>
-            {% for key, val in step.properties.items() %}
-            <entry>
-              <key>{{ key }}</key>
-              <value>{{ val | escape }}</value>
-            </entry>
-            {% endfor %}
-          </Properties>
-        </Config>
-        <Id>{{ step.id }}</Id>
-        <Name>{{ step.name | escape }}</Name>
-        <Status>
-<!-- does not exist for botocore 1.4.28
-          <FailureDetails>
-            <Reason/>
-            <Message/>
-            <LogFile/>
-          </FailureDetails>
--->
-          <State>{{ step.state }}</State>
-          <StateChangeReason>{{ step.state_change_reason }}</StateChangeReason>
-          <Timeline>
-            <CreationDateTime>{{ step.creation_datetime.isoformat() }}</CreationDateTime>
-            {% if step.end_datetime is not none %}
-            <EndDateTime>{{ step.end_datetime.isoformat() }}</EndDateTime>
-            {% endif %}
-            {% if step.start_datetime is not none %}
-            <StartDateTime>{{ step.start_datetime.isoformat() }}</StartDateTime>
-            {% endif %}
-          </Timeline>
-        </Status>
-      </member>
-      {% endfor %}
-    </Steps>
-    {% if marker is not none %}
-    <Marker>{{ marker }}</Marker>
-    {% endif %}
-  </ListStepsResult>
-  <ResponseMetadata>
-    <RequestId>df6f4f4a-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</ListStepsResponse>"""
-
-MODIFY_CLUSTER_TEMPLATE = """<ModifyClusterResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ModifyClusterResult>
-    <StepConcurrencyLevel>{{ cluster.step_concurrency_level }}</StepConcurrencyLevel>
-  </ModifyClusterResult>
-  <ResponseMetadata>
-    <RequestId>0751c837-e78d-4aef-95c9-9c4d29a092ff</RequestId>
-  </ResponseMetadata>
-</ModifyClusterResponse>
-"""
-
-MODIFY_INSTANCE_GROUPS_TEMPLATE = """<ModifyInstanceGroupsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</ModifyInstanceGroupsResponse>"""
-
-REMOVE_TAGS_TEMPLATE = """<RemoveTagsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</RemoveTagsResponse>"""
-
-RUN_JOB_FLOW_TEMPLATE = """<RunJobFlowResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <RunJobFlowResult>
-    <JobFlowId>{{ cluster.id }}</JobFlowId>
-    <ClusterArn>{{ cluster.arn }}</ClusterArn>
-  </RunJobFlowResult>
-  <ResponseMetadata>
-    <RequestId>8296d8b8-ed85-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</RunJobFlowResponse>"""
-
-SET_TERMINATION_PROTECTION_TEMPLATE = """<SetTerminationProtection xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</SetTerminationProtection>"""
-
-SET_VISIBLE_TO_ALL_USERS_TEMPLATE = """<SetVisibleToAllUsersResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</SetVisibleToAllUsersResponse>"""
-
-TERMINATE_JOB_FLOWS_TEMPLATE = """<TerminateJobFlowsResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</TerminateJobFlowsResponse>"""
-
-PUT_AUTO_SCALING_POLICY = """<PutAutoScalingPolicyResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <PutAutoScalingPolicyResult>
-    <ClusterId>{{cluster_id}}</ClusterId>
-    <InstanceGroupId>{{instance_group.id}}</InstanceGroupId>
-    {% if instance_group.auto_scaling_policy is not none %}
-    <AutoScalingPolicy>
-        {% if instance_group.auto_scaling_policy.constraints is not none %}
-        <Constraints>
-            {% if instance_group.auto_scaling_policy.constraints.min_capacity is not none %}
-            <MinCapacity>{{instance_group.auto_scaling_policy.constraints.min_capacity}}</MinCapacity>
-            {% endif %}
-            {% if instance_group.auto_scaling_policy.constraints.max_capacity is not none %}
-            <MaxCapacity>{{instance_group.auto_scaling_policy.constraints.max_capacity}}</MaxCapacity>
-            {% endif %}
-        </Constraints>
-        {% endif %}
-        {% if instance_group.auto_scaling_policy.rules is not none %}
-        <Rules>
-            {% for rule in instance_group.auto_scaling_policy.rules %}
-            <member>
-                {% if 'name' in rule %}
-                <Name>{{rule['name']}}</Name>
-                {% endif %}
-                {% if 'description' in rule %}
-                <Description>{{rule['description']}}</Description>
-                {% endif %}
-                {% if 'action' in rule %}
-                <Action>
-                    {% if 'market' in rule['action'] %}
-                    <Market>{{rule['action']['market']}}</Market>
-                    {% endif %}
-                    {% if 'simple_scaling_policy_configuration' in rule['action'] %}
-                    <SimpleScalingPolicyConfiguration>
-                        {% if 'adjustment_type' in rule['action']['simple_scaling_policy_configuration'] %}
-                        <AdjustmentType>{{rule['action']['simple_scaling_policy_configuration']['adjustment_type']}}</AdjustmentType>
-                        {% endif %}
-                        {% if 'scaling_adjustment' in rule['action']['simple_scaling_policy_configuration'] %}
-                        <ScalingAdjustment>{{rule['action']['simple_scaling_policy_configuration']['scaling_adjustment']}}</ScalingAdjustment>
-                        {% endif %}
-                        {% if 'cool_down' in rule['action']['simple_scaling_policy_configuration'] %}
-                        <CoolDown>{{rule['action']['simple_scaling_policy_configuration']['cool_down']}}</CoolDown>
-                        {% endif %}
-                    </SimpleScalingPolicyConfiguration>
-                    {% endif %}
-                </Action>
-                {% endif %}
-                {% if 'trigger' in rule %}
-                <Trigger>
-                    {% if 'cloud_watch_alarm_definition' in rule['trigger'] %}
-                    <CloudWatchAlarmDefinition>
-                        {% if 'comparison_operator' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <ComparisonOperator>{{rule['trigger']['cloud_watch_alarm_definition']['comparison_operator']}}</ComparisonOperator>
-                        {% endif %}
-                        {% if 'evaluation_periods' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <EvaluationPeriods>{{rule['trigger']['cloud_watch_alarm_definition']['evaluation_periods']}}</EvaluationPeriods>
-                        {% endif %}
-                        {% if 'metric_name' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <MetricName>{{rule['trigger']['cloud_watch_alarm_definition']['metric_name']}}</MetricName>
-                        {% endif %}
-                        {% if 'namespace' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <Namespace>{{rule['trigger']['cloud_watch_alarm_definition']['namespace']}}</Namespace>
-                        {% endif %}
-                        {% if 'period' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <Period>{{rule['trigger']['cloud_watch_alarm_definition']['period']}}</Period>
-                        {% endif %}
-                        {% if 'statistic' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <Statistic>{{rule['trigger']['cloud_watch_alarm_definition']['statistic']}}</Statistic>
-                        {% endif %}
-                        {% if 'threshold' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <Threshold>{{rule['trigger']['cloud_watch_alarm_definition']['threshold']}}</Threshold>
-                        {% endif %}
-                        {% if 'unit' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <Unit>{{rule['trigger']['cloud_watch_alarm_definition']['unit']}}</Unit>
-                        {% endif %}
-                        {% if 'dimensions' in rule['trigger']['cloud_watch_alarm_definition'] %}
-                        <Dimensions>
-                            {% for dimension in rule['trigger']['cloud_watch_alarm_definition']['dimensions'] %}
-                            <member>
-                                {% if 'key' in dimension %}
-                                <Key>{{dimension['key']}}</Key>
-                                {% endif %}
-                                {% if 'value' in dimension %}
-                                <Value>{{dimension['value']}}</Value>
-                                {% endif %}
-                            </member>
-                            {% endfor %}
-                        </Dimensions>
-                        {% endif %}
-                    </CloudWatchAlarmDefinition>
-                    {% endif %}
-                </Trigger>
-                {% endif %}
-            </member>
-            {% endfor %}
-        </Rules>
-        {% endif %}
-        {% if instance_group.auto_scaling_policy.status is not none %}
-        <Status>
-            {% if 'state' in instance_group.auto_scaling_policy.status %}
-            <State>{{instance_group.auto_scaling_policy.status['state']}}</State>
-            {% endif %}
-        </Status>
-        {% endif %}
-    </AutoScalingPolicy>
-    {% endif %}
-    <ClusterArn>{{ cluster.arn }}</ClusterArn>
-  </PutAutoScalingPolicyResult>
-  <ResponseMetadata>
-    <RequestId>d47379d9-b505-49af-9335-a68950d82535</RequestId>
-  </ResponseMetadata>
-</PutAutoScalingPolicyResponse>"""
-
-REMOVE_AUTO_SCALING_POLICY = """<RemoveAutoScalingPolicyResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>c04a1042-5340-4c0a-a7b5-7779725ce4f7</RequestId>
-  </ResponseMetadata>
-</RemoveAutoScalingPolicyResponse>"""
-
-CREATE_SECURITY_CONFIGURATION_TEMPLATE = """<CreateSecurityConfigurationResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <CreateSecurityConfigurationResult>
-    <Name>{{name}}</Name>
-    <CreationDateTime>{{creation_date_time}}</CreationDateTime>
-  </CreateSecurityConfigurationResult>
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</CreateSecurityConfigurationResponse>"""
-
-DESCRIBE_SECURITY_CONFIGURATION_TEMPLATE = """<DescribeSecurityConfigurationResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <DescribeSecurityConfigurationResult>
-    <Name>{{security_configuration['name']}}</Name>
-    <SecurityConfiguration>{{security_configuration['security_configuration']}}</SecurityConfiguration>
-    <CreationDateTime>{{security_configuration['creation_date_time']}}</CreationDateTime>
-  </DescribeSecurityConfigurationResult>
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</DescribeSecurityConfigurationResponse>"""
-
-DELETE_SECURITY_CONFIGURATION_TEMPLATE = """<DeleteSecurityConfigurationResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</DeleteSecurityConfigurationResponse>"""
-
-PUT_BLOCK_PUBLIC_ACCESS_CONFIGURATION_TEMPLATE = """<PutBlockPublicAccessConfigurationResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-  <ResponseMetadata>
-    <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-  </ResponseMetadata>
-</PutBlockPublicAccessConfigurationResponse>"""
-
-GET_BLOCK_PUBLIC_ACCESS_CONFIGURATION_TEMPLATE = """
-  <GetBlockPublicAccessConfigurationResponse xmlns="http://elasticmapreduce.amazonaws.com/doc/2009-03-31">
-    <GetBlockPublicAccessConfigurationResult>
-      <BlockPublicAccessConfiguration>
-        <BlockPublicSecurityGroupRules>
-          {{block_public_security_group_rules}}
-        </BlockPublicSecurityGroupRules>
-        <PermittedPublicSecurityGroupRuleRanges>
-          {% for rule_range in permitted_public_security_group_rule_ranges %}
-            <member>
-              <MinRange>{{rule_range['min_range']}}</MinRange>
-              <MaxRange>{{rule_range['max_range']}}</MaxRange>      
-            </member>
-          {% endfor %}
-        </PermittedPublicSecurityGroupRuleRanges>
-      </BlockPublicAccessConfiguration>
-      <BlockPublicAccessConfigurationMetadata>
-        <CreationDateTime>{{creation_date_time}}</CreationDateTime>
-        <CreatedByArn>{{created_by_arn}}</CreatedByArn>
-      </BlockPublicAccessConfigurationMetadata>
-    </GetBlockPublicAccessConfigurationResult>
-    <ResponseMetadata>
-      <RequestId>2690d7eb-ed86-11dd-9877-6fad448a8419</RequestId>
-    </ResponseMetadata>
-  </GetBlockPublicAccessConfigurationResponse>
-"""
+        return ActionResult({})

--- a/moto/emr/responses.py
+++ b/moto/emr/responses.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, Dict, List, Pattern
 
-from moto.core.responses import ActionResult, AWSServiceSpec, BaseResponse
+from moto.core.responses import ActionResult, AWSServiceSpec, BaseResponse, EmptyResult
 from moto.core.utils import tags_from_query_string
 
 from .exceptions import ValidationException
@@ -58,7 +58,7 @@ class ElasticMapReduceResponse(BaseResponse):
         cluster_id = self._get_param("ResourceId")
         tags = tags_from_query_string(self.querystring, prefix="Tags")
         self.backend.add_tags(cluster_id, tags)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_security_configuration(self) -> ActionResult:
         name = self._get_param("Name")
@@ -76,7 +76,7 @@ class ElasticMapReduceResponse(BaseResponse):
     def delete_security_configuration(self) -> ActionResult:
         name = self._get_param("Name")
         self.backend.delete_security_configuration(name=name)
-        return ActionResult({})
+        return EmptyResult()
 
     def describe_cluster(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
@@ -168,13 +168,13 @@ class ElasticMapReduceResponse(BaseResponse):
         for item in instance_groups:
             item["instance_count"] = int(item["instance_count"])
         self.backend.modify_instance_groups(instance_groups)
-        return ActionResult({})
+        return EmptyResult()
 
     def remove_tags(self) -> ActionResult:
         cluster_id = self._get_param("ResourceId")
         tag_keys = self._get_multi_param("TagKeys.member")
         self.backend.remove_tags(cluster_id, tag_keys)
-        return ActionResult({})
+        return EmptyResult()
 
     def run_job_flow(self) -> ActionResult:
         instance_attrs = dict(
@@ -434,18 +434,18 @@ class ElasticMapReduceResponse(BaseResponse):
         termination_protection = self._get_bool_param("TerminationProtected")
         job_ids = self._get_multi_param("JobFlowIds.member")
         self.backend.set_termination_protection(job_ids, termination_protection)
-        return ActionResult({})
+        return EmptyResult()
 
     def set_visible_to_all_users(self) -> ActionResult:
         visible_to_all_users = self._get_bool_param("VisibleToAllUsers", False)
         job_ids = self._get_multi_param("JobFlowIds.member")
         self.backend.set_visible_to_all_users(job_ids, visible_to_all_users)
-        return ActionResult({})
+        return EmptyResult()
 
     def terminate_job_flows(self) -> ActionResult:
         job_ids = self._get_multi_param("JobFlowIds.member.")
         self.backend.terminate_job_flows(job_ids)
-        return ActionResult({})
+        return EmptyResult()
 
     def put_auto_scaling_policy(self) -> ActionResult:
         cluster_id = self._get_param("ClusterId")
@@ -467,7 +467,7 @@ class ElasticMapReduceResponse(BaseResponse):
     def remove_auto_scaling_policy(self) -> ActionResult:
         instance_group_id = self._get_param("InstanceGroupId")
         self.backend.remove_auto_scaling_policy(instance_group_id)
-        return ActionResult({})
+        return EmptyResult()
 
     def get_block_public_access_configuration(self) -> ActionResult:
         configuration = self.backend.get_block_public_access_configuration()
@@ -493,4 +493,4 @@ class ElasticMapReduceResponse(BaseResponse):
                 "PermittedPublicSecurityGroupRuleRanges"
             ),
         )
-        return ActionResult({})
+        return EmptyResult()

--- a/tests/test_emr/test_emr_boto3.py
+++ b/tests/test_emr/test_emr_boto3.py
@@ -272,7 +272,7 @@ def test_describe_job_flow():
     jf = client.describe_job_flows(JobFlowIds=[cluster_id])["JobFlows"][0]
 
     assert jf["AmiVersion"] == args["AmiVersion"]
-    assert "BootstrapActions" not in jf
+    assert jf["BootstrapActions"] == []
     esd = jf["ExecutionStatusDetail"]
     assert isinstance(esd["CreationDateTime"], datetime)
     # assert isinstance(esd['EndDateTime'], 'datetime.datetime')
@@ -737,7 +737,7 @@ def test_set_visible_to_all_users():
     assert resp["Cluster"]["VisibleToAllUsers"] is False
 
     for expected in (True, False):
-        resp = client.set_visible_to_all_users(
+        client.set_visible_to_all_users(
             JobFlowIds=[cluster_id], VisibleToAllUsers=expected
         )
         resp = client.describe_cluster(ClusterId=cluster_id)

--- a/tests/test_emr/test_server.py
+++ b/tests/test_emr/test_server.py
@@ -11,5 +11,4 @@ def test_describe_jobflows():
 
     res = test_client.get("/?Action=DescribeJobFlows")
 
-    assert b"<DescribeJobFlowsResult>" in res.data
-    assert b"<JobFlows>" in res.data
+    assert b"JobFlows" in res.data


### PR DESCRIPTION
This PR excises the original Jinja/XML template-based responses for EMR in favor of direct integration with our dedicated AWS JSON Protocol Serializer.

> [!WARNING]  
> Although it's hard to imagine this impacting anyone (for reasons noted below), this is technically a breaking change. Merging of this Pull Request will drop `moto`'s current support for EMR API requests that use the AWS Query protocol. 

## Some Relevant History
`moto` was originally a mocking package created for use with the AWS [`boto`](https://github.com/boto/boto) library.  The `boto` library communicated with EMR using the AWS Query protocol, which resulted in `moto` using XML string templates for mocking EMR responses.  When [`botocore`](https://github.com/boto/botocore) and [`boto3`](https://github.com/boto/boto3) arrived on the scene, they communicated with EMR using the newer AWS JSON protocol. As `boto3` began to gain acceptance, `moto` was [modified](https://github.com/getmoto/moto/pull/733) to translate the original XML responses (for `boto`) into equivalent JSON responses (for `boto3`), and has supported both protocols for EMR ever since.  In the ensuing years, `boto` was deprecated, is no longer maintained, does not support Python versions beyond 3.4, and support for it has been [removed from `moto`](https://github.com/getmoto/moto/pull/4378).  All this to say, I did not feel compelled to find some way to continue supporting both communication protocols for EMR when integrating it with our core response serializer.  If the original Query protocol-based service definition for EMR exists somewhere--it never existed in `botocore` and I was unable to find it anywhere else--we could continue to support this, but ultimately I don't think it's worth maintaining any longer.