### PR TITLE
IAM: address resource response serialization inconsistencies

### DIFF
--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -3240,6 +3240,8 @@ def test_role_policy_encoding():
         RoleName=role_name, AssumeRolePolicyDocument=json.dumps(assume_policy_document)
     )
     assert resp["Role"]["AssumeRolePolicyDocument"] == assume_policy_document
+    resp = conn.get_role(RoleName=role_name)
+    assert resp["Role"]["AssumeRolePolicyDocument"] == assume_policy_document
     conn.put_role_policy(
         RoleName=role_name,
         PolicyName=policy_name,

--- a/tests/test_iam/test_iam.py
+++ b/tests/test_iam/test_iam.py
@@ -3346,9 +3346,6 @@ def test_create_role_with_permissions_boundary(region, partition):
             PermissionsBoundary=invalid_boundary_arn,
         )
 
-    # Ensure the PermissionsBoundary is included in role listing as well
-    assert conn.list_roles()["Roles"][0].get("PermissionsBoundary") == expected
-
 
 @mock_aws
 def test_create_role_with_same_name_should_fail():

--- a/tests/test_iam/test_iam_cloudformation.py
+++ b/tests/test_iam/test_iam_cloudformation.py
@@ -385,6 +385,7 @@ Resources:
   ThePolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      Description: "test description"
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -413,7 +414,7 @@ Resources:
     policy = iam_client.get_policy(PolicyArn=policy_arn)["Policy"]
     assert policy["Arn"] == policy_arn
     assert policy["PolicyName"] == expected_name
-    assert policy["Description"] == ""
+    assert policy["Description"] == "test description"
     assert policy["Path"] == "/"
 
 

--- a/tests/test_iam/test_iam_response_attributes.py
+++ b/tests/test_iam/test_iam_response_attributes.py
@@ -1,0 +1,224 @@
+import json
+from typing import Any
+from uuid import uuid4
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from tests import aws_verified
+
+BOUNDARY_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "BoundaryAllowAllNotAdminAccess",
+            "Effect": "Allow",
+            "Action": "*",
+            "Resource": "*",
+            "Condition": {
+                "ArnNotEquals": {
+                    "iam:PolicyArn": ["arn:aws:iam::aws:policy/AdministratorAccess"]
+                }
+            },
+        }
+    ],
+}
+
+DEFAULT_TAGS = [{"Key": "somekey", "Value": "somevalue"}]
+
+
+@aws_verified
+@pytest.mark.aws_verified
+@pytest.mark.parametrize(
+    "specify_optional_params",
+    [True, False],
+    ids=("SpecifyOptionalParams", "NoOptionalParams"),
+)
+def test_role_resource_returns_subset_of_available_attributes(specify_optional_params):
+    client = boto3.client("iam", region_name="us-east-1")
+    role_policy = {
+        "Version": "2012-10-17",
+        "Statement": {
+            "Effect": "Allow",
+            "Principal": {"Service": "ec2.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        },
+    }
+    test_guid = str(uuid4())
+    role_name = "TestRole" + test_guid
+    boundary_policy_name = "TestBoundaryPolicy" + test_guid
+    resp = client.create_policy(
+        PolicyName=boundary_policy_name, PolicyDocument=json.dumps(BOUNDARY_POLICY)
+    )
+    boundary_policy_arn = resp["Policy"]["Arn"]
+    try:
+        path = f"/{test_guid}/"
+        create_role_params: dict[str, Any] = dict(
+            Path=path,
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(role_policy),
+            Description="test",
+        )
+        if specify_optional_params:
+            create_role_params["PermissionsBoundary"] = boundary_policy_arn
+            create_role_params["Tags"] = DEFAULT_TAGS
+
+        def assert_resource_attributes(resource):
+            permissions_boundary_in_response = "PermissionsBoundary" in resource
+            assert permissions_boundary_in_response is bool(specify_optional_params), (
+                f"PermissionsBoundary in response: {permissions_boundary_in_response}, "
+                f"but specify_optional_params is {specify_optional_params}"
+            )
+            tags_in_response = "Tags" in resource
+            assert tags_in_response is bool(specify_optional_params), (
+                f"Tags in response: {tags_in_response}, "
+                f"but specify_optional_params is {specify_optional_params}"
+            )
+
+        # Create/GetRole calls return some attributes only when specified.
+        resp = client.create_role(**create_role_params)
+        assert_resource_attributes(resp["Role"])
+        resp = client.get_role(RoleName=role_name)
+        assert_resource_attributes(resp["Role"])
+        # ListRoles always returns a subset of all available attributes.
+        resp = client.list_roles(PathPrefix=path)
+        assert len(resp["Roles"]) == 1
+        role = resp["Roles"][0]
+        assert "PermissionsBoundary" not in role
+        assert "RoleLastUsed" not in role
+        assert "Tags" not in role
+    finally:
+        # Clean up created AWS resources
+        try:
+            client.delete_role(RoleName=role_name)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+        try:
+            client.delete_policy(PolicyArn=boundary_policy_arn)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+
+
+@aws_verified
+@pytest.mark.aws_verified
+@pytest.mark.parametrize(
+    "specify_optional_params",
+    [True, False],
+    ids=("SpecifyOptionalParams", "NoOptionalParams"),
+)
+def test_user_resource_returns_subset_of_available_attributes(specify_optional_params):
+    client = boto3.client("iam", region_name="us-east-1")
+    test_guid = str(uuid4())
+    user_name = "TestUser" + test_guid
+    boundary_policy_name = "TestBoundaryPolicy" + test_guid
+    resp = client.create_policy(
+        PolicyName=boundary_policy_name, PolicyDocument=json.dumps(BOUNDARY_POLICY)
+    )
+    boundary_policy_arn = resp["Policy"]["Arn"]
+    try:
+        path = f"/{test_guid}/"
+        create_user_params: dict[str, Any] = dict(
+            Path=path,
+            UserName=user_name,
+        )
+        if specify_optional_params:
+            create_user_params["PermissionsBoundary"] = boundary_policy_arn
+            create_user_params["Tags"] = DEFAULT_TAGS
+
+        def assert_resource_attributes(resource):
+            # TODO: Uncomment this when moto supports PermissionsBoundary for Users
+            # permissions_boundary_in_response = "PermissionsBoundary" in resource
+            # assert permissions_boundary_in_response is bool(specify_optional_params), (
+            #     f"PermissionsBoundary in response: {permissions_boundary_in_response}, "
+            #     f"but specify_optional_params is {specify_optional_params}"
+            # )
+            tags_in_response = "Tags" in resource
+            assert tags_in_response is bool(specify_optional_params), (
+                f"Tags in response: {tags_in_response}, "
+                f"but specify_optional_params is {specify_optional_params}"
+            )
+
+        # Create/GetUser calls return some attributes only when specified.
+        resp = client.create_user(**create_user_params)
+        assert_resource_attributes(resp["User"])
+        resp = client.get_user(UserName=user_name)
+        assert_resource_attributes(resp["User"])
+        # ListUsers always returns a subset of all available attributes.
+        resp = client.list_users(PathPrefix=path)
+        assert len(resp["Users"]) == 1
+        user = resp["Users"][0]
+        assert "PermissionsBoundary" not in user
+        assert "Tags" not in user
+    finally:
+        # Clean up created AWS resources
+        try:
+            client.delete_user(UserName=user_name)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+        try:
+            client.delete_policy(PolicyArn=boundary_policy_arn)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise
+
+
+@aws_verified
+@pytest.mark.aws_verified
+@pytest.mark.parametrize(
+    "specify_optional_params",
+    [True, False],
+    ids=("SpecifyOptionalParams", "NoOptionalParams"),
+)
+def test_policy_resource_returns_subset_of_available_attributes(
+    specify_optional_params,
+):
+    client = boto3.client("iam", region_name="us-east-1")
+    test_guid = str(uuid4())
+    policy_arn = None
+    try:
+        policy_name = "TestPolicy" + test_guid
+        path = f"/{test_guid}/"
+        create_policy_params: dict[str, Any] = dict(
+            Path=path,
+            PolicyName=policy_name,
+            PolicyDocument=json.dumps(BOUNDARY_POLICY),
+        )
+        if specify_optional_params:
+            create_policy_params["Description"] = "test description"
+            create_policy_params["Tags"] = DEFAULT_TAGS
+
+        # CreatePolicy returns some attributes only when specified.
+        resp = client.create_policy(**create_policy_params)
+        policy_arn = resp["Policy"]["Arn"]
+        assert "Description" not in resp["Policy"]
+        tags_in_response = "Tags" in resp["Policy"]
+        assert tags_in_response is bool(specify_optional_params), (
+            f"Tags in response: {tags_in_response}, "
+            f"but specify_optional_params is {specify_optional_params}"
+        )
+        # GetPolicy *does* return empty tags list...
+        resp = client.get_policy(PolicyArn=policy_arn)
+        description_in_response = "Description" in resp["Policy"]
+        assert description_in_response is bool(specify_optional_params), (
+            f"Description in response: {description_in_response}, "
+            f"but specify_optional_params is {specify_optional_params}"
+        )
+        assert "Tags" in resp["Policy"]
+        # ListPolices always returns a subset of all available attributes.
+        resp = client.list_policies(PathPrefix=path)
+        assert len(resp["Policies"]) == 1
+        policy = resp["Policies"][0]
+        assert "Description" not in policy
+        assert "Tags" not in policy
+    finally:
+        # Clean up created AWS resources
+        try:
+            if policy_arn is not None:
+                client.delete_policy(PolicyArn=policy_arn)
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "NoSuchEntity":
+                raise


### PR DESCRIPTION
# Background
The AWS IAM backend is inconsistent across various API calls with respect to the attributes it returns for Groups, Roles, Users, etc. (https://github.com/boto/boto3/issues/1855#issuecomment-460059883)

The official documentation does make note of this on several API operations, e.g. [ListRoles](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRoles.html).

> IAM resource-listing operations return a subset of the available attributes for the resource.

After the `moto` IAM backend was integrated with our new response serializer (#8970), some of these inconsistencies (and others) were encountered by the community (#8997).

# Changes Made
This PR includes a number of new tests that highlight various response inconsistencies among IAM resource entities and make assertions against verified AWS behavior.  It leverages recent updates to our core serialization code in order to provide specialized handling of individual response attributes as needed, e.g. to url-encode `Policies` or to omit `Tags` from the response if they were not supplied in the request.

# Rationale
I gave a lot of thought to the ideal way of handling this.  I wanted something that was explicitly clear and easy to maintain, but not overly verbose.  It would have been possible to handle each of these anomalies by making copies of the model objects in the various response methods and manipulating them as needed, but I think the concept of directly specifying an attribute and an accompanying transformer makes it easy to see in one place exactly what is going on.  I expect more of these inconsistencies to pop up, so I wanted something that others can easily update.  I'm considering all of this in the broader context of the new serialization code, which may lead to future refactors, but this seemed like a decent solution for addressing this relatively quickly.