### PR TITLE
[ELB] Added additional attribute to ELB response. 

### DIFF
--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -269,6 +269,7 @@ class FakeLoadBalancer(CloudFormationModel):
         attributes["connection_draining"] = {"enabled": False}
         attributes["access_log"] = {"enabled": False}
         attributes["connection_settings"] = {"idle_timeout": 60}
+        attributes["additional_attributes"] = []
 
         return attributes
 
@@ -551,6 +552,7 @@ class ELBBackend(BaseBackend):
         connection_settings: Optional[Dict[str, Any]] = None,
         connection_draining: Optional[Dict[str, Any]] = None,
         access_log: Optional[Dict[str, Any]] = None,
+        additional_attributes: Optional[List[Dict[str, str]]] = None,
     ) -> None:
         load_balancer = self.get_load_balancer(load_balancer_name)
         if cross_zone:
@@ -565,6 +567,16 @@ class ELBBackend(BaseBackend):
                 )
         if access_log:
             load_balancer.attributes["access_log"] = access_log
+        if additional_attributes:
+            load_balancer.attributes["additional_attributes"] = [
+                (attr["Key"], attr["Value"]) for attr in additional_attributes
+            ]
+        else:
+            if not load_balancer.attributes["additional_attributes"]:
+                load_balancer.attributes["additional_attributes"] = []
+            load_balancer.attributes["additional_attributes"].append(
+                ("elb.http.desyncmitigationmode", "defensive")
+            )
 
     def create_load_balancer_policy(
         self,

--- a/moto/elb/responses.py
+++ b/moto/elb/responses.py
@@ -189,6 +189,19 @@ class ELBResponse(BaseResponse):
                 load_balancer_name, connection_settings=connection_settings
             )
 
+        additional_attributes_raw = self._get_multi_param(
+            "LoadBalancerAttributes.AdditionalAttributes.member"
+        )
+        additional_attributes = []
+        for attr in additional_attributes_raw:
+            key = attr.get("Key")
+            value = attr.get("Value")
+            additional_attributes.append({"Key": key, "Value": value})
+
+        if additional_attributes:
+            self.elb_backend.modify_load_balancer_attributes(
+                load_balancer_name, additional_attributes=additional_attributes
+            )
         template = self.response_template(MODIFY_ATTRIBUTES_TEMPLATE)
         return template.render(
             load_balancer=load_balancer, attributes=load_balancer.attributes
@@ -744,6 +757,14 @@ DESCRIBE_ATTRIBUTES_TEMPLATE = """<DescribeLoadBalancerAttributesResponse  xmlns
         <Timeout>{{ attributes["connection_draining"]["timeout"] }}</Timeout>
         {% endif %}
       </ConnectionDraining>
+      <AdditionalAttributes>
+        {% for attribute in attributes.additional_attributes %}
+        <member>
+          <Key>{{ attribute[0] }}</Key>
+          <Value>{{ attribute[1] }}</Value>
+        </member>
+        {% endfor %}
+      </AdditionalAttributes>
     </LoadBalancerAttributes>
   </DescribeLoadBalancerAttributesResult>
   <ResponseMetadata>
@@ -778,6 +799,14 @@ MODIFY_ATTRIBUTES_TEMPLATE = """<ModifyLoadBalancerAttributesResponse xmlns="htt
         <Enabled>false</Enabled>
         {% endif %}
       </ConnectionDraining>
+      <AdditionalAttributes>
+        {% for attribute in attributes.additional_attributes %}
+        <member>
+          <Key>{{ attribute[0] }}</Key>
+          <Value>{{ attribute[1] }}</Value>
+        </member>
+        {% endfor %}
+      </AdditionalAttributes>
     </LoadBalancerAttributes>
   </ModifyLoadBalancerAttributesResult>
   <ResponseMetadata>

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -680,7 +680,7 @@ def test_default_attributes():
     assert attributes["AccessLog"] == {"Enabled": False}
     assert attributes["ConnectionDraining"] == {"Enabled": False}
     assert attributes["ConnectionSettings"] == {"IdleTimeout": 60}
-    # assert attributes["AdditionalAttributes"] == []
+    assert attributes["AdditionalAttributes"] == []
 
 
 @mock_aws

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -680,6 +680,7 @@ def test_default_attributes():
     assert attributes["AccessLog"] == {"Enabled": False}
     assert attributes["ConnectionDraining"] == {"Enabled": False}
     assert attributes["ConnectionSettings"] == {"IdleTimeout": 60}
+    # assert attributes["AdditionalAttributes"] == []
 
 
 @mock_aws
@@ -1073,6 +1074,24 @@ def test_modify_attributes():
     lb_attrs = client.describe_load_balancer_attributes(LoadBalancerName="my-lb")
     assert lb_attrs["LoadBalancerAttributes"]["ConnectionDraining"]["Enabled"] is True
     assert lb_attrs["LoadBalancerAttributes"]["ConnectionDraining"]["Timeout"] == 45
+
+    # Add additional attributes
+    client.modify_load_balancer_attributes(
+        LoadBalancerName="my-lb",
+        LoadBalancerAttributes={
+            "AdditionalAttributes": [
+                {
+                    "Key": "elb.http.desyncmitigationmode",
+                    "Value": "monitor",
+                }
+            ]
+        },
+    )
+    lb_attrs = client.describe_load_balancer_attributes(LoadBalancerName="my-lb")
+    assert lb_attrs["LoadBalancerAttributes"]["AdditionalAttributes"][0] == {
+        "Key": "elb.http.desyncmitigationmode",
+        "Value": "monitor",
+    }
 
 
 @mock_aws


### PR DESCRIPTION
To maintainers and reviewers @bblommers  and @bpandola. This PR fixes #9025. It adds the `AdditionalAttributes` to ELB response. This is unofficial because the aws boto3 api reference does not show an `AdditionalAttributes` block in their example xml, neither is there an example. This block is needed for the `modify_load_balancer_attributes()` and `describe_load_balancer_attributes() `endpoints. See [docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elb.html#client)

Here is the presented default xml:

```xml
<ModifyLoadBalancerAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <ModifyLoadBalancerAttributesResult> 
  <LoadBalancerName>my-loadbalancer</LoadBalancerName>
    <LoadBalancerAttributes>
      <CrossZoneLoadBalancing>
        <Enabled>true</Enabled>
      </CrossZoneLoadBalancing>
    </LoadBalancerAttributes>
  </ModifyLoadBalancerAttributesResult>
  <ResponseMetadata>
    <RequestId>83c88b9d-12b7-11e3-8b82-87b12EXAMPLE</RequestId>
  </ResponseMetadata>
</ModifyLoadBalancerAttributesResponse> 
```