### PR TITLE
Change MOTO_ALLOW_NONEXISTENT_REGION example to use a string value

### DIFF
--- a/docs/docs/faq.rst
+++ b/docs/docs/faq.rst
@@ -42,7 +42,7 @@ If you want to mock the default region, as an additional layer of protection aga
 
 .. sourcecode:: python
 
-    os.environ["MOTO_ALLOW_NONEXISTENT_REGION"] = True
+    os.environ["MOTO_ALLOW_NONEXISTENT_REGION"] = "True"
     os.environ["AWS_DEFAULT_REGION"] = "antarctica"
 
 


### PR DESCRIPTION
As reported in https://github.com/getmoto/moto/issues/9036, the example code currently will raise an exception, because os.environ enforces that the values are strings.

The value is parsed here: https://github.com/getmoto/moto/blob/538e5fb7e67e811d3f0b307d5c1eeb1b0947ef1d/moto/settings.py#L99-L100
so "True" is acceptable, but I can change it to "true" if you'd prefer.