### PR TITLE
Core: add serializer for Query protocol requests that return JSON responses

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -633,7 +633,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
     def serialized(self, action_result: ActionResult) -> TYPE_RESPONSE:
         service_model = get_service_model(self.service_name)
         operation_model = service_model.operation_model(self._get_action())
-        serializer_cls = SERIALIZERS[service_model.protocol]
+        protocol = service_model.protocol
+        protocol += "-json" if protocol == "query" and self.request_json else ""
+        serializer_cls = SERIALIZERS[protocol]
         context = ActionContext(
             service_model, operation_model, serializer_cls, self.__class__
         )

--- a/tests/test_core/protocols/output/query-json.json
+++ b/tests/test_core/protocols/output/query-json.json
@@ -1,0 +1,196 @@
+[
+  {
+    "description": "Scalar members",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "Str": {
+            "shape": "StringType"
+          },
+          "Num": {
+            "shape": "IntegerType",
+            "locationName": "FooNum"
+          },
+          "FalseBool": {
+            "shape": "BooleanType"
+          },
+          "TrueBool": {
+            "shape": "BooleanType"
+          },
+          "Float": {
+            "shape": "FloatType"
+          },
+          "Double": {
+            "shape": "DoubleType"
+          },
+          "Long": {
+            "shape": "LongType"
+          },
+          "Char": {
+            "shape": "CharType"
+          },
+          "Timestamp": {
+            "shape": "TimestampType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      },
+      "IntegerType": {
+        "type": "integer"
+      },
+      "BooleanType": {
+        "type": "boolean"
+      },
+      "FloatType": {
+        "type": "float"
+      },
+      "DoubleType": {
+        "type": "double"
+      },
+      "LongType": {
+        "type": "long"
+      },
+      "CharType": {
+        "type": "character"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Str": "myname",
+          "Num": 123,
+          "FalseBool": false,
+          "TrueBool": true,
+          "Float": 1.2,
+          "Double": 1.3,
+          "Long": 200,
+          "Char": "a",
+          "Timestamp": 1422172800
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"OperationNameResponse\": {\"OperationNameResult\": {\"Str\": \"myname\", \"FooNum\": 123, \"FalseBool\": false, \"TrueBool\": true, \"Float\": 1.2, \"Double\": 1.3, \"Long\": 200, \"Char\": \"a\", \"Timestamp\": \"2015-01-25T08:00:00Z\"}, \"ResponseMetadata\": {\"RequestId\": \"request-id\"}}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Lists",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "resultWrapper": "OperationNameResult",
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": [
+            "abc",
+            "123"
+          ]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"OperationNameResponse\": {\"OperationNameResult\": {\"ListMember\": [\"abc\", \"123\"]}, \"ResponseMetadata\": {\"RequestId\": \"request-id\"}}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Modeled exceptions",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "ExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          },
+          "Message": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "OtherExceptionShape": {
+        "exception": true,
+        "type": "structure",
+        "members": {
+          "BodyMember": {
+            "shape": "StringType"
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "errors": [
+            {
+              "shape": "ExceptionShape"
+            }
+          ],
+          "name": "OperationName"
+        },
+        "error": {
+          "BodyMember": "mybody",
+          "Message": "mymessage"
+        },
+        "errorCode": "ExceptionShape",
+        "errorMessage": "mymessage",
+        "response": {
+          "status_code": 400,
+          "headers": {},
+          "body": "{\"Error\": {\"Type\": \"Sender\", \"Code\": \"ExceptionShape\", \"Message\": \"mymessage\", \"BodyMember\": \"mybody\"}, \"RequestId\": \"request-id\"}"
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_core/test_protocols.py
+++ b/tests/test_core/test_protocols.py
@@ -75,6 +75,7 @@ def test_output_compliance(json_description: dict, case: dict, protocol):
         "ec2": "text/xml",
         "json": "application/x-amz-json-1.0",
         "query": "text/xml",
+        "query-json": "application/json",
         "rest-xml": "text/xml",
         "rest-json": "application/json",
     }


### PR DESCRIPTION
For a number of Query protocol-based services (e.g. Cloud Formation, Redshift, SNS), the original `boto` library would add a `ContentType=JSON` parameter to the request, which would cause the AWS backend to return JSON instead of the default XML normally used by the protocol.  When `botocore`/`boto3` came on the scene, they dropped this optional parameter and only supported XML responses for these services.  There was a bit of a painful transition for `moto` during this time, as it had to support both `boto` and `boto3` (see #402, #444, https://github.com/getmoto/moto/commit/3cdb4afad0f6a42c790c39c56e2b6f0680d54ff7).

Direct support for the `boto` library was dropped from `moto` long ago, but the code supporting both JSON and XML responses for some service backends remains.  The `ContentType=JSON` parameter is a limited use-case that (as far as I can tell) was only ever used by the the original `boto` library. I don't believe any current SDKs make use of this parameter, but I have confirmed that it is still supported by the AWS backend.

Despite the limited usefulness, it just wasn't that much work to implement a `QueryJSONSerializer`, so this PR adds support for it to aid in migrating the aforementioned services to our new core serialization code.