### PR TITLE
Core: rename InstanceTracker attribute

### DIFF
--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -38,7 +38,7 @@ class InstanceTrackerMeta(type):
         service = cls.__module__.split(".")[1]
         if name not in model_data[service]:
             model_data[service][name] = cls
-        cls._instances: ClassVar[List["BaseModel"]] = []  # type: ignore
+        cls.instances_tracked: ClassVar[List["BaseModel"]] = []  # type: ignore
         return cls
 
 

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -38,7 +38,7 @@ class InstanceTrackerMeta(type):
         service = cls.__module__.split(".")[1]
         if name not in model_data[service]:
             model_data[service][name] = cls
-        cls.instances: ClassVar[List["BaseModel"]] = []  # type: ignore
+        cls._instances: ClassVar[List["BaseModel"]] = []  # type: ignore
         return cls
 
 

--- a/moto/core/common_models.py
+++ b/moto/core/common_models.py
@@ -11,7 +11,7 @@ class BaseModel(metaclass=InstanceTrackerMeta):
         **kwargs: Any,
     ) -> "BaseModel":
         instance = super(BaseModel, cls).__new__(cls)
-        cls._instances.append(instance)  # type: ignore[attr-defined]
+        cls.instances_tracked.append(instance)  # type: ignore[attr-defined]
         return instance
 
 

--- a/moto/core/common_models.py
+++ b/moto/core/common_models.py
@@ -11,7 +11,7 @@ class BaseModel(metaclass=InstanceTrackerMeta):
         **kwargs: Any,
     ) -> "BaseModel":
         instance = super(BaseModel, cls).__new__(cls)
-        cls.instances.append(instance)  # type: ignore[attr-defined]
+        cls._instances.append(instance)  # type: ignore[attr-defined]
         return instance
 
 

--- a/moto/core/model_instances.py
+++ b/moto/core/model_instances.py
@@ -12,4 +12,4 @@ def reset_model_data() -> None:
     # Remove all references to the models stored
     for models in model_data.values():
         for model in models.values():
-            model.instances = []  # type: ignore[attr-defined]
+            model._instances = []  # type: ignore[attr-defined]

--- a/moto/core/model_instances.py
+++ b/moto/core/model_instances.py
@@ -12,4 +12,4 @@ def reset_model_data() -> None:
     # Remove all references to the models stored
     for models in model_data.values():
         for model in models.values():
-            model._instances = []  # type: ignore[attr-defined]
+            model.instances_tracked = []  # type: ignore[attr-defined]

--- a/moto/moto_api/_internal/responses.py
+++ b/moto/moto_api/_internal/responses.py
@@ -64,7 +64,7 @@ class MotoAPIResponse(BaseResponse):
             for name in sorted(models):
                 model = models[name]
                 results[service][name] = []
-                for instance in model._instances:  # type: ignore[attr-defined]
+                for instance in model.instances_tracked:  # type: ignore[attr-defined]
                     inst_result = {}
                     for attr in dir(instance):
                         if not attr.startswith("_"):

--- a/moto/moto_api/_internal/responses.py
+++ b/moto/moto_api/_internal/responses.py
@@ -64,7 +64,7 @@ class MotoAPIResponse(BaseResponse):
             for name in sorted(models):
                 model = models[name]
                 results[service][name] = []
-                for instance in model.instances:  # type: ignore[attr-defined]
+                for instance in model._instances:  # type: ignore[attr-defined]
                     inst_result = {}
                     for attr in dir(instance):
                         if not attr.startswith("_"):

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1767,9 +1767,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         #
         # Second, go through the list of instances
         # It may contain FakeKeys created earlier, which are no longer tracked
-        for mp in FakeMultipart.instances:  # type: ignore
+        for mp in FakeMultipart._instances:  # type: ignore
             mp.dispose()
-        for key in FakeKey.instances:  # type: ignore
+        for key in FakeKey._instances:  # type: ignore
             key.dispose()
         super().reset()
 

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1767,9 +1767,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         #
         # Second, go through the list of instances
         # It may contain FakeKeys created earlier, which are no longer tracked
-        for mp in FakeMultipart._instances:  # type: ignore
+        for mp in FakeMultipart.instances_tracked:  # type: ignore
             mp.dispose()
-        for key in FakeKey._instances:  # type: ignore
+        for key in FakeKey.instances_tracked:  # type: ignore
             key.dispose()
         super().reset()
 

--- a/tests/test_core/test_moto_api.py
+++ b/tests/test_core/test_moto_api.py
@@ -97,7 +97,7 @@ def test_model_data_is_emptied_as_necessary() -> None:
     # No instances exist, because we have just reset it
     for classes_per_service in model_data.values():
         for _class in classes_per_service.values():
-            assert _class._instances == []  # type: ignore[attr-defined]
+            assert _class.instances_tracked == []  # type: ignore[attr-defined]
 
     # TODO: ensure that iam is not loaded, and IAM policies are not created
     # with mock_aws(load_static_data=False) ?
@@ -105,18 +105,18 @@ def test_model_data_is_emptied_as_necessary() -> None:
         # When just starting a mock, it is empty
         for classes_per_service in model_data.values():
             for _class in classes_per_service.values():
-                assert _class._instances == []  # type: ignore[attr-defined]
+                assert _class.instances_tracked == []  # type: ignore[attr-defined]
 
         # After creating a queue, some data will be present
         conn = boto3.client("sqs", region_name="us-west-1")
         conn.create_queue(QueueName="queue1")
 
-        assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
+        assert len(model_data["sqs"]["Queue"].instances_tracked) == 1  # type: ignore[attr-defined]
 
     # But after the mock ends, it is empty again
     for classes_per_service in model_data.values():
         for _class in classes_per_service.values():
-            assert _class._instances == []  # type: ignore[attr-defined]
+            assert _class.instances_tracked == []  # type: ignore[attr-defined]
 
     # When we have multiple/nested mocks, the data should still be present after the first mock ends
     with mock_aws():
@@ -124,9 +124,9 @@ def test_model_data_is_emptied_as_necessary() -> None:
         conn.create_queue(QueueName="queue1")
         with mock_aws():
             # The data should still be here - instances should not reset if another mock is still active
-            assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
+            assert len(model_data["sqs"]["Queue"].instances_tracked) == 1  # type: ignore[attr-defined]
         # The data should still be here - the inner mock has exited, but the outer mock is still active
-        assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
+        assert len(model_data["sqs"]["Queue"].instances_tracked) == 1  # type: ignore[attr-defined]
 
 
 @mock_aws
@@ -138,10 +138,10 @@ class TestModelDataResetForClassDecorator(TestCase):
         # No data is present at the beginning
         for classes_per_service in model_data.values():
             for _class in classes_per_service.values():
-                assert _class._instances == []  # type: ignore[attr-defined]
+                assert _class.instances_tracked == []  # type: ignore[attr-defined]
 
         conn = boto3.client("sqs", region_name="us-west-1")
         conn.create_queue(QueueName="queue1")
 
     def test_should_find_bucket(self) -> None:
-        assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
+        assert len(model_data["sqs"]["Queue"].instances_tracked) == 1  # type: ignore[attr-defined]

--- a/tests/test_core/test_moto_api.py
+++ b/tests/test_core/test_moto_api.py
@@ -97,7 +97,7 @@ def test_model_data_is_emptied_as_necessary() -> None:
     # No instances exist, because we have just reset it
     for classes_per_service in model_data.values():
         for _class in classes_per_service.values():
-            assert _class.instances == []  # type: ignore[attr-defined]
+            assert _class._instances == []  # type: ignore[attr-defined]
 
     # TODO: ensure that iam is not loaded, and IAM policies are not created
     # with mock_aws(load_static_data=False) ?
@@ -105,18 +105,18 @@ def test_model_data_is_emptied_as_necessary() -> None:
         # When just starting a mock, it is empty
         for classes_per_service in model_data.values():
             for _class in classes_per_service.values():
-                assert _class.instances == []  # type: ignore[attr-defined]
+                assert _class._instances == []  # type: ignore[attr-defined]
 
         # After creating a queue, some data will be present
         conn = boto3.client("sqs", region_name="us-west-1")
         conn.create_queue(QueueName="queue1")
 
-        assert len(model_data["sqs"]["Queue"].instances) == 1  # type: ignore[attr-defined]
+        assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
 
     # But after the mock ends, it is empty again
     for classes_per_service in model_data.values():
         for _class in classes_per_service.values():
-            assert _class.instances == []  # type: ignore[attr-defined]
+            assert _class._instances == []  # type: ignore[attr-defined]
 
     # When we have multiple/nested mocks, the data should still be present after the first mock ends
     with mock_aws():
@@ -124,9 +124,9 @@ def test_model_data_is_emptied_as_necessary() -> None:
         conn.create_queue(QueueName="queue1")
         with mock_aws():
             # The data should still be here - instances should not reset if another mock is still active
-            assert len(model_data["sqs"]["Queue"].instances) == 1  # type: ignore[attr-defined]
+            assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
         # The data should still be here - the inner mock has exited, but the outer mock is still active
-        assert len(model_data["sqs"]["Queue"].instances) == 1  # type: ignore[attr-defined]
+        assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]
 
 
 @mock_aws
@@ -138,10 +138,10 @@ class TestModelDataResetForClassDecorator(TestCase):
         # No data is present at the beginning
         for classes_per_service in model_data.values():
             for _class in classes_per_service.values():
-                assert _class.instances == []  # type: ignore[attr-defined]
+                assert _class._instances == []  # type: ignore[attr-defined]
 
         conn = boto3.client("sqs", region_name="us-west-1")
         conn.create_queue(QueueName="queue1")
 
     def test_should_find_bucket(self) -> None:
-        assert len(model_data["sqs"]["Queue"].instances) == 1  # type: ignore[attr-defined]
+        assert len(model_data["sqs"]["Queue"]._instances) == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
Renaming for clarity and to avoid colliding with subclass attribute names (e.g. `ec2:Reservation.instances`).