### PR TITLE
Fix: incorrect tuple unpacking

### DIFF
--- a/moto/moto_server/threaded_moto_server.py
+++ b/moto/moto_server/threaded_moto_server.py
@@ -36,7 +36,7 @@ class ThreadedMotoServer:
 
     def get_host_and_port(self) -> Tuple[str, int]:
         assert self._server is not None, "Make sure to call start() first"
-        host, port = self._server.server_address
+        host, port = self._server.server_address[:2]
         return (str(host), port)
 
     def stop(self) -> None:

--- a/tests/test_core/utilities.py
+++ b/tests/test_core/utilities.py
@@ -25,7 +25,7 @@ class SimpleServer:
 
     def get_host_and_port(self) -> Tuple[str, int]:
         assert self._server
-        host, port = self._server.server_address
+        host, port = self._server.server_address[:2]
         return str(host), port
 
     def stop(self) -> None:


### PR DESCRIPTION
mypy 1.17.0 released today and highlighted the following issues:

```
tests/test_core/utilities.py:28:22: error: Too many values to unpack (2 expected, 4 provided)  [misc]
moto/moto_server/threaded_moto_server.py:39:22: error: Too many values to unpack (2 expected, 4 provided)  [misc]
```

I'm not exactly sure how this was ever working, as it appears to be a valid issue... maybe some other package was also recently updated?  Regardless, this PR contains a fix.