### PR TITLE
Reduce size of the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore everything by default
+*
+
+!README.md
+!moto/
+!setup.cfg
+!setup.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1
 
 WORKDIR /moto/
 RUN  pip3 --no-cache-dir install --upgrade pip setuptools && \
-     pip3 --no-cache-dir install ".[server]"
+     pip3 --no-cache-dir install --editable ".[server]"
 
 # Install cURL
 RUN  apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-alpine
 
 ADD . /moto/
 ENV PYTHONUNBUFFERED 1
@@ -8,9 +8,7 @@ RUN  pip3 --no-cache-dir install --upgrade pip setuptools && \
      pip3 --no-cache-dir install --editable ".[server]"
 
 # Install cURL
-RUN  apt-get update && \
-     apt-get install -y curl && \
-     rm -rf /var/lib/apt/lists/*
+RUN  apk add --no-cache curl
 
 ENTRYPOINT ["/usr/local/bin/moto_server", "-H", "0.0.0.0"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 ADD . /moto/
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
This takes a few steps to reduce the size of the generated Docker image, making it faster to load for developers and CI machines.

The arm64 image was 792 MB before I started this work and the result is a 523 MB image, so a reduction of 269 MB.

I have broken the steps taken into individual commits to make it easier to review. Each commit message mentions the size reduction the change gives.