### PR TITLE
[RDS] Adds support for modify db cluster  params.

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6269,7 +6269,7 @@
 - [X] list_tags_for_resource
 - [X] modify_db_cluster
 - [ ] modify_db_cluster_endpoint
-- [ ] modify_db_cluster_parameter_group
+- [X] modify_db_cluster_parameter_group
 - [X] modify_db_cluster_snapshot_attribute
 - [X] modify_db_instance
 - [X] modify_db_parameter_group

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -3196,6 +3196,21 @@ class RDSBackend(BaseBackend):
         db_parameter_group.update_parameters(db_parameter_group_parameters)
 
         return db_parameter_group
+    
+    def modify_db_cluster_parameter_group(
+        self,
+        db_cluster_parameter_group_name: str,
+        db_cluster_parameter_group_parameters: Iterable[Dict[str, Any]],
+    ) -> DBClusterParameterGroup:
+        if db_cluster_parameter_group_name not in self.db_cluster_parameter_groups:
+            raise DBClusterParameterGroupNotFoundError(db_cluster_parameter_group_name)
+
+        db_cluster_parameter_group = self.db_cluster_parameter_groups[
+            db_cluster_parameter_group_name
+        ]
+        db_cluster_parameter_group.update_cluster_parameters(db_cluster_parameter_group_parameters)
+
+        return db_cluster_parameter_group
 
     def describe_db_cluster_parameters(self) -> List[Dict[str, Any]]:
         return []
@@ -4238,6 +4253,11 @@ class DBClusterParameterGroup(CloudFormationModel, RDSBaseModel):
     @property
     def resource_id(self) -> str:
         return self.name
+    
+    def update_cluster_parameters(self, new_parameters: Iterable[Dict[str, Any]]) -> None:
+        for new_parameter in new_parameters:
+            parameter = self.parameters[new_parameter["ParameterName"]]
+            parameter.update(new_parameter)
 
 
 class Event:

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -373,6 +373,19 @@ class RDSResponse(BaseResponse):
         )
         result = {"DBParameterGroupName": db_parameter_group.name}
         return ActionResult(result)
+    
+    def modify_db_cluster_parameter_group(self) -> ActionResult:
+        db_parameter_group_name = self.parameters.get("DBClusterParameterGroupName")
+        param_list = self.parameters.get("Parameters", [])
+        # Raw dict is stored on the backend, so we need the original PascalCase items.
+        db_parameter_group_parameters = [
+            dict(param.original_items()) for param in param_list
+        ]
+        db_parameter_group = self.backend.modify_db_cluster_parameter_group(
+            db_parameter_group_name, db_parameter_group_parameters
+        )
+        result = {"DBClusterParameterGroupName": db_parameter_group.name}
+        return ActionResult(result)
 
     def describe_db_parameters(self) -> ActionResult:
         db_parameter_group_name = self.parameters.get("DBParameterGroupName")

--- a/moto/rds/responses.py
+++ b/moto/rds/responses.py
@@ -373,7 +373,7 @@ class RDSResponse(BaseResponse):
         )
         result = {"DBParameterGroupName": db_parameter_group.name}
         return ActionResult(result)
-    
+
     def modify_db_cluster_parameter_group(self) -> ActionResult:
         db_parameter_group_name = self.parameters.get("DBClusterParameterGroupName")
         param_list = self.parameters.get("Parameters", [])
@@ -404,9 +404,10 @@ class RDSResponse(BaseResponse):
         return ActionResult(db_parameter_group)
 
     def describe_db_cluster_parameters(self) -> ActionResult:
-        # TODO: This never worked at all...
-        db_parameter_group_name = self.parameters.get("DBParameterGroupName")
-        db_parameter_groups = self.backend.describe_db_cluster_parameters()
+        db_parameter_group_name = self.parameters.get("DBClusterParameterGroupName")
+        db_parameter_groups = self.backend.describe_db_cluster_parameters(
+            db_parameter_group_name
+        )
         if db_parameter_groups is None:
             raise DBParameterGroupNotFoundError(db_parameter_group_name)
         result = {"Parameters": db_parameter_groups}

--- a/tests/test_rds/test_db_cluster_params.py
+++ b/tests/test_rds/test_db_cluster_params.py
@@ -1,4 +1,5 @@
 import boto3
+import pytest
 
 from moto import mock_aws
 
@@ -6,6 +7,62 @@ from moto import mock_aws
 @mock_aws
 def test_describe_db_cluster_parameters():
     client = boto3.client("rds", "us-east-2")
+    # Create cluster
+    client.create_db_cluster(
+        DBClusterIdentifier="test-cluster",
+        Engine="aurora-postgresql",
+        MasterUsername="admin",
+        MasterUserPassword="password",
+        DBClusterParameterGroupName="group",
+    )
+    client.create_db_cluster_parameter_group(
+        DBClusterParameterGroupName="group",
+        DBParameterGroupFamily="aurora5.6",
+        Description="Test group",
+    )
 
     resp = client.describe_db_cluster_parameters(DBClusterParameterGroupName="group")
     assert resp["Parameters"] == []
+
+
+@mock_aws
+def test_modify_db_cluster_parameter_group():
+    client = boto3.client("rds", "us-east-2")
+    # Create cluster
+    client.create_db_cluster(
+        DBClusterIdentifier="test-cluster",
+        Engine="aurora-postgresql",
+        MasterUsername="admin",
+        MasterUserPassword="password",
+        DBClusterParameterGroupName="group",
+    )
+    client.create_db_cluster_parameter_group(
+        DBClusterParameterGroupName="group",
+        DBParameterGroupFamily="aurora5.6",
+        Description="Test group",
+    )
+
+    client.modify_db_cluster_parameter_group(
+        DBClusterParameterGroupName="group",
+        Parameters=[
+            {
+                "ParameterName": "rds.force_ssl",
+                "ParameterValue": "0",
+                "ApplyMethod": "immediate",
+            }
+        ],
+    )
+    resp = client.describe_db_cluster_parameters(DBClusterParameterGroupName="group")
+    assert resp["Parameters"][0]["ParameterName"] == "rds.force_ssl"
+    assert resp["Parameters"][0]["ParameterValue"] == "0"
+    assert resp["Parameters"][0]["ApplyMethod"] == "immediate"
+
+
+@mock_aws
+def test_describe_db_cluster_parameters_not_found():
+    client = boto3.client("rds", "us-east-2")
+    with pytest.raises(client.exceptions.DBParameterGroupNotFoundFault) as excinfo:
+        client.describe_db_cluster_parameters(
+            DBClusterParameterGroupName="nonexistent-group"
+        )
+    assert "DBClusterParameterGroup not found: nonexistent-group" in str(excinfo.value)


### PR DESCRIPTION
To reviewers and maintainers @bblommers and @bpandola. This PR adds support for 
- [x] [modify_db_cluster_parameter_group](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds/client/modify_db_cluster_parameter_group.html). It also fixes the  [describe_db_cluster_parameters](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds/client/describe_db_cluster_parameters.html) making tests easier. 

### Cloud Engineers Humor  (Dev's bad break-up with RDS )

```mermaid
flowchart TD
    subgraph Scene1 ["Scene 1"]
        A1["**👨‍💻 Dev**: Hey RDS, we need to talk..."]
    end

    subgraph Scene2 ["Scene 2"]
        A2["**🗄️ RDS**: Is it about the read replicas again?"]
        A3["**👨‍💻 Dev**: No, it's... something deeper."]
    end

    subgraph Scene3 ["Scene 3"]
        A4["**👨‍💻 Dev**: You have too many connections... and you never commit."]
    end

    subgraph Scene4 ["Scene 4"]
        A5["**🗄️ RDS**: That's not true! I committed last night at 03:00 UTC."]
        A6["**👨‍💻 Dev**: To a snapshot, not this relationship."]
    end

    %% Connect scenes
    A1 --> A2 --> A3 --> A4 --> A5 --> A6
```