### PR TITLE
Elastic Beanstalk: integrate with core response serializer

### DIFF
--- a/moto/elasticbeanstalk/exceptions.py
+++ b/moto/elasticbeanstalk/exceptions.py
@@ -13,11 +13,3 @@ class InvalidParameterValueError(ServiceException):
 class ResourceNotFoundException(ServiceException):
     def __init__(self, message: str):
         super().__init__("ResourceNotFoundException", message)
-
-
-class ApplicationNotFound(ElasticBeanstalkException):
-    def __init__(self, application_name: str):
-        super().__init__(
-            "ApplicationNotFound",
-            message=f"Elastic Beanstalk application {application_name} not found.",
-        )

--- a/moto/elasticbeanstalk/exceptions.py
+++ b/moto/elasticbeanstalk/exceptions.py
@@ -1,41 +1,21 @@
-from typing import Any
-
-from moto.core.exceptions import RESTError
-
-EXCEPTION_RESPONSE = """<?xml version="1.0"?>
-<ErrorResponse xmlns="http://elasticache.amazonaws.com/doc/2015-02-02/">
-  <Error>
-    <Type>Sender</Type>
-    <Code>{{ error_type }}</Code>
-    <Message>{{ message }}</Message>
-  </Error>
-  <{{ request_id_tag }}>30c0dedb-92b1-4e2b-9be4-1188e3ed86ab</{{ request_id_tag }}>
-</ErrorResponse>"""
+from moto.core.exceptions import ServiceException
 
 
-class ElasticBeanstalkException(RESTError):
-    code = 400
-    extended_templates = {"ecerror": EXCEPTION_RESPONSE}
-    env = RESTError.extended_environment(extended_templates)
-
-    def __init__(self, code: str, message: str, **kwargs: Any):
-        kwargs.setdefault("template", "ecerror")
-        super().__init__(code, message)
+class ElasticBeanstalkException(ServiceException):
+    pass
 
 
-class InvalidParameterValueError(RESTError):
+class InvalidParameterValueError(ServiceException):
     def __init__(self, message: str):
         super().__init__("InvalidParameterValue", message)
 
 
-class ResourceNotFoundException(RESTError):
+class ResourceNotFoundException(ServiceException):
     def __init__(self, message: str):
         super().__init__("ResourceNotFoundException", message)
 
 
 class ApplicationNotFound(ElasticBeanstalkException):
-    code = 404
-
     def __init__(self, application_name: str):
         super().__init__(
             "ApplicationNotFound",

--- a/moto/elasticbeanstalk/exceptions.py
+++ b/moto/elasticbeanstalk/exceptions.py
@@ -6,10 +6,8 @@ class ElasticBeanstalkException(ServiceException):
 
 
 class InvalidParameterValueError(ServiceException):
-    def __init__(self, message: str):
-        super().__init__("InvalidParameterValue", message)
+    code = "InvalidParameterValue"
 
 
 class ResourceNotFoundException(ServiceException):
-    def __init__(self, message: str):
-        super().__init__("ResourceNotFoundException", message)
+    code = "ResourceNotFoundException"

--- a/moto/elasticbeanstalk/models.py
+++ b/moto/elasticbeanstalk/models.py
@@ -5,7 +5,6 @@ from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 
 from .exceptions import (
-    ApplicationNotFound,
     InvalidParameterValueError,
     ResourceNotFoundException,
 )
@@ -151,11 +150,8 @@ class EBBackend(BaseBackend):
         self,
         application_name: str,
     ) -> None:
-        if application_name:
-            if application_name in self.applications:
-                self.applications.pop(application_name)
-            else:
-                raise ApplicationNotFound(application_name)
+        if application_name in self.applications:
+            self.applications.pop(application_name)
 
 
 eb_backends = BackendDict(EBBackend, "elasticbeanstalk")

--- a/moto/elasticbeanstalk/models.py
+++ b/moto/elasticbeanstalk/models.py
@@ -12,10 +12,10 @@ from .exceptions import (
 from .utils import make_arn
 
 
-class FakeEnvironment(BaseModel):
+class Environment(BaseModel):
     def __init__(
         self,
-        application: "FakeApplication",
+        application: "Application",
         environment_name: str,
         solution_stack_name: str,
         tags: Dict[str, str],
@@ -47,7 +47,7 @@ class FakeEnvironment(BaseModel):
         return self.application.region
 
 
-class FakeApplication(BaseModel):
+class Application(BaseModel):
     def __init__(
         self,
         backend: "EBBackend",
@@ -55,7 +55,7 @@ class FakeApplication(BaseModel):
     ):
         self.backend = weakref.proxy(backend)  # weakref to break cycles
         self.application_name = application_name
-        self.environments: Dict[str, FakeEnvironment] = dict()
+        self.environments: Dict[str, Environment] = dict()
         self.account_id = self.backend.account_id
         self.region = self.backend.region_name
         self.arn = make_arn(
@@ -64,11 +64,11 @@ class FakeApplication(BaseModel):
 
     def create_environment(
         self, environment_name: str, solution_stack_name: str, tags: Dict[str, str]
-    ) -> FakeEnvironment:
+    ) -> Environment:
         if environment_name in self.environments:
             raise InvalidParameterValueError(message="")
 
-        env = FakeEnvironment(
+        env = Environment(
             application=self,
             environment_name=environment_name,
             solution_stack_name=solution_stack_name,
@@ -82,29 +82,29 @@ class FakeApplication(BaseModel):
 class EBBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.applications: Dict[str, FakeApplication] = dict()
+        self.applications: Dict[str, Application] = dict()
 
-    def create_application(self, application_name: str) -> FakeApplication:
+    def create_application(self, application_name: str) -> Application:
         if application_name in self.applications:
             raise InvalidParameterValueError(
                 f"Application {application_name} already exists."
             )
-        new_app = FakeApplication(backend=self, application_name=application_name)
+        new_app = Application(backend=self, application_name=application_name)
         self.applications[application_name] = new_app
         return new_app
 
     def create_environment(
         self,
-        app: FakeApplication,
+        app: Application,
         environment_name: str,
         stack_name: str,
         tags: Dict[str, str],
-    ) -> FakeEnvironment:
+    ) -> Environment:
         return app.create_environment(
             environment_name=environment_name, solution_stack_name=stack_name, tags=tags
         )
 
-    def describe_environments(self) -> List[FakeEnvironment]:
+    def describe_environments(self) -> List[Environment]:
         envs = []
         for app in self.applications.values():
             for env in app.environments.values():
@@ -140,7 +140,7 @@ class EBBackend(BaseBackend):
             )
         return res.tags
 
-    def _find_environment_by_arn(self, arn: str) -> FakeEnvironment:
+    def _find_environment_by_arn(self, arn: str) -> Environment:
         for app in self.applications.keys():
             for env in self.applications[app].environments.values():
                 if env.environment_arn == arn:

--- a/moto/elasticbeanstalk/responses.py
+++ b/moto/elasticbeanstalk/responses.py
@@ -1,8 +1,228 @@
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 from moto.core.utils import tags_from_query_string
 
 from .exceptions import InvalidParameterValueError
 from .models import EBBackend, eb_backends
+
+# AWS Solution Stack Details as of 2025-07-13
+SOLUTION_STACK_DETAILS = [
+    {
+        "SolutionStackName": "64bit Windows Server 2019 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server Core 2019 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server 2025 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server Core 2016 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server Core 2025 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server 2022 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server 2016 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Windows Server Core 2022 v2.19.2 running IIS 10.0",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2017.03 v2.5.4 running Java 8",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v5.7.0 running Tomcat 9 Corretto 17",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v5.7.0 running Tomcat 11 Corretto 17",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v5.7.0 running Tomcat 10 Corretto 21",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v5.7.0 running Tomcat 11 Corretto 21",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v5.7.0 running Tomcat 10 Corretto 17",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v5.7.0 running Tomcat 9 Corretto 11",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Python 3.11",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.7.0 running PHP 8.2",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.7.0 running PHP 8.4",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Python 3.9",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Python 3.12",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Ruby 3.3",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Ruby 3.4",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Python 3.13",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.7.0 running PHP 8.3",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Ruby 3.2",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v6.6.0 running Node.js 22",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.7.0 running PHP 8.1",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v6.6.0 running Node.js 20",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Corretto 17",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v3.5.0 running .NET 9",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v6.6.0 running Node.js 18",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Corretto 8",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v3.5.0 running .NET 8",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Corretto 11",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Docker",
+        "PermittedFileTypes": [],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.2.0 running ECS",
+        "PermittedFileTypes": [],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.4.0 running Go 1",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2023 v4.6.0 running Corretto 21",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v4.9.0 running Tomcat 9 Corretto 11",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v2.11.0 running .NET Core",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.9.0 running Corretto 11",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.9.0 running Corretto 8",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.13.0 running Go 1",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v5.11.0 running Node.js 18",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.5.0 running ECS",
+        "PermittedFileTypes": [],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.9.0 running Corretto 17",
+        "PermittedFileTypes": ["jar", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.10.0 running PHP 8.1",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v4.9.0 running Tomcat 9 Corretto 8",
+        "PermittedFileTypes": ["war", "zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v4.2.0 running Docker",
+        "PermittedFileTypes": [],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v3.3.14 running Python 3.8",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v5.0.2 running Node.js 12",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v5.0.2 running Node.js 10",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2 v0.1.0 running Node.js 12 (BETA)",
+        "PermittedFileTypes": ["zip"],
+    },
+    {
+        "SolutionStackName": "64bit Amazon Linux 2018.03 v2.6.33 running Packer 1.0.3",
+        "PermittedFileTypes": [],
+    },
+]
 
 
 class EBResponse(BaseResponse):
@@ -16,23 +236,20 @@ class EBResponse(BaseResponse):
         """
         return eb_backends[self.current_account][self.region]
 
-    def create_application(self) -> str:
+    def create_application(self) -> ActionResult:
         app = self.elasticbeanstalk_backend.create_application(
             application_name=self._get_param("ApplicationName")
         )
 
-        template = self.response_template(EB_CREATE_APPLICATION)
-        return template.render(
-            region_name=self.elasticbeanstalk_backend.region_name, application=app
-        )
+        result = {"Application": app}
+        return ActionResult(result)
 
-    def describe_applications(self) -> str:
-        template = self.response_template(EB_DESCRIBE_APPLICATIONS)
-        return template.render(
-            applications=self.elasticbeanstalk_backend.applications.values()
-        )
+    def describe_applications(self) -> ActionResult:
+        applications = self.elasticbeanstalk_backend.applications.values()
+        result = {"Applications": applications}
+        return ActionResult(result)
 
-    def create_environment(self) -> str:
+    def create_environment(self) -> ActionResult:
         application_name = self._get_param("ApplicationName")
         try:
             app = self.elasticbeanstalk_backend.applications[application_name]
@@ -49,21 +266,25 @@ class EBResponse(BaseResponse):
             tags=tags,
         )
 
-        template = self.response_template(EB_CREATE_ENVIRONMENT)
-        return template.render(
-            environment=env, region=self.elasticbeanstalk_backend.region_name
-        )
+        result = env
+        return ActionResult(result)
 
-    def describe_environments(self) -> str:
+    def describe_environments(self) -> ActionResult:
         envs = self.elasticbeanstalk_backend.describe_environments()
 
-        template = self.response_template(EB_DESCRIBE_ENVIRONMENTS)
-        return template.render(environments=envs)
+        result = {"Environments": envs}
+        return ActionResult(result)
 
-    def list_available_solution_stacks(self) -> str:
-        return EB_LIST_AVAILABLE_SOLUTION_STACKS
+    def list_available_solution_stacks(self) -> ActionResult:
+        solution_stacks = {
+            "SolutionStacks": [
+                stack["SolutionStackName"] for stack in SOLUTION_STACK_DETAILS
+            ],
+            "SolutionStackDetails": SOLUTION_STACK_DETAILS,
+        }
+        return ActionResult(solution_stacks)
 
-    def update_tags_for_resource(self) -> str:
+    def update_tags_for_resource(self) -> ActionResult:
         resource_arn = self._get_param("ResourceArn")
         tags_to_add = tags_from_query_string(
             self.querystring, prefix="TagsToAdd.member"
@@ -72,1336 +293,20 @@ class EBResponse(BaseResponse):
         self.elasticbeanstalk_backend.update_tags_for_resource(
             resource_arn, tags_to_add, tags_to_remove
         )
+        return EmptyResult()
 
-        return EB_UPDATE_TAGS_FOR_RESOURCE
-
-    def list_tags_for_resource(self) -> str:
+    def list_tags_for_resource(self) -> ActionResult:
         resource_arn = self._get_param("ResourceArn")
         tags = self.elasticbeanstalk_backend.list_tags_for_resource(resource_arn)
+        result = {
+            "ResourceArn": resource_arn,
+            "ResourceTags": [{"Key": k, "Value": v} for k, v in tags.items()],
+        }
+        return ActionResult(result)
 
-        template = self.response_template(EB_LIST_TAGS_FOR_RESOURCE)
-        return template.render(tags=tags, arn=resource_arn)
-
-    def delete_application(self) -> str:
+    def delete_application(self) -> ActionResult:
         application_name = self._get_param("ApplicationName")
         self.elasticbeanstalk_backend.delete_application(
             application_name=application_name,
         )
-        return DELETE_APPLICATION_TEMPLATE
-
-
-EB_CREATE_APPLICATION = """
-<CreateApplicationResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <CreateApplicationResult>
-    <Application>
-      <ConfigurationTemplates/>
-      <DateCreated>2019-09-03T13:08:29.049Z</DateCreated>
-      <ResourceLifecycleConfig>
-        <VersionLifecycleConfig>
-          <MaxAgeRule>
-            <DeleteSourceFromS3>false</DeleteSourceFromS3>
-            <MaxAgeInDays>180</MaxAgeInDays>
-            <Enabled>false</Enabled>
-          </MaxAgeRule>
-          <MaxCountRule>
-            <DeleteSourceFromS3>false</DeleteSourceFromS3>
-            <MaxCount>200</MaxCount>
-            <Enabled>false</Enabled>
-          </MaxCountRule>
-        </VersionLifecycleConfig>
-      </ResourceLifecycleConfig>
-      <ApplicationArn>{{ application.arn }}</ApplicationArn>
-      <ApplicationName>{{ application.application_name }}</ApplicationName>
-      <DateUpdated>2019-09-03T13:08:29.049Z</DateUpdated>
-    </Application>
-  </CreateApplicationResult>
-  <ResponseMetadata>
-    <RequestId>1b6173c8-13aa-4b0a-99e9-eb36a1fb2778</RequestId>
-  </ResponseMetadata>
-</CreateApplicationResponse>
-"""
-
-EB_DESCRIBE_APPLICATIONS = """
-<DescribeApplicationsResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <DescribeApplicationsResult>
-    <Applications>
-      {% for application in applications %}
-      <member>
-        <ConfigurationTemplates/>
-        <DateCreated>2019-09-03T13:08:29.049Z</DateCreated>
-        <ResourceLifecycleConfig>
-          <VersionLifecycleConfig>
-            <MaxAgeRule>
-              <MaxAgeInDays>180</MaxAgeInDays>
-              <DeleteSourceFromS3>false</DeleteSourceFromS3>
-              <Enabled>false</Enabled>
-            </MaxAgeRule>
-            <MaxCountRule>
-              <DeleteSourceFromS3>false</DeleteSourceFromS3>
-              <MaxCount>200</MaxCount>
-              <Enabled>false</Enabled>
-            </MaxCountRule>
-          </VersionLifecycleConfig>
-        </ResourceLifecycleConfig>
-        <ApplicationArn>{{ application.arn }}</ApplicationArn>
-        <ApplicationName>{{ application.application_name }}</ApplicationName>
-        <DateUpdated>2019-09-03T13:08:29.049Z</DateUpdated>
-      </member>
-      {% endfor %}
-    </Applications>
-  </DescribeApplicationsResult>
-  <ResponseMetadata>
-    <RequestId>015a05eb-282e-4b76-bd18-663fdfaf42e4</RequestId>
-  </ResponseMetadata>
-</DescribeApplicationsResponse>
-"""
-
-DELETE_APPLICATION_TEMPLATE = """
-<DeleteApplicationResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <ResponseMetadata>
-    <RequestId>015a05eb-282e-4b76-bd18-663fdfaf42e4</RequestId>
-  </ResponseMetadata>
-</DeleteApplicationResponse>
-"""
-
-EB_CREATE_ENVIRONMENT = """
-<CreateEnvironmentResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <CreateEnvironmentResult>
-    <SolutionStackName>{{ environment.solution_stack_name }}</SolutionStackName>
-    <Health>Grey</Health>
-    <EnvironmentArn>{{ environment.environment_arn }}</EnvironmentArn>
-    <DateUpdated>2019-09-04T09:41:24.222Z</DateUpdated>
-    <DateCreated>2019-09-04T09:41:24.222Z</DateCreated>
-    <EnvironmentId>{{ environment_id }}</EnvironmentId>
-    <PlatformArn>{{ environment.platform_arn }}</PlatformArn>
-    <Tier>
-      <Name>WebServer</Name>
-      <Type>Standard</Type>
-      <Version>1.0</Version>
-    </Tier>
-    <EnvironmentName>{{ environment.environment_name }}</EnvironmentName>
-    <ApplicationName>{{ environment.application_name }}</ApplicationName>
-    <Status>Launching</Status>
-  </CreateEnvironmentResult>
-  <ResponseMetadata>
-    <RequestId>18dc8158-f5d7-4d5a-82ef-07fcaadf81c6</RequestId>
-  </ResponseMetadata>
-</CreateEnvironmentResponse>
-"""
-
-EB_DESCRIBE_ENVIRONMENTS = """
-<DescribeEnvironmentsResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <DescribeEnvironmentsResult>
-    <Environments>
-      {% for env in environments %}
-      <member>
-        <SolutionStackName>{{ env.solution_stack_name }}</SolutionStackName>
-        <Health>Grey</Health>
-        <EnvironmentArn>{{ env.environment_arn }}</EnvironmentArn>
-        <MinCapacityEnabled>false</MinCapacityEnabled>
-        <DateUpdated>2019-08-30T09:35:10.913Z</DateUpdated>
-        <AbortableOperationInProgress>false</AbortableOperationInProgress>
-        <Alerts/>
-        <DateCreated>2019-08-22T07:02:47.332Z</DateCreated>
-        <EnvironmentId>{{ env.environment_id }}</EnvironmentId>
-        <VersionLabel>1</VersionLabel>
-        <PlatformArn>{{ env.platform_arn }}</PlatformArn>
-        <Tier>
-          <Name>WebServer</Name>
-          <Type>Standard</Type>
-          <Version>1.0</Version>
-        </Tier>
-        <HealthStatus>No Data</HealthStatus>
-        <EnvironmentName>{{ env.environment_name }}</EnvironmentName>
-        <EndpointURL></EndpointURL>
-        <CNAME></CNAME>
-        <EnvironmentLinks/>
-        <ApplicationName>{{ env.application_name }}</ApplicationName>
-        <Status>Ready</Status>
-      </member>
-      {% endfor %}
-    </Environments>
-  </DescribeEnvironmentsResult>
-  <ResponseMetadata>
-    <RequestId>dd56b215-01a0-40b2-bd1e-57589c39424f</RequestId>
-  </ResponseMetadata>
-</DescribeEnvironmentsResponse>
-"""
-
-# Current list as of 2019-09-04
-EB_LIST_AVAILABLE_SOLUTION_STACKS = """
-<ListAvailableSolutionStacksResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <ListAvailableSolutionStacksResult>
-    <SolutionStacks>
-      <member>64bit Amazon Linux 2018.03 v4.10.1 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v4.9.2 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v4.8.0 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v4.6.0 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v4.5.3 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v4.5.1 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v4.5.0 running Node.js</member>
-      <member>64bit Amazon Linux 2017.09 v4.4.6 running Node.js</member>
-      <member>64bit Amazon Linux 2017.09 v4.4.5 running Node.js</member>
-      <member>64bit Amazon Linux 2017.09 v4.4.4 running Node.js</member>
-      <member>64bit Amazon Linux 2017.09 v4.4.2 running Node.js</member>
-      <member>64bit Amazon Linux 2017.09 v4.4.0 running Node.js</member>
-      <member>64bit Amazon Linux 2017.03 v4.3.0 running Node.js</member>
-      <member>64bit Amazon Linux 2017.03 v4.2.2 running Node.js</member>
-      <member>64bit Amazon Linux 2017.03 v4.2.1 running Node.js</member>
-      <member>64bit Amazon Linux 2017.03 v4.2.0 running Node.js</member>
-      <member>64bit Amazon Linux 2017.03 v4.1.1 running Node.js</member>
-      <member>64bit Amazon Linux 2017.03 v4.1.0 running Node.js</member>
-      <member>64bit Amazon Linux 2016.09 v4.0.1 running Node.js</member>
-      <member>64bit Amazon Linux 2016.09 v4.0.0 running Node.js</member>
-      <member>64bit Amazon Linux 2016.09 v3.3.1 running Node.js</member>
-      <member>64bit Amazon Linux 2016.09 v3.1.0 running Node.js</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.14 running PHP 5.4</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.14 running PHP 5.5</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.14 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.14 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.14 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.14 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.12 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.7 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.6 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.6 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.5 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.4 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.3 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.2 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.1 running PHP 7.2</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.0 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.1 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.1 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.1 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.0 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.0 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.6 running PHP 5.4</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.6 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.6 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.5 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running PHP 5.4</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running PHP 5.5</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.3 running PHP 5.4</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.3 running PHP 5.5</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.3 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.3 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.3 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.2 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.2 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.1 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.0 running PHP 5.4</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.0 running PHP 5.5</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.0 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.0 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.0 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2017.03 v2.5.0 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.03 v2.5.0 running PHP 7.1</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.4 running PHP 5.5</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.4 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.4 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.3 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.2 running PHP 5.4</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.2 running PHP 5.5</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.2 running PHP 5.6</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.2 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.1 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.0 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2016.09 v2.3.2 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2016.09 v2.3.1 running PHP 7.0</member>
-      <member>64bit Amazon Linux 2018.03 v2.9.1 running Python 3.6</member>
-      <member>64bit Amazon Linux 2018.03 v2.9.1 running Python 3.4</member>
-      <member>64bit Amazon Linux 2018.03 v2.9.1 running Python</member>
-      <member>64bit Amazon Linux 2018.03 v2.9.1 running Python 2.7</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.5 running Python 3.6</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.1 running Python 3.6</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.0 running Python 3.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running Python 3.6</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.1 running Python 3.6</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.0 running Python 3.4</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.6 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.5 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.4 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.3 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.2 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.1 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.0 (Puma)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.6 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.5 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.4 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.3 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.2 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.1 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.0 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 1.9.3</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.0 running Ruby 2.5 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.4 running Ruby 2.3 (Puma)</member>
-      <member>64bit Amazon Linux 2017.03 v2.4.4 running Ruby 2.3 (Passenger Standalone)</member>
-      <member>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 8.5 Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 8 Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 7 Java 7</member>
-      <member>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 7 Java 6</member>
-      <member>64bit Amazon Linux 2018.03 v3.1.1 running Tomcat 8.5 Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.6.5 running Tomcat 8 Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.6.2 running Tomcat 8 Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.6.1 running Tomcat 8 Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.6.0 running Tomcat 8 Java 8</member>
-      <member>64bit Amazon Linux 2016.09 v2.5.4 running Tomcat 8 Java 8</member>
-      <member>64bit Amazon Linux 2016.03 v2.1.0 running Tomcat 8 Java 8</member>
-      <member>64bit Windows Server Core 2016 v2.2.1 running IIS 10.0</member>
-      <member>64bit Windows Server 2016 v2.2.1 running IIS 10.0</member>
-      <member>64bit Windows Server Core 2012 R2 v2.2.1 running IIS 8.5</member>
-      <member>64bit Windows Server 2012 R2 v2.2.1 running IIS 8.5</member>
-      <member>64bit Windows Server Core 2016 v1.2.0 running IIS 10.0</member>
-      <member>64bit Windows Server 2016 v1.2.0 running IIS 10.0</member>
-      <member>64bit Windows Server Core 2012 R2 v1.2.0 running IIS 8.5</member>
-      <member>64bit Windows Server 2012 R2 v1.2.0 running IIS 8.5</member>
-      <member>64bit Windows Server 2012 v1.2.0 running IIS 8</member>
-      <member>64bit Windows Server 2008 R2 v1.2.0 running IIS 7.5</member>
-      <member>64bit Windows Server Core 2012 R2 running IIS 8.5</member>
-      <member>64bit Windows Server 2012 R2 running IIS 8.5</member>
-      <member>64bit Windows Server 2012 running IIS 8</member>
-      <member>64bit Windows Server 2008 R2 running IIS 7.5</member>
-      <member>64bit Amazon Linux 2018.03 v2.12.16 running Docker 18.06.1-ce</member>
-      <member>64bit Amazon Linux 2016.09 v2.5.2 running Docker 1.12.6</member>
-      <member>64bit Amazon Linux 2018.03 v2.15.2 running Multi-container Docker 18.06.1-ce (Generic)</member>
-      <member>64bit Debian jessie v2.12.16 running Go 1.4 (Preconfigured - Docker)</member>
-      <member>64bit Debian jessie v2.12.16 running Go 1.3 (Preconfigured - Docker)</member>
-      <member>64bit Debian jessie v2.12.16 running Python 3.4 (Preconfigured - Docker)</member>
-      <member>64bit Debian jessie v2.10.0 running Python 3.4 (Preconfigured - Docker)</member>
-      <member>64bit Amazon Linux 2018.03 v2.9.1 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.9.1 running Java 7</member>
-      <member>64bit Amazon Linux 2018.03 v2.8.0 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.6 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.5 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.4 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.2 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.7.1 running Java 8</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.8 running Java 8</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.5 running Java 8</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.4 running Java 8</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.3 running Java 8</member>
-      <member>64bit Amazon Linux 2017.09 v2.6.0 running Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.5.4 running Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.5.3 running Java 8</member>
-      <member>64bit Amazon Linux 2017.03 v2.5.2 running Java 8</member>
-      <member>64bit Amazon Linux 2016.09 v2.4.4 running Java 8</member>
-      <member>64bit Amazon Linux 2018.03 v2.12.1 running Go 1.12.7</member>
-      <member>64bit Amazon Linux 2018.03 v2.6.14 running Packer 1.0.3</member>
-      <member>64bit Amazon Linux 2018.03 v2.12.16 running GlassFish 5.0 Java 8 (Preconfigured - Docker)</member>
-    </SolutionStacks>
-    <SolutionStackDetails>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.10.1 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.9.2 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.8.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.6.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.5.3 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.5.1 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v4.5.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v4.4.6 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v4.4.5 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v4.4.4 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v4.4.2 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v4.4.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v4.3.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v4.2.2 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v4.2.1 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v4.2.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v4.1.1 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v4.1.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v4.0.1 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v4.0.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v3.3.1 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v3.1.0 running Node.js</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.14 running PHP 5.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.14 running PHP 5.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.14 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.14 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.14 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.14 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.12 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.7 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.6 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.6 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.5 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.4 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.3 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.2 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.1 running PHP 7.2</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.0 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.1 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.1 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.1 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.0 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.0 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.6 running PHP 5.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.6 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.6 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.5 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running PHP 5.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running PHP 5.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.3 running PHP 5.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.3 running PHP 5.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.3 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.3 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.3 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.2 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.2 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.1 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.0 running PHP 5.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.0 running PHP 5.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.0 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.0 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.0 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.5.0 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.5.0 running PHP 7.1</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.4 running PHP 5.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.4 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.4 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.3 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.2 running PHP 5.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.2 running PHP 5.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.2 running PHP 5.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.2 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.1 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.0 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v2.3.2 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v2.3.1 running PHP 7.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.9.1 running Python 3.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.9.1 running Python 3.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.9.1 running Python</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.9.1 running Python 2.7</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.5 running Python 3.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.1 running Python 3.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.0 running Python 3.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running Python 3.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.1 running Python 3.6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.0 running Python 3.4</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.6 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.5 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.4 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.3 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.2 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.1 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.0 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.6 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.5 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.4 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.3 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.2 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.1 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 2.0 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.10.1 running Ruby 1.9.3</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.0 running Ruby 2.5 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.4 running Ruby 2.3 (Puma)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.4.4 running Ruby 2.3 (Passenger Standalone)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 8.5 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 7 Java 7</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v3.2.1 running Tomcat 7 Java 6</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v3.1.1 running Tomcat 8.5 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.6.5 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.6.2 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.6.1 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.6.0 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v2.5.4 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.03 v2.1.0 running Tomcat 8 Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>war</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server Core 2016 v2.2.1 running IIS 10.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2016 v2.2.1 running IIS 10.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server Core 2012 R2 v2.2.1 running IIS 8.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2012 R2 v2.2.1 running IIS 8.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server Core 2016 v1.2.0 running IIS 10.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2016 v1.2.0 running IIS 10.0</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server Core 2012 R2 v1.2.0 running IIS 8.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2012 R2 v1.2.0 running IIS 8.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2012 v1.2.0 running IIS 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2008 R2 v1.2.0 running IIS 7.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server Core 2012 R2 running IIS 8.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2012 R2 running IIS 8.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2012 running IIS 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Windows Server 2008 R2 running IIS 7.5</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.12.16 running Docker 18.06.1-ce</SolutionStackName>
-        <PermittedFileTypes/>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v2.5.2 running Docker 1.12.6</SolutionStackName>
-        <PermittedFileTypes/>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.15.2 running Multi-container Docker 18.06.1-ce (Generic)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-          <member>json</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Debian jessie v2.12.16 running Go 1.4 (Preconfigured - Docker)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Debian jessie v2.12.16 running Go 1.3 (Preconfigured - Docker)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Debian jessie v2.12.16 running Python 3.4 (Preconfigured - Docker)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Debian jessie v2.10.0 running Python 3.4 (Preconfigured - Docker)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.9.1 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.9.1 running Java 7</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.8.0 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.6 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.5 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.4 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.2 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.7.1 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.8 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.5 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.4 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.3 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.09 v2.6.0 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.5.4 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.5.3 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2017.03 v2.5.2 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2016.09 v2.4.4 running Java 8</SolutionStackName>
-        <PermittedFileTypes>
-          <member>jar</member>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.12.1 running Go 1.12.7</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.6.14 running Packer 1.0.3</SolutionStackName>
-        <PermittedFileTypes/>
-      </member>
-      <member>
-        <SolutionStackName>64bit Amazon Linux 2018.03 v2.12.16 running GlassFish 5.0 Java 8 (Preconfigured - Docker)</SolutionStackName>
-        <PermittedFileTypes>
-          <member>zip</member>
-        </PermittedFileTypes>
-      </member>
-    </SolutionStackDetails>
-  </ListAvailableSolutionStacksResult>
-  <ResponseMetadata>
-    <RequestId>bd6bd2b2-9983-4845-b53b-fe53e8a5e1e7</RequestId>
-  </ResponseMetadata>
-</ListAvailableSolutionStacksResponse>
-"""
-
-EB_UPDATE_TAGS_FOR_RESOURCE = """
-<UpdateTagsForResourceResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <ResponseMetadata>
-    <RequestId>f355d788-e67e-440f-b915-99e35254ffee</RequestId>
-  </ResponseMetadata>
-</UpdateTagsForResourceResponse>
-"""
-
-EB_LIST_TAGS_FOR_RESOURCE = """
-<ListTagsForResourceResponse xmlns="http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/">
-  <ListTagsForResourceResult>
-    <ResourceTags>
-      {% for key, value in tags.items() %}
-      <member>
-        <Key>{{ key }}</Key>
-        <Value>{{ value }}</Value>
-      </member>
-      {% endfor %}
-    </ResourceTags>
-    <ResourceArn>{{ arn }}</ResourceArn>
-  </ListTagsForResourceResult>
-  <ResponseMetadata>
-    <RequestId>178e410f-3b57-456f-a64c-a3b6a16da9ab</RequestId>
-  </ResponseMetadata>
-</ListTagsForResourceResponse>
-"""
+        return EmptyResult()

--- a/tests/test_elasticbeanstalk/test_elasticbeanstalk.py
+++ b/tests/test_elasticbeanstalk/test_elasticbeanstalk.py
@@ -55,14 +55,8 @@ def test_delete_unknown_application():
     unknown_application_name = "myapp1"
 
     conn.create_application(ApplicationName=application_name)
-    with pytest.raises(ClientError) as exc:
-        conn.delete_application(ApplicationName=unknown_application_name)
-    err = exc.value.response["Error"]
-    assert err["Code"] == "ApplicationNotFound"
-    assert (
-        err["Message"]
-        == f"Elastic Beanstalk application {unknown_application_name} not found."
-    )
+    resp = conn.delete_application(ApplicationName=unknown_application_name)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
 @mock_aws

--- a/tests/test_elasticbeanstalk/test_elasticbeanstalk.py
+++ b/tests/test_elasticbeanstalk/test_elasticbeanstalk.py
@@ -160,3 +160,5 @@ def test_list_available_solution_stacks():
     stacks = conn.list_available_solution_stacks()
     assert len(stacks["SolutionStacks"]) > 0
     assert len(stacks["SolutionStacks"]) == len(stacks["SolutionStackDetails"])
+    assert "SolutionStackName" in stacks["SolutionStackDetails"][0]
+    assert "PermittedFileTypes" in stacks["SolutionStackDetails"][0]

--- a/tests/test_elasticbeanstalk/test_server.py
+++ b/tests/test_elasticbeanstalk/test_server.py
@@ -12,4 +12,4 @@ def test_elasticbeanstalk_describe():
     resp = test_client.post("/", data=data, headers=headers)
 
     assert resp.status_code == 200
-    assert "<Applications></Applications>" in str(resp.data)
+    assert "<DescribeApplicationsResult><Applications" in str(resp.data)


### PR DESCRIPTION
Relatively minor changeset required for integration:

* generated new list of solution stacks (previous values were from 2019).
* dropped `Fake` prefix from model names to align with Botocore.
* changed `DeleteApplication` logic when passed a non-existent application name (behavior verified against real AWS backend).

1300+ lines of XML templates deleted!