### PR TITLE
SNS: integrate with core response serializer

### DIFF
--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -112,6 +112,8 @@ class SerializationContext:
 
 
 class ErrorShape(StructureShape):
+    _shape_model: dict[str, Any]
+
     # Overriding super class property to keep mypy happy...
     @property
     def error_code(self) -> str:
@@ -659,7 +661,7 @@ class BaseXMLSerializer(ResponseSerializer):
         error: Exception,
         shape: ErrorShape,
     ) -> None:
-        at_fault = shape.metadata.get("error", {}).get("fault", False)
+        at_fault = shape._shape_model.get("fault", False)
         sender_fault = shape.metadata.get("error", {}).get("senderFault", False)
         serialized["Type"] = "Receiver" if (at_fault and not sender_fault) else "Sender"
         serialized["Code"] = shape.error_code

--- a/moto/sns/exceptions.py
+++ b/moto/sns/exceptions.py
@@ -1,94 +1,53 @@
-from typing import Any, Optional
-
-from moto.core.exceptions import RESTError
+from moto.core.exceptions import ServiceException
 
 
-class SNSException(RESTError):
-    def __init__(self, *args: Any, **kwargs: Any):
-        kwargs["template"] = "wrapped_single_error"
-        super().__init__(*args, **kwargs)
+class SNSException(ServiceException):
+    pass
 
 
 class SNSNotFoundError(SNSException):
-    code = 404
-
-    def __init__(self, message: str, template: Optional[str] = None):
-        super().__init__("NotFound", message, template=template)
+    code = "NotFound"
 
 
 class TopicNotFound(SNSNotFoundError):
-    def __init__(self) -> None:
-        super().__init__(message="Topic does not exist")
+    message = "Topic does not exist"
 
 
 class ResourceNotFoundError(SNSException):
-    code = 404
-
-    def __init__(self) -> None:
-        super().__init__("ResourceNotFound", "Resource does not exist")
+    code = "ResourceNotFound"
+    message = "Resource does not exist"
 
 
 class DuplicateSnsEndpointError(SNSException):
-    code = 400
-
-    def __init__(self, message: str):
-        super().__init__("InvalidParameter", message)
+    code = "InvalidParameter"
 
 
 class SnsEndpointDisabled(SNSException):
-    code = 400
-
-    def __init__(self, message: str):
-        super().__init__("EndpointDisabled", message)
+    code = "EndpointDisabled"
 
 
 class SNSInvalidParameter(SNSException):
-    code = 400
-
-    def __init__(self, message: str):
-        super().__init__("InvalidParameter", message)
+    code = "InvalidParameter"
 
 
 class InvalidParameterValue(SNSException):
-    code = 400
-
-    def __init__(self, message: str):
-        super().__init__("InvalidParameterValue", message)
+    code = "InvalidParameter"
 
 
 class TagLimitExceededError(SNSException):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            "TagLimitExceeded",
-            "Could not complete request: tag quota of per resource exceeded",
-        )
+    code = "TagLimitExceeded"
+    message = "Could not complete request: tag quota of per resource exceeded"
 
 
 class InternalError(SNSException):
-    code = 500
-    include_type_sender = False
-
-    def __init__(self, message: str):
-        super().__init__("InternalFailure", message)
+    code = "InternalError"
 
 
 class TooManyEntriesInBatchRequest(SNSException):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            "TooManyEntriesInBatchRequest",
-            "The batch request contains more entries than permissible.",
-        )
+    code = "TooManyEntriesInBatchRequest"
+    message = "The batch request contains more entries than permissible."
 
 
 class BatchEntryIdsNotDistinct(SNSException):
-    code = 400
-
-    def __init__(self) -> None:
-        super().__init__(
-            "BatchEntryIdsNotDistinct",
-            "Two or more batch entries in the request have the same Id.",
-        )
+    code = "BatchEntryIdsNotDistinct"
+    message = "Two or more batch entries in the request have the same Id."

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -215,6 +215,7 @@ class Topic(CloudFormationModel):
 class Subscription(BaseModel):
     def __init__(self, account_id: str, topic: Topic, endpoint: str, protocol: str):
         self.account_id = account_id
+        self.owner = account_id
         self.topic = topic
         self.endpoint = endpoint
         self.protocol = protocol
@@ -223,6 +224,10 @@ class Subscription(BaseModel):
         self._filter_policy = None  # filter policy as a dict, not json.
         self._filter_policy_matcher: Optional[FilterPolicyMatcher] = None
         self.confirmed = False
+
+    @property
+    def topic_arn(self) -> str:
+        return self.topic.arn
 
     def publish(
         self,

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -876,9 +876,7 @@ class SNSBackend(BaseBackend):
         subscription = self.subscriptions.get(arn)
 
         if not subscription:
-            raise SNSNotFoundError(
-                "Subscription does not exist", template="wrapped_single_error"
-            )
+            raise SNSNotFoundError("Subscription does not exist")
         # AWS does not return the FilterPolicy scope if the FilterPolicy is not set
         # if the FilterPolicy is set and not the FilterPolicyScope, it returns the default value
         attributes = {**subscription.attributes}

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -2,7 +2,7 @@ import re
 from collections import defaultdict
 from typing import Any, Dict, Tuple, Union
 
-from moto.core.responses import TYPE_RESPONSE, BaseResponse
+from moto.core.responses import TYPE_RESPONSE, ActionResult, BaseResponse, EmptyResult
 from moto.core.utils import camelcase_to_underscores
 
 from .exceptions import InvalidParameterValue, SNSNotFoundError
@@ -113,11 +113,10 @@ class SNSResponse(BaseResponse):
         template = self.response_template(LIST_TOPICS_TEMPLATE)
         return template.render(topics=topics, next_token=next_token)
 
-    def delete_topic(self) -> str:
+    def delete_topic(self) -> ActionResult:
         topic_arn = self._get_param("TopicArn")
         self.backend.delete_topic(topic_arn)
-        template = self.response_template(DELETE_TOPIC_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def get_topic_attributes(self) -> str:
         topic_arn = self._get_param("TopicArn")
@@ -125,14 +124,13 @@ class SNSResponse(BaseResponse):
         template = self.response_template(GET_TOPIC_ATTRIBUTES_TEMPLATE)
         return template.render(topic=topic)
 
-    def set_topic_attributes(self) -> str:
+    def set_topic_attributes(self) -> ActionResult:
         topic_arn = self._get_param("TopicArn")
         attribute_name = self._get_param("AttributeName")
         attribute_name = camelcase_to_underscores(attribute_name)
         attribute_value = self._get_param("AttributeValue")
         self.backend.set_topic_attribute(topic_arn, attribute_name, attribute_value)
-        template = self.response_template(SET_TOPIC_ATTRIBUTES_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def subscribe(self) -> str:
         topic_arn = self._get_param("TopicArn")
@@ -158,11 +156,10 @@ class SNSResponse(BaseResponse):
         template = self.response_template(SUBSCRIBE_TEMPLATE)
         return template.render(subscription=subscription)
 
-    def unsubscribe(self) -> str:
+    def unsubscribe(self) -> ActionResult:
         subscription_arn = self._get_param("SubscriptionArn")
         self.backend.unsubscribe(subscription_arn)
-        template = self.response_template(UNSUBSCRIBE_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def list_subscriptions(self) -> str:
         next_token = self._get_param("NextToken")
@@ -265,24 +262,22 @@ class SNSResponse(BaseResponse):
         template = self.response_template(GET_PLATFORM_APPLICATION_ATTRIBUTES_TEMPLATE)
         return template.render(attributes=attributes)
 
-    def set_platform_application_attributes(self) -> str:
+    def set_platform_application_attributes(self) -> ActionResult:
         arn = self._get_param("PlatformApplicationArn")
         attributes = self._get_attributes()
 
         self.backend.set_platform_application_attributes(arn, attributes)
-        template = self.response_template(SET_PLATFORM_APPLICATION_ATTRIBUTES_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def list_platform_applications(self) -> str:
         applications = self.backend.list_platform_applications()
         template = self.response_template(LIST_PLATFORM_APPLICATIONS_TEMPLATE)
         return template.render(applications=applications)
 
-    def delete_platform_application(self) -> str:
+    def delete_platform_application(self) -> ActionResult:
         platform_arn = self._get_param("PlatformApplicationArn")
         self.backend.delete_platform_application(platform_arn)
-        template = self.response_template(DELETE_PLATFORM_APPLICATION_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def create_platform_endpoint(self) -> str:
         application_arn = self._get_param("PlatformApplicationArn")
@@ -317,20 +312,16 @@ class SNSResponse(BaseResponse):
             error_response = self._error("NotFound", "Endpoint does not exist")
             return error_response, dict(status=404)
 
-    def set_endpoint_attributes(self) -> Union[str, Tuple[str, Dict[str, int]]]:
+    def set_endpoint_attributes(self) -> ActionResult:
         arn = self._get_param("EndpointArn")
         attributes = self._get_attributes()
-
         self.backend.set_endpoint_attributes(arn, attributes)
+        return EmptyResult()
 
-        template = self.response_template(SET_ENDPOINT_ATTRIBUTES_TEMPLATE)
-        return template.render()
-
-    def delete_endpoint(self) -> str:
+    def delete_endpoint(self) -> ActionResult:
         arn = self._get_param("EndpointArn")
         self.backend.delete_endpoint(arn)
-        template = self.response_template(DELETE_ENDPOINT_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def get_subscription_attributes(self) -> str:
         arn = self._get_param("SubscriptionArn")
@@ -338,15 +329,14 @@ class SNSResponse(BaseResponse):
         template = self.response_template(GET_SUBSCRIPTION_ATTRIBUTES_TEMPLATE)
         return template.render(attributes=attributes)
 
-    def set_subscription_attributes(self) -> str:
+    def set_subscription_attributes(self) -> ActionResult:
         arn = self._get_param("SubscriptionArn")
         attr_name = self._get_param("AttributeName")
         attr_value = self._get_param("AttributeValue")
         self.backend.set_subscription_attributes(arn, attr_name, attr_value)
-        template = self.response_template(SET_SUBSCRIPTION_ATTRIBUTES_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
-    def set_sms_attributes(self) -> str:
+    def set_sms_attributes(self) -> ActionResult:
         # attributes.entry.1.key
         # attributes.entry.1.value
         # to
@@ -368,8 +358,7 @@ class SNSResponse(BaseResponse):
 
         self.backend.set_sms_attributes(result)
 
-        template = self.response_template(SET_SMS_ATTRIBUTES_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def get_sms_attributes(self) -> str:
         filter_list = set()
@@ -402,20 +391,16 @@ class SNSResponse(BaseResponse):
         template = self.response_template(LIST_OPTOUT_TEMPLATE)
         return template.render(opt_outs=numbers)
 
-    def opt_in_phone_number(self) -> str:
+    def opt_in_phone_number(self) -> ActionResult:
         number = self._get_param("phoneNumber")
-
         self.backend.opt_in_phone_number(number)
+        return EmptyResult()
 
-        template = self.response_template(OPT_IN_NUMBER_TEMPLATE)
-        return template.render()
-
-    def add_permission(self) -> str:
+    def add_permission(self) -> ActionResult:
         topic_arn = self._get_param("TopicArn")
         label = self._get_param("Label")
         aws_account_ids = self._get_multi_param("AWSAccountId.member.")
         action_names = self._get_multi_param("ActionName.member.")
-
         self.backend.add_permission(
             region_name=self.region,
             topic_arn=topic_arn,
@@ -423,18 +408,13 @@ class SNSResponse(BaseResponse):
             aws_account_ids=aws_account_ids,
             action_names=action_names,
         )
+        return EmptyResult()
 
-        template = self.response_template(ADD_PERMISSION_TEMPLATE)
-        return template.render()
-
-    def remove_permission(self) -> str:
+    def remove_permission(self) -> ActionResult:
         topic_arn = self._get_param("TopicArn")
         label = self._get_param("Label")
-
         self.backend.remove_permission(topic_arn, label)
-
-        template = self.response_template(DEL_PERMISSION_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
     def confirm_subscription(self) -> Union[str, Tuple[str, Dict[str, int]]]:
         arn = self._get_param("TopicArn")
@@ -469,21 +449,17 @@ class SNSResponse(BaseResponse):
         template = self.response_template(LIST_TAGS_FOR_RESOURCE_TEMPLATE)
         return template.render(tags=result)
 
-    def tag_resource(self) -> str:
+    def tag_resource(self) -> ActionResult:
         arn = self._get_param("ResourceArn")
         tags = self._get_tags()
-
         self.backend.tag_resource(arn, tags)
+        return EmptyResult()
 
-        return self.response_template(TAG_RESOURCE_TEMPLATE).render()
-
-    def untag_resource(self) -> str:
+    def untag_resource(self) -> ActionResult:
         arn = self._get_param("ResourceArn")
         tag_keys = self._get_multi_param("TagKeys.member")
-
         self.backend.untag_resource(arn, tag_keys)
-
-        return self.response_template(UNTAG_RESOURCE_TEMPLATE).render()
+        return EmptyResult()
 
     @staticmethod
     def serve_pem(request: Any, full_url: str, headers: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
@@ -521,11 +497,6 @@ LIST_TOPICS_TEMPLATE = """<ListTopicsResponse xmlns="http://sns.amazonaws.com/do
   </ResponseMetadata>
 </ListTopicsResponse>"""
 
-DELETE_TOPIC_TEMPLATE = """<DeleteTopicResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>f3aa9ac9-3c3d-11df-8235-9dab105e9c32</RequestId>
-  </ResponseMetadata>
-</DeleteTopicResponse>"""
 
 GET_TOPIC_ATTRIBUTES_TEMPLATE = """<GetTopicAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <GetTopicAttributesResult>
@@ -589,11 +560,6 @@ GET_TOPIC_ATTRIBUTES_TEMPLATE = """<GetTopicAttributesResponse xmlns="http://sns
   </ResponseMetadata>
 </GetTopicAttributesResponse>"""
 
-SET_TOPIC_ATTRIBUTES_TEMPLATE = """<SetTopicAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>a8763b99-33a7-11df-a9b7-05d48da6f042</RequestId>
-  </ResponseMetadata>
-</SetTopicAttributesResponse>"""
 
 CREATE_PLATFORM_APPLICATION_TEMPLATE = """<CreatePlatformApplicationResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <CreatePlatformApplicationResult>
@@ -635,12 +601,6 @@ LIST_PLATFORM_APPLICATIONS_TEMPLATE = """<ListPlatformApplicationsResponse xmlns
     <RequestId>315a335e-85d8-52df-9349-791283cbb529</RequestId>
   </ResponseMetadata>
 </ListPlatformApplicationsResponse>"""
-
-DELETE_PLATFORM_APPLICATION_TEMPLATE = """<DeletePlatformApplicationResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>097dac18-7a77-5823-a8dd-e65476dcb037</RequestId>
-  </ResponseMetadata>
-</DeletePlatformApplicationResponse>"""
 
 GET_ENDPOINT_ATTRIBUTES_TEMPLATE = """<GetEndpointAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <GetEndpointAttributesResult>
@@ -706,24 +666,6 @@ PUBLISH_TEMPLATE = """<PublishResponse xmlns="http://sns.amazonaws.com/doc/2010-
   </ResponseMetadata>
 </PublishResponse>"""
 
-SET_ENDPOINT_ATTRIBUTES_TEMPLATE = """<SetEndpointAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>2fe0bfc7-3e85-5ee5-a9e2-f58b35e85f6a</RequestId>
-  </ResponseMetadata>
-</SetEndpointAttributesResponse>"""
-
-DELETE_ENDPOINT_TEMPLATE = """<DeleteEndpointResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
- <ResponseMetadata>
- <RequestId>c1d2b191-353c-5a5f-8969-fbdd3900afa8</RequestId>
- </ResponseMetadata>
-</DeleteEndpointResponse>"""
-
-
-SET_PLATFORM_APPLICATION_ATTRIBUTES_TEMPLATE = """<SetPlatformApplicationAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>cf577bcc-b3dc-5463-88f1-3180b9412395</RequestId>
-  </ResponseMetadata>
-</SetPlatformApplicationAttributesResponse>"""
 
 SUBSCRIBE_TEMPLATE = """<SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <SubscribeResult>
@@ -734,11 +676,6 @@ SUBSCRIBE_TEMPLATE = """<SubscribeResponse xmlns="http://sns.amazonaws.com/doc/2
   </ResponseMetadata>
 </SubscribeResponse>"""
 
-UNSUBSCRIBE_TEMPLATE = """<UnsubscribeResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>18e0ac39-3776-11df-84c0-b93cc1666b84</RequestId>
-  </ResponseMetadata>
-</UnsubscribeResponse>"""
 
 LIST_SUBSCRIPTIONS_TEMPLATE = """<ListSubscriptionsResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <ListSubscriptionsResult>
@@ -803,19 +740,6 @@ GET_SUBSCRIPTION_ATTRIBUTES_TEMPLATE = """<GetSubscriptionAttributesResponse xml
 </GetSubscriptionAttributesResponse>"""
 
 
-SET_SUBSCRIPTION_ATTRIBUTES_TEMPLATE = """<SetSubscriptionAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>a8763b99-33a7-11df-a9b7-05d48da6f042</RequestId>
-  </ResponseMetadata>
-</SetSubscriptionAttributesResponse>"""
-
-SET_SMS_ATTRIBUTES_TEMPLATE = """<SetSMSAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <SetSMSAttributesResult/>
-  <ResponseMetadata>
-    <RequestId>26332069-c04a-5428-b829-72524b56a364</RequestId>
-  </ResponseMetadata>
-</SetSMSAttributesResponse>"""
-
 GET_SMS_ATTRIBUTES_TEMPLATE = """<GetSMSAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <GetSMSAttributesResult>
     <attributes>
@@ -865,24 +789,6 @@ LIST_OPTOUT_TEMPLATE = """<ListPhoneNumbersOptedOutResponse xmlns="http://sns.am
   </ResponseMetadata>
 </ListPhoneNumbersOptedOutResponse>"""
 
-OPT_IN_NUMBER_TEMPLATE = """<OptInPhoneNumberResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <OptInPhoneNumberResult/>
-  <ResponseMetadata>
-    <RequestId>4c61842c-0796-50ef-95ac-d610c0bc8cf8</RequestId>
-  </ResponseMetadata>
-</OptInPhoneNumberResponse>"""
-
-ADD_PERMISSION_TEMPLATE = """<AddPermissionResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>c046e713-c5ff-5888-a7bc-b52f0e4f1299</RequestId>
-  </ResponseMetadata>
-</AddPermissionResponse>"""
-
-DEL_PERMISSION_TEMPLATE = """<RemovePermissionResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-  <ResponseMetadata>
-    <RequestId>e767cc9f-314b-5e1b-b283-9ea3fd4e38a3</RequestId>
-  </ResponseMetadata>
-</RemovePermissionResponse>"""
 
 CONFIRM_SUBSCRIPTION_TEMPLATE = """<ConfirmSubscriptionResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <ConfirmSubscriptionResult>
@@ -909,19 +815,6 @@ LIST_TAGS_FOR_RESOURCE_TEMPLATE = """<ListTagsForResourceResponse xmlns="http://
   </ResponseMetadata>
 </ListTagsForResourceResponse>"""
 
-TAG_RESOURCE_TEMPLATE = """<TagResourceResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-    <TagResourceResult/>
-    <ResponseMetadata>
-        <RequestId>fd4ab1da-692f-50a7-95ad-e7c665877d98</RequestId>
-    </ResponseMetadata>
-</TagResourceResponse>"""
-
-UNTAG_RESOURCE_TEMPLATE = """<UntagResourceResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
-    <UntagResourceResult/>
-    <ResponseMetadata>
-        <RequestId>14eb7b1a-4cbd-5a56-80db-2d06412df769</RequestId>
-    </ResponseMetadata>
-</UntagResourceResponse>"""
 
 PUBLISH_BATCH_TEMPLATE = """<PublishBatchResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <ResponseMetadata>

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -20,7 +20,7 @@ class SNSResponse(BaseResponse):
     )
     OPT_OUT_PHONE_NUMBER_REGEX = re.compile(r"^\+?\d+$")
     RESPONSE_KEY_PATH_TO_TRANSFORMER = {
-        "ListTagsForResourceResponse.Tags": transform_tags,  # TODO: transform shape TagList
+        "ListTagsForResourceResponse.Tags": transform_tags,
     }
 
     def __init__(self) -> None:

--- a/tests/test_sns/test_publishing_boto3.py
+++ b/tests/test_sns/test_publishing_boto3.py
@@ -220,7 +220,7 @@ def test_publish_to_sqs_bad():
             MessageAttributes={"store": {"DataType": "String"}},
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
     try:
         # Test empty DataType (if the DataType field is missing entirely
         # botocore throws an exception during validation)
@@ -232,7 +232,7 @@ def test_publish_to_sqs_bad():
             },
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
     try:
         # Test empty Value
         conn.publish(
@@ -241,7 +241,7 @@ def test_publish_to_sqs_bad():
             MessageAttributes={"store": {"DataType": "String", "StringValue": ""}},
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
     try:
         # Test Number DataType, with a non numeric value
         conn.publish(
@@ -250,7 +250,7 @@ def test_publish_to_sqs_bad():
             MessageAttributes={"price": {"DataType": "Number", "StringValue": "error"}},
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert err.response["Error"]["Message"] == (
             "An error occurred (ParameterValueInvalid) when calling the "
             "Publish operation: Could not cast message attribute 'price' "
@@ -2603,7 +2603,7 @@ def test_publish_with_message_structure_errors():
             MessageStructure="json",
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert err.response["Error"]["Message"] == "Message is not valid JSON."
 
     try:
@@ -2616,7 +2616,7 @@ def test_publish_with_message_structure_errors():
             MessageStructure="json",
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert (
             err.response["Error"]["Message"]
             == "Message does not contain sqs or default keys."
@@ -2628,7 +2628,7 @@ def test_publish_with_message_structure_errors():
             MessageStructure="no-json",
         )
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert (
             err.response["Error"]["Message"]
             == "MessageStructure must be 'json' if provided"

--- a/tests/test_sns/test_subscriptions_boto3.py
+++ b/tests/test_sns/test_subscriptions_boto3.py
@@ -564,7 +564,9 @@ def test_subscribe_invalid_filter_policy():
         )
 
     err = err_info.value
-    assert err.response["Error"]["Code"] == "InternalFailure"
+    assert err.response["Error"]["Code"] == "InternalError"
+    assert err.response["Error"]["Type"] == "Receiver"
+    assert err.response["ResponseMetadata"]["HTTPStatusCode"] == 500
 
     with pytest.raises(ClientError) as err_info:
         conn.subscribe(

--- a/tests/test_sns/test_topics_boto3.py
+++ b/tests/test_sns/test_topics_boto3.py
@@ -530,7 +530,7 @@ def test_create_fifo_topic():
     try:
         conn.create_topic(Name="test_topic", Attributes={"FifoTopic": "true"})
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert err.response["Error"]["Message"] == (
             "Fifo Topic names must end with .fifo and must be made up of only "
             "uppercase and lowercase ASCII letters, numbers, underscores, "
@@ -541,7 +541,7 @@ def test_create_fifo_topic():
     try:
         conn.create_topic(Name="test_topic.fifo")
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert err.response["Error"]["Message"] == (
             "Topic names must be made up of only uppercase and lowercase "
             "ASCII letters, numbers, underscores, "
@@ -551,7 +551,7 @@ def test_create_fifo_topic():
     try:
         conn.create_topic(Name="topic.name.fifo", Attributes={"FifoTopic": "true"})
     except ClientError as err:
-        assert err.response["Error"]["Code"] == "InvalidParameterValue"
+        assert err.response["Error"]["Code"] == "InvalidParameter"
         assert err.response["Error"]["Message"] == (
             "Fifo Topic names must end with .fifo and must be made up of only "
             "uppercase and lowercase ASCII letters, numbers, underscores, "


### PR DESCRIPTION
Relatively minor changeset required for integration:

* model only required the addition of a couple attributes
* http status code information was dropped from exception classes (because it's in the service definition)
* tests only required correcting the `InvalidParameter` code (verified against actual AWS)

This PR also contains a minor fix for determining "fault" when serializing errors for the Query and Rest-XML protocols.  The SNS service has an "InternalErrorException" that returns a 500 status code with fault set to "Receiver" (both of which are now covered by test assertions).

> [!NOTE]
> SNS is another service that supported (some) JSON responses for Boto along with the XML responses for Boto3.  None of this code has been covered by tests since Moto dropped support for Boto--and all of it has been removed in this PR--but the functionality *is* still supported by the new response serialization flow.
