### PR TITLE
EC2: integrate simple responses with core response serializer

### DIFF
--- a/moto/ec2/models/core.py
+++ b/moto/ec2/models/core.py
@@ -13,7 +13,7 @@ class TaggedEC2Resource(BaseModel):
         return tags
 
     @property
-    def tagSet(self) -> list[dict[str, str]]:
+    def tag_set(self) -> list[dict[str, str]]:
         return self.get_tags()
 
     def add_tag(self, key: str, value: str) -> None:

--- a/moto/ec2/models/internet_gateways.py
+++ b/moto/ec2/models/internet_gateways.py
@@ -33,6 +33,10 @@ class EgressOnlyInternetGateway(TaggedEC2Resource):
     def physical_resource_id(self) -> str:
         return self.id
 
+    @property
+    def attachments(self) -> List[Dict[str, str]]:
+        return [{"State": self.state, "VpcId": self.vpc_id}]
+
 
 class EgressOnlyInternetGatewayBackend:
     def __init__(self) -> None:

--- a/moto/ec2/responses/availability_zones_and_regions.py
+++ b/moto/ec2/responses/availability_zones_and_regions.py
@@ -1,8 +1,10 @@
+from moto.core.responses import ActionResult
+
 from ._base_response import EC2BaseResponse
 
 
 class AvailabilityZonesAndRegions(EC2BaseResponse):
-    def describe_availability_zones(self) -> str:
+    def describe_availability_zones(self) -> ActionResult:
         self.error_on_dryrun()
         filters = self._filters_from_querystring()
         zone_names = self._get_multi_param("ZoneName")
@@ -10,42 +12,12 @@ class AvailabilityZonesAndRegions(EC2BaseResponse):
         zones = self.ec2_backend.describe_availability_zones(
             filters, zone_names=zone_names, zone_ids=zone_ids
         )
-        template = self.response_template(DESCRIBE_ZONES_RESPONSE)
-        return template.render(zones=zones)
+        result = {"AvailabilityZones": zones}
+        return ActionResult(result)
 
-    def describe_regions(self) -> str:
+    def describe_regions(self) -> ActionResult:
         self.error_on_dryrun()
         region_names = self._get_multi_param("RegionName")
         regions = self.ec2_backend.describe_regions(region_names)
-        template = self.response_template(DESCRIBE_REGIONS_RESPONSE)
-        return template.render(regions=regions)
-
-
-DESCRIBE_REGIONS_RESPONSE = """<DescribeRegionsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
-   <regionInfo>
-      {% for region in regions %}
-          <item>
-             <regionName>{{ region.name }}</regionName>
-             <regionEndpoint>{{ region.endpoint }}</regionEndpoint>
-             <optInStatus>{{ region.opt_in_status }}</optInStatus>
-          </item>
-      {% endfor %}
-   </regionInfo>
-</DescribeRegionsResponse>"""
-
-DESCRIBE_ZONES_RESPONSE = """<DescribeAvailabilityZonesResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
-   <availabilityZoneInfo>
-   {% for zone in zones %}
-       <item>
-          <zoneName>{{ zone.name }}</zoneName>
-          <zoneState>available</zoneState>
-          <regionName>{{ zone.region_name }}</regionName>
-          <zoneId>{{ zone.zone_id }}</zoneId>
-          <zoneType>{{ zone.zone_type }}</zoneType>
-          <messageSet/>
-       </item>
-   {% endfor %}
-   </availabilityZoneInfo>
-</DescribeAvailabilityZonesResponse>"""
+        result = {"Regions": regions}
+        return ActionResult(result)

--- a/moto/ec2/responses/carrier_gateways.py
+++ b/moto/ec2/responses/carrier_gateways.py
@@ -1,10 +1,11 @@
+from moto.core.responses import ActionResult
 from moto.ec2.utils import add_tag_specification
 
 from ._base_response import EC2BaseResponse
 
 
 class CarrierGateway(EC2BaseResponse):
-    def create_carrier_gateway(self) -> str:
+    def create_carrier_gateway(self) -> ActionResult:
         vpc_id = self._get_param("VpcId")
         tag_param = self._get_multi_param("TagSpecification")
         tags = add_tag_specification(tag_param)
@@ -12,84 +13,22 @@ class CarrierGateway(EC2BaseResponse):
         carrier_gateway = self.ec2_backend.create_carrier_gateway(
             vpc_id=vpc_id, tags=tags
         )
-        template = self.response_template(CREATE_CARRIER_GATEWAY_RESPONSE)
-        return template.render(carrier_gateway=carrier_gateway)
+        result = {"CarrierGateway": carrier_gateway}
+        return ActionResult(result)
 
-    def delete_carrier_gateway(self) -> str:
+    def delete_carrier_gateway(self) -> ActionResult:
         carrier_gateway_id = self._get_param("CarrierGatewayId")
 
         carrier_gateway = self.ec2_backend.delete_carrier_gateway(carrier_gateway_id)
-        template = self.response_template(DELETE_CARRIER_GATEWAY_RESPONSE)
-        return template.render(carrier_gateway=carrier_gateway)
+        result = {"CarrierGateway": carrier_gateway}
+        return ActionResult(result)
 
-    def describe_carrier_gateways(self) -> str:
+    def describe_carrier_gateways(self) -> ActionResult:
         carrier_gateway_ids = self._get_multi_param("CarrierGatewayId")
         filters = self._filters_from_querystring()
 
         carrier_gateways = self.ec2_backend.describe_carrier_gateways(
             carrier_gateway_ids, filters
         )
-        template = self.response_template(DESCRIBE_CARRIER_GATEWAYS_RESPONSE)
-        return template.render(carrier_gateways=carrier_gateways)
-
-
-CREATE_CARRIER_GATEWAY_RESPONSE = """<CreateCarrierGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>c617595f-6c29-4a00-a941-example</requestId>
-    <carrierGateway>
-        <state>{{ carrier_gateway.state }}</state>
-        <vpcId>{{ carrier_gateway.vpc_id }}</vpcId>
-        <carrierGatewayId>{{ carrier_gateway.id }}</carrierGatewayId>
-        <ownerId>{{ carrier_gateway.owner_id }}</ownerId>
-        <tagSet>
-        {% for tag in carrier_gateway.get_tags() %}
-            <item>
-                <key>{{ tag.key }}</key>
-                <value>{{ tag.value }}</value>
-            </item>
-        {% endfor %}
-        </tagSet>
-    </carrierGateway>
-</CreateCarrierGatewayResponse>
-"""
-
-DELETE_CARRIER_GATEWAY_RESPONSE = """<DeleteCarrierGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>c617595f-6c29-4a00-a941-example</requestId>
-    <carrierGateway>
-        <state>{{ carrier_gateway.state }}</state>
-        <vpcId>{{ carrier_gateway.vpc_id }}</vpcId>
-        <carrierGatewayId>{{ carrier_gateway.id }}</carrierGatewayId>
-        <ownerId>{{ carrier_gateway.owner_id }}</ownerId>
-        <tagSet>
-        {% for tag in carrier_gateway.get_tags() %}
-            <item>
-                <key>{{ tag.key }}</key>
-                <value>{{ tag.value }}</value>
-            </item>
-        {% endfor %}
-        </tagSet>
-    </carrierGateway>
-</DeleteCarrierGatewayResponse>
-"""
-
-DESCRIBE_CARRIER_GATEWAYS_RESPONSE = """<DescribeCarrierGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>151283df-f7dc-4317-89b4-01c9888b1d45</requestId>
-    <carrierGatewaySet>
-    {% for carrier_gateway in carrier_gateways %}
-        <item>
-            <state>{{ carrier_gateway.state }}</state>
-            <vpcId>{{ carrier_gateway.vpc_id }}</vpcId>
-            <carrierGatewayId>{{ carrier_gateway.id }}</carrierGatewayId>
-            <ownerId>{{ carrier_gateway.owner_id }}</ownerId>
-            <tagSet>
-            {% for tag in carrier_gateway.get_tags() %}
-                <item>
-                    <key>{{ tag.key }}</key>
-                    <value>{{ tag.value }}</value>
-                </item>
-            {% endfor %}
-            </tagSet>
-        </item>
-    {% endfor %}
-    </carrierGatewaySet>
-</DescribeCarrierGatewaysResponse>
-"""
+        result = {"CarrierGateways": carrier_gateways}
+        return ActionResult(result)

--- a/moto/ec2/responses/customer_gateways.py
+++ b/moto/ec2/responses/customer_gateways.py
@@ -1,8 +1,10 @@
+from moto.core.responses import ActionResult
+
 from ._base_response import EC2BaseResponse
 
 
 class CustomerGateways(EC2BaseResponse):
-    def create_customer_gateway(self) -> str:
+    def create_customer_gateway(self) -> ActionResult:
         gateway_type = self._get_param("Type")
         ip_address = self._get_param("IpAddress") or self._get_param("PublicIp")
         bgp_asn = self._get_param("BgpAsn")
@@ -10,72 +12,20 @@ class CustomerGateways(EC2BaseResponse):
         customer_gateway = self.ec2_backend.create_customer_gateway(
             gateway_type, ip_address=ip_address, bgp_asn=bgp_asn, tags=tags
         )
-        template = self.response_template(CREATE_CUSTOMER_GATEWAY_RESPONSE)
-        return template.render(customer_gateway=customer_gateway)
+        result = {"CustomerGateway": customer_gateway}
+        return ActionResult(result)
 
-    def delete_customer_gateway(self) -> str:
+    def delete_customer_gateway(self) -> ActionResult:
         customer_gateway_id = self._get_param("CustomerGatewayId")
         self.ec2_backend.delete_customer_gateway(customer_gateway_id)
-        template = self.response_template(DELETE_CUSTOMER_GATEWAY_RESPONSE)
-        return template.render(delete_status="true")
+        return ActionResult({})
 
-    def describe_customer_gateways(self) -> str:
+    def describe_customer_gateways(self) -> ActionResult:
         self.error_on_dryrun()
         filters = self._filters_from_querystring()
         customer_gateway_ids = self._get_multi_param("CustomerGatewayId")
         customer_gateways = self.ec2_backend.describe_customer_gateways(
             filters, customer_gateway_ids
         )
-        template = self.response_template(DESCRIBE_CUSTOMER_GATEWAYS_RESPONSE)
-        return template.render(customer_gateways=customer_gateways)
-
-
-CREATE_CUSTOMER_GATEWAY_RESPONSE = """
-<CreateCustomerGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-   <customerGateway>
-      <customerGatewayId>{{ customer_gateway.id }}</customerGatewayId>
-      <state>{{ customer_gateway.state }}</state>
-      <type>{{ customer_gateway.type }}</type>
-      <ipAddress>{{ customer_gateway.ip_address }}</ipAddress>
-      <bgpAsn>{{ customer_gateway.bgp_asn }}</bgpAsn>
-      <tagSet>
-        {% for tag in customer_gateway.get_tags() %}
-          <item>
-            <key>{{ tag.key }}</key>
-              <value>{{ tag.value }}</value>
-          </item>
-        {% endfor %}
-      </tagSet>
-   </customerGateway>
-</CreateCustomerGatewayResponse>"""
-
-DELETE_CUSTOMER_GATEWAY_RESPONSE = """
-<DeleteCustomerGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-   <return>{{ delete_status }}</return>
-</DeleteCustomerGatewayResponse>"""
-
-DESCRIBE_CUSTOMER_GATEWAYS_RESPONSE = """
-<DescribeCustomerGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-10- 01/">
-  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-  <customerGatewaySet>
-  {% for customer_gateway in customer_gateways %}
-    <item>
-       <customerGatewayId>{{ customer_gateway.id }}</customerGatewayId>
-       <state>{{ customer_gateway.state }}</state>
-       <type>{{ customer_gateway.type }}</type>
-       <ipAddress>{{ customer_gateway.ip_address }}</ipAddress>
-       <bgpAsn>{{ customer_gateway.bgp_asn }}</bgpAsn>
-       <tagSet>
-        {% for tag in customer_gateway.get_tags() %}
-          <item>
-            <key>{{ tag.key }}</key>
-            <value>{{ tag.value }}</value>
-          </item>
-        {% endfor %}
-       </tagSet>
-    </item>
-  {% endfor %}
-  </customerGatewaySet>
-</DescribeCustomerGatewaysResponse>"""
+        result = {"CustomerGateways": customer_gateways}
+        return ActionResult(result)

--- a/moto/ec2/responses/egress_only_internet_gateways.py
+++ b/moto/ec2/responses/egress_only_internet_gateways.py
@@ -1,10 +1,11 @@
+from moto.core.responses import ActionResult
 from moto.ec2.utils import add_tag_specification
 
 from ._base_response import EC2BaseResponse
 
 
 class EgressOnlyInternetGateway(EC2BaseResponse):
-    def create_egress_only_internet_gateway(self) -> str:
+    def create_egress_only_internet_gateway(self) -> ActionResult:
         vpc_id = self._get_param("VpcId")
         tag_param = self._get_multi_param("TagSpecification")
         tags = add_tag_specification(tag_param)
@@ -12,74 +13,20 @@ class EgressOnlyInternetGateway(EC2BaseResponse):
         egress_only_igw = self.ec2_backend.create_egress_only_internet_gateway(
             vpc_id=vpc_id, tags=tags
         )
-        template = self.response_template(CREATE_EGRESS_ONLY_IGW_RESPONSE)
-        return template.render(egress_only_igw=egress_only_igw)
+        result = {"EgressOnlyInternetGateway": egress_only_igw}
+        return ActionResult(result)
 
-    def describe_egress_only_internet_gateways(self) -> str:
+    def describe_egress_only_internet_gateways(self) -> ActionResult:
         egress_only_igw_ids = self._get_multi_param("EgressOnlyInternetGatewayId")
         egress_only_igws = self.ec2_backend.describe_egress_only_internet_gateways(
             egress_only_igw_ids
         )
-        template = self.response_template(DESCRIBE_EGRESS_ONLY_IGW_RESPONSE)
-        return template.render(egress_only_igws=egress_only_igws)
+        result = {"EgressOnlyInternetGateways": egress_only_igws}
+        return ActionResult(result)
 
-    def delete_egress_only_internet_gateway(self) -> str:
+    def delete_egress_only_internet_gateway(self) -> ActionResult:
         egress_only_igw_id = self._get_param("EgressOnlyInternetGatewayId")
         self.ec2_backend.delete_egress_only_internet_gateway(
             gateway_id=egress_only_igw_id
         )
-        template = self.response_template(DELETE_EGRESS_ONLY_IGW_RESPONSE)
-        return template.render()
-
-
-CREATE_EGRESS_ONLY_IGW_RESPONSE = """<CreateEgressOnlyInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>c617595f-6c29-4a00-a941-example</requestId>
-    <egressOnlyInternetGateway>
-        <attachmentSet>
-            <item>
-                <state>{{ egress_only_igw.state }}</state>
-                <vpcId>{{ egress_only_igw.vpc_id }}</vpcId>
-            </item>
-        </attachmentSet>
-        <egressOnlyInternetGatewayId>{{ egress_only_igw.id }}</egressOnlyInternetGatewayId>
-        <tagSet>
-        {% for tag in egress_only_igw.get_tags() %}
-            <item>
-                <key>{{ tag.key }}</key>
-                <value>{{ tag.value }}</value>
-            </item>
-        {% endfor %}
-        </tagSet>
-    </egressOnlyInternetGateway>
-</CreateEgressOnlyInternetGatewayResponse>
-"""
-
-DESCRIBE_EGRESS_ONLY_IGW_RESPONSE = """<DescribeEgressOnlyInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>ec441b4c-357f-4483-b4a7-example</requestId>
-    <egressOnlyInternetGatewaySet>
-        {% for egress_only_igw in egress_only_igws %}
-        <item>
-            <attachmentSet>
-                <item>
-                    <state>{{ egress_only_igw.state }}</state>
-                    <vpcId>{{ egress_only_igw.vpc_id }}</vpcId>
-                </item>
-            </attachmentSet>
-            <egressOnlyInternetGatewayId>{{ egress_only_igw.id }}</egressOnlyInternetGatewayId>
-            <tagSet>
-            {% for tag in egress_only_igw.get_tags() %}
-                <item>
-                    <key>{{ tag.key }}</key>
-                    <value>{{ tag.value }}</value>
-                </item>
-            {% endfor %}
-            </tagSet>
-        </item>
-        {% endfor %}
-    </egressOnlyInternetGatewaySet>
-</DescribeEgressOnlyInternetGatewaysResponse>"""
-
-DELETE_EGRESS_ONLY_IGW_RESPONSE = """<DeleteEgressOnlyInternetGateway xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
-  <returnCode>true</returnCode>
-</DeleteEgressOnlyInternetGateway>"""
+        return ActionResult({"ReturnCode": True})

--- a/moto/ec2/responses/tags.py
+++ b/moto/ec2/responses/tags.py
@@ -1,4 +1,4 @@
-from moto.core.responses import ActionResult
+from moto.core.responses import ActionResult, EmptyResult
 from moto.core.utils import tags_from_query_string
 from moto.ec2.models import validate_resource_ids
 
@@ -15,7 +15,7 @@ class TagResponse(EC2BaseResponse):
         self.error_on_dryrun()
 
         self.ec2_backend.create_tags(resource_ids, tags)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_tags(self) -> ActionResult:
         resource_ids = self._get_multi_param("ResourceId")
@@ -25,7 +25,7 @@ class TagResponse(EC2BaseResponse):
         self.error_on_dryrun()
 
         self.ec2_backend.delete_tags(resource_ids, tags)
-        return ActionResult({})
+        return EmptyResult()
 
     def describe_tags(self) -> ActionResult:
         filters = self._filters_from_querystring()

--- a/moto/ec2/responses/tags.py
+++ b/moto/ec2/responses/tags.py
@@ -1,3 +1,4 @@
+from moto.core.responses import ActionResult
 from moto.core.utils import tags_from_query_string
 from moto.ec2.models import validate_resource_ids
 
@@ -5,7 +6,7 @@ from ._base_response import EC2BaseResponse
 
 
 class TagResponse(EC2BaseResponse):
-    def create_tags(self) -> str:
+    def create_tags(self) -> ActionResult:
         resource_ids = self._get_multi_param("ResourceId")
         validate_resource_ids(resource_ids)
         self.ec2_backend.do_resources_exist(resource_ids)
@@ -14,9 +15,9 @@ class TagResponse(EC2BaseResponse):
         self.error_on_dryrun()
 
         self.ec2_backend.create_tags(resource_ids, tags)
-        return CREATE_RESPONSE
+        return ActionResult({})
 
-    def delete_tags(self) -> str:
+    def delete_tags(self) -> ActionResult:
         resource_ids = self._get_multi_param("ResourceId")
         validate_resource_ids(resource_ids)
         tags = tags_from_query_string(self.querystring)
@@ -24,38 +25,13 @@ class TagResponse(EC2BaseResponse):
         self.error_on_dryrun()
 
         self.ec2_backend.delete_tags(resource_ids, tags)
-        return DELETE_RESPONSE
+        return ActionResult({})
 
-    def describe_tags(self) -> str:
+    def describe_tags(self) -> ActionResult:
         filters = self._filters_from_querystring()
 
         self.error_on_dryrun()
 
         tags = self.ec2_backend.describe_tags(filters=filters)
-        template = self.response_template(DESCRIBE_RESPONSE)
-        return template.render(tags=tags)
-
-
-CREATE_RESPONSE = """<CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-  <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-  <return>true</return>
-</CreateTagsResponse>"""
-
-DELETE_RESPONSE = """<DeleteTagsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-   <return>true</return>
-</DeleteTagsResponse>"""
-
-DESCRIBE_RESPONSE = """<DescribeTagsResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
-   <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
-   <tagSet>
-      {% for tag in tags %}
-          <item>
-             <resourceId>{{ tag.resource_id }}</resourceId>
-             <resourceType>{{ tag.resource_type }}</resourceType>
-             <key>{{ tag.key }}</key>
-             <value>{{ tag.value }}</value>
-          </item>
-      {% endfor %}
-    </tagSet>
-</DescribeTagsResponse>"""
+        result = {"Tags": tags}
+        return ActionResult(result)

--- a/moto/ec2/responses/windows.py
+++ b/moto/ec2/responses/windows.py
@@ -1,3 +1,4 @@
+from moto.core.responses import ActionResult
 from moto.ec2.utils import utc_date_and_time
 
 from ._base_response import EC2BaseResponse
@@ -15,23 +16,12 @@ class Windows(EC2BaseResponse):
             "Windows.describe_bundle_tasks is not yet implemented"
         )
 
-    def get_password_data(self) -> str:
+    def get_password_data(self) -> ActionResult:
         instance_id = self._get_param("InstanceId")
         password_data = self.ec2_backend.get_password_data(instance_id)
-        template = self.response_template(GET_PASSWORD_DATA_RESPONSE)
-        return template.render(
-            password_data=password_data,
-            instance_id=instance_id,
-            timestamp=utc_date_and_time(),
+        result = dict(
+            InstanceId=instance_id,
+            Timestamp=utc_date_and_time(),
+            PasswordData=password_data,
         )
-
-
-GET_PASSWORD_DATA_RESPONSE = """
-<?xml version="1.0" encoding="UTF-8"?>
-<GetPasswordDataResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-  <requestId>6b9528d5-6818-4bd0-8936-cdedaEXAMPLE</requestId>
-  <instanceId>{{ instance_id }}</instanceId>
-  <timestamp>{{ timestamp }}</timestamp>
-  <passwordData>{{ password_data }}</passwordData>
-</GetPasswordDataResponse>
-"""
+        return ActionResult(result)

--- a/moto/ec2/responses/windows.py
+++ b/moto/ec2/responses/windows.py
@@ -1,5 +1,5 @@
 from moto.core.responses import ActionResult
-from moto.ec2.utils import utc_date_and_time
+from moto.core.utils import utcnow
 
 from ._base_response import EC2BaseResponse
 
@@ -19,9 +19,9 @@ class Windows(EC2BaseResponse):
     def get_password_data(self) -> ActionResult:
         instance_id = self._get_param("InstanceId")
         password_data = self.ec2_backend.get_password_data(instance_id)
-        result = dict(
-            InstanceId=instance_id,
-            Timestamp=utc_date_and_time(),
-            PasswordData=password_data,
-        )
+        result = {
+            "InstanceId": instance_id,
+            "Timestamp": utcnow(),
+            "PasswordData": password_data,
+        }
         return ActionResult(result)


### PR DESCRIPTION
This PR integrates a few of the simpler EC2 backends (i.e. those that require only additive model updates and no logic updates) with the new serialization flow.  