### PR TITLE
CloudFormation: rename `type` attribute to avoid clashes

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -398,7 +398,7 @@ def parse_and_create_resource(
     resource = resource_class.create_from_cloudformation_json(
         resource_physical_name, resource_json, account_id, region_name, **kwargs
     )
-    resource.type = resource_type
+    resource.resource_type = resource_type
     resource.logical_resource_id = logical_id
     return resource
 
@@ -427,7 +427,7 @@ def parse_and_update_resource(
             account_id=account_id,
             region_name=region_name,
         )
-        new_resource.type = resource_json["Type"]
+        new_resource.resource_type = resource_json["Type"]
         new_resource.logical_resource_id = logical_id
         return new_resource
     else:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -907,7 +907,7 @@ DESCRIBE_STACK_RESOURCE_RESPONSE_TEMPLATE = """<DescribeStackResourceResponse>
       <StackName>{{ stack.name }}</StackName>
       <LogicalResourceId>{{ resource.logical_resource_id }}</LogicalResourceId>
       <PhysicalResourceId>{{ resource.physical_resource_id }}</PhysicalResourceId>
-      <ResourceType>{{ resource.type }}</ResourceType>
+      <ResourceType>{{ resource.resource_type }}</ResourceType>
       <Timestamp>2010-07-27T22:27:28Z</Timestamp>
       <ResourceStatus>{{ stack.status }}</ResourceStatus>
     </StackResourceDetail>
@@ -923,7 +923,7 @@ DESCRIBE_STACK_RESOURCES_RESPONSE = """<DescribeStackResourcesResponse>
           <StackName>{{ stack.name }}</StackName>
           <LogicalResourceId>{{ resource.logical_resource_id }}</LogicalResourceId>
           <PhysicalResourceId>{{ resource.physical_resource_id }}</PhysicalResourceId>
-          <ResourceType>{{ resource.type }}</ResourceType>
+          <ResourceType>{{ resource.resource_type }}</ResourceType>
           <Timestamp>2010-07-27T22:27:28Z</Timestamp>
           <ResourceStatus>{{ stack.status }}</ResourceStatus>
         </member>
@@ -1001,7 +1001,7 @@ LIST_STACKS_RESOURCES_RESPONSE = """<ListStackResourcesResponse>
         <LogicalResourceId>{{ resource.logical_resource_id }}</LogicalResourceId>
         <LastUpdatedTimestamp>2011-06-21T20:15:58Z</LastUpdatedTimestamp>
         <PhysicalResourceId>{{ resource.physical_resource_id }}</PhysicalResourceId>
-        <ResourceType>{{ resource.type }}</ResourceType>
+        <ResourceType>{{ resource.resource_type }}</ResourceType>
       </member>
       {% endfor %}
     </StackResourceSummaries>


### PR DESCRIPTION
Moto's Cloud Formation parser manually sets a `type` attribute on each resource after instantiation.  This attribute name is generic and not defined in the [CloudFormationModel](https://github.com/getmoto/moto/blob/f8638d14d2ea245f697d86090fd0f6fc925bd7a3/moto/core/common_models.py#L20) interface.  I considered refactoring this out altogether, as it strikes me as brittle and error-prone, but it would take some effort to get the current custom resource implementation to work.  

Taking everything into consideration, I settled on simply renaming the attribute for clarity and to avoid clashing with the many model definitions that also contain a generic "type" attribute (e.g. `elbv2:LoadBalancer.type`).

