### PR TITLE
ELBv2: integrate with core response serializer

### DIFF
--- a/moto/core/parsers.py
+++ b/moto/core/parsers.py
@@ -56,8 +56,7 @@ class QueryParser:
 
     def _handle_list(self, shape, node, prefix=""):
         # The query protocol serializes empty lists as an empty string.
-        value = self._parse_shape(shape.member, node, prefix)
-        if value == "":
+        if node.get(prefix, UNDEFINED) == "":
             return []
 
         list_name = shape.member.serialization.get("name", "member")

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -947,6 +947,8 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             ]
         }
         """
+        if self.automated_parameter_parsing:
+            return self.params
         params: Dict[str, Any] = {}
         for k, v in sorted(self.querystring.items(), key=params_sort_function):
             self._parse_param(k, v[0], params)

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -491,4 +491,4 @@ def _get_value_for_key(obj: Any, key: int | str, default: Any) -> Any:
     try:
         return obj[key]
     except (KeyError, IndexError, TypeError, AttributeError):
-        return getattr(obj, str(key), default)
+        return default

--- a/moto/ec2/models/vpc_service_configuration.py
+++ b/moto/ec2/models/vpc_service_configuration.py
@@ -28,7 +28,7 @@ class VPCServiceConfiguration(TaggedEC2Resource, CloudFormationModel):
         self.gateway_load_balancer_arns = []
         self.network_load_balancer_arns = []
         for lb in load_balancers:
-            if lb.loadbalancer_type == "network":
+            if lb.type == "network":
                 self.service_type = "Interface"
                 self.network_load_balancer_arns.append(lb.arn)
             else:

--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -1,13 +1,10 @@
 from typing import Any, List, Optional
 
-from moto.core.exceptions import RESTError
+from moto.core.exceptions import ServiceException
 
 
-class ELBClientError(RESTError):
-    code = 400
-
-    def __init__(self, error_type: str, message: str):
-        super().__init__(error_type, message, template="wrapped_single_error")
+class ELBClientError(ServiceException):
+    pass
 
 
 class DuplicateTagKeysError(ELBClientError):
@@ -18,10 +15,8 @@ class DuplicateTagKeysError(ELBClientError):
 
 
 class LoadBalancerNotFoundError(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "LoadBalancerNotFound", "The specified load balancer does not exist."
-        )
+    code = "LoadBalancerNotFound"
+    message = "The specified load balancer does not exist."
 
 
 class ListenerNotFoundError(ELBClientError):
@@ -40,58 +35,38 @@ class TargetGroupNotFoundError(ELBClientError):
 
 
 class TooManyTagsError(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "TooManyTagsError",
-            "The quota for the number of tags that can be assigned to a load balancer has been reached",
-        )
+    code = "TooManyTags"
+    message = "The quota for the number of tags that can be assigned to a load balancer has been reached"
 
 
 class TooManyCertificatesError(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "TooManyCertificates",
-            "You've reached the limit on the number of certificates per load balancer",
-        )
+    code = "TooManyCertificates"
+    message = "You've reached the limit on the number of certificates per load balancer"
 
 
 class BadHealthCheckDefinition(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "ValidationError",
-            "HealthCheck Target must begin with one of HTTP, TCP, HTTPS, SSL",
-        )
+    code = "ValidationError"
+    message = "HealthCheck Target must begin with one of HTTP, TCP, HTTPS, SSL"
 
 
 class DuplicateListenerError(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "DuplicateListener", "A listener with the specified port already exists."
-        )
+    code = "DuplicateListener"
+    message = "A listener with the specified port already exists."
 
 
 class DuplicateLoadBalancerName(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "DuplicateLoadBalancerName",
-            "A load balancer with the specified name already exists.",
-        )
+    code = "DuplicateLoadBalancerName"
+    message = "A load balancer with the specified name already exists."
 
 
 class DuplicateTargetGroupName(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "DuplicateTargetGroupName",
-            "A target group with the specified name already exists.",
-        )
+    code = "DuplicateTargetGroupName"
+    message = "A target group with the specified name already exists."
 
 
 class InvalidTargetError(ELBClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "InvalidTarget",
-            "The specified target does not exist or is not in the same VPC as the target group.",
-        )
+    code = "InvalidTarget"
+    message = "The specified target does not exist or is not in the same VPC as the target group."
 
 
 class TargetNotRunning(ELBClientError):
@@ -131,8 +106,7 @@ class InvalidConditionFieldError(ELBClientError):
 
 
 class InvalidConditionValueError(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("ValidationError", msg)
+    code = "ValidationError"
 
 
 class InvalidActionTypeError(ELBClientError):
@@ -157,8 +131,7 @@ class ListenerOrBalancerMissingError(ELBClientError):
 
 
 class InvalidDescribeRulesRequest(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("ValidationError", msg)
+    code = "ValidationError"
 
 
 class ResourceInUseError(ELBClientError):
@@ -180,8 +153,7 @@ class DuplicatePriorityError(ELBClientError):
 
 
 class InvalidTargetGroupNameError(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("ValidationError", msg)
+    code = "ValidationError"
 
 
 class InvalidModifyRuleArgumentsError(ELBClientError):
@@ -192,23 +164,19 @@ class InvalidModifyRuleArgumentsError(ELBClientError):
 
 
 class InvalidStatusCodeActionTypeError(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("ValidationError", msg)
+    code = "ValidationError"
 
 
 class InvalidLoadBalancerActionException(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("InvalidLoadBalancerAction", msg)
+    code = "InvalidLoadBalancerAction"
 
 
 class ValidationError(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("ValidationError", msg)
+    code = "ValidationError"
 
 
 class InvalidConfigurationRequest(ELBClientError):
-    def __init__(self, msg: str):
-        super().__init__("InvalidConfigurationRequest", msg)
+    code = "InvalidConfigurationRequest"
 
 
 class InvalidProtocol(ELBClientError):

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -829,5 +829,5 @@ class ELBV2Response(BaseResponse):
         return ActionResult(result)
 
     def describe_capacity_reservation(self) -> ActionResult:
-        result = {"CapacityReservationState": ["provisioned"]}
+        result = {"CapacityReservationState": [{"State": {"Code": "provisioned"}}]}
         return ActionResult(result)

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -1,5 +1,5 @@
 from moto.core.exceptions import RESTError
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 
 from .exceptions import ListenerOrBalancerMissingError, TargetGroupNotFoundError
 from .models import ELBv2Backend, elbv2_backends
@@ -366,15 +366,38 @@ SSL_POLICIES = [
 ]
 
 
+def transform_dict(data: dict[str, str]) -> list[dict[str, str]]:
+    transformed = [{"Key": key, "Value": value} for key, value in data.items()]
+    return transformed
+
+
+def transform_certificates(data: list[str]) -> list[dict[str, str]]:
+    return [{"CertificateArn": cert} for cert in data]
+
+
 class ELBV2Response(BaseResponse):
+    RESPONSE_KEY_PATH_TO_TRANSFORMER = {
+        "CreateListenerOutput.Listeners.Listener.Certificates": transform_certificates,
+        "DescribeListenerAttributesOutput.Attributes": transform_dict,
+        "DescribeListenersOutput.Listeners.Listener.Certificates": transform_certificates,
+        "DescribeLoadBalancerAttributesOutput.Attributes": transform_dict,
+        "DescribeTagsOutput.TagDescriptions.TagDescription.Tags": transform_dict,
+        "DescribeTargetGroupAttributesOutput.Attributes": transform_dict,
+        "ModifyListenerAttributesOutput.Attributes": transform_dict,
+        "ModifyListenerOutput.Listeners.Listener.Certificates": transform_certificates,
+        "ModifyLoadBalancerAttributesOutput.Attributes": transform_dict,
+        "ModifyTargetGroupAttributesOutput.Attributes": transform_dict,
+    }
+
     def __init__(self) -> None:
         super().__init__(service_name="elbv2")
+        self.automated_parameter_parsing = True
 
     @property
     def elbv2_backend(self) -> ELBv2Backend:
         return elbv2_backends[self.current_account][self.region]
 
-    def create_load_balancer(self) -> str:
+    def create_load_balancer(self) -> ActionResult:
         params = self._get_params()
         load_balancer_name = params.get("Name")
         subnet_ids = self._get_multi_param("Subnets.member")
@@ -383,7 +406,6 @@ class ELBV2Response(BaseResponse):
         scheme = params.get("Scheme")
         loadbalancer_type = params.get("Type")
         tags = params.get("Tags")
-
         load_balancer = self.elbv2_backend.create_load_balancer(
             name=load_balancer_name,  # type: ignore
             security_groups=security_groups,
@@ -393,23 +415,22 @@ class ELBV2Response(BaseResponse):
             loadbalancer_type=loadbalancer_type,
             tags=tags,
         )
-        template = self.response_template(CREATE_LOAD_BALANCER_TEMPLATE)
-        return template.render(load_balancer=load_balancer)
+        result = {"LoadBalancers": [load_balancer]}
+        return ActionResult(result)
 
-    def create_rule(self) -> str:
+    def create_rule(self) -> ActionResult:
         params = self._get_params()
-        rules = self.elbv2_backend.create_rule(
+        rule = self.elbv2_backend.create_rule(
             listener_arn=params["ListenerArn"],
             conditions=params["Conditions"],
             priority=params["Priority"],
             actions=params["Actions"],
             tags=params.get("Tags"),
         )
+        result = {"Rules": [rule]}
+        return ActionResult(result)
 
-        template = self.response_template(CREATE_RULE_TEMPLATE)
-        return template.render(rules=rules)
-
-    def create_target_group(self) -> str:
+    def create_target_group(self) -> ActionResult:
         params = self._get_params()
         name = params.get("Name")
         vpc_id = params.get("VpcId")
@@ -419,8 +440,8 @@ class ELBV2Response(BaseResponse):
         healthcheck_protocol = self._get_param("HealthCheckProtocol")
         healthcheck_port = self._get_param("HealthCheckPort")
         healthcheck_path = self._get_param("HealthCheckPath")
-        healthcheck_interval_seconds = self._get_param("HealthCheckIntervalSeconds")
-        healthcheck_timeout_seconds = self._get_param("HealthCheckTimeoutSeconds")
+        healthcheck_interval_seconds = self._get_int_param("HealthCheckIntervalSeconds")
+        healthcheck_timeout_seconds = self._get_int_param("HealthCheckTimeoutSeconds")
         healthcheck_enabled = self._get_param("HealthCheckEnabled")
         healthy_threshold_count = self._get_param("HealthyThresholdCount")
         unhealthy_threshold_count = self._get_param("UnhealthyThresholdCount")
@@ -448,11 +469,10 @@ class ELBV2Response(BaseResponse):
             target_type=target_type,
             tags=tags,
         )
+        result = {"TargetGroups": [target_group]}
+        return ActionResult(result)
 
-        template = self.response_template(CREATE_TARGET_GROUP_TEMPLATE)
-        return template.render(target_group=target_group)
-
-    def create_listener(self) -> str:
+    def create_listener(self) -> ActionResult:
         params = self._get_params()
         load_balancer_arn = self._get_param("LoadBalancerArn")
         protocol = self._get_param("Protocol")
@@ -478,10 +498,10 @@ class ELBV2Response(BaseResponse):
             tags=tags,
         )
 
-        template = self.response_template(CREATE_LISTENER_TEMPLATE)
-        return template.render(listener=listener)
+        result = {"Listeners": [listener]}
+        return ActionResult(result)
 
-    def describe_load_balancers(self) -> str:
+    def describe_load_balancers(self) -> ActionResult:
         arns = self._get_multi_param("LoadBalancerArns.member")
         names = self._get_multi_param("Names.member")
         all_load_balancers = list(
@@ -500,11 +520,10 @@ class ELBV2Response(BaseResponse):
         next_marker = None
         if len(all_load_balancers) > start + page_size:
             next_marker = load_balancers_resp[-1].name
+        result = {"LoadBalancers": load_balancers_resp, "NextMarker": next_marker}
+        return ActionResult(result)
 
-        template = self.response_template(DESCRIBE_LOAD_BALANCERS_TEMPLATE)
-        return template.render(load_balancers=load_balancers_resp, marker=next_marker)
-
-    def describe_rules(self) -> str:
+    def describe_rules(self) -> ActionResult:
         listener_arn = self._get_param("ListenerArn")
         rule_arns = (
             self._get_multi_param("RuleArns.member")
@@ -529,29 +548,28 @@ class ELBV2Response(BaseResponse):
 
         if len(all_rules) > start + page_size:
             next_marker = rules_resp[-1].arn
-        template = self.response_template(DESCRIBE_RULES_TEMPLATE)
-        return template.render(rules=rules_resp, marker=next_marker)
+        result = {"Rules": rules_resp, "NextMarker": next_marker}
+        return ActionResult(result)
 
-    def describe_target_groups(self) -> str:
+    def describe_target_groups(self) -> ActionResult:
         load_balancer_arn = self._get_param("LoadBalancerArn")
         target_group_arns = self._get_multi_param("TargetGroupArns.member")
         names = self._get_multi_param("Names.member")
-
         target_groups = self.elbv2_backend.describe_target_groups(
             load_balancer_arn, target_group_arns, names
         )
-        template = self.response_template(DESCRIBE_TARGET_GROUPS_TEMPLATE)
-        return template.render(target_groups=target_groups)
+        result = {"TargetGroups": target_groups}
+        return ActionResult(result)
 
-    def describe_target_group_attributes(self) -> str:
+    def describe_target_group_attributes(self) -> ActionResult:
         target_group_arn = self._get_param("TargetGroupArn")
         target_group = self.elbv2_backend.target_groups.get(target_group_arn)
         if not target_group:
             raise TargetGroupNotFoundError()
-        template = self.response_template(DESCRIBE_TARGET_GROUP_ATTRIBUTES_TEMPLATE)
-        return template.render(attributes=target_group.attributes)
+        result = {"Attributes": target_group.attributes}
+        return ActionResult(result)
 
-    def describe_listeners(self) -> str:
+    def describe_listeners(self) -> ActionResult:
         load_balancer_arn = self._get_param("LoadBalancerArn")
         listener_arns = self._get_multi_param("ListenerArns.member")
         if not load_balancer_arn and not listener_arns:
@@ -560,118 +578,106 @@ class ELBV2Response(BaseResponse):
         listeners = self.elbv2_backend.describe_listeners(
             load_balancer_arn, listener_arns
         )
-        template = self.response_template(DESCRIBE_LISTENERS_TEMPLATE)
-        return template.render(listeners=listeners)
+        result = {"Listeners": listeners}
+        return ActionResult(result)
 
-    def delete_load_balancer(self) -> str:
+    def delete_load_balancer(self) -> ActionResult:
         arn = self._get_param("LoadBalancerArn")
         self.elbv2_backend.delete_load_balancer(arn)
-        template = self.response_template(DELETE_LOAD_BALANCER_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
-    def delete_rule(self) -> str:
+    def delete_rule(self) -> ActionResult:
         arn = self._get_param("RuleArn")
         self.elbv2_backend.delete_rule(arn)
-        template = self.response_template(DELETE_RULE_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
-    def delete_target_group(self) -> str:
+    def delete_target_group(self) -> ActionResult:
         arn = self._get_param("TargetGroupArn")
         self.elbv2_backend.delete_target_group(arn)
-        template = self.response_template(DELETE_TARGET_GROUP_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
-    def delete_listener(self) -> str:
+    def delete_listener(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         self.elbv2_backend.delete_listener(arn)
-        template = self.response_template(DELETE_LISTENER_TEMPLATE)
-        return template.render()
+        return EmptyResult()
 
-    def modify_rule(self) -> str:
+    def modify_rule(self) -> ActionResult:
         rule_arn = self._get_param("RuleArn")
         params = self._get_params()
         conditions = params.get("Conditions", [])
         actions = params.get("Actions", [])
-        rules = self.elbv2_backend.modify_rule(
+        rule = self.elbv2_backend.modify_rule(
             rule_arn=rule_arn, conditions=conditions, actions=actions
         )
-        template = self.response_template(MODIFY_RULE_TEMPLATE)
-        return template.render(rules=rules)
+        result = {"Rules": [rule]}
+        return ActionResult(result)
 
-    def modify_target_group_attributes(self) -> str:
+    def modify_target_group_attributes(self) -> ActionResult:
         target_group_arn = self._get_param("TargetGroupArn")
         attrs = self._get_list_prefix("Attributes.member")
         attributes = {attr["key"]: attr["value"] for attr in attrs}
         self.elbv2_backend.modify_target_group_attributes(target_group_arn, attributes)
+        result = {"Attributes": attributes}
+        return ActionResult(result)
 
-        template = self.response_template(MODIFY_TARGET_GROUP_ATTRIBUTES_TEMPLATE)
-        return template.render(attributes=attributes)
-
-    def register_targets(self) -> str:
+    def register_targets(self) -> ActionResult:
         target_group_arn = self._get_param("TargetGroupArn")
         targets = self._get_list_prefix("Targets.member")
         self.elbv2_backend.register_targets(target_group_arn, targets)
+        return EmptyResult()
 
-        template = self.response_template(REGISTER_TARGETS_TEMPLATE)
-        return template.render()
-
-    def deregister_targets(self) -> str:
+    def deregister_targets(self) -> ActionResult:
         target_group_arn = self._get_param("TargetGroupArn")
         targets = self._get_list_prefix("Targets.member")
         self.elbv2_backend.deregister_targets(target_group_arn, targets)
+        return EmptyResult()
 
-        template = self.response_template(DEREGISTER_TARGETS_TEMPLATE)
-        return template.render()
-
-    def describe_target_health(self) -> str:
+    def describe_target_health(self) -> ActionResult:
         target_group_arn = self._get_param("TargetGroupArn")
         targets = self._get_list_prefix("Targets.member")
         target_health_descriptions = self.elbv2_backend.describe_target_health(
             target_group_arn, targets
         )
+        result = {"TargetHealthDescriptions": target_health_descriptions}
+        return ActionResult(result)
 
-        template = self.response_template(DESCRIBE_TARGET_HEALTH_TEMPLATE)
-        return template.render(target_health_descriptions=target_health_descriptions)
-
-    def set_rule_priorities(self) -> str:
+    def set_rule_priorities(self) -> ActionResult:
         rule_priorities = self._get_list_prefix("RulePriorities.member")
         for rule_priority in rule_priorities:
             rule_priority["priority"] = int(rule_priority["priority"])
         rules = self.elbv2_backend.set_rule_priorities(rule_priorities)
-        template = self.response_template(SET_RULE_PRIORITIES_TEMPLATE)
-        return template.render(rules=rules)
+        result = {"Rules": rules}
+        return ActionResult(result)
 
-    def add_tags(self) -> str:
+    def add_tags(self) -> ActionResult:
         resource_arns = self._get_multi_param("ResourceArns.member")
         tags = self._get_params().get("Tags")
-
         self.elbv2_backend.add_tags(resource_arns, tags)  # type: ignore
+        return EmptyResult()
 
-        template = self.response_template(ADD_TAGS_TEMPLATE)
-        return template.render()
-
-    def remove_tags(self) -> str:
+    def remove_tags(self) -> ActionResult:
         resource_arns = self._get_multi_param("ResourceArns.member")
         tag_keys = self._get_multi_param("TagKeys.member")
-
         self.elbv2_backend.remove_tags(resource_arns, tag_keys)
+        return EmptyResult()
 
-        template = self.response_template(REMOVE_TAGS_TEMPLATE)
-        return template.render()
-
-    def describe_tags(self) -> str:
+    def describe_tags(self) -> ActionResult:
         resource_arns = self._get_multi_param("ResourceArns.member")
         resource_tags = self.elbv2_backend.describe_tags(resource_arns)
+        result = {
+            "TagDescriptions": [
+                {"ResourceArn": arn, "Tags": tags}
+                for arn, tags in resource_tags.items()
+            ]
+        }
+        return ActionResult(result)
 
-        template = self.response_template(DESCRIBE_TAGS_TEMPLATE)
-        return template.render(resource_tags=resource_tags)
-
-    def describe_account_limits(self) -> str:
+    def describe_account_limits(self) -> ActionResult:
         # Supports paging but not worth implementing yet
         # marker = self._get_param('Marker')
         # page_size = self._get_int_param('PageSize')
 
-        limits = {
+        limit_data = {
             "application-load-balancers": 20,
             "target-groups": 3000,
             "targets-per-application-load-balancer": 30,
@@ -682,11 +688,11 @@ class ELBV2Response(BaseResponse):
             "listeners-per-network-load-balancer": 50,
             "certificates-per-application-load-balancer": 25,
         }
+        limits = [{"Name": k, "Max": v} for k, v in limit_data.items()]
+        result = {"Limits": limits}
+        return ActionResult(result)
 
-        template = self.response_template(DESCRIBE_LIMITS_TEMPLATE)
-        return template.render(limits=limits)
-
-    def describe_ssl_policies(self) -> str:
+    def describe_ssl_policies(self) -> ActionResult:
         names = self._get_multi_param("Names.member.")
         # Supports paging but not worth implementing yet
         # marker = self._get_param('Marker')
@@ -696,56 +702,47 @@ class ELBV2Response(BaseResponse):
         if names:
             policies = filter(lambda policy: policy["name"] in names, policies)  # type: ignore
 
-        template = self.response_template(DESCRIBE_SSL_POLICIES_TEMPLATE)
-        return template.render(policies=policies)
+        result = {"SslPolicies": policies}
+        return ActionResult(result)
 
-    def set_ip_address_type(self) -> str:
+    def set_ip_address_type(self) -> ActionResult:
         arn = self._get_param("LoadBalancerArn")
         ip_type = self._get_param("IpAddressType")
-
         self.elbv2_backend.set_ip_address_type(arn, ip_type)
+        result = {"IpAddressType": ip_type}
+        return ActionResult(result)
 
-        template = self.response_template(SET_IP_ADDRESS_TYPE_TEMPLATE)
-        return template.render(ip_type=ip_type)
-
-    def set_security_groups(self) -> str:
+    def set_security_groups(self) -> ActionResult:
         arn = self._get_param("LoadBalancerArn")
         sec_groups = self._get_multi_param("SecurityGroups.member.")
-
         self.elbv2_backend.set_security_groups(arn, sec_groups)
+        result = {"SecurityGroups": sec_groups}
+        return ActionResult(result)
 
-        template = self.response_template(SET_SECURITY_GROUPS_TEMPLATE)
-        return template.render(sec_groups=sec_groups)
-
-    def set_subnets(self) -> str:
+    def set_subnets(self) -> ActionResult:
         arn = self._get_param("LoadBalancerArn")
         subnets = self._get_multi_param("Subnets.member.")
         subnet_mappings = self._get_params().get("SubnetMappings", [])
-
         subnet_zone_list = self.elbv2_backend.set_subnets(arn, subnets, subnet_mappings)
+        result = {"AvailabilityZones": subnet_zone_list}
+        return ActionResult(result)
 
-        template = self.response_template(SET_SUBNETS_TEMPLATE)
-        return template.render(subnets=subnet_zone_list)
-
-    def modify_load_balancer_attributes(self) -> str:
+    def modify_load_balancer_attributes(self) -> ActionResult:
         arn = self._get_param("LoadBalancerArn")
         attrs = self._get_map_prefix(
             "Attributes.member", key_end="Key", value_end="Value"
         )
-
         all_attrs = self.elbv2_backend.modify_load_balancer_attributes(arn, attrs)
+        result = {"Attributes": all_attrs}
+        return ActionResult(result)
 
-        template = self.response_template(MODIFY_LOADBALANCER_ATTRS_TEMPLATE)
-        return template.render(attrs=all_attrs)
-
-    def describe_load_balancer_attributes(self) -> str:
+    def describe_load_balancer_attributes(self) -> ActionResult:
         arn = self._get_param("LoadBalancerArn")
         attrs = self.elbv2_backend.describe_load_balancer_attributes(arn)
+        result = {"Attributes": attrs}
+        return ActionResult(result)
 
-        template = self.response_template(DESCRIBE_LOADBALANCER_ATTRS_TEMPLATE)
-        return template.render(attrs=attrs)
-
-    def modify_target_group(self) -> str:
+    def modify_target_group(self) -> ActionResult:
         arn = self._get_param("TargetGroupArn")
 
         health_check_proto = self._get_param(
@@ -753,13 +750,12 @@ class ELBV2Response(BaseResponse):
         )  # 'HTTP' | 'HTTPS' | 'TCP',
         health_check_port = self._get_param("HealthCheckPort")
         health_check_path = self._get_param("HealthCheckPath")
-        health_check_interval = self._get_param("HealthCheckIntervalSeconds")
-        health_check_timeout = self._get_param("HealthCheckTimeoutSeconds")
+        health_check_interval = self._get_int_param("HealthCheckIntervalSeconds")
+        health_check_timeout = self._get_int_param("HealthCheckTimeoutSeconds")
         health_check_enabled = self._get_param("HealthCheckEnabled")
         healthy_threshold_count = self._get_param("HealthyThresholdCount")
         unhealthy_threshold_count = self._get_param("UnhealthyThresholdCount")
         http_codes = self._get_param("Matcher.HttpCode")
-
         target_group = self.elbv2_backend.modify_target_group(
             arn,
             health_check_proto,
@@ -772,11 +768,10 @@ class ELBV2Response(BaseResponse):
             http_codes,
             health_check_enabled=health_check_enabled,
         )
+        result = {"TargetGroups": [target_group]}
+        return ActionResult(result)
 
-        template = self.response_template(MODIFY_TARGET_GROUP_TEMPLATE)
-        return template.render(target_group=target_group)
-
-    def modify_listener(self) -> str:
+    def modify_listener(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         port = self._get_param("Port")
         protocol = self._get_param("Protocol")
@@ -794,1186 +789,45 @@ class ELBV2Response(BaseResponse):
             arn, port, protocol, ssl_policy, certificates, default_actions
         )
 
-        template = self.response_template(MODIFY_LISTENER_TEMPLATE)
-        return template.render(listener=listener)
+        result = {"Listeners": [listener]}
+        return ActionResult(result)
 
-    def add_listener_certificates(self) -> str:
+    def add_listener_certificates(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         certificates = self._get_list_prefix("Certificates.member")
         certificate_arns = self.elbv2_backend.add_listener_certificates(
             arn, certificates
         )
+        result = {"Certificates": [{"CertificateArn": arn} for arn in certificate_arns]}
+        return ActionResult(result)
 
-        template = self.response_template(ADD_LISTENER_CERTIFICATES_TEMPLATE)
-        return template.render(certificates=certificate_arns)
-
-    def describe_listener_certificates(self) -> str:
+    def describe_listener_certificates(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         certificates = self.elbv2_backend.describe_listener_certificates(arn)
+        result = {"Certificates": [{"CertificateArn": arn} for arn in certificates]}
+        return ActionResult(result)
 
-        template = self.response_template(DESCRIBE_LISTENER_CERTIFICATES_TEMPLATE)
-        return template.render(certificates=certificates)
-
-    def remove_listener_certificates(self) -> str:
+    def remove_listener_certificates(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         certificates = self._get_list_prefix("Certificates.member")
         self.elbv2_backend.remove_listener_certificates(arn, certificates)
+        return EmptyResult()
 
-        template = self.response_template(REMOVE_LISTENER_CERTIFICATES_TEMPLATE)
-        return template.render()
-
-    def describe_listener_attributes(self) -> str:
+    def describe_listener_attributes(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         attrs = self.elbv2_backend.describe_listener_attributes(arn)
-        template = self.response_template(DESCRIBE_LISTENER_ATTRIBUTES)
-        return template.render(attributes=attrs)
+        result = {"Attributes": attrs}
+        return ActionResult(result)
 
-    def modify_listener_attributes(self) -> str:
+    def modify_listener_attributes(self) -> ActionResult:
         arn = self._get_param("ListenerArn")
         attrs = self._get_params()["Attributes"]
         updated_attrs = self.elbv2_backend.modify_listener_attributes(
             listener_arn=arn, attrs=attrs
         )
-        template = self.response_template(MODIFY_LISTENER_ATTRIBUTES)
-        return template.render(attributes=updated_attrs)
+        result = {"Attributes": updated_attrs}
+        return ActionResult(result)
 
-    def describe_capacity_reservation(self) -> str:
-        return DESCRIBE_CAPACITY_RESERVATION
-
-
-ADD_TAGS_TEMPLATE = """<AddTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <AddTagsResult/>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</AddTagsResponse>"""
-
-REMOVE_TAGS_TEMPLATE = """<RemoveTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <RemoveTagsResult/>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</RemoveTagsResponse>"""
-
-DESCRIBE_TAGS_TEMPLATE = """<DescribeTagsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeTagsResult>
-    <TagDescriptions>
-      {% for resource_arn, tags in resource_tags.items() %}
-      <member>
-        <ResourceArn>{{ resource_arn }}</ResourceArn>
-        <Tags>
-          {% for key, value in tags.items() %}
-          <member>
-            <Value>{{ value }}</Value>
-            <Key>{{ key }}</Key>
-          </member>
-          {% endfor %}
-        </Tags>
-      </member>
-      {% endfor %}
-    </TagDescriptions>
-  </DescribeTagsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeTagsResponse>"""
-
-CREATE_LOAD_BALANCER_TEMPLATE = """<CreateLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <CreateLoadBalancerResult>
-    <LoadBalancers>
-      <member>
-        <LoadBalancerArn>{{ load_balancer.arn }}</LoadBalancerArn>
-        <Scheme>{{ load_balancer.scheme }}</Scheme>
-        <LoadBalancerName>{{ load_balancer.name }}</LoadBalancerName>
-        <VpcId>{{ load_balancer.vpc_id }}</VpcId>
-        <CanonicalHostedZoneId>Z2P70J7EXAMPLE</CanonicalHostedZoneId>
-        <CreatedTime>{{ load_balancer.created_time }}</CreatedTime>
-        <AvailabilityZones>
-          {% for subnet in load_balancer.subnets %}
-          <member>
-            <SubnetId>{{ subnet.id }}</SubnetId>
-            <ZoneName>{{ subnet.availability_zone }}</ZoneName>
-          </member>
-          {% endfor %}
-        </AvailabilityZones>
-        <SecurityGroups>
-          {% for security_group in load_balancer.security_groups %}
-          <member>{{ security_group }}</member>
-          {% endfor %}
-        </SecurityGroups>
-        <DNSName>{{ load_balancer.dns_name }}</DNSName>
-        <State>
-          <Code>{{ load_balancer.state }}</Code>
-        </State>
-        <Type>{{ load_balancer.loadbalancer_type }}</Type>
-      </member>
-    </LoadBalancers>
-  </CreateLoadBalancerResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</CreateLoadBalancerResponse>"""
-
-CREATE_RULE_TEMPLATE = """<CreateRuleResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <CreateRuleResult>
-    <Rules>
-      <member>
-        <IsDefault>{{ "true" if rules.is_default else "false" }}</IsDefault>
-        <Conditions>
-          {% for condition in rules.conditions %}
-          <member>
-            <Field>{{ condition["Field"] }}</Field>
-            {% if "Values" in condition %}
-            <Values>
-              {% for value in condition["Values"] %}
-              <member>{{ value }}</member>
-              {% endfor %}
-            </Values>
-            {% endif %}
-            {% if "HttpHeaderConfig" in condition %}
-            <HttpHeaderConfig>
-              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
-              <Values>
-                {% for value in condition["HttpHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpHeaderConfig>
-            {% endif %}
-            {% if "HttpRequestMethodConfig" in condition %}
-            <HttpRequestMethodConfig>
-              <Values>
-                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpRequestMethodConfig>
-            {% endif %}
-            {% if "QueryStringConfig" in condition %}
-            <QueryStringConfig>
-              <Values>
-                {% for value in condition["QueryStringConfig"]["Values"] %}
-                <member>
-                    <Key>{{ value["Key"] }}</Key>
-                    <Value>{{ value["Value"] }}</Value>
-                </member>
-                {% endfor %}
-              </Values>
-            </QueryStringConfig>
-            {% endif %}
-            {% if "SourceIpConfig" in condition %}
-            <SourceIpConfig>
-              <Values>
-                {% for value in condition["SourceIpConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </SourceIpConfig>
-            {% endif %}
-            {% if "PathPatternConfig" in condition %}
-            <PathPatternConfig>
-              <Values>
-                {% for value in condition["PathPatternConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </PathPatternConfig>
-            {% endif %}
-            {% if "HostHeaderConfig" in condition %}
-            <HostHeaderConfig>
-              <Values>
-                {% for value in condition["HostHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HostHeaderConfig>
-            {% endif %}
-          </member>
-          {% endfor %}
-        </Conditions>
-        <Priority>{{ rules.priority }}</Priority>
-        <RuleArn>{{ rules.arn }}</RuleArn>
-        <Actions>
-          {% for action in rules.actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </Actions>
-      </member>
-    </Rules>
-  </CreateRuleResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</CreateRuleResponse>"""
-
-CREATE_TARGET_GROUP_TEMPLATE = """<CreateTargetGroupResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <CreateTargetGroupResult>
-    <TargetGroups>
-      <member>
-        <TargetGroupArn>{{ target_group.arn }}</TargetGroupArn>
-        <TargetGroupName>{{ target_group.name }}</TargetGroupName>
-        {% if target_group.protocol %}
-        <Protocol>{{ target_group.protocol }}</Protocol>
-        {% if target_group.protocol_version %}
-        <ProtocolVersion>{{ target_group.protocol_version }}</ProtocolVersion>
-        {% endif %}
-        {% endif %}
-        {% if target_group.port %}
-        <Port>{{ target_group.port }}</Port>
-        {% endif %}
-        {% if target_group.vpc_id %}
-        <VpcId>{{ target_group.vpc_id }}</VpcId>
-        {% endif %}
-        {% if target_group.healthcheck_enabled %}
-        {% if target_group.healthcheck_port %}
-        <HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>
-        {% endif %}
-        {% if target_group.healthcheck_protocol %}
-        <HealthCheckProtocol>{{ target_group.healthcheck_protocol or "None" }}</HealthCheckProtocol>
-        {% endif %}
-        {% endif %}
-        {% if target_group.healthcheck_path %}
-        <HealthCheckPath>{{ target_group.healthcheck_path or '' }}</HealthCheckPath>
-        {% endif %}
-        <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>
-        <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
-        <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
-        <UnhealthyThresholdCount>{{ target_group.unhealthy_threshold_count }}</UnhealthyThresholdCount>
-        <HealthCheckEnabled>{{ target_group.healthcheck_enabled and 'true' or 'false' }}</HealthCheckEnabled>
-        {% if target_group.matcher %}
-        <Matcher>
-          {% if target_group.matcher.get("HttpCode") %}<HttpCode>{{ target_group.matcher['HttpCode'] }}</HttpCode>{% endif %}
-          {% if target_group.matcher.get("GrpcCode") %}<GrpcCode>{{ target_group.matcher['GrpcCode'] }}</GrpcCode>{% endif %}
-        </Matcher>
-        {% endif %}
-        {% if target_group.target_type %}
-        <TargetType>{{ target_group.target_type }}</TargetType>
-        {% endif %}
-        {% if target_group.ip_address_type %}
-        <IpAddressType>{{ target_group.ip_address_type }}</IpAddressType>
-        {% endif %}
-      </member>
-    </TargetGroups>
-  </CreateTargetGroupResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</CreateTargetGroupResponse>"""
-
-CREATE_LISTENER_TEMPLATE = """<CreateListenerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <CreateListenerResult>
-    <Listeners>
-      <member>
-        <LoadBalancerArn>{{ listener.load_balancer_arn }}</LoadBalancerArn>
-        <Protocol>{{ listener.protocol }}</Protocol>
-        {% if listener.certificates %}
-        <Certificates>
-          {% for cert in listener.certificates %}
-          <member>
-            <CertificateArn>{{ cert }}</CertificateArn>
-          </member>
-          {% endfor %}
-        </Certificates>
-        {% endif %}
-        {% if listener.port %}
-        <Port>{{ listener.port }}</Port>
-        {% endif %}
-        <SslPolicy>{{ listener.ssl_policy }}</SslPolicy>
-        <ListenerArn>{{ listener.arn }}</ListenerArn>
-        <DefaultActions>
-          {% for action in listener.default_actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </DefaultActions>
-        <AlpnPolicy>
-          {% for policy in listener.alpn_policy %}
-          <member>{{ policy }}</member>
-          {% endfor %}
-        </AlpnPolicy>
-      </member>
-    </Listeners>
-  </CreateListenerResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</CreateListenerResponse>"""
-
-DELETE_LOAD_BALANCER_TEMPLATE = """<DeleteLoadBalancerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DeleteLoadBalancerResult/>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DeleteLoadBalancerResponse>"""
-
-DELETE_RULE_TEMPLATE = """<DeleteRuleResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DeleteRuleResult/>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DeleteRuleResponse>"""
-
-DELETE_TARGET_GROUP_TEMPLATE = """<DeleteTargetGroupResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DeleteTargetGroupResult/>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DeleteTargetGroupResponse>"""
-
-DELETE_LISTENER_TEMPLATE = """<DeleteListenerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DeleteListenerResult/>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DeleteListenerResponse>"""
-
-DESCRIBE_LOAD_BALANCERS_TEMPLATE = """<DescribeLoadBalancersResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeLoadBalancersResult>
-    <LoadBalancers>
-      {% for load_balancer in load_balancers %}
-      <member>
-        <LoadBalancerArn>{{ load_balancer.arn }}</LoadBalancerArn>
-        <Scheme>{{ load_balancer.scheme }}</Scheme>
-        <LoadBalancerName>{{ load_balancer.name }}</LoadBalancerName>
-        <VpcId>{{ load_balancer.vpc_id }}</VpcId>
-        <CanonicalHostedZoneId>Z2P70J7EXAMPLE</CanonicalHostedZoneId>
-        <CreatedTime>{{ load_balancer.created_time }}</CreatedTime>
-        <AvailabilityZones>
-          {% for subnet in load_balancer.subnets %}
-          <member>
-            <SubnetId>{{ subnet.id }}</SubnetId>
-            <ZoneName>{{ subnet.availability_zone }}</ZoneName>
-          </member>
-          {% endfor %}
-        </AvailabilityZones>
-        <SecurityGroups>
-          {% for security_group in load_balancer.security_groups %}
-          <member>{{ security_group }}</member>
-          {% endfor %}
-        </SecurityGroups>
-        <DNSName>{{ load_balancer.dns_name }}</DNSName>
-        <State>
-          <Code>{{ load_balancer.state }}</Code>
-        </State>
-        <Type>{{ load_balancer.loadbalancer_type }}</Type>
-        <IpAddressType>ipv4</IpAddressType>
-      </member>
-      {% endfor %}
-    </LoadBalancers>
-    {% if marker %}
-    <NextMarker>{{ marker }}</NextMarker>
-    {% endif %}
-  </DescribeLoadBalancersResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeLoadBalancersResponse>"""
-
-DESCRIBE_RULES_TEMPLATE = """<DescribeRulesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeRulesResult>
-    <Rules>
-      {% for rule in rules %}
-      <member>
-        <IsDefault>{{ "true" if rule.is_default else "false" }}</IsDefault>
-        <Conditions>
-          {% for condition in rule.conditions %}
-          <member>
-            <Field>{{ condition["Field"] }}</Field>
-            {% if "HttpHeaderConfig" in condition %}
-            <HttpHeaderConfig>
-              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
-              <Values>
-                {% for value in condition["HttpHeaderConfig"]["Values"] %}
-                  <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpHeaderConfig>
-            {% endif %}
-            {% if "HttpRequestMethodConfig" in condition %}
-            <HttpRequestMethodConfig>
-              <Values>
-                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpRequestMethodConfig>
-            {% endif %}
-            {% if "QueryStringConfig" in condition %}
-            <QueryStringConfig>
-              <Values>
-                {% for value in condition["QueryStringConfig"]["Values"] %}
-                <member>
-                    <Key>{{ value["Key"] }}</Key>
-                    <Value>{{ value["Value"] }}</Value>
-                </member>
-                {% endfor %}
-              </Values>
-            </QueryStringConfig>
-            {% endif %}
-            {% if "SourceIpConfig" in condition %}
-            <SourceIpConfig>
-              <Values>
-                {% for value in condition["SourceIpConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </SourceIpConfig>
-            {% endif %}
-            {% if "PathPatternConfig" in condition %}
-            <PathPatternConfig>
-              <Values>
-                {% for value in condition["PathPatternConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </PathPatternConfig>
-            {% endif %}
-            {% if "HostHeaderConfig" in condition %}
-            <HostHeaderConfig>
-              <Values>
-                {% for value in condition["HostHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HostHeaderConfig>
-            {% endif %}
-            {% if "Values" in condition %}
-            <Values>
-              {% for value in condition["Values"] %}
-              <member>{{ value }}</member>
-              {% endfor %}
-            </Values>
-            {% endif %}
-          </member>
-          {% endfor %}
-        </Conditions>
-        <Priority>{{ rule.priority }}</Priority>
-        <RuleArn>{{ rule.arn }}</RuleArn>
-        <Actions>
-          {% for action in rule.actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </Actions>
-      </member>
-      {% endfor %}
-    </Rules>
-    {% if marker %}
-    <NextMarker>{{ marker }}</NextMarker>
-    {% endif %}
-  </DescribeRulesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeRulesResponse>"""
-
-DESCRIBE_TARGET_GROUPS_TEMPLATE = """<DescribeTargetGroupsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeTargetGroupsResult>
-    <TargetGroups>
-      {% for target_group in target_groups %}
-      <member>
-        <TargetGroupArn>{{ target_group.arn }}</TargetGroupArn>
-        <TargetGroupName>{{ target_group.name }}</TargetGroupName>
-        {% if target_group.protocol %}
-        <Protocol>{{ target_group.protocol }}</Protocol>
-        <ProtocolVersion>{{ target_group.protocol_version }}</ProtocolVersion>
-        {% endif %}
-        {% if target_group.port %}
-        <Port>{{ target_group.port }}</Port>
-        {% endif %}
-        {% if target_group.vpc_id %}
-        <VpcId>{{ target_group.vpc_id }}</VpcId>
-        {% endif %}
-        <IpAddressType>{{ target_group.ip_address_type }}</IpAddressType>
-        <HealthCheckProtocol>{{ target_group.healthcheck_protocol }}</HealthCheckProtocol>
-        {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
-        <HealthCheckPath>{{ target_group.healthcheck_path or '' }}</HealthCheckPath>
-        <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>
-        <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
-        <HealthCheckEnabled>{{ target_group.healthcheck_enabled and 'true' or 'false' }}</HealthCheckEnabled>
-        <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
-        <UnhealthyThresholdCount>{{ target_group.unhealthy_threshold_count }}</UnhealthyThresholdCount>
-        {% if target_group.matcher %}
-        <Matcher>
-            {% if target_group.matcher.get("HttpCode") %}<HttpCode>{{ target_group.matcher['HttpCode'] }}</HttpCode>{% endif %}
-            {% if target_group.matcher.get("GrpcCode") %}<GrpcCode>{{ target_group.matcher['GrpcCode'] }}</GrpcCode>{% endif %}
-        </Matcher>
-        {% endif %}
-        {% if target_group.target_type %}
-        <TargetType>{{ target_group.target_type }}</TargetType>
-        {% endif %}
-        <LoadBalancerArns>
-          {% for load_balancer_arn in target_group.load_balancer_arns %}
-          <member>{{ load_balancer_arn }}</member>
-          {% endfor %}
-        </LoadBalancerArns>
-      </member>
-      {% endfor %}
-    </TargetGroups>
-  </DescribeTargetGroupsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeTargetGroupsResponse>"""
-
-DESCRIBE_TARGET_GROUP_ATTRIBUTES_TEMPLATE = """<DescribeTargetGroupAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeTargetGroupAttributesResult>
-    <Attributes>
-      {% for key, value in attributes.items() %}
-      <member>
-        <Key>{{ key }}</Key>
-        <Value>{{ value }}</Value>
-      </member>
-      {% endfor %}
-    </Attributes>
-  </DescribeTargetGroupAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeTargetGroupAttributesResponse>"""
-
-DESCRIBE_LISTENERS_TEMPLATE = """<DescribeListenersResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeListenersResult>
-    <Listeners>
-      {% for listener in listeners %}
-      <member>
-        <LoadBalancerArn>{{ listener.load_balancer_arn }}</LoadBalancerArn>
-        <Protocol>{{ listener.protocol }}</Protocol>
-        {% if listener.certificate %}
-        <Certificates>
-          <member>
-            <CertificateArn>{{ listener.certificate }}</CertificateArn>
-          </member>
-        </Certificates>
-        {% endif %}
-        {% if listener.port %}<Port>{{ listener.port }}</Port>{% endif %}
-        <SslPolicy>{{ listener.ssl_policy }}</SslPolicy>
-        <ListenerArn>{{ listener.arn }}</ListenerArn>
-        <DefaultActions>
-          {% for action in listener.default_actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </DefaultActions>
-        <AlpnPolicy>
-          {% for policy in listener.alpn_policy %}
-          <member>{{ policy }}</member>
-          {% endfor %}
-        </AlpnPolicy>
-      </member>
-      {% endfor %}
-    </Listeners>
-  </DescribeListenersResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeListenersResponse>"""
-
-CONFIGURE_HEALTH_CHECK_TEMPLATE = """<ConfigureHealthCheckResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ConfigureHealthCheckResult>
-    <HealthCheck>
-      <Interval>{{ check.interval }}</Interval>
-      <Target>{{ check.target }}</Target>
-      <HealthyThreshold>{{ check.healthy_threshold }}</HealthyThreshold>
-      <Timeout>{{ check.timeout }}</Timeout>
-      <UnhealthyThreshold>{{ check.unhealthy_threshold }}</UnhealthyThreshold>
-    </HealthCheck>
-  </ConfigureHealthCheckResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ConfigureHealthCheckResponse>"""
-
-MODIFY_RULE_TEMPLATE = """<ModifyRuleResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ModifyRuleResult>
-    <Rules>
-      <member>
-        <IsDefault>{{ "true" if rules.is_default else "false" }}</IsDefault>
-        <Conditions>
-          {% for condition in rules.conditions %}
-          <member>
-            <Field>{{ condition["Field"] }}</Field>
-            {% if "PathPatternConfig" in condition %}
-            <PathPatternConfig>
-              <Values>
-                {% for value in condition["PathPatternConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </PathPatternConfig>
-            {% endif %}
-            {% if "HostHeaderConfig" in condition %}
-            <HostHeaderConfig>
-              <Values>
-                {% for value in condition["HostHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HostHeaderConfig>
-            {% endif %}
-            {% if "HttpHeaderConfig" in condition %}
-            <HttpHeaderConfig>
-              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
-              <Values>
-                {% for value in condition["HttpHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpHeaderConfig>
-            {% endif %}
-            {% if "HttpRequestMethodConfig" in condition %}
-            <HttpRequestMethodConfig>
-              <Values>
-                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpRequestMethodConfig>
-            {% endif %}
-            {% if "QueryStringConfig" in condition %}
-            <QueryStringConfig>
-              <Values>
-                {% for value in condition["QueryStringConfig"]["Values"] %}
-                <member>
-                    <Key>{{ value["Key"] }}</Key>
-                    <Value>{{ value["Value"] }}</Value>
-                </member>
-                {% endfor %}
-              </Values>
-            </QueryStringConfig>
-            {% endif %}
-            {% if "SourceIpConfig" in condition %}
-            <SourceIpConfig>
-              <Values>
-                {% for value in condition["SourceIpConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </SourceIpConfig>
-            {% endif %}
-            {% if "Values" in condition %}
-            <Values>
-              {% for value in condition["Values"] %}
-              <member>{{ value }}</member>
-              {% endfor %}
-            </Values>
-            {% endif %}
-          </member>
-          {% endfor %}
-        </Conditions>
-        <Priority>{{ rules.priority }}</Priority>
-        <RuleArn>{{ rules.arn }}</RuleArn>
-        <Actions>
-          {% for action in rules.actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </Actions>
-      </member>
-    </Rules>
-  </ModifyRuleResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ModifyRuleResponse>"""
-
-MODIFY_TARGET_GROUP_ATTRIBUTES_TEMPLATE = """<ModifyTargetGroupAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ModifyTargetGroupAttributesResult>
-    <Attributes>
-      {% for key, value in attributes.items() %}
-      <member>
-        <Key>{{ key }}</Key>
-        <Value>{{ value }}</Value>
-      </member>
-      {% endfor %}
-    </Attributes>
-  </ModifyTargetGroupAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ModifyTargetGroupAttributesResponse>"""
-
-REGISTER_TARGETS_TEMPLATE = """<RegisterTargetsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <RegisterTargetsResult>
-  </RegisterTargetsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</RegisterTargetsResponse>"""
-
-DEREGISTER_TARGETS_TEMPLATE = """<DeregisterTargetsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DeregisterTargetsResult>
-  </DeregisterTargetsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DeregisterTargetsResponse>"""
-
-SET_LOAD_BALANCER_SSL_CERTIFICATE = """<SetLoadBalancerListenerSSLCertificateResponse xmlns="http://elasticloadbalan cing.amazonaws.com/doc/2015-12-01/">
- <SetLoadBalancerListenerSSLCertificateResult/>
-<ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-</ResponseMetadata>
-</SetLoadBalancerListenerSSLCertificateResponse>"""
-
-DELETE_LOAD_BALANCER_LISTENERS = """<DeleteLoadBalancerListenersResponse xmlns="http://elasticloadbalan cing.amazonaws.com/doc/2015-12-01/">
- <DeleteLoadBalancerListenersResult/>
-<ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-</ResponseMetadata>
-</DeleteLoadBalancerListenersResponse>"""
-
-DESCRIBE_ATTRIBUTES_TEMPLATE = """<DescribeLoadBalancerAttributesResponse  xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeLoadBalancerAttributesResult>
-    <LoadBalancerAttributes>
-      <AccessLog>
-        <Enabled>{{ attributes.access_log.enabled }}</Enabled>
-        {% if attributes.access_log.enabled %}
-        <S3BucketName>{{ attributes.access_log.s3_bucket_name }}</S3BucketName>
-        <S3BucketPrefix>{{ attributes.access_log.s3_bucket_prefix }}</S3BucketPrefix>
-        <EmitInterval>{{ attributes.access_log.emit_interval }}</EmitInterval>
-        {% endif %}
-      </AccessLog>
-      <ConnectionSettings>
-        <IdleTimeout>{{ attributes.connecting_settings.idle_timeout }}</IdleTimeout>
-      </ConnectionSettings>
-      <CrossZoneLoadBalancing>
-        <Enabled>{{ attributes.cross_zone_load_balancing.enabled }}</Enabled>
-      </CrossZoneLoadBalancing>
-      <ConnectionDraining>
-        {% if attributes.connection_draining.enabled %}
-        <Enabled>true</Enabled>
-        <Timeout>{{ attributes.connection_draining.timeout }}</Timeout>
-        {% else %}
-        <Enabled>false</Enabled>
-        {% endif %}
-      </ConnectionDraining>
-    </LoadBalancerAttributes>
-  </DescribeLoadBalancerAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeLoadBalancerAttributesResponse>
-"""
-
-CREATE_LOAD_BALANCER_POLICY_TEMPLATE = """<CreateLoadBalancerPolicyResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <CreateLoadBalancerPolicyResult/>
-  <ResponseMetadata>
-      <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</CreateLoadBalancerPolicyResponse>
-"""
-
-SET_LOAD_BALANCER_POLICIES_OF_LISTENER_TEMPLATE = """<SetLoadBalancerPoliciesOfListenerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-    <SetLoadBalancerPoliciesOfListenerResult/>
-    <ResponseMetadata>
-        <RequestId>{{ request_id }}</RequestId>
-    </ResponseMetadata>
-</SetLoadBalancerPoliciesOfListenerResponse>
-"""
-
-SET_LOAD_BALANCER_POLICIES_FOR_BACKEND_SERVER_TEMPLATE = """<SetLoadBalancerPoliciesForBackendServerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-    <SetLoadBalancerPoliciesForBackendServerResult/>
-    <ResponseMetadata>
-        <RequestId>{{ request_id }}</RequestId>
-    </ResponseMetadata>
-</SetLoadBalancerPoliciesForBackendServerResponse>
-"""
-
-DESCRIBE_TARGET_HEALTH_TEMPLATE = """<DescribeTargetHealthResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeTargetHealthResult>
-    <TargetHealthDescriptions>
-      {% for target_health in target_health_descriptions %}
-      <member>
-        {% if target_health.health_port %}<HealthCheckPort>{{ target_health.health_port }}</HealthCheckPort>{% endif %}
-        <TargetHealth>
-          <State>{{ target_health.status }}</State>
-          {% if target_health.reason %}
-            <Reason>{{ target_health.reason }}</Reason>
-          {% endif %}
-          {% if target_health.description %}
-            <Description>{{ target_health.description }}</Description>
-          {% endif %}
-        </TargetHealth>
-        <Target>
-          {% if target_health.port %}
-          <Port>{{ target_health.port }}</Port>
-          {% endif %}
-          <Id>{{ target_health.instance_id }}</Id>
-        </Target>
-      </member>
-      {% endfor %}
-    </TargetHealthDescriptions>
-  </DescribeTargetHealthResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeTargetHealthResponse>"""
-
-SET_RULE_PRIORITIES_TEMPLATE = """<SetRulePrioritiesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <SetRulePrioritiesResult>
-    <Rules>
-      {% for rule in rules %}
-      <member>
-        <IsDefault>{{ "true" if rule.is_default else "false" }}</IsDefault>
-        <Conditions>
-          {% for condition in rule.conditions %}
-          <member>
-            <Field>{{ condition["Field"] }}</Field>
-            {% if "Values" in condition %}
-            <Values>
-              {% for value in condition["Values"] %}
-              <member>{{ value }}</member>
-              {% endfor %}
-            </Values>
-            {% endif %}
-            {% if "HttpHeaderConfig" in condition %}
-            <HttpHeaderConfig>
-              <HttpHeaderName>{{ condition["HttpHeaderConfig"]["HttpHeaderName"] }}</HttpHeaderName>
-              <Values>
-                {% for value in condition["HttpHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpHeaderConfig>
-            {% endif %}
-            {% if "HttpRequestMethodConfig" in condition %}
-            <HttpRequestMethodConfig>
-              <Values>
-                {% for value in condition["HttpRequestMethodConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HttpRequestMethodConfig>
-            {% endif %}
-            {% if "QueryStringConfig" in condition %}
-            <QueryStringConfig>
-              <Values>
-                {% for value in condition["QueryStringConfig"]["Values"] %}
-                <member>
-                    <Key>{{ value["Key"] }}</Key>
-                    <Value>{{ value["Value"] }}</Value>
-                </member>
-                {% endfor %}
-              </Values>
-            </QueryStringConfig>
-            {% endif %}
-            {% if "SourceIpConfig" in condition %}
-            <SourceIpConfig>
-              <Values>
-                {% for value in condition["SourceIpConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </SourceIpConfig>
-            {% endif %}
-            {% if "PathPatternConfig" in condition %}
-            <PathPatternConfig>
-              <Values>
-                {% for value in condition["PathPatternConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </PathPatternConfig>
-            {% endif %}
-            {% if "HostHeaderConfig" in condition %}
-            <HostHeaderConfig>
-              <Values>
-                {% for value in condition["HostHeaderConfig"]["Values"] %}
-                <member>{{ value }}</member>
-                {% endfor %}
-              </Values>
-            </HostHeaderConfig>
-            {% endif %}
-          </member>
-          {% endfor %}
-        </Conditions>
-        <Priority>{{ rule.priority }}</Priority>
-        <RuleArn>{{ rule.arn }}</RuleArn>
-        <Actions>
-          {% for action in rule.actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </Actions>
-      </member>
-      {% endfor %}
-    </Rules>
-  </SetRulePrioritiesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</SetRulePrioritiesResponse>"""
-
-DESCRIBE_LIMITS_TEMPLATE = """<DescribeAccountLimitsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeAccountLimitsResult>
-    <Limits>
-      {% for key, value in limits.items() %}
-      <member>
-        <Name>{{ key }}</Name>
-        <Max>{{ value }}</Max>
-      </member>
-      {% endfor %}
-    </Limits>
-  </DescribeAccountLimitsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeAccountLimitsResponse>"""
-
-DESCRIBE_SSL_POLICIES_TEMPLATE = """<DescribeSSLPoliciesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeSSLPoliciesResult>
-    <SslPolicies>
-      {% for policy in policies %}
-      <member>
-        <Name>{{ policy['name'] }}</Name>
-        <Ciphers>
-          {% for cipher in policy['ciphers'] %}
-          <member>
-            <Name>{{ cipher['name'] }}</Name>
-            <Priority>{{ cipher['priority'] }}</Priority>
-          </member>
-          {% endfor %}
-        </Ciphers>
-        <SslProtocols>
-          {% for proto in policy['ssl_protocols'] %}
-          <member>{{ proto }}</member>
-          {% endfor %}
-        </SslProtocols>
-      </member>
-      {% endfor %}
-    </SslPolicies>
-  </DescribeSSLPoliciesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeSSLPoliciesResponse>"""
-
-SET_IP_ADDRESS_TYPE_TEMPLATE = """<SetIpAddressTypeResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <SetIpAddressTypeResult>
-    <IpAddressType>{{ ip_type }}</IpAddressType>
-  </SetIpAddressTypeResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</SetIpAddressTypeResponse>"""
-
-SET_SECURITY_GROUPS_TEMPLATE = """<SetSecurityGroupsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <SetSecurityGroupsResult>
-    <SecurityGroupIds>
-      {% for group in sec_groups %}
-      <member>{{ group }}</member>
-      {% endfor %}
-    </SecurityGroupIds>
-  </SetSecurityGroupsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</SetSecurityGroupsResponse>"""
-
-SET_SUBNETS_TEMPLATE = """<SetSubnetsResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <SetSubnetsResult>
-    <AvailabilityZones>
-      {% for zone_id, subnet_id in subnets.items() %}
-      <member>
-        <SubnetId>{{ subnet_id }}</SubnetId>
-        <ZoneName>{{ zone_id }}</ZoneName>
-      </member>
-      {% endfor %}
-    </AvailabilityZones>
-  </SetSubnetsResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</SetSubnetsResponse>"""
-
-MODIFY_LOADBALANCER_ATTRS_TEMPLATE = """<ModifyLoadBalancerAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ModifyLoadBalancerAttributesResult>
-    <Attributes>
-      {% for key, value in attrs.items() %}
-      <member>
-        {% if value == None %}<Value />{% else %}<Value>{{ value }}</Value>{% endif %}
-        <Key>{{ key }}</Key>
-      </member>
-      {% endfor %}
-    </Attributes>
-  </ModifyLoadBalancerAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ModifyLoadBalancerAttributesResponse>"""
-
-DESCRIBE_LOADBALANCER_ATTRS_TEMPLATE = """<DescribeLoadBalancerAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeLoadBalancerAttributesResult>
-    <Attributes>
-      {% for key, value in attrs.items() %}
-      <member>
-        {% if value == None %}<Value />{% else %}<Value>{{ value }}</Value>{% endif %}
-        <Key>{{ key }}</Key>
-      </member>
-      {% endfor %}
-    </Attributes>
-  </DescribeLoadBalancerAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeLoadBalancerAttributesResponse>"""
-
-
-MODIFY_TARGET_GROUP_TEMPLATE = """<ModifyTargetGroupResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ModifyTargetGroupResult>
-    <TargetGroups>
-      <member>
-        <TargetGroupArn>{{ target_group.arn }}</TargetGroupArn>
-        <TargetGroupName>{{ target_group.name }}</TargetGroupName>
-        <Protocol>{{ target_group.protocol }}</Protocol>
-        {% if target_group.port %}<Port>{{ target_group.port }}</Port>{% endif %}
-        <VpcId>{{ target_group.vpc_id }}</VpcId>
-        <HealthCheckProtocol>{{ target_group.healthcheck_protocol }}</HealthCheckProtocol>
-        {% if target_group.healthcheck_port %}<HealthCheckPort>{{ target_group.healthcheck_port }}</HealthCheckPort>{% endif %}
-        <HealthCheckPath>{{ target_group.healthcheck_path }}</HealthCheckPath>
-        <HealthCheckIntervalSeconds>{{ target_group.healthcheck_interval_seconds }}</HealthCheckIntervalSeconds>
-        <HealthCheckTimeoutSeconds>{{ target_group.healthcheck_timeout_seconds }}</HealthCheckTimeoutSeconds>
-        <HealthyThresholdCount>{{ target_group.healthy_threshold_count }}</HealthyThresholdCount>
-        <UnhealthyThresholdCount>{{ target_group.unhealthy_threshold_count }}</UnhealthyThresholdCount>
-        {% if target_group.protocol in ["HTTP", "HTTPS"] %}
-        <Matcher>
-          <HttpCode>{{ target_group.matcher['HttpCode'] }}</HttpCode>
-        </Matcher>
-        {% endif %}
-        <LoadBalancerArns>
-          {% for load_balancer_arn in target_group.load_balancer_arns %}
-          <member>{{ load_balancer_arn }}</member>
-          {% endfor %}
-        </LoadBalancerArns>
-      </member>
-    </TargetGroups>
-  </ModifyTargetGroupResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ModifyTargetGroupResponse>"""
-
-MODIFY_LISTENER_TEMPLATE = """<ModifyListenerResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ModifyListenerResult>
-    <Listeners>
-      <member>
-        <LoadBalancerArn>{{ listener.load_balancer_arn }}</LoadBalancerArn>
-        <Protocol>{{ listener.protocol }}</Protocol>
-        {% if listener.certificates %}
-        <Certificates>
-          {% for cert in listener.certificates %}
-          <member>
-            <CertificateArn>{{ cert["certificate_arn"] }}</CertificateArn>
-          </member>
-          {% endfor %}
-        </Certificates>
-        {% endif %}
-        <Port>{{ listener.port }}</Port>
-        <SslPolicy>{{ listener.ssl_policy }}</SslPolicy>
-        <ListenerArn>{{ listener.arn }}</ListenerArn>
-        <DefaultActions>
-          {% for action in listener.default_actions %}
-          <member>
-            {{ action.to_xml() }}
-          </member>
-          {% endfor %}
-        </DefaultActions>
-      </member>
-    </Listeners>
-  </ModifyListenerResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ModifyListenerResponse>"""
-
-ADD_LISTENER_CERTIFICATES_TEMPLATE = """<AddListenerCertificatesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <AddListenerCertificatesResult>
-    <Certificates>
-      {% for cert in certificates %}
-      <member>
-        <CertificateArn>{{ cert }}</CertificateArn>
-      </member>
-      {% endfor %}
-    </Certificates>
-  </AddListenerCertificatesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</AddListenerCertificatesResponse>"""
-
-DESCRIBE_LISTENER_CERTIFICATES_TEMPLATE = """<DescribeListenerCertificatesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeListenerCertificatesResult>
-    <Certificates>
-      {% for cert in certificates %}
-      <member>
-        <CertificateArn>{{ cert }}</CertificateArn>
-      </member>
-      {% endfor %}
-    </Certificates>
-  </DescribeListenerCertificatesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeListenerCertificatesResponse>"""
-
-REMOVE_LISTENER_CERTIFICATES_TEMPLATE = """<RemoveListenerCertificatesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <RemoveListenerCertificatesResult />
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</RemoveListenerCertificatesResponse>"""
-
-DESCRIBE_LISTENER_ATTRIBUTES = """<DescribeListenerAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeListenerAttributesResult>
-    <Attributes>
-      {% for attr, value in attributes.items() %}
-      <ListenerAttribute>
-        <Key>{{ attr }}</Key>
-        <Value>{{ value }}</Value>
-      </ListenerAttribute>
-      {% endfor %}
-    </Attributes>
-  </DescribeListenerAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeListenerAttributesResponse>"""
-
-MODIFY_LISTENER_ATTRIBUTES = """<ModifyListenerAttributesResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <ModifyListenerAttributesResult>
-    <Attributes>
-      {% for attr, value in attributes.items() %}
-      <ListenerAttribute>
-        <Key>{{ attr }}</Key>
-        <Value>{{ value }}</Value>
-      </ListenerAttribute>
-      {% endfor %}
-    </Attributes>
-  </ModifyListenerAttributesResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</ModifyListenerAttributesResponse>"""
-
-DESCRIBE_CAPACITY_RESERVATION = """<DescribeCapacityReservationResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/">
-  <DescribeCapacityReservationResult>
-    <CapacityReservationState>
-      <item>
-        <State>
-          <code>provisioned</code>
-        </State>
-      </item>
-    </CapacityReservationState>
-  </DescribeCapacityReservationResult>
-  <ResponseMetadata>
-    <RequestId>{{ request_id }}</RequestId>
-  </ResponseMetadata>
-</DescribeCapacityReservationResponse>"""
+    def describe_capacity_reservation(self) -> ActionResult:
+        result = {"CapacityReservationState": ["provisioned"]}
+        return ActionResult(result)

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -2103,3 +2103,12 @@ def test_create_listener_with_alpn_policy():
 
     describe = conn.describe_listeners(ListenerArns=[listener_arn])["Listeners"][0]
     assert describe["AlpnPolicy"] == ["pol1", "pol2"]
+
+
+@mock_aws
+def test_describe_capacity_reservation():
+    lbs, _, _, _, _, conn = create_load_balancer()
+    load_balancer_arn = lbs["LoadBalancers"][0]["LoadBalancerArn"]
+    resp = conn.describe_capacity_reservation(LoadBalancerArn=load_balancer_arn)
+    for crs in resp["CapacityReservationState"]:
+        assert crs["State"]["Code"] == "provisioned"

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -173,7 +173,7 @@ def test_add_remove_tags():
             ResourceArns=[lb["LoadBalancerArn"]], Tags=[{"Key": "k", "Value": "b"}]
         )
     err = exc.value.response["Error"]
-    assert err["Code"] == "TooManyTagsError"
+    assert err["Code"] == "TooManyTags"
 
     conn.add_tags(
         ResourceArns=[lb["LoadBalancerArn"]], Tags=[{"Key": "j", "Value": "c"}]


### PR DESCRIPTION
Another fairly clean integration.  Model updates amounted to just renaming a few attributes and using `bool` and `int` instead of `str` where appropriate.  A couple response transformers were needed, but they are simple and easy to understand.

Outside of a single error code correction, all tests continue to pass with no modifications.

Note: this PR also contains some minor tweaks to the core request parsing code, all of which are detailed in individual atomic commits.