### PR TITLE
CloudFormation: integrate with core response serializer

### DIFF
--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -1,81 +1,67 @@
 from typing import Optional
 
-from jinja2 import Template
+from moto.core.exceptions import ServiceException
 
-from moto.core.exceptions import RESTError
+
+class CloudFormationError(ServiceException):
+    pass
 
 
 class UnformattedGetAttTemplateException(Exception):
-    description = (
+    message = (
         "Template error: resource {0} does not support attribute type {1} in Fn::GetAtt"
     )
     status_code = 400
 
 
-class ValidationError(RESTError):
+class AlreadyExistsException(CloudFormationError):
+    code = "AlreadyExistsException"
+
+
+class ValidationError(CloudFormationError):
+    code = "ValidationError"
+
     def __init__(self, name_or_id: Optional[str] = None, message: Optional[str] = None):
+        # FIXME: This is an abomination.
+        #  The "stack does not exist" message should be provided by the caller, not here.
         if message is None:
             message = f"Stack with id {name_or_id} does not exist"
-
-        template = Template(ERROR_RESPONSE)
-        super().__init__(error_type="ValidationError", message=message)
-        self.description = template.render(code="ValidationError", message=message)
+        super().__init__(message)
 
 
-class MissingParameterError(RESTError):
+class MissingParameterError(CloudFormationError):
+    code = "Missing Parameter"
+
     def __init__(self, parameter_name: str):
-        template = Template(ERROR_RESPONSE)
         message = f"Missing parameter {parameter_name}"
-        super().__init__(error_type="ValidationError", message=message)
-        self.description = template.render(code="Missing Parameter", message=message)
+        super().__init__(message)
 
 
-class ExportNotFound(RESTError):
-    """Exception to raise if a template tries to import a non-existent export"""
+class ExportNotFound(CloudFormationError):
+    code = "ExportNotFound"
 
     def __init__(self, export_name: str):
-        template = Template(ERROR_RESPONSE)
         message = f"No export named {export_name} found."
-        super().__init__(error_type="ExportNotFound", message=message)
-        self.description = template.render(code="ExportNotFound", message=message)
+        super().__init__(message)
 
 
-class StackSetNotEmpty(RESTError):
-    def __init__(self) -> None:
-        template = Template(ERROR_RESPONSE)
-        message = "StackSet is not empty"
-        super().__init__(error_type="StackSetNotEmptyException", message=message)
-        self.description = template.render(
-            code="StackSetNotEmptyException", message=message
-        )
+class StackSetNotEmpty(CloudFormationError):
+    code = "StackSetNotEmptyException"
+    message = "StackSet is not empty"
 
 
-class StackSetNotFoundException(RESTError):
+class StackSetNotFoundException(CloudFormationError):
+    code = "StackSetNotFoundException"
+
     def __init__(self, name: str):
-        template = Template(ERROR_RESPONSE)
         message = f"StackSet {name} not found"
-        super().__init__(error_type="StackSetNotFoundException", message=message)
-        self.description = template.render(
-            code="StackSetNotFoundException", message=message
-        )
+        super().__init__(message)
 
 
-class UnsupportedAttribute(ValidationError):
+class UnsupportedAttribute(CloudFormationError):
+    code = "ValidationError"
+
     def __init__(self, resource: str, attr: str):
-        template = Template(ERROR_RESPONSE)
-        super().__init__()
-        self.description = template.render(
-            code="ValidationError",
-            message=f"Template error: resource {resource} does not support attribute type {attr} in Fn::GetAtt",
+        super().__init__(
+            f"Template error: resource {resource} does not support attribute type {attr} in Fn::GetAtt"
         )
-
-
-ERROR_RESPONSE = """<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
-  <Error>
-    <Type>Sender</Type>
-    <Code>{{ code }}</Code>
-    <Message>{{ message }}</Message>
-  </Error>
-  <RequestId>cf4c737e-5ae2-11e4-a7c9-ad44eEXAMPLE</RequestId>
-</ErrorResponse>
-"""

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -8,7 +8,7 @@ class CloudFormationError(ServiceException):
 
 
 class UnformattedGetAttTemplateException(Exception):
-    message = (
+    description = (
         "Template error: resource {0} does not support attribute type {1} in Fn::GetAtt"
     )
     status_code = 400

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -22,8 +22,7 @@ class ValidationError(CloudFormationError):
     code = "ValidationError"
 
     def __init__(self, name_or_id: Optional[str] = None, message: Optional[str] = None):
-        # FIXME: This is an abomination.
-        #  The "stack does not exist" message should be provided by the caller, not here.
+        # FIXME: The "stack does not exist" message should be provided by the caller, not here.
         if message is None:
             message = f"Stack with id {name_or_id} does not exist"
         super().__init__(message)

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -20,7 +20,12 @@ from moto.sns.models import sns_backends
 from moto.utilities.utils import get_partition
 
 from .custom_model import CustomModel
-from .exceptions import StackSetNotEmpty, StackSetNotFoundException, ValidationError
+from .exceptions import (
+    AlreadyExistsException,
+    StackSetNotEmpty,
+    StackSetNotFoundException,
+    ValidationError,
+)
 from .parsing import Export, Output, OutputMap, ResourceMap
 from .utils import (
     generate_changeset_id,
@@ -970,6 +975,8 @@ class CloudFormationBackend(BaseBackend):
         """
         The functionality behind EnableTerminationProtection is not yet implemented.
         """
+        if name in [stack.name for stack in self.stacks.values()]:
+            raise AlreadyExistsException(f"Stack {name} already exists")
         stack_id = generate_stack_id(name, self.region_name, self.account_id)
         new_stack = FakeStack(
             stack_id=stack_id,

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -79,6 +79,22 @@ class StackSet(BaseModel):
         self.operations: List[Dict[str, Any]] = []
         self.permission_model = permission_model or "SELF_MANAGED"
 
+    @property
+    def administration_role_arn(self) -> str:
+        return self.admin_role
+
+    @property
+    def template_body(self) -> str:
+        return self.template
+
+    @property
+    def execution_role_name(self) -> str:
+        return self.execution_role
+
+    @property
+    def managed_execution(self) -> Dict[str, Any]:
+        return {"Active": False}
+
     def _create_operation(
         self,
         operation_id: str,

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -59,11 +59,13 @@ class StackSet(BaseModel):
         self.description = description
         self.parameters = parameters
         self.tags = tags
-        self.admin_role = (
+        self.administration_role_arn = (
             admin_role
             or f"arn:{get_partition(region)}:iam::{account_id}:role/AWSCloudFormationStackSetAdministrationRole"
         )
-        self.execution_role = execution_role or "AWSCloudFormationStackSetExecutionRole"
+        self.execution_role_name = (
+            execution_role or "AWSCloudFormationStackSetExecutionRole"
+        )
         self.status = "ACTIVE"
         self.instances = StackInstances(
             account_id=account_id,
@@ -78,16 +80,8 @@ class StackSet(BaseModel):
         self.permission_model = permission_model or "SELF_MANAGED"
 
     @property
-    def administration_role_arn(self) -> str:
-        return self.admin_role
-
-    @property
     def template_body(self) -> str:
         return self.template
-
-    @property
-    def execution_role_name(self) -> str:
-        return self.execution_role
 
     @property
     def managed_execution(self) -> Dict[str, Any]:
@@ -147,8 +141,8 @@ class StackSet(BaseModel):
         self.description = description if description is not None else self.description
         self.parameters = parameters or self.parameters
         self.tags = tags or self.tags
-        self.admin_role = admin_role or self.admin_role
-        self.execution_role = execution_role or self.execution_role
+        self.administration_role_arn = admin_role or self.administration_role_arn
+        self.execution_role_name = execution_role or self.execution_role_name
 
         if accounts and regions:
             self.update_instances(accounts, regions, self.parameters)  # type: ignore[arg-type]

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -394,7 +394,7 @@ class StackInstances(BaseModel):
 class Stack(CloudFormationModel):
     class Meta:
         serialization_aliases = {
-            "Parameters": "stack_parameters",
+            "Parameters": "parameter_list",
         }
 
     def __init__(
@@ -502,7 +502,7 @@ class Stack(CloudFormationModel):
             return json.loads(template)
 
     @property
-    def stack_parameters(self) -> List[Dict[str, Any]]:  # type: ignore[misc]
+    def parameter_list(self) -> List[Dict[str, Any]]:  # type: ignore[misc]
         parameters = [
             {
                 "ParameterKey": k,
@@ -513,6 +513,10 @@ class Stack(CloudFormationModel):
             for k, v in self.resource_map.resolved_parameters.items()
         ]
         return parameters
+
+    @property
+    def stack_parameters(self) -> Dict[str, Any]:  # type: ignore[misc]
+        return self.resource_map.resolved_parameters
 
     @property
     def stack_resources(self) -> Iterable[Type[CloudFormationModel]]:

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from collections import OrderedDict
 from datetime import timedelta
@@ -614,7 +616,7 @@ class Stack(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Stack":
+    ) -> Stack:
         cf_backend: CloudFormationBackend = cloudformation_backends[account_id][
             region_name
         ]
@@ -639,7 +641,7 @@ class Stack(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "Stack":
+    ) -> Stack:
         cls.delete_from_cloudformation_json(
             original_resource.name, cloudformation_json, account_id, region_name
         )

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1,6 +1,6 @@
 import json
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import yaml
@@ -9,11 +9,7 @@ from yaml.scanner import ScannerError
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
-from moto.core.utils import (
-    iso_8601_datetime_with_milliseconds,
-    iso_8601_datetime_without_milliseconds,
-    utcnow,
-)
+from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.moto_api._internal import mock_random
 from moto.organizations.models import OrganizationsBackend, organizations_backends
 from moto.sns.models import sns_backends
@@ -109,10 +105,8 @@ class StackSet(BaseModel):
             "OperationId": operation_id,
             "Action": action,
             "Status": status,
-            "CreationTimestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%f"),
-            "EndTimestamp": (datetime.now() + timedelta(minutes=2)).strftime(
-                "%Y-%m-%dT%H:%M:%S.%f"
-            ),
+            "CreationTimestamp": utcnow(),
+            "EndTimestamp": utcnow() + timedelta(minutes=2),
             "Instances": [
                 {account: region} for account in accounts for region in regions
             ],
@@ -474,10 +468,6 @@ class Stack(CloudFormationModel):
     def _create_output_map(self) -> OutputMap:
         return OutputMap(self.resource_map, self.template_dict, self.stack_id)
 
-    @property
-    def creation_time_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.creation_time)
-
     def _add_stack_event(
         self,
         resource_status: str,
@@ -720,10 +710,6 @@ class FakeChangeSet(BaseModel):
             self.template_dict = yaml.load(self.template, Loader=yaml.Loader)
         except (ParserError, ScannerError):
             self.template_dict = json.loads(self.template)
-
-    @property
-    def creation_time_iso_8601(self) -> str:
-        return iso_8601_datetime_without_milliseconds(self.creation_time)
 
     def diff(self) -> List[FakeChange]:
         changes = []

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -546,6 +546,10 @@ class Stack(CloudFormationModel):
     def exports(self) -> List[Export]:
         return self.output_map.exports
 
+    @property
+    def template_description(self) -> Optional[str]:
+        return self.template_dict.get("Description")
+
     def add_custom_resource(self, custom_resource: CustomModel) -> None:
         self.custom_resources[custom_resource.logical_id] = custom_resource
 

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -34,7 +34,7 @@ from .utils import (
 )
 
 
-class FakeStackSet(BaseModel):
+class StackSet(BaseModel):
     def __init__(
         self,
         stackset_id: str,
@@ -760,7 +760,7 @@ class CloudFormationBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.stacks: Dict[str, FakeStack] = OrderedDict()
-        self.stacksets: Dict[str, FakeStackSet] = OrderedDict()
+        self.stacksets: Dict[str, StackSet] = OrderedDict()
         self.deleted_stacks: Dict[str, FakeStack] = {}
         self.exports: Dict[str, Export] = OrderedDict()
         self.change_sets: Dict[str, FakeChangeSet] = OrderedDict()
@@ -776,7 +776,7 @@ class CloudFormationBackend(BaseBackend):
 
     def _resolve_update_parameters(
         self,
-        instance: Union[FakeStack, FakeStackSet],
+        instance: Union[FakeStack, StackSet],
         incoming_params: List[Dict[str, str]],
     ) -> Dict[str, str]:
         parameters = dict(
@@ -810,12 +810,12 @@ class CloudFormationBackend(BaseBackend):
         admin_role: Optional[str],
         exec_role: Optional[str],
         description: Optional[str],
-    ) -> FakeStackSet:
+    ) -> StackSet:
         """
         The following parameters are not yet implemented: StackId, AdministrationRoleARN, AutoDeployment, ExecutionRoleName, CallAs, ClientRequestToken, ManagedExecution
         """
         stackset_id = generate_stackset_id(name)
-        new_stackset = FakeStackSet(
+        new_stackset = StackSet(
             stackset_id=stackset_id,
             account_id=self.account_id,
             name=name,
@@ -831,7 +831,7 @@ class CloudFormationBackend(BaseBackend):
         self.stacksets[stackset_id] = new_stackset
         return new_stackset
 
-    def describe_stack_set(self, name: str) -> FakeStackSet:
+    def describe_stack_set(self, name: str) -> StackSet:
         stacksets = self.stacksets.keys()
         if name in stacksets and self.stacksets[name].status != "DELETED":
             return self.stacksets[name]
@@ -844,7 +844,7 @@ class CloudFormationBackend(BaseBackend):
         raise StackSetNotFoundException(name)
 
     def delete_stack_set(self, name: str) -> None:
-        stackset_to_delete: Optional[FakeStackSet] = None
+        stackset_to_delete: Optional[StackSet] = None
         if name in self.stacksets:
             stackset_to_delete = self.stacksets[name]
         for stackset in self.stacksets.values():
@@ -857,7 +857,7 @@ class CloudFormationBackend(BaseBackend):
             # We don't remove StackSets from the list - they still show up when calling list_stack_sets
             stackset_to_delete.delete()
 
-    def list_stack_sets(self) -> Iterable[FakeStackSet]:
+    def list_stack_sets(self) -> Iterable[StackSet]:
         return self.stacksets.values()
 
     def list_stack_set_operations(self, stackset_name: str) -> List[Dict[str, Any]]:
@@ -870,7 +870,7 @@ class CloudFormationBackend(BaseBackend):
 
     def describe_stack_set_operation(
         self, stackset_name: str, operation_id: str
-    ) -> Tuple[FakeStackSet, Dict[str, Any]]:
+    ) -> Tuple[StackSet, Dict[str, Any]]:
         stackset = self.describe_stack_set(stackset_name)
         operation = stackset.get_operation(operation_id)
         return stackset, operation
@@ -947,7 +947,7 @@ class CloudFormationBackend(BaseBackend):
 
     def delete_stack_instances(
         self, stackset_name: str, accounts: List[str], regions: List[str]
-    ) -> FakeStackSet:
+    ) -> StackSet:
         """
         The following parameters are not  yet implemented: DeploymentTargets, OperationPreferences, RetainStacks, OperationId, CallAs
         """

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -554,11 +554,11 @@ class CloudFormationResponse(BaseResponse):
         result = {"Summaries": stacksets}
         return ActionResult(result)
 
-    def list_stack_instances(self) -> str:
+    def list_stack_instances(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
         instances = self.cloudformation_backend.list_stack_instances(stackset_name)
-        template = self.response_template(LIST_STACK_INSTANCES_TEMPLATE)
-        return template.render(instances=instances)
+        result = {"Summaries": instances}
+        return ActionResult(result)
 
     def list_stack_set_operations(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
@@ -1003,27 +1003,6 @@ DESCRIBE_STACK_SET_RESPONSE_TEMPLATE = """<DescribeStackSetResponse xmlns="http:
     <RequestId>d8b64e11-5332-46e1-9603-example</RequestId>
   </ResponseMetadata>
 </DescribeStackSetResponse>"""
-
-
-LIST_STACK_INSTANCES_TEMPLATE = """<ListStackInstancesResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
-  <ListStackInstancesResult>
-    <Summaries>
-    {% for instance in instances %}
-      <member>
-        <StackId>{{ instance["StackId"] }}</StackId>
-        <StackSetId>{{ instance["StackSetId"] }}</StackSetId>
-        <Region>{{ instance["Region"] }}</Region>
-        <Account>{{ instance["Account"] }}</Account>
-        <Status>{{ instance["Status"] }}</Status>
-      </member>
-    {% endfor %}
-    </Summaries>
-  </ListStackInstancesResult>
-  <ResponseMetadata>
-    <RequestId>83c27e73-b498-410f-993c-example</RequestId>
-  </ResponseMetadata>
-</ListStackInstancesResponse>
-"""
 
 
 DESCRIBE_STACK_INSTANCE_TEMPLATE = """<DescribeStackInstanceResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -294,10 +294,10 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(DESCRIBE_STACK_EVENTS_RESPONSE)
         return template.render(events=events)
 
-    def list_change_sets(self) -> str:
+    def list_change_sets(self) -> ActionResult:
         change_sets = self.cloudformation_backend.list_change_sets()
-        template = self.response_template(LIST_CHANGE_SETS_RESPONSE)
-        return template.render(change_sets=change_sets)
+        result = {"Summaries": change_sets}
+        return ActionResult(result)
 
     def list_stacks(self) -> ActionResult:
         status_filter = self._get_multi_param("StackStatusFilter.member")
@@ -884,26 +884,6 @@ DESCRIBE_STACK_EVENTS_RESPONSE = """<DescribeStackEventsResponse xmlns="http://c
     <RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
   </ResponseMetadata>
 </DescribeStackEventsResponse>"""
-
-LIST_CHANGE_SETS_RESPONSE = """<ListChangeSetsResponse>
- <ListChangeSetsResult>
-  <Summaries>
-    {% for change_set in change_sets %}
-    <member>
-        <StackId>{{ change_set.stack_id }}</StackId>
-        <StackName>{{ change_set.stack_name }}</StackName>
-        <ChangeSetId>{{ change_set.change_set_id }}</ChangeSetId>
-        <ChangeSetName>{{ change_set.change_set_name }}</ChangeSetName>
-        <ExecutionStatus>{{ change_set.execution_status }}</ExecutionStatus>
-        <Status>{{ change_set.status }}</Status>
-        <StatusReason>{{ change_set.status_reason }}</StatusReason>
-        <CreationTime>2011-05-23T15:47:44Z</CreationTime>
-        <Description>{{ change_set.description }}</Description>
-    </member>
-    {% endfor %}
-  </Summaries>
- </ListChangeSetsResult>
-</ListChangeSetsResponse>"""
 
 
 DESCRIBE_STACK_SET_RESPONSE_TEMPLATE = """<DescribeStackSetResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -571,7 +571,7 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(DESCRIBE_STACK_SET_RESPONSE_TEMPLATE)
         return template.render(stackset=stackset)
 
-    def describe_stack_instance(self) -> str:
+    def describe_stack_instance(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
         account = self._get_param("StackInstanceAccount")
         region = self._get_param("StackInstanceRegion")
@@ -579,9 +579,8 @@ class CloudFormationResponse(BaseResponse):
         instance = self.cloudformation_backend.describe_stack_instance(
             stackset_name, account, region
         )
-        template = self.response_template(DESCRIBE_STACK_INSTANCE_TEMPLATE)
-        rendered = template.render(instance=instance)
-        return rendered
+        result = {"StackInstance": instance}
+        return ActionResult(result)
 
     def list_stack_sets(self) -> ActionResult:
         stacksets = self.cloudformation_backend.list_stack_sets()
@@ -879,61 +878,3 @@ DESCRIBE_STACK_SET_RESPONSE_TEMPLATE = """<DescribeStackSetResponse xmlns="http:
     <RequestId>d8b64e11-5332-46e1-9603-example</RequestId>
   </ResponseMetadata>
 </DescribeStackSetResponse>"""
-
-
-DESCRIBE_STACK_INSTANCE_TEMPLATE = """<DescribeStackInstanceResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
-  <DescribeStackInstanceResult>
-    <StackInstance>
-      <StackId>{{ instance["StackId"] }}</StackId>
-      <StackSetId>{{ instance["StackSetId"] }}</StackSetId>
-    {% if instance["ParameterOverrides"] %}
-      <ParameterOverrides>
-      {% for override in instance["ParameterOverrides"] %}
-      {% if override['ParameterKey'] or override['ParameterValue'] %}
-        <member>
-          <ParameterKey>{{ override["ParameterKey"] }}</ParameterKey>
-          <UsePreviousValue>false</UsePreviousValue>
-          <ParameterValue>{{ override["ParameterValue"] }}</ParameterValue>
-        </member>
-      {% endif %}
-      {% endfor %}
-      </ParameterOverrides>
-    {% else %}
-      <ParameterOverrides/>
-    {% endif %}
-      <Region>{{ instance["Region"] }}</Region>
-      <Account>{{ instance["Account"] }}</Account>
-      <Status>{{ instance["Status"] }}</Status>
-      <StackInstanceStatus>
-          <DetailedStatus>{{ instance["StackInstanceStatus"]["DetailedStatus"] }}</DetailedStatus>
-      </StackInstanceStatus>
-    </StackInstance>
-  </DescribeStackInstanceResult>
-  <ResponseMetadata>
-    <RequestId>c6c7be10-0343-4319-8a25-example</RequestId>
-  </ResponseMetadata>
-</DescribeStackInstanceResponse>
-"""
-
-
-DESCRIBE_STACKSET_OPERATION_RESPONSE_TEMPLATE = """<DescribeStackSetOperationResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
-  <DescribeStackSetOperationResult>
-    <StackSetOperation>
-      <ExecutionRoleName>{{ stackset.execution_role }}</ExecutionRoleName>
-      <AdministrationRoleARN>{{ stackset.admin_role }}</AdministrationRoleARN>
-      <StackSetId>{{ stackset.id }}</StackSetId>
-      <CreationTimestamp>{{ operation.CreationTimestamp }}</CreationTimestamp>
-      <OperationId>{{ operation.OperationId }}</OperationId>
-      <Action>{{ operation.Action }}</Action>
-      <OperationPreferences>
-        <RegionOrder/>
-      </OperationPreferences>
-      <EndTimestamp>{{ operation.EndTimestamp }}</EndTimestamp>
-      <Status>{{ operation.Status }}</Status>
-    </StackSetOperation>
-  </DescribeStackSetOperationResult>
-  <ResponseMetadata>
-    <RequestId>2edc27b6-9ce2-486a-a192-example</RequestId>
-  </ResponseMetadata>
-</DescribeStackSetOperationResponse>
-"""

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -303,26 +303,12 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(LIST_STACKS_RESOURCES_RESPONSE)
         return template.render(resources=resources)
 
-    def get_template(self) -> str:
+    def get_template(self) -> ActionResult:
         name_or_stack_id = self.querystring.get("StackName")[0]  # type: ignore[index]
         stack_template = self.cloudformation_backend.get_template(name_or_stack_id)
 
-        if self.request_json:
-            return json.dumps(
-                {
-                    "GetTemplateResponse": {
-                        "GetTemplateResult": {
-                            "TemplateBody": stack_template,
-                            "ResponseMetadata": {
-                                "RequestId": "2d06e36c-ac1d-11e0-a958-f9382b6eb86bEXAMPLE"
-                            },
-                        }
-                    }
-                }
-            )
-        else:
-            template = self.response_template(GET_TEMPLATE_RESPONSE_TEMPLATE)
-            return template.render(stack_template=stack_template)
+        result = {"TemplateBody": stack_template}
+        return ActionResult(result)
 
     def get_template_summary(self) -> str:
         stack_name = self._get_param("StackName")
@@ -933,15 +919,6 @@ LIST_STACKS_RESOURCES_RESPONSE = """<ListStackResourcesResponse>
     <RequestId>2d06e36c-ac1d-11e0-a958-f9382b6eb86b</RequestId>
   </ResponseMetadata>
 </ListStackResourcesResponse>"""
-
-GET_TEMPLATE_RESPONSE_TEMPLATE = """<GetTemplateResponse>
-  <GetTemplateResult>
-    <TemplateBody>{{ stack_template }}</TemplateBody>
-  </GetTemplateResult>
-  <ResponseMetadata>
-    <RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
-  </ResponseMetadata>
-</GetTemplateResponse>"""
 
 
 DESCRIBE_STACK_SET_RESPONSE_TEMPLATE = """<DescribeStackSetResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -22,7 +22,7 @@ class StackResourceDTO:
         # FIXME: None of these attributes are part of CloudFormationModel interface...
         self.logical_resource_id = getattr(resource, "logical_resource_id", None)
         self.physical_resource_id = getattr(resource, "physical_resource_id", None)
-        self.resource_type = getattr(resource, "type", None)
+        self.resource_type = getattr(resource, "resource_type", None)
         self.stack_status = stack.status
         self.creation_time = stack.creation_time
         self.timestamp = "2010-07-27T22:27:28Z"  # Hardcoded in original XML template.
@@ -367,7 +367,7 @@ class CloudFormationResponse(BaseResponse):
                     "LogicalResourceId": getattr(resource, "logical_resource_id", ""),
                     "LastUpdateTimestamp": "2011-06-21T20:15:58Z",
                     "PhysicalResourceId": getattr(resource, "physical_resource_id", ""),
-                    "ResourceType": getattr(resource, "type", ""),
+                    "ResourceType": getattr(resource, "resource_type", ""),
                 }
                 for resource in resources
             ]

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -427,7 +427,7 @@ class CloudFormationResponse(BaseResponse):
         result = {"Exports": exports, "NextToken": next_token}
         return ActionResult(result)
 
-    def validate_template(self) -> str:
+    def validate_template(self) -> ActionResult:
         template_body = self._get_param("TemplateBody")
         template_url = self._get_param("TemplateURL")
         if template_url:
@@ -445,8 +445,13 @@ class CloudFormationResponse(BaseResponse):
             description = yaml.load(template_body, Loader=yaml.Loader)["Description"]
         except (ParserError, ScannerError, KeyError):
             pass
-        template = self.response_template(VALIDATE_STACK_RESPONSE_TEMPLATE)
-        return template.render(description=description)
+        result = {
+            "Description": description,
+            "Parameters": [],
+            "Capabilities": [],
+            "DeclaredTransforms": [],
+        }
+        return ActionResult(result)
 
     def create_stack_set(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
@@ -669,17 +674,6 @@ class CloudFormationResponse(BaseResponse):
             stack_name, policy_body=policy_body
         )
         return EmptyResult()
-
-
-VALIDATE_STACK_RESPONSE_TEMPLATE = """<ValidateTemplateResponse>
-        <ValidateTemplateResult>
-        <Capabilities></Capabilities>
-<CapabilitiesReason></CapabilitiesReason>
-<DeclaredTransforms></DeclaredTransforms>
-<Description>{{ description }}</Description>
-<Parameters></Parameters>
-</ValidateTemplateResult>
-</ValidateTemplateResponse>"""
 
 
 DESCRIBE_CHANGE_SET_RESPONSE_TEMPLATE = """<DescribeChangeSetResponse>

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -680,7 +680,7 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(GET_STACK_POLICY_RESPONSE)
         return template.render(policy=policy)
 
-    def set_stack_policy(self) -> str:
+    def set_stack_policy(self) -> ActionResult:
         stack_name = self._get_param("StackName")
         policy_url = self._get_param("StackPolicyURL")
         policy_body = self._get_param("StackPolicyBody")
@@ -698,7 +698,7 @@ class CloudFormationResponse(BaseResponse):
         self.cloudformation_backend.set_stack_policy(
             stack_name, policy_body=policy_body
         )
-        return SET_STACK_POLICY_RESPONSE
+        return EmptyResult()
 
 
 VALIDATE_STACK_RESPONSE_TEMPLATE = """<ValidateTemplateResponse>
@@ -1294,12 +1294,6 @@ GET_TEMPLATE_SUMMARY_TEMPLATE = """<GetTemplateSummaryResponse xmlns="http://clo
   </ResponseMetadata>
 </GetTemplateSummaryResponse>
 """
-
-SET_STACK_POLICY_RESPONSE = """<SetStackPolicyResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
-  <ResponseMetadata>
-    <RequestId>abe48993-e23f-4167-b703-5b0f1b6aa84f</RequestId>
-  </ResponseMetadata>
-</SetStackPolicyResponse>"""
 
 
 GET_STACK_POLICY_RESPONSE = """<GetStackPolicyResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -650,7 +650,7 @@ class CloudFormationResponse(BaseResponse):
     def get_stack_policy(self) -> ActionResult:
         stack_name = self._get_param("StackName")
         policy = self.cloudformation_backend.get_stack_policy(stack_name)
-        result = {"StackPolicyBody": policy}
+        result = {"StackPolicyBody": policy if policy else None}
         return ActionResult(result)
 
     def set_stack_policy(self) -> ActionResult:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -641,11 +641,11 @@ class CloudFormationResponse(BaseResponse):
         result = {"OperationId": operation["OperationId"]}
         return ActionResult(result)
 
-    def get_stack_policy(self) -> str:
+    def get_stack_policy(self) -> ActionResult:
         stack_name = self._get_param("StackName")
         policy = self.cloudformation_backend.get_stack_policy(stack_name)
-        template = self.response_template(GET_STACK_POLICY_RESPONSE)
-        return template.render(policy=policy)
+        result = {"StackPolicyBody": policy}
+        return ActionResult(result)
 
     def set_stack_policy(self) -> ActionResult:
         stack_name = self._get_param("StackName")
@@ -1185,15 +1185,3 @@ GET_TEMPLATE_SUMMARY_TEMPLATE = """<GetTemplateSummaryResponse xmlns="http://clo
   </ResponseMetadata>
 </GetTemplateSummaryResponse>
 """
-
-
-GET_STACK_POLICY_RESPONSE = """<GetStackPolicyResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
-  <GetStackPolicyResult>
-    {% if policy %}
-    <StackPolicyBody>{{ policy }}</StackPolicyBody>
-    {% endif %}
-  </GetStackPolicyResult>
-  <ResponseMetadata>
-    <RequestId>e9e39eb6-1c05-4f0e-958a-b63f420e0a07</RequestId>
-  </ResponseMetadata>
-</GetStackPolicyResponse>"""

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -287,12 +287,12 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(DESCRIBE_STACK_RESOURCES_RESPONSE)
         return template.render(stack=stack, resources=resources)
 
-    def describe_stack_events(self) -> str:
+    def describe_stack_events(self) -> ActionResult:
         stack_name = self._get_param("StackName")
         events = self.cloudformation_backend.describe_stack_events(stack_name)
 
-        template = self.response_template(DESCRIBE_STACK_EVENTS_RESPONSE)
-        return template.render(events=events)
+        result = {"StackEvents": events[::-1]}
+        return ActionResult(result)
 
     def list_change_sets(self) -> ActionResult:
         change_sets = self.cloudformation_backend.list_change_sets()
@@ -860,30 +860,6 @@ DESCRIBE_STACK_RESOURCES_RESPONSE = """<DescribeStackResourcesResponse>
       </StackResources>
     </DescribeStackResourcesResult>
 </DescribeStackResourcesResponse>"""
-
-DESCRIBE_STACK_EVENTS_RESPONSE = """<DescribeStackEventsResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
-  <DescribeStackEventsResult>
-    <StackEvents>
-      {% for event in events[::-1] %}
-      <member>
-        <Timestamp>{{ event.timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}</Timestamp>
-        <ResourceStatus>{{ event.resource_status }}</ResourceStatus>
-        <StackId>{{ event.stack_id }}</StackId>
-        <EventId>{{ event.event_id }}</EventId>
-        <LogicalResourceId>{{ event.logical_resource_id }}</LogicalResourceId>
-        {% if event.resource_status_reason %}<ResourceStatusReason>{{ event.resource_status_reason }}</ResourceStatusReason>{% endif %}
-        <StackName>{{ event.stack_name }}</StackName>
-        <PhysicalResourceId>{{ event.physical_resource_id }}</PhysicalResourceId>
-        {% if event.resource_properties %}<ResourceProperties>{{ event.resource_properties }}</ResourceProperties>{% endif %}
-        <ResourceType>{{ event.resource_type }}</ResourceType>
-      </member>
-      {% endfor %}
-    </StackEvents>
-  </DescribeStackEventsResult>
-  <ResponseMetadata>
-    <RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
-  </ResponseMetadata>
-</DescribeStackEventsResponse>"""
 
 
 DESCRIBE_STACK_SET_RESPONSE_TEMPLATE = """<DescribeStackSetResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -549,10 +549,10 @@ class CloudFormationResponse(BaseResponse):
         rendered = template.render(instance=instance)
         return rendered
 
-    def list_stack_sets(self) -> str:
+    def list_stack_sets(self) -> ActionResult:
         stacksets = self.cloudformation_backend.list_stack_sets()
-        template = self.response_template(LIST_STACK_SETS_TEMPLATE)
-        return template.render(stacksets=stacksets)
+        result = {"Summaries": stacksets}
+        return ActionResult(result)
 
     def list_stack_instances(self) -> str:
         stackset_name = self._get_param("StackSetName")
@@ -1058,24 +1058,6 @@ DESCRIBE_STACK_INSTANCE_TEMPLATE = """<DescribeStackInstanceResponse xmlns="http
     <RequestId>c6c7be10-0343-4319-8a25-example</RequestId>
   </ResponseMetadata>
 </DescribeStackInstanceResponse>
-"""
-
-LIST_STACK_SETS_TEMPLATE = """<ListStackSetsResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
-  <ListStackSetsResult>
-    <Summaries>
-    {% for stackset in stacksets %}
-      <member>
-        <StackSetName>{{ stackset.name }}</StackSetName>
-        <StackSetId>{{ stackset.id }}</StackSetId>
-        <Status>{{ stackset.status }}</Status>
-      </member>
-    {% endfor %}
-    </Summaries>
-  </ListStackSetsResult>
-  <ResponseMetadata>
-    <RequestId>4dcacb73-841e-4ed8-b335-example</RequestId>
-  </ResponseMetadata>
-</ListStackSetsResponse>
 """
 
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -220,17 +220,11 @@ class CloudFormationResponse(BaseResponse):
         result = {"Id": change_set_id, "StackId": stack_id}
         return ActionResult(result)
 
-    def delete_change_set(self) -> str:
+    def delete_change_set(self) -> ActionResult:
         change_set_name = self._get_param("ChangeSetName")
 
         self.cloudformation_backend.delete_change_set(change_set_name=change_set_name)
-        if self.request_json:
-            return json.dumps(
-                {"DeleteChangeSetResponse": {"DeleteChangeSetResult": {}}}
-            )
-        else:
-            template = self.response_template(DELETE_CHANGE_SET_RESPONSE_TEMPLATE)
-            return template.render()
+        return EmptyResult()
 
     def describe_change_set(self) -> str:
         change_set_name = self._get_param("ChangeSetName")

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -37,8 +37,8 @@ class StackResourceDTO:
 
 class StackSetOperationDTO:
     def __init__(self, operation: Dict[str, Any], stack_set: StackSet) -> None:
-        self.execution_role_name = stack_set.execution_role
-        self.administration_role_arn = stack_set.admin_role
+        self.execution_role_name = stack_set.execution_role_name
+        self.administration_role_arn = stack_set.administration_role_arn
         self.stack_set_id = stack_set.id
         self.creation_timestamp = operation["CreationTimestamp"]
         self.operation_id = operation["OperationId"]
@@ -589,10 +589,6 @@ class CloudFormationResponse(BaseResponse):
     def describe_stack_set(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
         stackset = self.cloudformation_backend.describe_stack_set(stackset_name)
-
-        if not stackset.execution_role:
-            stackset.execution_role = "AWSCloudFormationStackSetExecutionRole"
-
         result = {"StackSet": stackset}
         return ActionResult(result)
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -418,11 +418,11 @@ class CloudFormationResponse(BaseResponse):
         self.cloudformation_backend.delete_stack(name_or_stack_id)
         return EmptyResult()
 
-    def list_exports(self) -> str:
+    def list_exports(self) -> ActionResult:
         token = self._get_param("NextToken")
         exports, next_token = self.cloudformation_backend.list_exports(tokenstr=token)
-        template = self.response_template(LIST_EXPORTS_RESPONSE)
-        return template.render(exports=exports, next_token=next_token)
+        result = {"Exports": exports, "NextToken": next_token}
+        return ActionResult(result)
 
     def validate_template(self) -> str:
         template_body = self._get_param("TemplateBody")
@@ -942,27 +942,6 @@ GET_TEMPLATE_RESPONSE_TEMPLATE = """<GetTemplateResponse>
     <RequestId>b9b4b068-3a41-11e5-94eb-example</RequestId>
   </ResponseMetadata>
 </GetTemplateResponse>"""
-
-
-LIST_EXPORTS_RESPONSE = """<ListExportsResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
-  <ListExportsResult>
-    <Exports>
-      {% for export in exports %}
-      <member>
-        <ExportingStackId>{{ export.exporting_stack_id }}</ExportingStackId>
-        <Name>{{ export.name }}</Name>
-        <Value>{{ export.value }}</Value>
-      </member>
-      {% endfor %}
-    </Exports>
-    {% if next_token %}
-    <NextToken>{{ next_token }}</NextToken>
-    {% endif %}
-  </ListExportsResult>
-  <ResponseMetadata>
-    <RequestId>5ccc7dcd-744c-11e5-be70-example</RequestId>
-  </ResponseMetadata>
-</ListExportsResponse>"""
 
 
 DESCRIBE_STACK_SET_RESPONSE_TEMPLATE = """<DescribeStackSetResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -41,15 +41,6 @@ class StackSetOperationDTO:
         self.status = operation["Status"]
 
 
-class StackSummaryDTO:
-    def __init__(self, stack: Stack) -> None:
-        self.stack_id = stack.stack_id
-        self.stack_status = stack.status
-        self.stack_name = stack.name
-        self.creation_time = stack.creation_time
-        self.template_description = stack.description
-
-
 def get_template_summary_response_from_template(template_body: str) -> Dict[str, Any]:
     def get_resource_types(template_dict: Dict[str, Any]) -> List[Any]:
         resources = {}
@@ -353,7 +344,7 @@ class CloudFormationResponse(BaseResponse):
     def list_stacks(self) -> ActionResult:
         status_filter = self._get_multi_param("StackStatusFilter.member")
         stacks = self.cloudformation_backend.list_stacks(status_filter)
-        result = {"StackSummaries": [StackSummaryDTO(stack) for stack in stacks]}
+        result = {"StackSummaries": stacks}
         return ActionResult(result)
 
     def list_stack_resources(self) -> ActionResult:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -560,13 +560,13 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(LIST_STACK_INSTANCES_TEMPLATE)
         return template.render(instances=instances)
 
-    def list_stack_set_operations(self) -> str:
+    def list_stack_set_operations(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
         operations = self.cloudformation_backend.list_stack_set_operations(
             stackset_name
         )
-        template = self.response_template(LIST_STACK_SET_OPERATIONS_RESPONSE_TEMPLATE)
-        return template.render(operations=operations)
+        result = {"Summaries": operations}
+        return ActionResult(result)
 
     def stop_stack_set_operation(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
@@ -1076,27 +1076,6 @@ LIST_STACK_SETS_TEMPLATE = """<ListStackSetsResponse xmlns="http://internal.amaz
     <RequestId>4dcacb73-841e-4ed8-b335-example</RequestId>
   </ResponseMetadata>
 </ListStackSetsResponse>
-"""
-
-
-LIST_STACK_SET_OPERATIONS_RESPONSE_TEMPLATE = """<ListStackSetOperationsResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
-  <ListStackSetOperationsResult>
-    <Summaries>
-    {% for operation in operations %}
-      <member>
-        <CreationTimestamp>{{ operation.CreationTimestamp }}</CreationTimestamp>
-        <OperationId>{{ operation.OperationId }}</OperationId>
-        <Action>{{ operation.Action }}</Action>
-        <EndTimestamp>{{ operation.EndTimestamp }}</EndTimestamp>
-        <Status>{{ operation.Status }}</Status>
-      </member>
-    {% endfor %}
-    </Summaries>
-  </ListStackSetOperationsResult>
-  <ResponseMetadata>
-    <RequestId>65b9d9be-08bb-4a43-9a21-example</RequestId>
-  </ResponseMetadata>
-</ListStackSetOperationsResponse>
 """
 
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -516,7 +516,7 @@ class CloudFormationResponse(BaseResponse):
         self.cloudformation_backend.delete_stack_set(stackset_name)
         return EmptyResult()
 
-    def delete_stack_instances(self) -> str:
+    def delete_stack_instances(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
         accounts = self._get_multi_param("Accounts.member")
         regions = self._get_multi_param("Regions.member")
@@ -524,8 +524,8 @@ class CloudFormationResponse(BaseResponse):
             stackset_name, accounts, regions
         )
 
-        template = self.response_template(DELETE_STACK_INSTANCES_TEMPLATE)
-        return template.render(operation=operation)
+        result = {"OperationId": operation.operations[-1]["OperationId"]}
+        return ActionResult(result)
 
     def describe_stack_set(self) -> str:
         stackset_name = self._get_param("StackSetName")
@@ -1025,15 +1025,6 @@ LIST_STACK_INSTANCES_TEMPLATE = """<ListStackInstancesResponse xmlns="http://int
 </ListStackInstancesResponse>
 """
 
-DELETE_STACK_INSTANCES_TEMPLATE = """<DeleteStackInstancesResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
-  <DeleteStackInstancesResult>
-    <OperationId>{{ operation.OperationId }}</OperationId>
-  </DeleteStackInstancesResult>
-  <ResponseMetadata>
-    <RequestId>e5325090-66f6-4ecd-a531-example</RequestId>
-  </ResponseMetadata>
-</DeleteStackInstancesResponse>
-"""
 
 DESCRIBE_STACK_INSTANCE_TEMPLATE = """<DescribeStackInstanceResponse xmlns="http://internal.amazon.com/coral/com.amazonaws.maestro.service.v20160713/">
   <DescribeStackInstanceResult>

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -715,10 +715,11 @@ class BaseXMLSerializer(ResponseSerializer):
             items_name = self.get_serialized_name(shape.member, "member")
             serialized[key] = {items_name: list_obj}
         for list_item in value:
-            item_key = shape.member.name
             wrapper = {}
+            item_key = shape.member.name
             self._serialize(wrapper, list_item, shape.member, item_key)
-            list_obj.append(wrapper[item_key])
+            if item_key in wrapper and wrapper[item_key]:
+                list_obj.append(wrapper[item_key])
         if not list_obj:
             serialized[key] = ""
 

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -878,11 +878,13 @@ def test_delete_stack_set__while_instances_are_running():
 @mock_aws
 def test_create_stack_set():
     cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    tags = [{"Key": "key1", "Value": "value1"}, {"Key": "key2", "Value": "value2"}]
     response = cf.create_stack_set(
         StackSetName="teststackset",
         TemplateBody=dummy_template_json,
         Description="desc",
         AdministrationRoleARN="admin/role/arn:asdfasdfadsf",
+        Tags=tags,
     )
     assert response["StackSetId"] is not None
 
@@ -890,6 +892,9 @@ def test_create_stack_set():
     assert stack_set["TemplateBody"] == dummy_template_json
     assert stack_set["AdministrationRoleARN"] == "admin/role/arn:asdfasdfadsf"
     assert stack_set["Description"] == "desc"
+    assert stack_set["ExecutionRoleName"] == "AWSCloudFormationStackSetExecutionRole"
+    assert stack_set["Tags"] == tags
+    assert stack_set["ManagedExecution"]["Active"] is False
 
 
 @mock_aws

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -859,6 +859,7 @@ def test_delete_stack_set__while_instances_are_running():
     )
     with pytest.raises(ClientError) as exc:
         cf.delete_stack_set(StackSetName="a")
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 409
     err = exc.value.response["Error"]
     assert err["Code"] == "StackSetNotEmptyException"
     assert err["Message"] == "StackSet is not empty"

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1619,6 +1619,9 @@ def test_describe_change_set(stack_template, change_template):
     assert change_set["ChangeSetName"] == "NewChangeSet2"
     assert change_set["StackName"] == "NewStack"
     assert len(change_set["Changes"]) == 2
+    assert change_set["Parameters"] == [
+        {"ParameterKey": "KeyName", "ParameterValue": "value"}
+    ]
 
     # Execute change set
     cf.execute_change_set(ChangeSetName="NewChangeSet2")

--- a/tests/test_cloudformation/test_server.py
+++ b/tests/test_cloudformation/test_server.py
@@ -16,7 +16,7 @@ def test_cloudformation_server_get():
     create_stack_resp = test_client.action_data(
         "CreateStack", StackName=stack_name, TemplateBody=json.dumps(template_body)
     )
-    assert "<CreateStackResponse>" in create_stack_resp
+    assert "</CreateStackResponse>" in create_stack_resp
     assert "<StackId>" in create_stack_resp
     stack_id_from_create = re.search(
         "<StackId>(.*)</StackId>", create_stack_resp

--- a/tests/test_cloudformation/test_stack_parsing.py
+++ b/tests/test_cloudformation/test_stack_parsing.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 
 from moto import mock_aws, settings
 from moto.cloudformation.exceptions import ValidationError
-from moto.cloudformation.models import FakeStack
+from moto.cloudformation.models import Stack
 from moto.cloudformation.parsing import (
     Output,
     parse_condition,
@@ -248,7 +248,7 @@ to_json_string_template_json = json.dumps(to_json_string_template)
 
 
 def test_parse_stack_resources():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=dummy_template_json,
@@ -275,7 +275,7 @@ def test_missing_resource_logs(logger):
 
 
 def test_parse_stack_with_name_type_resource():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=name_type_template_json,
@@ -291,7 +291,7 @@ def test_parse_stack_with_name_type_resource():
 
 
 def test_parse_stack_with_tabbed_json_template():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=name_type_template_with_tabs_json,
@@ -307,7 +307,7 @@ def test_parse_stack_with_tabbed_json_template():
 
 
 def test_parse_stack_with_yaml_template():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=yaml.dump(name_type_template),
@@ -323,7 +323,7 @@ def test_parse_stack_with_yaml_template():
 
 
 def test_parse_stack_with_outputs():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=output_type_template_json,
@@ -340,7 +340,7 @@ def test_parse_stack_with_outputs():
 
 
 def test_parse_stack_with_get_attribute_outputs():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=get_attribute_outputs_template_json,
@@ -360,7 +360,7 @@ def test_parse_stack_with_get_attribute_kms():
     from .fixtures.kms_key import template
 
     template_json = json.dumps(template)
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=template_json,
@@ -376,7 +376,7 @@ def test_parse_stack_with_get_attribute_kms():
 
 
 def test_parse_stack_with_get_availability_zones():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=get_availability_zones_template_json,
@@ -407,7 +407,7 @@ def test_parse_stack_with_bad_get_attribute_outputs_using_boto3():
 
 def test_parse_stack_with_null_outputs_section():
     with pytest.raises(ValidationError) as exc:
-        FakeStack(
+        Stack(
             "test_id",
             "test_stack",
             null_output_template_json,
@@ -419,7 +419,7 @@ def test_parse_stack_with_null_outputs_section():
 
 
 def test_parse_stack_with_parameters():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=parameters_template_json,
@@ -553,7 +553,7 @@ def test_reference_other_conditions():
 
 
 def test_parse_split_and_select():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=split_select_template_json,
@@ -568,7 +568,7 @@ def test_parse_split_and_select():
 
 
 def test_sub():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=sub_template_json,
@@ -583,7 +583,7 @@ def test_sub():
 
 
 def test_sub_num():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=sub_num_template_json,
@@ -598,7 +598,7 @@ def test_sub_num():
 
 
 def test_sub_mapping():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=sub_mapping_json,
@@ -609,7 +609,7 @@ def test_sub_mapping():
     queue = stack.resource_map["Queue"]
     assert queue.name == "test_stack-queue-apple-yes"
 
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=sub_mapping_json,
@@ -622,7 +622,7 @@ def test_sub_mapping():
 
 
 def test_import():
-    export_stack = FakeStack(
+    export_stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=export_value_template_json,
@@ -630,7 +630,7 @@ def test_import():
         account_id=ACCOUNT_ID,
         region_name="us-west-1",
     )
-    import_stack = FakeStack(
+    import_stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=import_value_template_json,
@@ -645,7 +645,7 @@ def test_import():
 
 
 def test_to_json_string():
-    stack = FakeStack(
+    stack = Stack(
         stack_id="test_id",
         name="test_stack",
         template=to_json_string_template_json,
@@ -710,7 +710,7 @@ def test_ssm_parameter_parsing():
     )
 
     if not settings.TEST_SERVER_MODE:
-        stack = FakeStack(
+        stack = Stack(
             stack_id="test_id",
             name="test_stack",
             template=ssm_parameter_template_json,
@@ -728,7 +728,7 @@ def test_ssm_parameter_parsing():
 
     # Not passing in a value for ListParamCfn to test Default value
     if not settings.TEST_SERVER_MODE:
-        stack = FakeStack(
+        stack = Stack(
             stack_id="test_id",
             name="test_stack",
             template=ssm_parameter_template_json,


### PR DESCRIPTION
Relatively minor changeset required for integration:

* Model changes consist of just adding/renaming attributes, and dropping the "Fake" prefix from model names.
* Response(s) changes include some DTO classes (to combine data from multiple models) along with some simple transformers.
* Tests did not require any changes; some new assertions were added for better coverage.

This is the first integration to specify a "serialization alias" for a response.  The `Stack` model has both a `parameters` and `stack_parameters` attribute, which differ in their behavior and were the source of a recently reported issue (#9077).  Instead of trying to untangle exactly how these attribute work/should work, I elected to bypass them entirely for the `Stack.Parameters` response attribute, which is aliased to a new `parameter_list` property that duplicates the logic from the original XML template(s). 

> [!NOTE]
> This is another service that supported (some) JSON responses for Boto along with the XML responses for Boto3.  None of this code has been covered by tests since Moto dropped support for Boto--and all of it has been removed in this PR--but the functionality *is* still supported by the new response serialization flow.
