### PR TITLE
SES: integrate with core response serializer

### DIFF
--- a/moto/core/parsers.py
+++ b/moto/core/parsers.py
@@ -22,6 +22,8 @@ class QueryParser:
 
     def parse(self, request_dict, operation_model):
         shape = operation_model.input_shape
+        if shape is None:
+            return {}
         parsed = self._do_parse(request_dict, shape)
         return parsed if parsed is not UNDEFINED else {}
 

--- a/moto/ses/exceptions.py
+++ b/moto/ses/exceptions.py
@@ -22,7 +22,7 @@ class EventDestinationAlreadyExists(SesError):
 
 
 class TemplateNameAlreadyExists(SesError):
-    code = "TemplateNameAlreadyExists"
+    code = "AlreadyExists"
 
 
 class ValidationError(SesError):

--- a/moto/ses/exceptions.py
+++ b/moto/ses/exceptions.py
@@ -1,14 +1,8 @@
-from typing import Any
-
-from moto.core.exceptions import RESTError
+from moto.core.exceptions import ServiceException
 
 
-class SesError(RESTError):
-    code = 400
-
-    def __init__(self, error_type: str, message: str, *args: Any, **kwargs: Any):
-        kwargs.setdefault("template", "wrapped_single_error")
-        super().__init__(error_type, message, *args, **kwargs)
+class SesError(ServiceException):
+    pass
 
 
 class MessageRejectedError(SesError):

--- a/moto/ses/exceptions.py
+++ b/moto/ses/exceptions.py
@@ -6,68 +6,55 @@ class SesError(ServiceException):
 
 
 class MessageRejectedError(SesError):
-    def __init__(self, message: str):
-        super().__init__("MessageRejected", message)
+    code = "MessageRejected"
 
 
 class ConfigurationSetDoesNotExist(SesError):
-    def __init__(self, message: str):
-        super().__init__("ConfigurationSetDoesNotExist", message)
+    code = "ConfigurationSetDoesNotExist"
 
 
 class ConfigurationSetAlreadyExists(SesError):
-    def __init__(self, message: str):
-        super().__init__("ConfigurationSetAlreadyExists", message)
+    code = "ConfigurationSetAlreadyExists"
 
 
 class EventDestinationAlreadyExists(SesError):
-    def __init__(self, message: str):
-        super().__init__("EventDestinationAlreadyExists", message)
+    code = "EventDestinationAlreadyExists"
 
 
 class TemplateNameAlreadyExists(SesError):
-    def __init__(self, message: str):
-        super().__init__("TemplateNameAlreadyExists", message)
+    code = "TemplateNameAlreadyExists"
 
 
 class ValidationError(SesError):
-    def __init__(self, message: str):
-        super().__init__("ValidationError", message)
+    code = "ValidationError"
 
 
 class InvalidParameterValue(SesError):
-    def __init__(self, message: str):
-        super().__init__("InvalidParameterValue", message)
+    code = "InvalidParameterValue"
 
 
 class InvalidRenderingParameterException(SesError):
-    def __init__(self, message: str):
-        super().__init__("InvalidRenderingParameterException", message)
+    code = "InvalidRenderingParameterException"
 
 
 class TemplateDoesNotExist(SesError):
-    def __init__(self, message: str):
-        super().__init__("TemplateDoesNotExist", message)
+    code = "TemplateDoesNotExist"
 
 
 class AlreadyExists(SesError):
-    def __init__(self, message: str):
-        super().__init__("AlreadyExists", message)
+    code = "AlreadyExists"
 
 
 class RuleSetDoesNotExist(SesError):
-    def __init__(self, message: str):
-        super().__init__("RuleSetDoesNotExist", message)
+    code = "RuleSetDoesNotExist"
 
 
 class RuleDoesNotExist(SesError):
-    def __init__(self, message: str):
-        super().__init__("RuleDoesNotExist", message)
+    code = "RuleDoesNotExist"
 
 
 class MissingRenderingAttributeException(SesError):
+    code = "MissingRenderingAttributeException"
+
     def __init__(self, var: str):
-        super().__init__(
-            "MissingRenderingAttributeException",
-            f"Attribute '{var}' is not present in the rendering data.",
-        )
+        super().__init__(f"Attribute '{var}' is not present in the rendering data.")

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -132,11 +132,9 @@ class RawMessage(BaseModel):
 
 class SESQuota(BaseModel):
     def __init__(self, sent: int):
-        self.sent = sent
-
-    @property
-    def sent_past_24(self) -> int:
-        return self.sent
+        self.sent_last24_hours = sent
+        self.max24_hour_send = 200
+        self.max_send_rate = 1
 
 
 class ConfigurationSet(BaseModel):

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -433,7 +433,13 @@ class SESBackend(BaseBackend):
     ) -> Dict[str, Dict[str, Any]]:
         response: Dict[str, Dict[str, Any]] = {}
         for identity in identities:
-            response[identity] = self.sns_topics.get(identity, {})
+            config = self.sns_topics.get(identity, {})
+            response[identity] = {
+                "ForwardingEnabled": config.get("feedback_forwarding_enabled", True),
+                "HeadersInBounceNotificationsEnabled": False,
+                "HeadersInComplaintNotificationsEnabled": False,
+                "HeadersInDeliveryNotificationsEnabled": False,
+            }
         return response
 
     def set_identity_feedback_forwarding_enabled(
@@ -701,27 +707,32 @@ class SESBackend(BaseBackend):
     ) -> Dict[str, Dict[str, str]]:
         if identities is None:
             identities = []
-
         attributes_by_identity = {}
         for identity in identities:
             if identity in (self.domains + self.addresses):
-                attributes_by_identity[identity] = self.identity_mail_from_domains.get(
-                    identity
-                ) or {"behavior_on_mx_failure": "UseDefaultValue"}
-
+                value = self.identity_mail_from_domains.get(identity, {})
+                mail_from_domain = value.get("mail_from_domain")
+                attributes_by_identity[identity] = {
+                    "MailFromDomain": mail_from_domain,
+                    "MailFromDomainStatus": "Success" if mail_from_domain else None,
+                    "BehaviorOnMXFailure": value.get(
+                        "behavior_on_mx_failure", "UseDefaultValue"
+                    ),
+                }
         return attributes_by_identity
 
     def get_identity_verification_attributes(
         self, identities: Optional[List[str]] = None
-    ) -> Dict[str, str]:
+    ) -> Dict[str, Dict[str, str]]:
         if identities is None:
             identities = []
-
-        attributes_by_identity: Dict[str, str] = {}
+        attributes_by_identity = {}
         for identity in identities:
             if identity in (self.domains + self.addresses):
-                attributes_by_identity[identity] = "Success"
-
+                attributes_by_identity[identity] = {
+                    "VerificationStatus": "Success",
+                    "VerificationToken": "ILQMESfEW0p6i6gIJcEWvO65TP5hg6B99hGFZ2lxrIs=",
+                }
         return attributes_by_identity
 
     def update_configuration_set_reputation_metrics_enabled(

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -41,17 +41,23 @@ class EmailResponse(BaseResponse):
         result = {"VerifiedEmailAddresses": email_addresses}
         return ActionResult(result)
 
-    def verify_domain_dkim(self) -> str:
+    def verify_domain_dkim(self) -> ActionResult:
         domain = self.querystring.get("Domain")[0]  # type: ignore
         self.backend.verify_domain(domain)
-        template = self.response_template(VERIFY_DOMAIN_DKIM_RESPONSE)
-        return template.render()
+        result = {
+            "DkimTokens": [
+                "vvjuipp74whm76gqoni7qmwwn4w4qusjiainivf6sf",
+                "3frqe7jn4obpuxjpwpolz6ipb3k5nvt2nhjpik2oy",
+                "wrqplteh7oodxnad7hsl4mixg2uavzneazxv5sxi2",
+            ]
+        }
+        return ActionResult(result)
 
-    def verify_domain_identity(self) -> str:
+    def verify_domain_identity(self) -> ActionResult:
         domain = self.querystring.get("Domain")[0]  # type: ignore
         self.backend.verify_domain(domain)
-        template = self.response_template(VERIFY_DOMAIN_IDENTITY_RESPONSE)
-        return template.render()
+        result = {"VerificationToken": "QTKknzFg2J4ygwa+XvHAxUl1hyHoY0gVfZdfjIedHZ0="}
+        return ActionResult(result)
 
     def delete_identity(self) -> ActionResult:
         domain = self.querystring.get("Identity")[0]  # type: ignore
@@ -166,10 +172,9 @@ class EmailResponse(BaseResponse):
         result = {"MessageId": message.id}
         return ActionResult(result)
 
-    def get_send_quota(self) -> str:
+    def get_send_quota(self) -> ActionResult:
         quota = self.backend.get_send_quota()
-        template = self.response_template(GET_SEND_QUOTA_RESPONSE)
-        return template.render(quota=quota)
+        return ActionResult(quota)
 
     def get_identity_notification_attributes(self) -> str:
         identities = self._get_params()["Identities"]
@@ -405,41 +410,6 @@ class EmailResponse(BaseResponse):
         template = self.response_template(GET_IDENTITY_DKIM_ATTRIBUTES_RESPONSE)
         return template.render(dkim_attributes=dkim_attributes)
 
-
-VERIFY_DOMAIN_DKIM_RESPONSE = """<VerifyDomainDkimResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
-  <VerifyDomainDkimResult>
-    <DkimTokens>
-      <member>vvjuipp74whm76gqoni7qmwwn4w4qusjiainivf6sf</member>
-      <member>3frqe7jn4obpuxjpwpolz6ipb3k5nvt2nhjpik2oy</member>
-      <member>wrqplteh7oodxnad7hsl4mixg2uavzneazxv5sxi2</member>
-    </DkimTokens>
-    </VerifyDomainDkimResult>
-    <ResponseMetadata>
-      <RequestId>9662c15b-c469-11e1-99d1-797d6ecd6414</RequestId>
-    </ResponseMetadata>
-</VerifyDomainDkimResponse>"""
-
-VERIFY_DOMAIN_IDENTITY_RESPONSE = """\
-<VerifyDomainIdentityResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
-  <VerifyDomainIdentityResult>
-    <VerificationToken>QTKknzFg2J4ygwa+XvHAxUl1hyHoY0gVfZdfjIedHZ0=</VerificationToken>
-  </VerifyDomainIdentityResult>
-  <ResponseMetadata>
-    <RequestId>94f6368e-9bf2-11e1-8ee7-c98a0037a2b6</RequestId>
-  </ResponseMetadata>
-</VerifyDomainIdentityResponse>"""
-
-
-GET_SEND_QUOTA_RESPONSE = """<GetSendQuotaResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
-  <GetSendQuotaResult>
-    <SentLast24Hours>{{ quota.sent_past_24 }}</SentLast24Hours>
-    <Max24HourSend>200.0</Max24HourSend>
-    <MaxSendRate>1.0</MaxSendRate>
-  </GetSendQuotaResult>
-  <ResponseMetadata>
-    <RequestId>273021c6-c866-11e0-b926-699e21c3af9e</RequestId>
-  </ResponseMetadata>
-</GetSendQuotaResponse>"""
 
 GET_IDENTITY_NOTIFICATION_ATTRIBUTES = """<GetIdentityNotificationAttributesResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
   <GetIdentityNotificationAttributesResult>

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -308,8 +308,8 @@ class EmailResponse(BaseResponse):
 
     def create_receipt_rule(self) -> ActionResult:
         params = self._get_params()
-        rule_set_name = params.get("RuleSetName")
-        rule = params.get("Rule")
+        rule_set_name = params.get("RuleSetName", "")
+        rule = params.get("Rule", {})
         self.backend.create_receipt_rule(rule_set_name, rule)
         return EmptyResult()
 
@@ -328,8 +328,8 @@ class EmailResponse(BaseResponse):
 
     def update_receipt_rule(self) -> ActionResult:
         params = self._get_params()
-        rule_set_name = params.get("RuleSetName")
-        rule = params.get("Rule")
+        rule_set_name = params.get("RuleSetName", "")
+        rule = params.get("Rule", {})
         self.backend.update_receipt_rule(rule_set_name, rule)
         return EmptyResult()
 

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -363,7 +363,10 @@ class EmailResponse(BaseResponse):
             max_items=max_items,
         )
         config_set_names = [c.configuration_set_name for c in configuration_sets]
-        result = {"ConfigurationSets": [{"Name": name} for name in config_set_names]}
+        result = {
+            "ConfigurationSets": [{"Name": name} for name in config_set_names],
+            "NextToken": next_token,
+        }
         return ActionResult(result)
 
     def update_configuration_set_reputation_metrics_enabled(self) -> ActionResult:

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -290,11 +290,11 @@ class EmailResponse(BaseResponse):
         result = {"TemplatesMetadata": metadata}
         return ActionResult(result)
 
-    def test_render_template(self) -> str:
+    def test_render_template(self) -> ActionResult:
         render_info = self._get_dict_param("Template")
         rendered_template = self.backend.render_template(render_info)
-        template = self.response_template(RENDER_TEMPLATE)
-        return template.render(template=rendered_template)
+        result = {"RenderedTemplate": rendered_template}
+        return ActionResult(result)
 
     def delete_template(self) -> ActionResult:
         name = self._get_param("TemplateName")
@@ -424,17 +424,3 @@ DESCRIBE_CONFIGURATION_SET = """<DescribeConfigurationSetResponse xmlns="http://
     <RequestId>8e410745-c1bd-4450-82e0-f968cf2105f2</RequestId>
   </ResponseMetadata>
 </DescribeConfigurationSetResponse>"""
-
-
-RENDER_TEMPLATE = """
-<TestRenderTemplateResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
-    <TestRenderTemplateResult>
-      <RenderedTemplate>
-      {{template | e}}
-      </RenderedTemplate>
-    </TestRenderTemplateResult>
-    <ResponseMetadata>
-        <RequestId>47e0ef1a-9bf2-11e1-9279-0100e8cf12ba</RequestId>
-    </ResponseMetadata>
-</TestRenderTemplateResponse>
-"""

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -1315,7 +1315,7 @@ def test_render_template():
 
     with pytest.raises(ClientError) as ex:
         conn.test_render_template(**kwargs)
-    assert ex.value.response["Error"]["Code"] == "MissingRenderingAttributeException"
+    assert ex.value.response["Error"]["Code"] == "MissingRenderingAttribute"
     assert (
         ex.value.response["Error"]["Message"]
         == "Attribute 'favoriteanimal' is not present in the rendering data."

--- a/tests/test_ses/test_ses_boto3.py
+++ b/tests/test_ses/test_ses_boto3.py
@@ -1240,7 +1240,7 @@ def test_create_ses_template():
             }
         )
 
-    assert ex.value.response["Error"]["Code"] == "TemplateNameAlreadyExists"
+    assert ex.value.response["Error"]["Code"] == "AlreadyExists"
 
     # get a template which is already added
     result = conn.get_template(TemplateName="MyTemplate")


### PR DESCRIPTION
This one was very straightforward.  There was a lot of really old parameter parsing code in `responses.py`, which I cleaned up a bit.  No tests were modified except for a couple of corrected error code assertions.