### PR TITLE
Route53: fix create and delete same record multiple times

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -719,7 +719,10 @@ class Route53Backend(BaseBackend):
             if value["Action"] == "CREATE" and value in the_zone.rr_changes:
                 name = value["ResourceRecordSet"]["Name"] + "."
                 _type = value["ResourceRecordSet"]["Type"]
-                raise ResourceRecordAlreadyExists(name=name, _type=_type)
+                # check if the record exists or just in rr_changes (journal)
+                all_records = list(the_zone.get_record_sets(start_type=_type, start_name=name))
+                if all_records:
+                    raise ResourceRecordAlreadyExists(name=name, _type=_type)
 
         for value in change_list:
             if value["Action"] == "DELETE":

--- a/tests/test_route53/test_route53.py
+++ b/tests/test_route53/test_route53.py
@@ -395,6 +395,63 @@ def test_deleting_weighted_route():
     assert cnames[-1]["Name"] == "cname.testdns.aws.com."
     assert cnames[-1]["SetIdentifier"] == "success-test-bar"
 
+@mock_aws
+def test_create_delete_create():
+    """
+    Validation that we can create and delete a record set multiple times
+    """
+    conn = boto3.client("route53", region_name="us-east-1")
+
+    zone = conn.create_hosted_zone(
+        Name="testdns.aws.com", CallerReference=str(hash("foo"))
+    )
+    zone_id = zone["HostedZone"]["Id"]
+
+    def _build_change_payload(action):
+        return [
+            {
+                "Action": action.upper(),
+                "ResourceRecordSet": {
+                    "Name": "record.testdns.aws.com",
+                    "Type": "A",
+                    "TTL": 60,
+                    "ResourceRecords": [{"Value": "192.168.1.1"}],
+                },
+            },
+            {
+                "Action": action.upper(),
+                "ResourceRecordSet": {
+                    "Name": "cname.testdns.aws.com",
+                    "Type": "CNAME",
+                    "ResourceRecords": [{"Value": "example.com"}],
+                },
+            },
+        ]
+
+    for i in range(10):
+        conn.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                "Changes":  _build_change_payload("create")
+            },
+        )
+
+        response = conn.list_resource_record_sets(
+            HostedZoneId=zone_id, StartRecordName="record.testdns.aws.com",
+        )["ResourceRecordSets"]
+        assert len(response) == 1
+
+        conn.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch={
+                "Changes": _build_change_payload("delete")
+            },
+        )
+
+        response = conn.list_resource_record_sets(
+            HostedZoneId=zone_id, StartRecordName="record.testdns.aws.com",
+        )["ResourceRecordSets"]
+        assert len(response) == 0
 
 @mock_aws
 def test_deleting_latency_route():


### PR DESCRIPTION
# Motivation

This pr fixes an issue that would arise when attempting to create and delete same record multiple times. The record is successfully deleted from record set (rrsets), but the reference is stored in journal `rr_changes`

While everything else in route53 seemed unaffected by that change, the fix does a validation where change is in journal, if yes, validates where or not the record set is in zone.

Relates https://github.com/localstack/localstack/issues/12910

# Changes

- Added unit test
- Add validation check where the record is in `rrsets`
