### PR TITLE
ELBv2: Add CanonicalHostedZoneId attribute to LoadBalancer

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -608,6 +608,8 @@ class FakeLoadBalancer(CloudFormationModel):
             # "idle_timeout.timeout_seconds": "60",  # commented out for TF compatibility
             "load_balancing.cross_zone.enabled": "false",
         }
+        # TODO: This was hardcoded in the original XML template and still needs to be implemented.
+        self.canonical_hosted_zone_id = "Z2P70J7EXAMPLE"
 
     @property
     def load_balancer_state(self) -> dict[str, str]:

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -16,6 +16,7 @@ def test_create_load_balancer():
     response, _, security_group, subnet1, subnet2, conn = create_load_balancer()
 
     lb = response["LoadBalancers"][0]
+    assert lb["CanonicalHostedZoneId"].startswith("Z")
     assert lb["DNSName"] == "my-lb-1.us-east-1.elb.amazonaws.com"
     assert (
         lb["LoadBalancerArn"]
@@ -102,6 +103,7 @@ def test_describe_load_balancers():
 
     assert len(response["LoadBalancers"]) == 1
     lb = response["LoadBalancers"][0]
+    assert lb["CanonicalHostedZoneId"].startswith("Z")
     assert lb["LoadBalancerName"] == "my-lb"
     assert lb["State"]["Code"] == "active"
 


### PR DESCRIPTION
Looks like this attribute was hardcoded in the [original XML template](https://github.com/getmoto/moto/blob/60378f74fdcd90f08795262a8c45fe67efa9d169/moto/elbv2/responses.py#L1142C32-L1142C46) and I missed it when I migrated this service to the new serializer (#9098).

This PR just puts the hardcoded value back.  Some additional effort would still be required to make this value meaningful.

Closes #9115 