### PR TITLE
CloudFormation: Add LogicalResourceId param to DescribeStackResources

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1264,9 +1264,16 @@ class CloudFormationBackend(BaseBackend):
         raise ValidationError(stack_name, message)
 
     def describe_stack_resources(
-        self, stack_name: str
+        self, stack_name: str, logical_resource_id: str
     ) -> Tuple[Stack, Iterable[Type[CloudFormationModel]]]:
         stack = self.get_stack(stack_name)
+
+        if logical_resource_id is not None:
+            for res in stack.stack_resources:
+                if res.logical_resource_id == logical_resource_id:
+                    return stack, [res]
+            return stack, []
+
         return stack, stack.stack_resources
 
     def list_stack_resources(

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -1270,7 +1270,7 @@ class CloudFormationBackend(BaseBackend):
 
         if logical_resource_id is not None:
             for res in stack.stack_resources:
-                if res.logical_resource_id == logical_resource_id:
+                if res.logical_resource_id == logical_resource_id:  # type: ignore[attr-defined]
                     return stack, [res]
             return stack, []
 

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -325,8 +325,9 @@ class CloudFormationResponse(BaseResponse):
 
     def describe_stack_resources(self) -> ActionResult:
         stack_name = self._get_param("StackName")
+        logical_resource_id = self._get_param("LogicalResourceId")
         stack, resources = self.cloudformation_backend.describe_stack_resources(
-            stack_name
+            stack_name, logical_resource_id
         )
 
         result = {

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1723,14 +1723,43 @@ def test_describe_stack_resources():
     cf = boto3.client("cloudformation", region_name=REGION_NAME)
     cf.create_stack(StackName=TEST_STACK_NAME, TemplateBody=dummy_template_json)
 
-    stack = cf.describe_stacks(StackName=TEST_STACK_NAME)["Stacks"][0]
+    response = cf.describe_stack_resources(StackName=TEST_STACK_NAME)
 
-    response = cf.describe_stack_resources(StackName=stack["StackName"])
     resource = response["StackResources"][0]
     assert resource["LogicalResourceId"] == "EC2Instance1"
     assert resource["ResourceStatus"] == "CREATE_COMPLETE"
     assert resource["ResourceType"] == "AWS::EC2::Instance"
-    assert resource["StackId"] == stack["StackId"]
+    assert resource["StackName"] == TEST_STACK_NAME
+
+
+@mock_aws
+def test_describe_stack_resources_when_logical_resource_exists():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    cf.create_stack(StackName=TEST_STACK_NAME, TemplateBody=dummy_template_json)
+
+    response = cf.describe_stack_resources(
+        StackName=TEST_STACK_NAME,
+        LogicalResourceId="EC2Instance1",
+    )
+
+    resource = response["StackResources"][0]
+    assert resource["LogicalResourceId"] == "EC2Instance1"
+    assert resource["ResourceStatus"] == "CREATE_COMPLETE"
+    assert resource["ResourceType"] == "AWS::EC2::Instance"
+    assert resource["StackName"] == TEST_STACK_NAME
+
+
+@mock_aws
+def test_describe_stack_resources_when_logical_resource_does_not_exist():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+    cf.create_stack(StackName=TEST_STACK_NAME, TemplateBody=dummy_template_json)
+
+    response = cf.describe_stack_resources(
+        StackName=TEST_STACK_NAME,
+        LogicalResourceId="NotHere",
+    )
+
+    assert response["StackResources"] == []
 
 
 @mock_aws


### PR DESCRIPTION
Support the LogicalResourceId parameter in the DescribeStackResources API.

When set, it returns the resource wrapped in a list if it exists, or returns an empty list if the resource doesn't exist.

Make the tests clearer by removing an unneeded call to DescribeStacks. We don't need to compare the StackId here.

A solution for #9116 .