### PR TITLE
RDS: fix modifying DBCluster.VpcSecurityGroupIds

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -591,7 +591,7 @@ class DBCluster(RDSBaseModel):
         self.preferred_maintenance_window = preferred_maintenance_window
         self.publicly_accessible = publicly_accessible
         # This should default to the default security group
-        self._vpc_security_group_ids = vpc_security_group_ids or []
+        self.vpc_security_group_ids = vpc_security_group_ids
         self.hosted_zone_id = "".join(
             random.choice(string.ascii_uppercase + string.digits) for _ in range(14)
         )
@@ -828,9 +828,21 @@ class DBCluster(RDSBaseModel):
     def vpc_security_groups(self) -> List[Dict[str, Any]]:  # type: ignore[misc]
         groups = [
             {"VpcSecurityGroupId": sg_id, "Status": "active"}
-            for sg_id in self._vpc_security_group_ids
+            for sg_id in self.vpc_security_group_ids
         ]
         return groups
+
+    @property
+    def vpc_security_group_ids(self) -> List[str]:
+        return self._vpc_security_group_ids
+
+    @vpc_security_group_ids.setter
+    def vpc_security_group_ids(
+        self, vpc_security_group_ids: Optional[List[str]]
+    ) -> None:
+        if vpc_security_group_ids is None:
+            vpc_security_group_ids = []
+        self._vpc_security_group_ids = vpc_security_group_ids
 
     @property
     def domain_memberships(self) -> List[str]:
@@ -1120,12 +1132,6 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self.multi_az = multi_az
         self.db_subnet_group_name = db_subnet_group_name
         self.db_security_groups = db_security_groups or []
-        self.vpc_security_group_ids = vpc_security_group_ids or []
-        if not self.vpc_security_group_ids:
-            ec2_backend = ec2_backends[self.account_id][self.region]
-            default_vpc = ec2_backend.default_vpc
-            default_sg = ec2_backend.get_default_security_group(default_vpc.id)
-            self.vpc_security_group_ids.append(default_sg.id)  # type: ignore
         self.preferred_maintenance_window = preferred_maintenance_window.lower()
         self.db_parameter_group_name = db_parameter_group_name
         if (
@@ -1145,6 +1151,12 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self.enabled_cloudwatch_logs_exports = enable_cloudwatch_logs_exports or []
         self.db_cluster_identifier = db_cluster_identifier
         if self.db_cluster_identifier is None:
+            self.vpc_security_group_ids = vpc_security_group_ids or []
+            if not self.vpc_security_group_ids:
+                ec2_backend = ec2_backends[self.account_id][self.region]
+                default_vpc = ec2_backend.default_vpc
+                default_sg = ec2_backend.get_default_security_group(default_vpc.id)
+                self.vpc_security_group_ids.append(default_sg.id)  # type: ignore
             self.storage_type = storage_type or DBInstance.default_storage_type(
                 iops=self.iops
             )
@@ -1780,6 +1792,14 @@ class DBInstanceClustered(DBInstance):
 
     @storage_type.setter
     def storage_type(self, value: str) -> None:
+        raise NotImplementedError("Not valid for clustered db instances.")
+
+    @property
+    def vpc_security_group_ids(self) -> List[str]:
+        return self.cluster.vpc_security_group_ids
+
+    @vpc_security_group_ids.setter
+    def vpc_security_group_ids(self, value: List[str]) -> None:
         raise NotImplementedError("Not valid for clustered db instances.")
 
 


### PR DESCRIPTION
Extracted the `VPCSecurityGroupIds` attribute out into an explicit getter/setter property, with differing behavior for `DBInstance` depending on whether it's part of a `DBCluster`.

Closes #9126 