### PR TITLE
EC2: add missing attributes to `DescribeVpcEndpoints` response

### DIFF
--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -374,7 +374,11 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
 
     @property
     def groups(self) -> List[Dict[str, str]]:
-        return [{"GroupId": group_id} for group_id in self.security_group_ids]
+        # TODO: Populate GroupName
+        return [
+            {"GroupId": group_id, "GroupName": "TODO"}
+            for group_id in self.security_group_ids
+        ]
 
     def modify(
         self,

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from moto.core.base_backend import BaseBackend
 from moto.core.common_models import CloudFormationModel
+from moto.core.utils import utcnow
 from moto.utilities.utils import get_partition
 
 from ..exceptions import (
@@ -35,7 +36,6 @@ from ..utils import (
     random_vpc_cidr_association_id,
     random_vpc_ep_id,
     random_vpc_id,
-    utc_date_and_time,
 )
 from .availability_zones_and_regions import RegionsAndZonesBackend
 from .core import TaggedEC2Resource
@@ -364,13 +364,17 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
         self.network_interface_ids = network_interface_ids or []
         self.subnet_ids = subnet_ids
         self.client_token = client_token
-        self.security_group_ids = security_group_ids
+        self.security_group_ids = security_group_ids or []
         self.private_dns_enabled = private_dns_enabled
         self.dns_entries = dns_entries
         self.add_tags(tags or {})
         self.destination_prefix_list_id = destination_prefix_list_id
 
-        self.created_at = utc_date_and_time()
+        self.creation_timestamp = utcnow()
+
+    @property
+    def groups(self) -> List[Dict[str, str]]:
+        return [{"GroupId": group_id} for group_id in self.security_group_ids]
 
     def modify(
         self,


### PR DESCRIPTION
Adds `Groups` and `CreationTimestamp` to the `DescribeVpcEndpoints` response, as well as associated test coverage.

I left in the `TODO` from the [original XML template](https://github.com/getmoto/moto/blob/b55f533b711f68fa4c4b6950a0a2b42e99af4779/moto/ec2/responses/vpcs.py#L744)

Closes #9124 