### PR TITLE
EC2: Add subnet removal funtionality to modify_vpc_endpoints, check for duplicates in adds

### DIFF
--- a/moto/ec2/responses/vpcs.py
+++ b/moto/ec2/responses/vpcs.py
@@ -215,6 +215,7 @@ class VPCs(EC2BaseResponse):
     def modify_vpc_endpoint(self) -> ActionResult:
         vpc_id = self._get_param("VpcEndpointId")
         add_subnets = self._get_multi_param("AddSubnetId")
+        remove_subnets = self._get_multi_param("RemoveSubnetId")
         add_route_tables = self._get_multi_param("AddRouteTableId")
         remove_route_tables = self._get_multi_param("RemoveRouteTableId")
         policy_doc = self._get_param("PolicyDocument")
@@ -222,6 +223,7 @@ class VPCs(EC2BaseResponse):
             vpc_id=vpc_id,
             policy_doc=policy_doc,
             add_subnets=add_subnets,
+            remove_subnets=remove_subnets,
             add_route_tables=add_route_tables,
             remove_route_tables=remove_route_tables,
         )


### PR DESCRIPTION
Fixes https://github.com/getmoto/moto/issues/9111, I decided to separate the tests for the API call and also added tests for the duplicate checks for both subnets and route tables.

If possible I'd also take a crack at the GroupName population in a separate PR.