### PR TITLE
[ResourceGroupsTaggingAPI] Add untag_resources functionality and update tag_resources

### DIFF
--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1310,7 +1310,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self, resource_arns: List[str], tags: Dict[str, str]
     ) -> Dict[str, Dict[str, Any]]:
         """
-        Only DynamoDB, Logs, RDS, and SageMaker resources are currently supported
+        Only DynamoDB, EFS, Lambda Logs, RDS, and SageMaker resources are currently supported
         """
         missing_resources = []
         missing_error: Dict[str, Any] = {
@@ -1346,6 +1346,15 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:sagemaker:"):
                 self.sagemaker_backend.add_tags(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
+                )
+            elif arn.startswith(f"arn:{get_partition(self.region_name)}:lambda:"):
+                self.lambda_backend.tag_resource(arn, tags)
+            elif arn.startswith(
+                f"arn:{get_partition(self.region_name)}:elasticfilesystem:"
+            ):
+                resource_id = arn.split("/")[-1]
+                self.efs_backend.tag_resource(
+                    resource_id, TaggingService.convert_dict_to_tags_input(tags)
                 )
             else:
                 missing_resources.append(arn)

--- a/moto/resourcegroupstaggingapi/responses.py
+++ b/moto/resourcegroupstaggingapi/responses.py
@@ -63,13 +63,13 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
 
         return json.dumps({"FailedResourcesMap": failed_resources})
 
-    # def untag_resources(self):
-    #     resource_arn_list = self._get_list_prefix("ResourceARNList.member")
-    #     tag_keys = self._get_list_prefix("TagKeys.member")
-    #     failed_resources_map = self.backend.untag_resources(
-    #         resource_arn_list=resource_arn_list,
-    #         tag_keys=tag_keys,
-    #     )
-    #
-    #     # failed_resources_map should be {'resource': {'ErrorCode': str, 'ErrorMessage': str, 'StatusCode': int}}
-    #     return json.dumps({'FailedResourcesMap': failed_resources_map})
+    def untag_resources(self):
+        resource_arn_list = self._get_param("ResourceARNList")
+        tag_keys = self._get_param("TagKeys")
+
+        failed_resources = self.backend.untag_resources(
+            resource_arn_list=resource_arn_list,
+            tag_keys=tag_keys,
+        )
+
+        return json.dumps({"FailedResourcesMap": failed_resources})

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -1017,6 +1017,53 @@ def test_tag_resources_lambda():
 
 
 @mock_aws
+def test_untag_resources_lambda():
+    client = boto3.client("lambda", region_name="us-west-2")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+
+    def get_role_name():
+        iam = boto3.client("iam", region_name="us-west-2")
+        try:
+            return iam.get_role(RoleName="my-role")["Role"]["Arn"]
+        except ClientError:
+            return iam.create_role(
+                RoleName="my-role",
+                AssumeRolePolicyDocument="some policy",
+                Path="/my-path/",
+            )["Role"]["Arn"]
+
+    zipfile = """
+              def lambda_handler(event, context):
+                  print("custom log event")
+                  return event
+              """
+
+    func = client.create_function(
+        FunctionName="lambda-tag-resource-test",
+        Runtime="python3.13",
+        Role=get_role_name(),
+        Handler="lambda_function.lambda_handler",
+        Code={"ZipFile": zipfile},
+        Description="test lambda function",
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+        Tags={"tag": "a", "secondtag": "b", "thirdtag": "c"},
+    )
+
+    rtapi.untag_resources(
+        ResourceARNList=[func["FunctionArn"]], TagKeys=["tag", "secondtag"]
+    )
+
+    resp = client.list_tags(Resource=func["FunctionArn"])
+
+    assert len(resp["Tags"]) == 1
+    assert "tag" not in resp["Tags"]
+    assert "secondtag" not in resp["Tags"]
+    assert "thirdtag" in resp["Tags"]
+
+
+@mock_aws
 def test_get_resources_sqs():
     sqs = boto3.resource("sqs", region_name="eu-central-1")
 
@@ -1211,6 +1258,20 @@ def test_tag_resources_for_unknown_service():
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
     missing_resources = rtapi.tag_resources(
         ResourceARNList=["arn:aws:service_x"], Tags={"key1": "k", "key2": "v"}
+    )["FailedResourcesMap"]
+
+    assert "arn:aws:service_x" in missing_resources
+    assert (
+        missing_resources["arn:aws:service_x"]["ErrorCode"]
+        == "InternalServiceException"
+    )
+
+
+@mock_aws
+def test_untag_resources_for_unknown_service():
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+    missing_resources = rtapi.untag_resources(
+        ResourceARNList=["arn:aws:service_x"], TagKeys=["key1", "key2"]
     )["FailedResourcesMap"]
 
     assert "arn:aws:service_x" in missing_resources
@@ -1462,8 +1523,19 @@ def test_tag_resources_efs():
         CreationToken="test-token-1", Tags=[{"Key": "tag", "Value": "a"}]
     )
 
+    ap = efs.create_access_point(
+        ClientToken="ct-1",
+        FileSystemId=fs["FileSystemId"],
+        Tags=[{"Key": "aptag", "Value": "ap-a"}],
+    )
+
     rtapi.tag_resources(
         ResourceARNList=[fs["FileSystemArn"]], Tags={"secondtag": "b", "thirdtag": "c"}
+    )
+
+    rtapi.tag_resources(
+        ResourceARNList=[ap["AccessPointArn"]],
+        Tags={"apsecondtag": "ap-b", "apthirdtag": "ap-c"},
     )
 
     resp = efs.list_tags_for_resource(ResourceId=fs["FileSystemId"])
@@ -1471,6 +1543,59 @@ def test_tag_resources_efs():
     assert {"Key": "tag", "Value": "a"} in resp["Tags"]
     assert {"Key": "secondtag", "Value": "b"} in resp["Tags"]
     assert {"Key": "thirdtag", "Value": "c"} in resp["Tags"]
+
+    resp = efs.list_tags_for_resource(ResourceId=ap["AccessPointId"])
+
+    assert {"Key": "aptag", "Value": "ap-a"} in resp["Tags"]
+    assert {"Key": "apsecondtag", "Value": "ap-b"} in resp["Tags"]
+    assert {"Key": "apthirdtag", "Value": "ap-c"} in resp["Tags"]
+
+
+@mock_aws
+def test_untag_resources_efs():
+    efs = boto3.client("efs", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    fs = efs.create_file_system(
+        CreationToken="test-token-1",
+        Tags=[
+            {"Key": "tag", "Value": "a"},
+            {"Key": "secondtag", "Value": "b"},
+            {"Key": "thirdtag", "Value": "c"},
+        ],
+    )
+
+    ap = efs.create_access_point(
+        ClientToken="ct-1",
+        FileSystemId=fs["FileSystemId"],
+        Tags=[
+            {"Key": "aptag", "Value": "ap-a"},
+            {"Key": "apsecondtag", "Value": "ap-b"},
+            {"Key": "apthirdtag", "Value": "ap-c"},
+        ],
+    )
+
+    rtapi.untag_resources(
+        ResourceARNList=[fs["FileSystemArn"]], TagKeys=["tag", "secondtag"]
+    )
+
+    rtapi.untag_resources(
+        ResourceARNList=[ap["AccessPointArn"]], TagKeys=["apthirdtag"]
+    )
+
+    resp = efs.list_tags_for_resource(ResourceId=fs["FileSystemId"])
+
+    assert len(resp["Tags"]) == 1
+    assert {"Key": "tag", "Value": "a"} not in resp["Tags"]
+    assert {"Key": "secondtag", "Value": "b"} not in resp["Tags"]
+    assert {"Key": "thirdtag", "Value": "c"} in resp["Tags"]
+
+    resp = efs.list_tags_for_resource(ResourceId=ap["AccessPointId"])
+
+    assert len(resp["Tags"]) == 2
+    assert {"Key": "aptag", "Value": "ap-a"} in resp["Tags"]
+    assert {"Key": "apsecondtag", "Value": "ap-b"} in resp["Tags"]
+    assert {"Key": "apthirdtag", "Value": "ap-c"} not in resp["Tags"]
 
 
 @mock_aws


### PR DESCRIPTION
This PR adds the `untag_resources` function/functionality. 

Currently the only supported resources are:
  - Lambda
  - EFS

Added EFS and Lambda to `tag_resources`