### PR TITLE
added delete_replication_group endpoint

### DIFF
--- a/moto/elasticache/models.py
+++ b/moto/elasticache/models.py
@@ -947,5 +947,21 @@ class ElastiCacheBackend(BaseBackend):
         replication_groups = list(self.replication_groups.values())
         return replication_groups
 
+    def delete_replication_group(
+        self, replication_group_id: str, retain_primary_cluster: Optional[bool]
+    ) -> ReplicationGroup:
+        if replication_group_id:
+            if replication_group_id in self.replication_groups:
+                replication_group = self.replication_groups[replication_group_id]
+                replication_group.status = "deleting"
+            if not retain_primary_cluster:
+                replication_group = self.replication_groups[replication_group_id]
+                replication_group.member_clusters.remove(
+                    replication_group.primary_cluster_id
+                )
+                replication_group.primary_cluster_id = ""
+            return replication_group
+        raise ReplicationGroupNotFound(replication_group_id)
+
 
 elasticache_backends = BackendDict(ElastiCacheBackend, "elasticache")

--- a/moto/elasticache/responses.py
+++ b/moto/elasticache/responses.py
@@ -322,3 +322,12 @@ class ElastiCacheResponse(BaseResponse):
         )
         result = {"ReplicationGroups": replication_groups, "Marker": marker}
         return ActionResult(result)
+
+    def delete_replication_group(self) -> ActionResult:
+        replication_group_id = self._get_param("ReplicationGroupId")
+        retain_primary_cluster = self._get_bool_param("RetainPrimaryCluster")
+        replication_group = self.elasticache_backend.delete_replication_group(
+            replication_group_id=replication_group_id,
+            retain_primary_cluster=retain_primary_cluster,
+        )
+        return ActionResult({"ReplicationGroup": replication_group})


### PR DESCRIPTION
To reviewers and maintainers @bblommers and @bpandola. This small PR adds [delete_replication_group()](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elasticache/client/delete_replication_group.html) endpoint to elasticache.