### PR TITLE
SQS: Support MessageGroupId on standard queues

### DIFF
--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -839,13 +839,6 @@ class SQSBackend(BaseBackend):
             # MessageGroupId is a mandatory parameter for all
             # messages in a fifo queue
             raise MissingParameter("MessageGroupId")
-        if group_id and not queue.fifo_queue and validate_group_id:
-            # If the request comes from SNS, we don't need to validate the existence of a group ID
-            msg = (
-                f"Value {group_id} for parameter MessageGroupId is invalid. "
-                "Reason: The request include parameter that is not valid for this queue type."
-            )
-            raise InvalidParameterValue(msg)
 
     def send_message(
         self,

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -631,22 +631,6 @@ def test_send_message_with_message_group_id():
 
 
 @mock_aws
-def test_send_message_with_message_group_id_standard_queue():
-    sqs = boto3.resource("sqs", region_name=REGION)
-    queue = sqs.create_queue(QueueName=str(uuid4())[0:6])
-
-    with pytest.raises(ClientError) as ex:
-        queue.send_message(MessageBody="mydata", MessageGroupId="group_id_1")
-
-    err = ex.value.response["Error"]
-    assert err["Code"] == "InvalidParameterValue"
-    assert err["Message"] == (
-        "Value group_id_1 for parameter MessageGroupId is invalid. "
-        "Reason: The request include parameter that is not valid for this queue type."
-    )
-
-
-@mock_aws
 def test_send_message_with_unicode_characters():
     body_one = "Héllo!😀"
 


### PR DESCRIPTION
Now that SQS supports setting a MessageGroupId on standard queues as part of the "fair queues" feature, this validation logic isn't necessary. See https://github.com/getmoto/moto/issues/9146 for more context

Linting, type checking, and unit tests were all run locally and passed. 
