### PR TITLE
[S3 Control] Adding support for storage lens configuration tagging 

### DIFF
--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -203,34 +203,27 @@ class S3ControlBackend(BaseBackend):
         return storage_lens_configuration_list
 
     def put_storage_lens_configuration_tagging(
-        self,
-        config_id: str,
-        account_id: str,
-        tags: Dict[str, str]
+        self, config_id: str, account_id: str, tags: Dict[str, str]
     ) -> None:
         # The account ID should equal the account id that is set for Moto:
         if account_id != self.account_id:
             raise WrongPublicAccessBlockAccountIdError()
-        
+
         if config_id not in self.storage_lens_configs:
             raise AccessPointNotFound(config_id)
-        
-        self.storage_lens_configs[account_id].tags = tags
 
+        self.storage_lens_configs[config_id].tags = tags
 
     def get_storage_lens_configuration_tagging(
-        self,
-        config_id: str,
-        account_id: str
+        self, config_id: str, account_id: str
     ) -> Dict[str, str]:
-        print("MODELS ACCOUNT ID:", self.account_id)
         if account_id != self.account_id:
             raise WrongPublicAccessBlockAccountIdError()
-        print("MODELS CONFIG ID:", config_id)
         if config_id not in self.storage_lens_configs:
             raise AccessPointNotFound(config_id)
-        
+
         return self.storage_lens_configs[config_id].tags
+
 
 s3control_backends = BackendDict(
     S3ControlBackend,

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -202,6 +202,35 @@ class S3ControlBackend(BaseBackend):
         storage_lens_configuration_list = list(self.storage_lens_configs.values())
         return storage_lens_configuration_list
 
+    def put_storage_lens_configuration_tagging(
+        self,
+        config_id: str,
+        account_id: str,
+        tags: Dict[str, str]
+    ) -> None:
+        # The account ID should equal the account id that is set for Moto:
+        if account_id != self.account_id:
+            raise WrongPublicAccessBlockAccountIdError()
+        
+        if config_id not in self.storage_lens_configs:
+            raise AccessPointNotFound(config_id)
+        
+        self.storage_lens_configs[account_id].tags = tags
+
+
+    def get_storage_lens_configuration_tagging(
+        self,
+        config_id: str,
+        account_id: str
+    ) -> Dict[str, str]:
+        print("MODELS ACCOUNT ID:", self.account_id)
+        if account_id != self.account_id:
+            raise WrongPublicAccessBlockAccountIdError()
+        print("MODELS CONFIG ID:", config_id)
+        if config_id not in self.storage_lens_configs:
+            raise AccessPointNotFound(config_id)
+        
+        return self.storage_lens_configs[config_id].tags
 
 s3control_backends = BackendDict(
     S3ControlBackend,

--- a/moto/s3control/responses.py
+++ b/moto/s3control/responses.py
@@ -156,6 +156,31 @@ class S3ControlResponse(BaseResponse):
             next_token=next_token, configs=storage_lens_configuration_list
         )
 
+    def put_storage_lens_configuration_tagging(self) -> str:
+        account_id = self.headers.get("x-amz-account-id")
+        config_id = self.path.split("/")[-1]
+        request = xmltodict.parse(self.body)["PutStorageLensConfigurationTaggingRequest"]
+        tags = request.get("Tags")
+        self.backend.put_storage_lens_configuration_tagging(
+            config_id=config_id,
+            account_id=account_id,
+            tags=tags,
+        )
+        return ""
+    
+    def get_storage_lens_configuration_tagging(self) -> str:
+        account_id = self.headers.get("x-amz-account-id")
+        print("RESPONSES PATH: ", self.path)
+        config_id = self.path.split("/")[-2]
+        storage_lens_tags = self.backend.get_storage_lens_configuration_tagging(
+            config_id=config_id,
+            account_id=account_id,
+
+        )
+        template = self.response_template(GET_STORAGE_LENS_CONFIGURATION_TAGGING_TEMPLATE)
+        print("RESPONSE TAGS: ",storage_lens_tags)
+        return template.render(tags=storage_lens_tags)
+        
 
 CREATE_ACCESS_POINT_TEMPLATE = """<CreateAccessPointResult>
   <ResponseMetadata>
@@ -275,4 +300,19 @@ LIST_STORAGE_LENS_CONFIGURATIONS_TEMPLATE = """
     </StorageLensConfiguration>
     {% endfor %}
 </ListStorageLensConfigurationsResult>
+"""
+
+
+GET_STORAGE_LENS_CONFIGURATION_TAGGING_TEMPLATE = """
+<GetStorageLensConfigurationTaggingResult>
+   <Tags>
+      {% for tag in tags["Tag"] %}
+      <Tag>
+         <Key>{{ tag["Key"] }}</Key>
+         <Value>{{ tag["Value"] }}</Value>
+      </Tag>
+      {% endfor %}
+   </Tags>
+</GetStorageLensConfigurationTaggingResult>
+
 """

--- a/moto/s3control/responses.py
+++ b/moto/s3control/responses.py
@@ -158,8 +158,10 @@ class S3ControlResponse(BaseResponse):
 
     def put_storage_lens_configuration_tagging(self) -> str:
         account_id = self.headers.get("x-amz-account-id")
-        config_id = self.path.split("/")[-1]
-        request = xmltodict.parse(self.body)["PutStorageLensConfigurationTaggingRequest"]
+        config_id = self.path.split("/")[-2]
+        request = xmltodict.parse(self.body)[
+            "PutStorageLensConfigurationTaggingRequest"
+        ]
         tags = request.get("Tags")
         self.backend.put_storage_lens_configuration_tagging(
             config_id=config_id,
@@ -167,20 +169,19 @@ class S3ControlResponse(BaseResponse):
             tags=tags,
         )
         return ""
-    
+
     def get_storage_lens_configuration_tagging(self) -> str:
         account_id = self.headers.get("x-amz-account-id")
-        print("RESPONSES PATH: ", self.path)
         config_id = self.path.split("/")[-2]
         storage_lens_tags = self.backend.get_storage_lens_configuration_tagging(
             config_id=config_id,
             account_id=account_id,
-
         )
-        template = self.response_template(GET_STORAGE_LENS_CONFIGURATION_TAGGING_TEMPLATE)
-        print("RESPONSE TAGS: ",storage_lens_tags)
+        template = self.response_template(
+            GET_STORAGE_LENS_CONFIGURATION_TAGGING_TEMPLATE
+        )
         return template.render(tags=storage_lens_tags)
-        
+
 
 CREATE_ACCESS_POINT_TEMPLATE = """<CreateAccessPointResult>
   <ResponseMetadata>

--- a/moto/s3control/urls.py
+++ b/moto/s3control/urls.py
@@ -13,5 +13,6 @@ url_paths = {
     r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policy$": S3ControlResponse.dispatch,
     r"{0}/v20180820/accesspoint/(?P<name>[\w_:%-]+)/policyStatus$": S3ControlResponse.dispatch,
     "{0}/v20180820/storagelens/(?P<storagelensid>[^/]+)$": S3ControlResponse.dispatch,
+    "{0}/v20180820/storagelens/(?P<storagelensid>[^/]+)/tagging$": S3ControlResponse.dispatch,
     "{0}/v20180820/storagelens$": S3ControlResponse.dispatch,
 }

--- a/tests/test_s3control/test_s3control.py
+++ b/tests/test_s3control/test_s3control.py
@@ -217,10 +217,119 @@ def test_storage_lens_configuration_tagging():
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-    # Get the configuration:
+    # Assert get tags
     resp = client.get_storage_lens_configuration_tagging(
         AccountId=ACCOUNT_ID, ConfigId=config_id
     )
-    print("TESTS GET TAGGING: ", resp)
 
-    
+    assert resp["Tags"] == tags
+
+    new_tags = [
+        {
+            "Key": "new_tag_key_1",
+            "Value": "new_tag_value_1",
+        },
+        {
+            "Key": "new_tag_key_2",
+            "Value": "new_tag_value_2",
+        },
+    ]
+
+    # Assert put tags
+    client.put_storage_lens_configuration_tagging(
+        AccountId=ACCOUNT_ID, ConfigId=config_id, Tags=new_tags
+    )
+
+    new_tags_resp = client.get_storage_lens_configuration_tagging(
+        AccountId=ACCOUNT_ID, ConfigId=config_id
+    )
+
+    assert new_tags_resp["Tags"] == new_tags
+
+
+@mock_aws
+def test_put_storage_lens_configuration_tagging():
+    client = boto3.client("s3control", region_name="us-east-2")
+    config_id = "my-test-config-id"
+    config = {
+        "Id": "id-test",
+        "AccountLevel": {
+            "BucketLevel": {},
+        },
+        "IsEnabled": True,
+    }
+    tags = [
+        {
+            "Key": "tag_key_1",
+            "Value": "tag_value_1",
+        },
+        {
+            "Key": "tag_key_2",
+            "Value": "tag_value_2",
+        },
+    ]
+    resp = client.put_storage_lens_configuration(
+        AccountId=ACCOUNT_ID,
+        ConfigId=config_id,
+        StorageLensConfiguration=config,
+        Tags=tags,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # With an invalid account ID:
+    with pytest.raises(ClientError) as ce_err:
+        client.put_storage_lens_configuration_tagging(
+            AccountId="111111111111", ConfigId=config_id, Tags=[]
+        )
+    assert ce_err.value.response["Error"]["Code"] == "AccessDenied"
+
+    # With an invalid config ID:
+    with pytest.raises(ClientError) as ce_err:
+        client.put_storage_lens_configuration_tagging(
+            AccountId=ACCOUNT_ID, ConfigId="111111111111", Tags=[]
+        )
+    assert ce_err.value.response["Error"]["Code"] == "NoSuchAccessPoint"
+
+
+@mock_aws
+def test_get_storage_lens_configuration_tagging():
+    client = boto3.client("s3control", region_name="us-east-2")
+    config_id = "my-test-config-id"
+    config = {
+        "Id": "id-test",
+        "AccountLevel": {
+            "BucketLevel": {},
+        },
+        "IsEnabled": True,
+    }
+    tags = [
+        {
+            "Key": "tag_key_1",
+            "Value": "tag_value_1",
+        },
+        {
+            "Key": "tag_key_2",
+            "Value": "tag_value_2",
+        },
+    ]
+    resp = client.put_storage_lens_configuration(
+        AccountId=ACCOUNT_ID,
+        ConfigId=config_id,
+        StorageLensConfiguration=config,
+        Tags=tags,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # With an invalid account ID:
+    with pytest.raises(ClientError) as ce_err:
+        client.get_storage_lens_configuration_tagging(
+            AccountId="111111111111", ConfigId=config_id
+        )
+    assert ce_err.value.response["Error"]["Code"] == "AccessDenied"
+
+    # With an invalid config ID:
+    with pytest.raises(ClientError) as ce_err:
+        client.get_storage_lens_configuration_tagging(
+            AccountId=ACCOUNT_ID, ConfigId="111111111111"
+        )
+    assert ce_err.value.response["Error"]["Code"] == "NoSuchAccessPoint"

--- a/tests/test_s3control/test_s3control.py
+++ b/tests/test_s3control/test_s3control.py
@@ -185,3 +185,42 @@ def test_storage_lens_configuration():
     assert resp["StorageLensConfigurationList"][0]["Id"] == "id-test"
     assert "StorageLensArn" in resp["StorageLensConfigurationList"][0]
     assert resp["StorageLensConfigurationList"][0]["IsEnabled"] is True
+
+
+@mock_aws
+def test_storage_lens_configuration_tagging():
+    client = boto3.client("s3control", region_name="us-east-2")
+    config_id = "my-test-config-id"
+    config = {
+        "Id": "id-test",
+        "AccountLevel": {
+            "BucketLevel": {},
+        },
+        "IsEnabled": True,
+    }
+    tags = [
+        {
+            "Key": "tag_key_1",
+            "Value": "tag_value_1",
+        },
+        {
+            "Key": "tag_key_2",
+            "Value": "tag_value_2",
+        },
+    ]
+
+    resp = client.put_storage_lens_configuration(
+        AccountId=ACCOUNT_ID,
+        ConfigId=config_id,
+        StorageLensConfiguration=config,
+        Tags=tags,
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    # Get the configuration:
+    resp = client.get_storage_lens_configuration_tagging(
+        AccountId=ACCOUNT_ID, ConfigId=config_id
+    )
+    print("TESTS GET TAGGING: ", resp)
+
+    


### PR DESCRIPTION
This PR adds support for the following S3 Control APIs:
- [put_storage_lens_configuration_tagging](https://docs.getmoto.org/en/latest/docs/services/s3control.html#:~:text=put_storage_lens_configuration_tagging)
- [get_storage_lens_configuration_tagging](https://docs.getmoto.org/en/latest/docs/services/s3control.html#:~:text=get_storage_lens_configuration_tagging)

Addresses https://github.com/getmoto/moto/issues/9150