### PR TITLE
EC2: Fix missing response fields for AZs and Security Groups

### DIFF
--- a/moto/ec2/models/availability_zones_and_regions.py
+++ b/moto/ec2/models/availability_zones_and_regions.py
@@ -25,6 +25,7 @@ class Zone:
         self.zone_id = zone_id
         self.zone_type = zone_type
         self.state = "available"
+        self.messages = []
 
 
 class RegionsAndZonesBackend:

--- a/moto/ec2/responses/security_groups.py
+++ b/moto/ec2/responses/security_groups.py
@@ -165,7 +165,10 @@ class SecurityGroups(EC2BaseResponse):
         group = self.ec2_backend.create_security_group(
             name, description, vpc_id=vpc_id, tags=tags
         )
-        result = {"GroupId": group.id}
+        result = {
+            "GroupId": group.id,
+            "SecurityGroupArn": group.arn,
+        }
         return ActionResult(result)
 
     def delete_security_group(self) -> ActionResult:

--- a/tests/test_ec2/test_availability_zones_and_regions.py
+++ b/tests/test_ec2/test_availability_zones_and_regions.py
@@ -47,6 +47,7 @@ def test_availability_zones__parameters():
     ]
     assert len(zones) == 1
     assert zones[0]["ZoneId"] == "use1-az1"
+    assert zones[0]["Messages"] == []
 
     zones = us_east.describe_availability_zones(ZoneNames=["us-east-1a", "us-east-1b"])[
         "AvailabilityZones"


### PR DESCRIPTION
This PR adds fields that are missing in EC2 responses:
- [CreateSecurityGroup](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html): [`securityGroupArn`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSecurityGroup.html#API_CreateSecurityGroup_ResponseElements)
- [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html): `messages`. This appears to be aliased to [`messageSet`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AvailabilityZone.html). Here are the [Smithy models](https://github.com/aws/api-models-aws/blob/main/models/ec2/service/2016-11-15/ec2-2016-11-15.json) for DescribeAvailabilityZonesResult


```
    "com.amazonaws.ec2#AvailabilityZone": {
      "type": "structure",
      "members": {
        ...
        "Messages": {
          "target": "com.amazonaws.ec2#AvailabilityZoneMessageList",
          "traits": {
            "aws.protocols#ec2QueryName": "MessageSet",
            "smithy.api#documentation": "<p>Any messages about the Availability Zone, Local Zone, or Wavelength Zone.</p>",
            "smithy.api#xmlName": "messageSet"
          }
        },
        ...
```