### PR TITLE
Enabling describe_elasticsearch_domain_config in ES service

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3982,7 +3982,7 @@
 - [ ] describe_domain_auto_tunes
 - [ ] describe_domain_change_progress
 - [X] describe_elasticsearch_domain
-- [ ] describe_elasticsearch_domain_config
+- [X] describe_elasticsearch_domain_config
 - [X] describe_elasticsearch_domains
 - [ ] describe_elasticsearch_instance_type_limits
 - [ ] describe_inbound_cross_cluster_search_connections

--- a/docs/docs/services/es.rst
+++ b/docs/docs/services/es.rst
@@ -33,7 +33,7 @@ es
 - [ ] describe_domain_auto_tunes
 - [ ] describe_domain_change_progress
 - [X] describe_elasticsearch_domain
-- [ ] describe_elasticsearch_domain_config
+- [X] describe_elasticsearch_domain_config
 - [X] describe_elasticsearch_domains
 - [ ] describe_elasticsearch_instance_type_limits
 - [ ] describe_inbound_cross_cluster_search_connections

--- a/moto/es/models.py
+++ b/moto/es/models.py
@@ -23,5 +23,10 @@ class ElasticsearchServiceBackend(OpenSearchServiceBackend):
         # Method is kept here to make sure our documentation register this as supported
         pass
 
+    def describe_elasticsearch_domain_config(self) -> None:
+        # Functionality is part of OpenSearch, as that includes all of ES functionality + more
+        # Method is kept here to make sure our documentation register this as supported
+        pass
+
 
 es_backends = BackendDict(ElasticsearchServiceBackend, "es")

--- a/moto/es/urls.py
+++ b/moto/es/urls.py
@@ -6,6 +6,7 @@ url_bases = [
 
 
 url_paths = {
+    "{0}/2015-01-01/es/domain/(?P<domainname>[^/]+)/config": OpenSearchServiceResponse.describe_es_domain_config,
     "{0}/2015-01-01/domain$": OpenSearchServiceResponse.list_domains,
     "{0}/2015-01-01/es/domain$": OpenSearchServiceResponse.domains,
     "{0}/2015-01-01/es/domain/(?P<domainname>[^/]+)": OpenSearchServiceResponse.domain,

--- a/moto/opensearch/responses.py
+++ b/moto/opensearch/responses.py
@@ -19,7 +19,6 @@ class OpenSearchServiceResponse(BaseResponse):
 
     @property
     def opensearch_backend(self) -> OpenSearchServiceBackend:
-        """Return backend instance specific for this region."""
         return opensearch_backends[self.current_account][self.region]
 
     @classmethod
@@ -137,48 +136,52 @@ class OpenSearchServiceResponse(BaseResponse):
         return json.dumps(dict(DomainStatus=domain.to_dict()))
 
     def describe_domain_config(self) -> str:
-        domain_name = self.path.split("/")[-2]
-        domain = self.opensearch_backend.describe_domain_config(
+        # Supports both body param and URL form (/domain/{name}/config)
+        domain_name = self._get_param("DomainName")
+        if not domain_name and self.path:
+            parts = [p for p in self.path.split("/") if p]
+            if len(parts) >= 2 and parts[-1] == "config":
+                domain_name = parts[-2]
+        config = self.opensearch_backend.describe_domain_config(domain_name=domain_name)  # type: ignore[arg-type]
+        return json.dumps({"DomainConfig": config})
+
+    @classmethod
+    def describe_es_domain_config(
+        cls, request: Any, full_url: str, headers: Any
+    ) -> TYPE_RESPONSE:
+        response = cls()
+        response.setup_class(request, full_url, headers)
+
+        domain_name = request.url.split("/")[-2]
+        domain_config = response.opensearch_backend.describe_domain_config(
             domain_name=domain_name,
         )
-        return json.dumps(dict(DomainConfig=domain.to_config_dict()))
+
+        return 200, {}, json.dumps(dict(DomainConfig=domain_config))
 
     def update_domain_config(self) -> str:
         domain_name = self._get_param("DomainName")
-        cluster_config = self._get_param("ClusterConfig")
-        ebs_options = self._get_param("EBSOptions")
-        access_policies = self._get_param("AccessPolicies")
-        snapshot_options = self._get_param("SnapshotOptions")
-        vpc_options = self._get_param("VPCOptions")
-        cognito_options = self._get_param("CognitoOptions")
-        encryption_at_rest_options = self._get_param("EncryptionAtRestOptions")
-        node_to_node_encryption_options = self._get_param("NodeToNodeEncryptionOptions")
-        advanced_options = self._get_param("AdvancedOptions")
-        log_publishing_options = self._get_param("LogPublishingOptions")
-        domain_endpoint_options = self._get_param("DomainEndpointOptions")
-        advanced_security_options = self._get_param("AdvancedSecurityOptions")
-        auto_tune_options = self._get_param("AutoTuneOptions")
-        off_peak_window_options = self._get_param("OffPeakWindowOptions")
-        software_update_options = self._get_param("SoftwareUpdateOptions")
         domain = self.opensearch_backend.update_domain_config(
             domain_name=domain_name,
-            cluster_config=cluster_config,
-            ebs_options=ebs_options,
-            access_policies=access_policies,
-            snapshot_options=snapshot_options,
-            vpc_options=vpc_options,
-            cognito_options=cognito_options,
-            encryption_at_rest_options=encryption_at_rest_options,
-            node_to_node_encryption_options=node_to_node_encryption_options,
-            advanced_options=advanced_options,
-            log_publishing_options=log_publishing_options,
-            domain_endpoint_options=domain_endpoint_options,
-            advanced_security_options=advanced_security_options,
-            auto_tune_options=auto_tune_options,
-            off_peak_window_options=off_peak_window_options,
-            software_update_options=software_update_options,
+            cluster_config=self._get_param("ClusterConfig"),
+            ebs_options=self._get_param("EBSOptions"),
+            access_policies=self._get_param("AccessPolicies"),
+            snapshot_options=self._get_param("SnapshotOptions"),
+            vpc_options=self._get_param("VPCOptions"),
+            cognito_options=self._get_param("CognitoOptions"),
+            encryption_at_rest_options=self._get_param("EncryptionAtRestOptions"),
+            node_to_node_encryption_options=self._get_param(
+                "NodeToNodeEncryptionOptions"
+            ),
+            advanced_options=self._get_param("AdvancedOptions"),
+            log_publishing_options=self._get_param("LogPublishingOptions"),
+            domain_endpoint_options=self._get_param("DomainEndpointOptions"),
+            advanced_security_options=self._get_param("AdvancedSecurityOptions"),
+            auto_tune_options=self._get_param("AutoTuneOptions"),
+            off_peak_window_options=self._get_param("OffPeakWindowOptions"),
+            software_update_options=self._get_param("SoftwareUpdateOptions"),
         )
-        return json.dumps(dict(DomainConfig=domain.to_config_dict()))
+        return json.dumps({"DomainConfig": domain.to_config_dict()})
 
     def list_tags(self) -> str:
         arn = self._get_param("arn")

--- a/tests/test_es/test_es.py
+++ b/tests/test_es/test_es.py
@@ -202,6 +202,7 @@ def test_describe_elasticsearch_domain():
     assert domain["UpgradeProcessing"] is False
     assert "ElasticsearchVersion" not in domain
 
+
 @mock_aws
 def test_describe_elasticsearch_domain_config():
     client = boto3.client("es", region_name="ap-southeast-1")
@@ -210,6 +211,7 @@ def test_describe_elasticsearch_domain_config():
     resp = client.describe_elasticsearch_domain_config(DomainName="motosearch")
     domain_config = resp["DomainConfig"]
     assert domain_config["ElasticsearchClusterConfig"]["Options"]["InstanceCount"] == 1
+
 
 @mock_aws
 def test_list_domain_names_initial():

--- a/tests/test_es/test_es.py
+++ b/tests/test_es/test_es.py
@@ -202,6 +202,14 @@ def test_describe_elasticsearch_domain():
     assert domain["UpgradeProcessing"] is False
     assert "ElasticsearchVersion" not in domain
 
+@mock_aws
+def test_describe_elasticsearch_domain_config():
+    client = boto3.client("es", region_name="ap-southeast-1")
+    client.create_elasticsearch_domain(DomainName="motosearch")
+
+    resp = client.describe_elasticsearch_domain_config(DomainName="motosearch")
+    domain_config = resp["DomainConfig"]
+    assert domain_config["ElasticsearchClusterConfig"]["Options"]["InstanceCount"] == 1
 
 @mock_aws
 def test_list_domain_names_initial():


### PR DESCRIPTION
This PR enables describe_elasticsearch_domain_config in ES service which uses merged functionality from OpenSearch service.