### PR TITLE
ELBv2: Default weights for TargetGroups

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -530,6 +530,9 @@ class FakeAction(BaseModel):
                 self.data["ForwardConfig"]["TargetGroupStickinessConfig"] = {
                     "Enabled": False
                 }
+
+            for target_group in self.data["ForwardConfig"].get("TargetGroups", []):
+                target_group.setdefault("Weight", 1)
         # Dynamically give our Action class all properties of the source data.
         self.__dict__.update(self.data)
 

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -996,17 +996,26 @@ def test_handle_listener_rules():
                     "TargetGroups": [
                         {
                             "TargetGroupArn": target_group["TargetGroupArn"],
-                            "Weight": 1,
                         },
                         {
                             "TargetGroupArn": target_group["TargetGroupArn"],
-                            "Weight": 2,
+                            "Weight": 20,
                         },
                     ]
                 },
             },
         ],
     )
+    # test for default weights
+    rule_arn = rules["Rules"][0]["RuleArn"]
+    forward_rule = conn.describe_rules(RuleArns=[rule_arn])["Rules"][0]
+    assert len(forward_rule["Actions"]) == 1
+    assert len(forward_rule["Actions"][0]["ForwardConfig"]["TargetGroups"]) == 2
+    weights = [
+        tg["Weight"]
+        for tg in forward_rule["Actions"][0]["ForwardConfig"]["TargetGroups"]
+    ]
+    assert weights == [1, 20]
 
     # test for PriorityInUse
     with pytest.raises(ClientError):


### PR DESCRIPTION
This PR makes ELB rules assume a default weight if not specified in the request.

This behaviour was checked against AWS.