### PR TITLE
ELB: Resource ARNs must be unique

### DIFF
--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1396,10 +1396,9 @@ Member must satisfy regular expression pattern: {expression}"
         self._validate_port_and_protocol(balancer.type, port, protocol)
         self._validate_actions(default_actions)
 
-        arn = (
-            load_balancer_arn.replace(":loadbalancer/", ":listener/")
-            + f"/{port}{id(self)}"
-        )
+        arn = load_balancer_arn.replace(":loadbalancer/", ":listener/")
+        arn += f"/{mock_random.get_random_hex(16)}"
+
         listener = FakeListener(
             load_balancer_arn,
             arn,

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -117,8 +117,12 @@ class FakeTargetGroup(CloudFormationModel):
         self.name = name
         self.account_id = account_id
         self.region_name = region_name
+        tg_id = mock_random.get_random_hex(length=16)
         self.arn = make_arn_for_target_group(
-            account_id=self.account_id, name=name, region_name=self.region_name
+            account_id=self.account_id,
+            tg_id=tg_id,
+            name=name,
+            region_name=self.region_name,
         )
         self.vpc_id = vpc_id
         if target_type == "lambda":
@@ -744,8 +748,12 @@ class ELBv2Backend(BaseBackend):
             subnets.append(subnet)
 
         vpc_id = subnets[0].vpc_id
+        lb_id = mock_random.get_random_hex(length=16)
         arn = make_arn_for_load_balancer(
-            account_id=self.account_id, name=name, region_name=self.region_name
+            account_id=self.account_id,
+            lb_id=lb_id,
+            name=name,
+            region_name=self.region_name,
         )
         dns_name = f"{name}-1.{self.region_name}.elb.amazonaws.com"
 

--- a/moto/elbv2/utils.py
+++ b/moto/elbv2/utils.py
@@ -1,9 +1,12 @@
+from moto.moto_api._internal import mock_random
 from moto.utilities.utils import get_partition
 
 
 def make_arn_for_load_balancer(account_id: str, name: str, region_name: str) -> str:
-    return f"arn:{get_partition(region_name)}:elasticloadbalancing:{region_name}:{account_id}:loadbalancer/app/{name}/50dc6c495c0c9188"
+    lb_id = mock_random.get_random_hex(length=16)
+    return f"arn:{get_partition(region_name)}:elasticloadbalancing:{region_name}:{account_id}:loadbalancer/app/{name}/{lb_id}"
 
 
 def make_arn_for_target_group(account_id: str, name: str, region_name: str) -> str:
-    return f"arn:{get_partition(region_name)}:elasticloadbalancing:{region_name}:{account_id}:targetgroup/{name}/50dc6c495c0c9188"
+    tg_id = mock_random.get_random_hex(length=16)
+    return f"arn:{get_partition(region_name)}:elasticloadbalancing:{region_name}:{account_id}:targetgroup/{name}/{tg_id}"

--- a/moto/elbv2/utils.py
+++ b/moto/elbv2/utils.py
@@ -1,12 +1,13 @@
-from moto.moto_api._internal import mock_random
 from moto.utilities.utils import get_partition
 
 
-def make_arn_for_load_balancer(account_id: str, name: str, region_name: str) -> str:
-    lb_id = mock_random.get_random_hex(length=16)
+def make_arn_for_load_balancer(
+    account_id: str, lb_id: str, name: str, region_name: str
+) -> str:
     return f"arn:{get_partition(region_name)}:elasticloadbalancing:{region_name}:{account_id}:loadbalancer/app/{name}/{lb_id}"
 
 
-def make_arn_for_target_group(account_id: str, name: str, region_name: str) -> str:
-    tg_id = mock_random.get_random_hex(length=16)
+def make_arn_for_target_group(
+    account_id: str, tg_id: str, name: str, region_name: str
+) -> str:
     return f"arn:{get_partition(region_name)}:elasticloadbalancing:{region_name}:{account_id}:targetgroup/{name}/{tg_id}"

--- a/tests/test_elbv2/test_elbv2.py
+++ b/tests/test_elbv2/test_elbv2.py
@@ -18,9 +18,8 @@ def test_create_load_balancer():
     lb = response["LoadBalancers"][0]
     assert lb["CanonicalHostedZoneId"].startswith("Z")
     assert lb["DNSName"] == "my-lb-1.us-east-1.elb.amazonaws.com"
-    assert (
-        lb["LoadBalancerArn"]
-        == f"arn:aws:elasticloadbalancing:us-east-1:{ACCOUNT_ID}:loadbalancer/app/my-lb/50dc6c495c0c9188"
+    assert lb["LoadBalancerArn"].startswith(
+        f"arn:aws:elasticloadbalancing:us-east-1:{ACCOUNT_ID}:loadbalancer/app/my-lb/"
     )
     assert lb["SecurityGroups"] == [security_group.id]
     assert lb["AvailabilityZones"] == [

--- a/tests/test_elbv2/test_elbv2_target_groups.py
+++ b/tests/test_elbv2/test_elbv2_target_groups.py
@@ -207,7 +207,7 @@ def test_create_target_group_and_listeners():
     assert e.value.operation_name == "DeleteTargetGroup"
     assert (
         e.value.response["Error"]["Message"]
-        == f"The target group 'arn:aws:elasticloadbalancing:us-east-1:{ACCOUNT_ID}:targetgroup/a-target/50dc6c495c0c9188' is currently in use by a listener or a rule"
+        == f"The target group '{target_group_arn}' is currently in use by a listener or a rule"
     )
 
     # Delete one listener


### PR DESCRIPTION
This PR updates the ARN construction logic for following resources such that they are unique:
- Listeners
- Load balancers
- Target groups