### PR TITLE
Making start job run a little more functional

### DIFF
--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -778,6 +778,16 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
             return int(val)
         return if_none
 
+    def _get_float_param(
+        self,
+        param_name: str,
+        if_none: TYPE_IF_NONE = None,  # type: ignore[assignment]
+    ) -> Union[float, TYPE_IF_NONE]:
+        val = self._get_param(param_name)
+        if val is not None:
+            return float(val)
+        return if_none
+
     def _get_bool_param(
         self,
         param_name: str,

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
 
+from .exceptions import InvalidInputException
 from .models import (
     FakeCrawler,
     FakeJob,
@@ -401,14 +402,41 @@ class GlueResponse(BaseResponse):
         )
 
     def start_job_run(self) -> str:
-        name = self.parameters.get("JobName")
-        job_run_id = self.glue_backend.start_job_run(name)  # type: ignore[arg-type]
-        return json.dumps(dict(JobRunId=job_run_id))
+        allocated_capacity = self._get_int_param("AllocatedCapacity")
+        notification_property = self._get_dict_param("NotificationProperty")
+        number_of_workers = self._get_int_param("NumberOfWorkers")
+        security_configuration = self._get_param("SecurityConfiguration")
+        timeout = self._get_int_param("Timeout")
+        worker_type = self._get_param("WorkerType")
+        name = self._get_param("JobName")
+        arguments = self._get_param("Arguments")
+        max_capacity = self._get_float_param("MaxCapacity")
+        previous_job_run_id = self._get_param("JobRunId")
+
+        if allocated_capacity and max_capacity:
+            raise InvalidInputException(
+                "StartJobRun", "Please set only Allocated Capacity or Max Capacity"
+            )
+
+        job_run_id = self.glue_backend.start_job_run(
+            name,
+            arguments,
+            allocated_capacity,
+            max_capacity,
+            timeout,
+            worker_type,
+            security_configuration,
+            number_of_workers,
+            notification_property,
+            previous_job_run_id,
+        )
+        return json.dumps({"JobRunId": job_run_id})
 
     def get_job_run(self) -> str:
         name = self.parameters.get("JobName")
         run_id = self.parameters.get("RunId")
         job_run = self.glue_backend.get_job_run(name, run_id)  # type: ignore[arg-type]
+        print(job_run.arguments)
         return json.dumps({"JobRun": job_run.as_dict()})
 
     def get_job_runs(self) -> str:

--- a/tests/test_glue/test_glue_job_runs.py
+++ b/tests/test_glue/test_glue_job_runs.py
@@ -80,26 +80,7 @@ def test_get_job_run():
 
     response = client.get_job_run(JobName=job_name, RunId=job_run_id)
     assert response["JobRun"]["Id"] == job_run_id
-    assert response["JobRun"]["Attempt"]
-    assert response["JobRun"]["PreviousRunId"]
-    assert response["JobRun"]["TriggerName"]
-    assert response["JobRun"]["StartedOn"]
-    assert response["JobRun"]["LastModifiedOn"]
-    assert response["JobRun"]["CompletedOn"]
     assert response["JobRun"]["JobRunState"] == "SUCCEEDED"
-    assert response["JobRun"]["Arguments"]
-    assert response["JobRun"]["ErrorMessage"] == ""
-    assert response["JobRun"]["PredecessorRuns"]
-    assert response["JobRun"]["AllocatedCapacity"]
-    assert response["JobRun"]["ExecutionTime"]
-    assert response["JobRun"]["Timeout"]
-    assert response["JobRun"]["MaxCapacity"]
-    assert response["JobRun"]["WorkerType"]
-    assert response["JobRun"]["NumberOfWorkers"]
-    assert response["JobRun"]["SecurityConfiguration"]
-    assert response["JobRun"]["LogGroupName"]
-    assert response["JobRun"]["NotificationProperty"]
-    assert response["JobRun"]["GlueVersion"]
 
 
 @mock_aws
@@ -182,6 +163,142 @@ def test_job_run_transition():
 
     # unset transition
     state_manager.unset_transition("glue::job_run")
+
+
+@mock_aws
+def test_job_run_arguments() -> None:
+    client = create_glue_client()
+    job_name = create_test_job(client)
+
+    args = {
+        "--arg": "value",
+    }
+    run_id = client.start_job_run(JobName=job_name, Arguments=args)["JobRunId"]
+    job_run = client.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]
+    assert job_run["Arguments"] == args
+
+
+@mock_aws
+def test_job_default_arguments_go_through_to_job_run() -> None:
+    client = create_glue_client()
+    default_args = {
+        "--default_arg": "default_value",
+    }
+    job_name = client.create_job(
+        Name="job-with-default-args",
+        Role="some-role",
+        DefaultArguments=default_args,
+        Command={
+            "Name": "some-name",
+            "ScriptLocation": "some-location",
+            "PythonVersion": "some-version",
+        },
+    )["Name"]
+
+    # Start job run without overriding arguments
+    run_id = client.start_job_run(JobName=job_name)["JobRunId"]
+    job_run = client.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]
+    assert job_run["Arguments"] == default_args
+
+
+@mock_aws
+def test_non_overridable_arguments_go_through_to_job_run():
+    client = create_glue_client()
+    args = {
+        "--default_arg": "default_value",
+    }
+    job_name = client.create_job(
+        Name="job-with-default-args",
+        Role="some-role",
+        NonOverridableArguments=args,
+        Command={
+            "Name": "some-name",
+            "ScriptLocation": "some-location",
+            "PythonVersion": "some-version",
+        },
+    )["Name"]
+
+    # Start job run without overriding arguments
+    run_id = client.start_job_run(JobName=job_name)["JobRunId"]
+    job_run = client.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]
+    assert job_run["Arguments"] == args
+
+
+@mock_aws
+def test_non_overridable_arguments_cant_be_overridden():
+    client = create_glue_client()
+    args = {
+        "--default_arg": "default_value",
+    }
+    job_name = client.create_job(
+        Name="job-with-default-args",
+        Role="some-role",
+        NonOverridableArguments=args,
+        Command={
+            "Name": "some-name",
+            "ScriptLocation": "some-location",
+            "PythonVersion": "some-version",
+        },
+    )["Name"]
+
+    override_args = {
+        "--default_arg": "attempted_override",
+    }
+
+    # Start job run without overriding arguments
+    run_id = client.start_job_run(JobName=job_name, Arguments=override_args)["JobRunId"]
+    job_run = client.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]
+    assert job_run["Arguments"] == args
+
+
+@mock_aws
+def test_job_run_id_passed_in_goes_to_previous_run_id_field():
+    client = create_glue_client()
+    job_name = create_test_job(client)
+
+    run_id = client.start_job_run(JobName=job_name)["JobRunId"]
+    job_run = client.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]
+
+    second_run_id = client.start_job_run(JobName=job_name, JobRunId=job_run["Id"])[
+        "JobRunId"
+    ]
+    second_job_run = client.get_job_run(JobName=job_name, RunId=second_run_id)["JobRun"]
+    assert second_job_run["PreviousRunId"] == run_id
+
+
+@mock_aws
+def test_start_job_run_allocated_capacity_and_max_capacity_mutually_exclusive():
+    client = create_glue_client()
+    job_name = create_test_job(client)
+
+    with pytest.raises(ClientError) as exc:
+        client.start_job_run(JobName=job_name, AllocatedCapacity=2, MaxCapacity=5.0)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidInputException"
+    assert err["Message"] == "Please set only Allocated Capacity or Max Capacity"
+
+
+parameters_and_values = [
+    ("AllocatedCapacity", 5),
+    ("MaxCapacity", 5.0),
+    ("NumberOfWorkers", 3),
+    ("SecurityConfiguration", "my-security-config"),
+    ("Timeout", 60),
+    ("WorkerType", "G.1X"),
+]
+
+
+@mock_aws
+@pytest.mark.parametrize("parameter,value", parameters_and_values)
+def test_start_job_run_setting_is_set(parameter, value):
+    client = create_glue_client()
+    job_name = create_test_job(client)
+
+    start_kwargs = {parameter: value}
+    run_id = client.start_job_run(JobName=job_name, **start_kwargs)["JobRunId"]
+    job_run = client.get_job_run(JobName=job_name, RunId=run_id)["JobRun"]
+
+    assert job_run[parameter] == value
 
 
 def expect_job_state(client, job_name, run_id, expected_state):


### PR DESCRIPTION
This addresses [this issue](https://github.com/getmoto/moto/issues/9033). Previously we were just generating hardcoded mock values for all the values of the job. This allows us to pass in most of the supported values from the start_job_run, otherwise it gets them from the create_job values.