### PR TITLE
EC2: integrate IamInstanceProfileAssociation responses with core serializer

### DIFF
--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -24,8 +24,9 @@ class IamInstanceProfileAssociation(CloudFormationModel):
         iam_instance_profile: InstanceProfile,
     ):
         self.ec2_backend = ec2_backend
-        self.id = association_id
+        self.association_id = association_id
         self.instance = instance
+        self.instance_id = instance.id
         self.iam_instance_profile = iam_instance_profile
         self.state = "associated"
         ec2_backend.modify_instance_attribute(
@@ -81,7 +82,7 @@ class IamInstanceProfileAssociationBackend:
         associations_list: List[IamInstanceProfileAssociation] = []
         if association_ids:
             for association in self.iam_instance_profile_associations.values():
-                if association.id in association_ids:
+                if association.association_id in association_ids:
                     associations_list.append(association)
         else:
             # That's mean that no association id were given. Showing all.
@@ -106,7 +107,7 @@ class IamInstanceProfileAssociationBackend:
         iam_instance_profile_association = None
         for association_key in self.iam_instance_profile_associations.keys():
             if (
-                self.iam_instance_profile_associations[association_key].id
+                self.iam_instance_profile_associations[association_key].association_id
                 == association_id
             ):
                 iam_instance_profile_association = (
@@ -142,7 +143,7 @@ class IamInstanceProfileAssociationBackend:
         iam_instance_profile_association = None
         for association_key in self.iam_instance_profile_associations.keys():
             if (
-                self.iam_instance_profile_associations[association_key].id
+                self.iam_instance_profile_associations[association_key].association_id
                 == association_id
             ):
                 self.iam_instance_profile_associations[

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -467,7 +467,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
             self.ec2_backend.disassociate_iam_instance_profile(
                 association_id=self.ec2_backend.iam_instance_profile_associations[
                     self.id
-                ].id
+                ].association_id
             )
 
         return previous_state

--- a/moto/ec2/responses/iam_instance_profiles.py
+++ b/moto/ec2/responses/iam_instance_profiles.py
@@ -1,20 +1,28 @@
+from moto.core.responses import ActionResult
+
 from ._base_response import EC2BaseResponse
 
 
 class IamInstanceProfiles(EC2BaseResponse):
-    def associate_iam_instance_profile(self) -> str:
+    RESPONSE_KEY_PATH_TO_TRANSFORMER = {
+        "AssociateIamInstanceProfileResult.iamInstanceProfileAssociation.State": lambda _: "associating",
+        "ReplaceIamInstanceProfileAssociationResult.iamInstanceProfileAssociation.State": lambda _: "associating",
+        "DisassociateIamInstanceProfileResult.iamInstanceProfileAssociation.State": lambda _: "disassociating",
+    }
+
+    def associate_iam_instance_profile(self) -> ActionResult:
         instance_id = self._get_param("InstanceId")
         iam_instance_profile_name = self._get_param("IamInstanceProfile.Name")
         iam_instance_profile_arn = self._get_param("IamInstanceProfile.Arn")
         iam_association = self.ec2_backend.associate_iam_instance_profile(
             instance_id, iam_instance_profile_name, iam_instance_profile_arn
         )
-        template = self.response_template(IAM_INSTANCE_PROFILE_RESPONSE)
-        return template.render(iam_association=iam_association, state="associating")
+        result = {"IamInstanceProfileAssociation": iam_association}
+        return ActionResult(result)
 
-    def describe_iam_instance_profile_associations(self) -> str:
+    def describe_iam_instance_profile_associations(self) -> ActionResult:
         association_ids = self._get_multi_param("AssociationId")
-        filters = self._get_object_map("Filter")
+        filters = self._filters_from_querystring()
         max_items = self._get_param("MaxItems")
         next_token = self._get_param("NextToken")
         (
@@ -23,66 +31,26 @@ class IamInstanceProfiles(EC2BaseResponse):
         ) = self.ec2_backend.describe_iam_instance_profile_associations(
             association_ids, filters, max_items, next_token
         )
-        template = self.response_template(DESCRIBE_IAM_INSTANCE_PROFILE_RESPONSE)
-        return template.render(iam_associations=iam_associations, next_token=next_token)
+        result = {
+            "IamInstanceProfileAssociations": iam_associations,
+            "NextToken": next_token,
+        }
+        return ActionResult(result)
 
-    def disassociate_iam_instance_profile(self) -> str:
+    def disassociate_iam_instance_profile(self) -> ActionResult:
         association_id = self._get_param("AssociationId")
         iam_association = self.ec2_backend.disassociate_iam_instance_profile(
             association_id
         )
-        template = self.response_template(IAM_INSTANCE_PROFILE_RESPONSE)
-        return template.render(iam_association=iam_association, state="disassociating")
+        result = {"IamInstanceProfileAssociation": iam_association}
+        return ActionResult(result)
 
-    def replace_iam_instance_profile_association(self) -> str:
+    def replace_iam_instance_profile_association(self) -> ActionResult:
         association_id = self._get_param("AssociationId")
         iam_instance_profile_name = self._get_param("IamInstanceProfile.Name")
         iam_instance_profile_arn = self._get_param("IamInstanceProfile.Arn")
         iam_association = self.ec2_backend.replace_iam_instance_profile_association(
             association_id, iam_instance_profile_name, iam_instance_profile_arn
         )
-        template = self.response_template(IAM_INSTANCE_PROFILE_RESPONSE)
-        return template.render(iam_association=iam_association, state="associating")
-
-
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateIamInstanceProfile.html
-IAM_INSTANCE_PROFILE_RESPONSE = """
-<AssociateIamInstanceProfileResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>e10deeaf-7cda-48e7-950b-example</requestId>
-    <iamInstanceProfileAssociation>
-        <associationId>{{ iam_association.id }}</associationId>
-        {% if iam_association.iam_instance_profile %}
-        <iamInstanceProfile>
-            <arn>{{ iam_association.iam_instance_profile.arn }}</arn>
-            <id>{{ iam_association.iam_instance_profile.id }}</id>
-        </iamInstanceProfile>
-        {% endif %}
-        <instanceId>{{ iam_association.instance.id }}</instanceId>
-        <state>{{ state }}</state>
-    </iamInstanceProfileAssociation>
-</AssociateIamInstanceProfileResponse>
-"""
-
-
-# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeIamInstanceProfileAssociations.html
-# Note: this API description page contains an error! Provided `iamInstanceProfileAssociations` doesn't work, you
-# should use `iamInstanceProfileAssociationSet` instead.
-DESCRIBE_IAM_INSTANCE_PROFILE_RESPONSE = """
-<DescribeIamInstanceProfileAssociationsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
-    <requestId>84c2d2a6-12dc-491f-a9ee-example</requestId>
-    {% if next_token %}<nextToken>{{ next_token }}</nextToken>{% endif %}
-    <iamInstanceProfileAssociationSet>
-         {% for iam_association in iam_associations %}
-            <item>
-                <associationId>{{ iam_association.id }}</associationId>
-                <iamInstanceProfile>
-                    <arn>{{ iam_association.iam_instance_profile.arn }}</arn>
-                    <id>{{ iam_association.iam_instance_profile.id }}</id>
-                </iamInstanceProfile>
-                <instanceId>{{ iam_association.instance.id }}</instanceId>
-                <state>{{ iam_association.state }}</state>
-            </item>
-        {% endfor %}
-    </iamInstanceProfileAssociationSet>
-</DescribeIamInstanceProfileAssociationsResponse>
-"""
+        result = {"IamInstanceProfileAssociation": iam_association}
+        return ActionResult(result)

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -806,11 +806,11 @@ def filter_iam_instance_profile_associations(
         if filter_dict.get("instance-id"):
             if (
                 iam_instance_association.instance.id  # type: ignore[attr-defined]
-                not in filter_dict.get("instance-id").values()
+                not in filter_dict.get("instance-id", [])
             ):
                 filter_passed = False
         if filter_dict.get("state"):
-            if iam_instance_association.state not in filter_dict.get("state").values():  # type: ignore[attr-defined]
+            if iam_instance_association.state not in filter_dict.get("state", []):  # type: ignore[attr-defined]
                 filter_passed = False
         if filter_passed:
             result.append(iam_instance_association)


### PR DESCRIPTION
One model attribute renamed, no changes to any tests.  Also standardizes the filtering code to match all other EC2 backends. 