### PR TITLE
MediaPackage: parameter parsing fix-ups

### DIFF
--- a/moto/mediapackage/responses.py
+++ b/moto/mediapackage/responses.py
@@ -49,8 +49,8 @@ class MediaPackageResponse(BaseResponse):
         origination = self._get_param("origination")
         startover_window_seconds = self._get_int_param("startoverWindowSeconds")
         tags = self._get_param("tags")
-        time_delay_seconds = self._get_int_param("timeDelaySeconds.member")
-        whitelist = self._get_list_prefix("whitelist.member")
+        time_delay_seconds = self._get_int_param("timeDelaySeconds")
+        whitelist = self._get_param("whitelist")
         origin_endpoint = self.mediapackage_backend.create_origin_endpoint(
             authorization=authorization,
             channel_id=channel_id,
@@ -99,7 +99,7 @@ class MediaPackageResponse(BaseResponse):
         origination = self._get_param("origination")
         startover_window_seconds = self._get_int_param("startoverWindowSeconds")
         time_delay_seconds = self._get_int_param("timeDelaySeconds")
-        whitelist = self._get_list_prefix("whitelist.member")
+        whitelist = self._get_param("whitelist")
         origin_endpoint = self.mediapackage_backend.update_origin_endpoint(
             authorization=authorization,
             cmaf_package=cmaf_package,

--- a/tests/test_mediapackage/test_mediapackage.py
+++ b/tests/test_mediapackage/test_mediapackage.py
@@ -141,6 +141,8 @@ def test_create_origin_endpoint_succeeds():
     assert endpoint["Description"] == origin_endpoint_config["Description"]
     assert endpoint["HlsPackage"] == origin_endpoint_config["HlsPackage"]
     assert endpoint["Origination"] == "ALLOW"
+    assert endpoint["Whitelist"] == ["whitelist"]
+    assert endpoint["TimeDelaySeconds"] == 1
 
 
 @mock_aws
@@ -209,9 +211,11 @@ def test_update_origin_endpoint_succeeds():
         Id=endpoint_id,
         Description="updated-channel-description",
         ManifestName="updated-manifest-name",
+        Whitelist=["new-whitelist-item"],
     )
     assert endpoint["Description"] == "updated-channel-description"
     assert endpoint["ManifestName"] == "updated-manifest-name"
+    assert endpoint["Whitelist"] == ["new-whitelist-item"]
 
 
 @mock_aws


### PR DESCRIPTION
This started with just trying to get rid of the `._get_list_prefix()` call, but then I realized these parameters weren't being parsed at all.  Parsing of the `timeDelaySeconds` and `whitelist` parameters is now fixed and covered with test assertions.