### PR TITLE
DMS: fix ReplicationTask filtering

### DIFF
--- a/moto/dms/models.py
+++ b/moto/dms/models.py
@@ -95,7 +95,7 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         """
         The parameter WithoutSettings has not yet been implemented
         """
-        replication_tasks = filter_tasks(self.replication_tasks.values(), filters)
+        replication_tasks = filter_tasks(list(self.replication_tasks.values()), filters)
 
         if max_records and max_records > 0:
             replication_tasks = replication_tasks[:max_records]

--- a/moto/dms/responses.py
+++ b/moto/dms/responses.py
@@ -58,7 +58,7 @@ class DatabaseMigrationServiceResponse(BaseResponse):
         return json.dumps({"ReplicationTask": replication_task.to_dict()})
 
     def describe_replication_tasks(self) -> str:
-        filters = self._get_list_prefix("Filters.member")
+        filters = self._get_param("Filters")
         max_records = self._get_int_param("MaxRecords")
         replication_tasks = self.dms_backend.describe_replication_tasks(
             filters=filters, max_records=max_records
@@ -74,27 +74,6 @@ class DatabaseMigrationServiceResponse(BaseResponse):
         allocated_storage = params.get("AllocatedStorage")
         replication_instance_class = params.get("ReplicationInstanceClass")
         vpc_security_group_ids = self._get_param("VpcSecurityGroupIds")
-        if vpc_security_group_ids:
-            # If the parameter is directly available, use it
-            vpc_security_group_ids = (
-                vpc_security_group_ids.split(",")
-                if isinstance(vpc_security_group_ids, str)
-                else [vpc_security_group_ids]
-            )
-        else:
-            # If we need to extract from list prefix, get string values
-            vpc_security_group_list = self._get_list_prefix(
-                "VpcSecurityGroupIds.member"
-            )
-            vpc_security_group_ids = (
-                [
-                    sg_id.get("VpcSecurityGroupId", "")
-                    for sg_id in vpc_security_group_list
-                ]
-                if vpc_security_group_list
-                else None
-            )
-
         availability_zone = params.get("AvailabilityZone")
         replication_subnet_group_identifier = params.get(
             "ReplicationSubnetGroupIdentifier"

--- a/moto/dms/utils.py
+++ b/moto/dms/utils.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import random
 import string
-from typing import Any, Dict, Iterable, List
+from typing import TYPE_CHECKING, Any, Dict, List
+
+if TYPE_CHECKING:
+    from moto.dms.models import FakeReplicationTask
 
 
 def random_id(uppercase: bool = True, length: int = 13) -> str:
@@ -12,29 +17,33 @@ def random_id(uppercase: bool = True, length: int = 13) -> str:
     return resource_id
 
 
-def match_task_arn(task: Dict[str, Any], arns: List[str]) -> bool:
-    return task["ReplicationTaskArn"] in arns
+def match_task_arn(task: FakeReplicationTask, arns: List[str]) -> bool:
+    return task.arn in arns
 
 
-def match_task_id(task: Dict[str, Any], ids: List[str]) -> bool:
-    return task["ReplicationTaskIdentifier"] in ids
+def match_task_id(task: FakeReplicationTask, ids: List[str]) -> bool:
+    return task.id in ids
 
 
-def match_task_migration_type(task: Dict[str, Any], migration_types: List[str]) -> bool:
-    return task["MigrationType"] in migration_types
+def match_task_migration_type(
+    task: FakeReplicationTask, migration_types: List[str]
+) -> bool:
+    return task.migration_type in migration_types
 
 
-def match_task_endpoint_arn(task: Dict[str, Any], endpoint_arns: List[str]) -> bool:
+def match_task_endpoint_arn(
+    task: FakeReplicationTask, endpoint_arns: List[str]
+) -> bool:
     return (
-        task["SourceEndpointArn"] in endpoint_arns
-        or task["TargetEndpointArn"] in endpoint_arns
+        task.source_endpoint_arn in endpoint_arns
+        or task.target_endpoint_arn in endpoint_arns
     )
 
 
 def match_task_replication_instance_arn(
-    task: Dict[str, Any], replication_instance_arns: List[str]
+    task: FakeReplicationTask, replication_instance_arns: List[str]
 ) -> bool:
-    return task["ReplicationInstanceArn"] in replication_instance_arns
+    return task.replication_instance_arn in replication_instance_arns
 
 
 task_filter_functions = {
@@ -46,7 +55,9 @@ task_filter_functions = {
 }
 
 
-def filter_tasks(tasks: Iterable[Any], filters: List[Dict[str, Any]]) -> Any:
+def filter_tasks(
+    tasks: List[FakeReplicationTask], filters: List[Dict[str, Any]]
+) -> Any:
     matching_tasks = tasks
 
     for f in filters:
@@ -55,8 +66,8 @@ def filter_tasks(tasks: Iterable[Any], filters: List[Dict[str, Any]]) -> Any:
         if not filter_function:
             continue
 
-        matching_tasks = filter(
-            lambda task: filter_function(task, f["Values"]), matching_tasks
+        matching_tasks = list(
+            filter(lambda task: filter_function(task, f["Values"]), matching_tasks)
         )
 
     return matching_tasks

--- a/tests/test_dms/test_dms.py
+++ b/tests/test_dms/test_dms.py
@@ -22,7 +22,18 @@ def test_create_and_get_replication_task():
     )
 
     tasks = client.describe_replication_tasks(
-        Filters=[{"Name": "replication-task-id", "Values": ["test"]}]
+        Filters=[
+            {"Name": "replication-task-id", "Values": ["test"]},
+            {"Name": "migration-type", "Values": ["full-load"]},
+            {
+                "Name": "endpoint-arn",
+                "Values": ["source-endpoint-arn", "target-endpoint-arn"],
+            },
+            {
+                "Name": "replication-instance-arn",
+                "Values": ["replication-instance-arn"],
+            },
+        ]
     )
 
     assert len(tasks["ReplicationTasks"]) == 1
@@ -237,6 +248,9 @@ def test_create_replication_instance():
     assert instance["AutoMinorVersionUpgrade"] is True
     assert instance["PubliclyAccessible"] is True
     assert instance["NetworkType"] == "IPV4"
+    assert instance["VpcSecurityGroups"] == [
+        {"Status": "active", "VpcSecurityGroupId": "sg-12345"}
+    ]
 
     arn = instance["ReplicationInstanceArn"]
     assert arn.startswith("arn:aws:dms:us-east-1:")
@@ -246,10 +260,11 @@ def test_create_replication_instance():
         Filters=[{"Name": "replication-instance-id", "Values": ["test-instance"]}]
     )
     assert len(response["ReplicationInstances"]) == 1
-    assert (
-        response["ReplicationInstances"][0]["ReplicationInstanceIdentifier"]
-        == "test-instance"
-    )
+    instance = response["ReplicationInstances"][0]
+    assert instance["ReplicationInstanceIdentifier"] == "test-instance"
+    assert instance["VpcSecurityGroups"] == [
+        {"Status": "active", "VpcSecurityGroupId": "sg-12345"}
+    ]
 
 
 @mock_aws


### PR DESCRIPTION
This started with me just trying to get rid of the call to `_get_list_prefix()`, but in doing so I discovered that none of the filtering for ReplicationTasks worked at all (or had test coverage).  This PR fixes that.  I jammed all the filters into an existing test, but at least now all of the various filter methods are covered.

I also discovered that the `VpcSecurityGroupsIds` parameter was not being parsed correctly, nor was it being serialized correctly in the response.  This has also been fixed, with test assertions added.