### PR TITLE
Cognito: integrate with core response serializer

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1,4 +1,3 @@
-import datetime
 import enum
 import re
 import time
@@ -794,7 +793,7 @@ class CognitoIdpGroup(BaseModel):
         self.description = description or ""
         self.role_arn = role_arn
         self.precedence = precedence
-        self.last_modified_date = datetime.datetime.now()
+        self.last_modified_date = utcnow()
         self.creation_date = self.last_modified_date
 
         # Users who are members of this group.
@@ -813,7 +812,7 @@ class CognitoIdpGroup(BaseModel):
             self.role_arn = role_arn
         if precedence is not None:
             self.precedence = precedence
-        self.last_modified_date = datetime.datetime.now()
+        self.last_modified_date = utcnow()
 
     def to_json(self) -> Dict[str, Any]:
         return {

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -481,8 +481,8 @@ class CognitoIdpUserPool(BaseModel):
             "Arn": self.arn,
             "Name": self.name,
             "Status": self.status,
-            "CreationDate": time.mktime(self.creation_date.timetuple()),
-            "LastModifiedDate": time.mktime(self.last_modified_date.timetuple()),
+            "CreationDate": self.creation_date,
+            "LastModifiedDate": self.last_modified_date,
             "MfaConfiguration": self.mfa_config,
             "EstimatedNumberOfUsers": len(self.users),
         }
@@ -768,8 +768,8 @@ class CognitoIdpIdentityProvider(BaseModel):
         return {
             "ProviderName": self.name,
             "ProviderType": self.extended_config.get("ProviderType"),
-            "CreationDate": time.mktime(self.creation_date.timetuple()),
-            "LastModifiedDate": time.mktime(self.last_modified_date.timetuple()),
+            "CreationDate": self.creation_date,
+            "LastModifiedDate": self.last_modified_date,
         }
 
     def to_json(self, extended: bool = False) -> Dict[str, Any]:
@@ -822,8 +822,8 @@ class CognitoIdpGroup(BaseModel):
             "Description": self.description,
             "RoleArn": self.role_arn,
             "Precedence": self.precedence,
-            "LastModifiedDate": time.mktime(self.last_modified_date.timetuple()),
-            "CreationDate": time.mktime(self.creation_date.timetuple()),
+            "LastModifiedDate": self.last_modified_date,
+            "CreationDate": self.creation_date,
         }
 
 
@@ -865,8 +865,8 @@ class CognitoIdpUser(BaseModel):
             "UserPoolId": self.user_pool_id,
             "Username": self.username,
             "UserStatus": self.status,
-            "UserCreateDate": time.mktime(self.create_date.timetuple()),
-            "UserLastModifiedDate": time.mktime(self.last_modified_date.timetuple()),
+            "UserCreateDate": self.create_date,
+            "UserLastModifiedDate": self.last_modified_date,
         }
 
     # list_users brings back "Attributes" while admin_get_user brings back "UserAttributes".

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -103,9 +103,7 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, domain, custom_domain_config
         )
         domain_description = user_pool_domain.to_json(extended=False)
-        if domain_description:
-            return ActionResult(domain_description)
-        return EmptyResult()
+        return ActionResult(domain_description)
 
     def describe_user_pool_domain(self) -> ActionResult:
         domain = self._get_param("Domain")
@@ -128,9 +126,7 @@ class CognitoIdpResponse(BaseResponse):
             domain, custom_domain_config
         )
         domain_description = user_pool_domain.to_json(extended=False)
-        if domain_description:
-            return ActionResult(domain_description)
-        return EmptyResult()
+        return ActionResult(domain_description)
 
     # User pool client
     def create_user_pool_client(self) -> ActionResult:

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict
 
-from moto.core.responses import TYPE_RESPONSE, BaseResponse
+from moto.core.responses import TYPE_RESPONSE, ActionResult, BaseResponse, EmptyResult
 from moto.utilities.utils import load_resource
 
 from .exceptions import InvalidParameterException
@@ -30,12 +30,12 @@ class CognitoIdpResponse(BaseResponse):
         return cognitoidp_backends[self.current_account][self.region]
 
     # User pool
-    def create_user_pool(self) -> str:
+    def create_user_pool(self) -> ActionResult:
         name = self.parameters.pop("PoolName")
         user_pool = self.backend.create_user_pool(name, self.parameters)
-        return json.dumps({"UserPool": user_pool.to_json(extended=True)})
+        return ActionResult({"UserPool": user_pool.to_json(extended=True)})
 
-    def set_user_pool_mfa_config(self) -> str:
+    def set_user_pool_mfa_config(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         sms_config = self._get_param("SmsMfaConfiguration", None)
         token_config = self._get_param("SoftwareTokenMfaConfiguration", None)
@@ -60,14 +60,14 @@ class CognitoIdpResponse(BaseResponse):
         response = self.backend.set_user_pool_mfa_config(
             user_pool_id, sms_config, token_config, mfa_config
         )
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def get_user_pool_mfa_config(self) -> str:
+    def get_user_pool_mfa_config(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         response = self.backend.get_user_pool_mfa_config(user_pool_id)
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def list_user_pools(self) -> str:
+    def list_user_pools(self) -> ActionResult:
         max_results = self._get_param("MaxResults")
         next_token = self._get_param("NextToken")
         user_pools, next_token = self.backend.list_user_pools(
@@ -78,24 +78,24 @@ class CognitoIdpResponse(BaseResponse):
         }
         if next_token:
             response["NextToken"] = str(next_token)
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def describe_user_pool(self) -> str:
+    def describe_user_pool(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         user_pool = self.backend.describe_user_pool(user_pool_id)
-        return json.dumps({"UserPool": user_pool.to_json(extended=True)})
+        return ActionResult({"UserPool": user_pool.to_json(extended=True)})
 
     def update_user_pool(self) -> None:
         user_pool_id = self._get_param("UserPoolId")
         self.backend.update_user_pool(user_pool_id, self.parameters)
 
-    def delete_user_pool(self) -> str:
+    def delete_user_pool(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         self.backend.delete_user_pool(user_pool_id)
-        return ""
+        return EmptyResult()
 
     # User pool domain
-    def create_user_pool_domain(self) -> str:
+    def create_user_pool_domain(self) -> ActionResult:
         domain = self._get_param("Domain")
         user_pool_id = self._get_param("UserPoolId")
         custom_domain_config = self._get_param("CustomDomainConfig")
@@ -104,24 +104,24 @@ class CognitoIdpResponse(BaseResponse):
         )
         domain_description = user_pool_domain.to_json(extended=False)
         if domain_description:
-            return json.dumps(domain_description)
-        return ""
+            return ActionResult(domain_description)
+        return EmptyResult()
 
-    def describe_user_pool_domain(self) -> str:
+    def describe_user_pool_domain(self) -> ActionResult:
         domain = self._get_param("Domain")
         user_pool_domain = self.backend.describe_user_pool_domain(domain)
         domain_description: Dict[str, Any] = {}
         if user_pool_domain:
             domain_description = user_pool_domain.to_json()
 
-        return json.dumps({"DomainDescription": domain_description})
+        return ActionResult({"DomainDescription": domain_description})
 
-    def delete_user_pool_domain(self) -> str:
+    def delete_user_pool_domain(self) -> ActionResult:
         domain = self._get_param("Domain")
         self.backend.delete_user_pool_domain(domain)
-        return ""
+        return EmptyResult()
 
-    def update_user_pool_domain(self) -> str:
+    def update_user_pool_domain(self) -> ActionResult:
         domain = self._get_param("Domain")
         custom_domain_config = self._get_param("CustomDomainConfig")
         user_pool_domain = self.backend.update_user_pool_domain(
@@ -129,19 +129,19 @@ class CognitoIdpResponse(BaseResponse):
         )
         domain_description = user_pool_domain.to_json(extended=False)
         if domain_description:
-            return json.dumps(domain_description)
-        return ""
+            return ActionResult(domain_description)
+        return EmptyResult()
 
     # User pool client
-    def create_user_pool_client(self) -> str:
+    def create_user_pool_client(self) -> ActionResult:
         user_pool_id = self.parameters.pop("UserPoolId")
         generate_secret = self.parameters.pop("GenerateSecret", False)
         user_pool_client = self.backend.create_user_pool_client(
             user_pool_id, generate_secret, self.parameters
         )
-        return json.dumps({"UserPoolClient": user_pool_client.to_json(extended=True)})
+        return ActionResult({"UserPoolClient": user_pool_client.to_json(extended=True)})
 
-    def list_user_pool_clients(self) -> str:
+    def list_user_pool_clients(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         max_results = self._get_param("MaxResults")
         next_token = self._get_param("NextToken")
@@ -155,42 +155,42 @@ class CognitoIdpResponse(BaseResponse):
         }
         if next_token:
             response["NextToken"] = str(next_token)
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def describe_user_pool_client(self) -> str:
+    def describe_user_pool_client(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         client_id = self._get_param("ClientId")
         user_pool_client = self.backend.describe_user_pool_client(
             user_pool_id, client_id
         )
-        return json.dumps({"UserPoolClient": user_pool_client.to_json(extended=True)})
+        return ActionResult({"UserPoolClient": user_pool_client.to_json(extended=True)})
 
-    def update_user_pool_client(self) -> str:
+    def update_user_pool_client(self) -> ActionResult:
         user_pool_id = self.parameters.pop("UserPoolId")
         client_id = self.parameters.pop("ClientId")
         user_pool_client = self.backend.update_user_pool_client(
             user_pool_id, client_id, self.parameters
         )
-        return json.dumps({"UserPoolClient": user_pool_client.to_json(extended=True)})
+        return ActionResult({"UserPoolClient": user_pool_client.to_json(extended=True)})
 
-    def delete_user_pool_client(self) -> str:
+    def delete_user_pool_client(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         client_id = self._get_param("ClientId")
         self.backend.delete_user_pool_client(user_pool_id, client_id)
-        return ""
+        return EmptyResult()
 
     # Identity provider
-    def create_identity_provider(self) -> str:
+    def create_identity_provider(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         name = self.parameters.pop("ProviderName")
         identity_provider = self.backend.create_identity_provider(
             user_pool_id, name, self.parameters
         )
-        return json.dumps(
+        return ActionResult(
             {"IdentityProvider": identity_provider.to_json(extended=True)}
         )
 
-    def list_identity_providers(self) -> str:
+    def list_identity_providers(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         max_results = self._get_param("MaxResults")
         next_token = self._get_param("NextToken")
@@ -204,34 +204,34 @@ class CognitoIdpResponse(BaseResponse):
         }
         if next_token:
             response["NextToken"] = str(next_token)
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def describe_identity_provider(self) -> str:
+    def describe_identity_provider(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         name = self._get_param("ProviderName")
         identity_provider = self.backend.describe_identity_provider(user_pool_id, name)
-        return json.dumps(
+        return ActionResult(
             {"IdentityProvider": identity_provider.to_json(extended=True)}
         )
 
-    def update_identity_provider(self) -> str:
+    def update_identity_provider(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         name = self._get_param("ProviderName")
         identity_provider = self.backend.update_identity_provider(
             user_pool_id, name, self.parameters
         )
-        return json.dumps(
+        return ActionResult(
             {"IdentityProvider": identity_provider.to_json(extended=True)}
         )
 
-    def delete_identity_provider(self) -> str:
+    def delete_identity_provider(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         name = self._get_param("ProviderName")
         self.backend.delete_identity_provider(user_pool_id, name)
-        return ""
+        return EmptyResult()
 
     # Group
-    def create_group(self) -> str:
+    def create_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         user_pool_id = self._get_param("UserPoolId")
         description = self._get_param("Description")
@@ -242,15 +242,15 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, group_name, description, role_arn, precedence
         )
 
-        return json.dumps({"Group": group.to_json()})
+        return ActionResult({"Group": group.to_json()})
 
-    def get_group(self) -> str:
+    def get_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         user_pool_id = self._get_param("UserPoolId")
         group = self.backend.get_group(user_pool_id, group_name)
-        return json.dumps({"Group": group.to_json()})
+        return ActionResult({"Group": group.to_json()})
 
-    def list_groups(self) -> str:
+    def list_groups(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         limit = self._get_param("Limit")
         token = self._get_param("NextToken")
@@ -258,15 +258,15 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, limit=limit, next_token=token
         )
         response = {"Groups": [group.to_json() for group in groups], "NextToken": token}
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def delete_group(self) -> str:
+    def delete_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         user_pool_id = self._get_param("UserPoolId")
         self.backend.delete_group(user_pool_id, group_name)
-        return ""
+        return EmptyResult()
 
-    def update_group(self) -> str:
+    def update_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         user_pool_id = self._get_param("UserPoolId")
         description = self._get_param("Description")
@@ -277,18 +277,18 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, group_name, description, role_arn, precedence
         )
 
-        return json.dumps({"Group": group.to_json()})
+        return ActionResult({"Group": group.to_json()})
 
-    def admin_add_user_to_group(self) -> str:
+    def admin_add_user_to_group(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         group_name = self._get_param("GroupName")
 
         self.backend.admin_add_user_to_group(user_pool_id, group_name, username)
 
-        return ""
+        return EmptyResult()
 
-    def list_users_in_group(self) -> str:
+    def list_users_in_group(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         group_name = self._get_param("GroupName")
         limit = self._get_param("Limit")
@@ -300,9 +300,9 @@ class CognitoIdpResponse(BaseResponse):
             "Users": [user.to_json(extended=True) for user in users],
             "NextToken": token,
         }
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def admin_list_groups_for_user(self) -> str:
+    def admin_list_groups_for_user(self) -> ActionResult:
         username = self._get_param("Username")
         user_pool_id = self._get_param("UserPoolId")
         limit = self._get_param("Limit")
@@ -311,25 +311,25 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, username, limit=limit, next_token=token
         )
         response = {"Groups": [group.to_json() for group in groups], "NextToken": token}
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def admin_remove_user_from_group(self) -> str:
+    def admin_remove_user_from_group(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         group_name = self._get_param("GroupName")
 
         self.backend.admin_remove_user_from_group(user_pool_id, group_name, username)
 
-        return ""
+        return EmptyResult()
 
-    def admin_reset_user_password(self) -> str:
+    def admin_reset_user_password(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         self.backend.admin_reset_user_password(user_pool_id, username)
-        return ""
+        return EmptyResult()
 
     # User
-    def admin_create_user(self) -> str:
+    def admin_create_user(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         message_action = self._get_param("MessageAction")
@@ -342,25 +342,30 @@ class CognitoIdpResponse(BaseResponse):
             self._get_param("UserAttributes", []),
         )
 
-        return json.dumps({"User": user.to_json(extended=True)})
+        return ActionResult({"User": user.to_json(extended=True)})
 
-    def admin_confirm_sign_up(self) -> str:
+    def admin_confirm_sign_up(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
-        return self.backend.admin_confirm_sign_up(user_pool_id, username)
+        self.backend.admin_confirm_sign_up(user_pool_id, username)
+        return EmptyResult()
 
-    def admin_get_user(self) -> str:
+    def admin_get_user(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         user = self.backend.admin_get_user(user_pool_id, username)
-        return json.dumps(user.to_json(extended=True, attributes_key="UserAttributes"))
+        return ActionResult(
+            user.to_json(extended=True, attributes_key="UserAttributes")
+        )
 
-    def get_user(self) -> str:
+    def get_user(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         user = self._get_region_agnostic_backend().get_user(access_token=access_token)
-        return json.dumps(user.to_json(extended=True, attributes_key="UserAttributes"))
+        return ActionResult(
+            user.to_json(extended=True, attributes_key="UserAttributes")
+        )
 
-    def list_users(self) -> str:
+    def list_users(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         limit = self._get_param("Limit")
         token = self._get_param("PaginationToken")
@@ -377,27 +382,27 @@ class CognitoIdpResponse(BaseResponse):
         }
         if token:
             response["PaginationToken"] = str(token)
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def admin_disable_user(self) -> str:
+    def admin_disable_user(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         self.backend.admin_disable_user(user_pool_id, username)
-        return ""
+        return EmptyResult()
 
-    def admin_enable_user(self) -> str:
+    def admin_enable_user(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         self.backend.admin_enable_user(user_pool_id, username)
-        return ""
+        return EmptyResult()
 
-    def admin_delete_user(self) -> str:
+    def admin_delete_user(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         self.backend.admin_delete_user(user_pool_id, username)
-        return ""
+        return EmptyResult()
 
-    def admin_initiate_auth(self) -> str:
+    def admin_initiate_auth(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         client_id = self._get_param("ClientId")
         auth_flow = self._get_param("AuthFlow")
@@ -407,9 +412,9 @@ class CognitoIdpResponse(BaseResponse):
             user_pool_id, client_id, auth_flow, auth_parameters
         )
 
-        return json.dumps(auth_result)
+        return ActionResult(auth_result)
 
-    def admin_respond_to_auth_challenge(self) -> str:
+    def admin_respond_to_auth_challenge(self) -> ActionResult:
         session = self._get_param("Session")
         client_id = self._get_param("ClientId")
         challenge_name = self._get_param("ChallengeName")
@@ -419,9 +424,9 @@ class CognitoIdpResponse(BaseResponse):
             session, client_id, challenge_name, challenge_responses
         )
 
-        return json.dumps(auth_result)
+        return ActionResult(auth_result)
 
-    def respond_to_auth_challenge(self) -> str:
+    def respond_to_auth_challenge(self) -> ActionResult:
         session = self._get_param("Session")
         client_id = self._get_param("ClientId")
         challenge_name = self._get_param("ChallengeName")
@@ -430,9 +435,9 @@ class CognitoIdpResponse(BaseResponse):
             session, client_id, challenge_name, challenge_responses
         )
 
-        return json.dumps(auth_result)
+        return ActionResult(auth_result)
 
-    def forgot_password(self) -> str:
+    def forgot_password(self) -> ActionResult:
         client_id = self._get_param("ClientId")
         username = self._get_param("Username")
         account, region = find_account_region_by_value(
@@ -444,13 +449,13 @@ class CognitoIdpResponse(BaseResponse):
         self.response_headers["x-moto-forgot-password-confirmation-code"] = (
             confirmation_code  # type: ignore[assignment]
         )
-        return json.dumps(response)
+        return ActionResult(response)
 
     # This endpoint receives no authorization header, so if moto-server is listening
     # on localhost (doesn't get a region in the host header), it doesn't know what
     # region's backend should handle the traffic, and we use `find_region_by_value` to
     # solve that problem.
-    def confirm_forgot_password(self) -> str:
+    def confirm_forgot_password(self) -> ActionResult:
         client_id = self._get_param("ClientId")
         username = self._get_param("Username")
         password = self._get_param("Password")
@@ -461,10 +466,10 @@ class CognitoIdpResponse(BaseResponse):
         cognitoidp_backends[account][region].confirm_forgot_password(
             client_id, username, password, confirmation_code
         )
-        return ""
+        return EmptyResult()
 
     # Ditto the comment on confirm_forgot_password.
-    def change_password(self) -> str:
+    def change_password(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         previous_password = self._get_param("PreviousPassword")
         proposed_password = self._get_param("ProposedPassword")
@@ -474,35 +479,35 @@ class CognitoIdpResponse(BaseResponse):
         cognitoidp_backends[account][region].change_password(
             access_token, previous_password, proposed_password
         )
-        return ""
+        return EmptyResult()
 
-    def admin_update_user_attributes(self) -> str:
+    def admin_update_user_attributes(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         attributes = self._get_param("UserAttributes")
         self.backend.admin_update_user_attributes(user_pool_id, username, attributes)
-        return ""
+        return EmptyResult()
 
-    def admin_delete_user_attributes(self) -> str:
+    def admin_delete_user_attributes(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         attributes = self._get_param("UserAttributeNames")
         self.backend.admin_delete_user_attributes(user_pool_id, username, attributes)
-        return ""
+        return EmptyResult()
 
-    def admin_user_global_sign_out(self) -> str:
+    def admin_user_global_sign_out(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         self.backend.admin_user_global_sign_out(user_pool_id, username)
-        return ""
+        return EmptyResult()
 
-    def global_sign_out(self) -> str:
+    def global_sign_out(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         self.backend.global_sign_out(access_token)
-        return ""
+        return EmptyResult()
 
     # Resource Server
-    def create_resource_server(self) -> str:
+    def create_resource_server(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         identifier = self._get_param("Identifier")
         name = self._get_param("Name")
@@ -510,17 +515,17 @@ class CognitoIdpResponse(BaseResponse):
         resource_server = self.backend.create_resource_server(
             user_pool_id, identifier, name, scopes
         )
-        return json.dumps({"ResourceServer": resource_server.to_json()})
+        return ActionResult({"ResourceServer": resource_server.to_json()})
 
-    def describe_resource_server(self) -> str:
+    def describe_resource_server(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         identifier = self._get_param("Identifier")
         resource_server = self.backend.describe_resource_server(
             user_pool_id, identifier
         )
-        return json.dumps({"ResourceServer": resource_server.to_json()})
+        return ActionResult({"ResourceServer": resource_server.to_json()})
 
-    def list_resource_servers(self) -> str:
+    def list_resource_servers(self) -> ActionResult:
         max_results = self._get_param("MaxResults")
         next_token = self._get_param("NextToken")
         user_pool_id = self._get_param("UserPoolId")
@@ -534,9 +539,9 @@ class CognitoIdpResponse(BaseResponse):
         }
         if next_token:
             response["NextToken"] = str(next_token)
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def sign_up(self) -> str:
+    def sign_up(self) -> ActionResult:
         client_id = self._get_param("ClientId")
         username = self._get_param("Username")
         password = self._get_param("Password")
@@ -552,17 +557,17 @@ class CognitoIdpResponse(BaseResponse):
         }
         if code_delivery_details:
             response["CodeDeliveryDetails"] = code_delivery_details
-        return json.dumps(response)
+        return ActionResult(response)
 
-    def confirm_sign_up(self) -> str:
+    def confirm_sign_up(self) -> ActionResult:
         client_id = self._get_param("ClientId")
         username = self._get_param("Username")
         self._get_region_agnostic_backend().confirm_sign_up(
             client_id=client_id, username=username
         )
-        return ""
+        return EmptyResult()
 
-    def initiate_auth(self) -> str:
+    def initiate_auth(self) -> ActionResult:
         client_id = self._get_param("ClientId")
         auth_flow = self._get_param("AuthFlow")
         auth_parameters = self._get_param("AuthParameters")
@@ -571,34 +576,34 @@ class CognitoIdpResponse(BaseResponse):
             client_id, auth_flow, auth_parameters
         )
 
-        return json.dumps(auth_result)
+        return ActionResult(auth_result)
 
-    def associate_software_token(self) -> str:
+    def associate_software_token(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         session = self._get_param("Session")
         result = self._get_region_agnostic_backend().associate_software_token(
             access_token, session
         )
-        return json.dumps(result)
+        return ActionResult(result)
 
-    def verify_software_token(self) -> str:
+    def verify_software_token(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         session = self._get_param("Session")
         result = self._get_region_agnostic_backend().verify_software_token(
             access_token, session
         )
-        return json.dumps(result)
+        return ActionResult(result)
 
-    def set_user_mfa_preference(self) -> str:
+    def set_user_mfa_preference(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         software_token_mfa_settings = self._get_param("SoftwareTokenMfaSettings")
         sms_mfa_settings = self._get_param("SMSMfaSettings")
         self._get_region_agnostic_backend().set_user_mfa_preference(
             access_token, software_token_mfa_settings, sms_mfa_settings
         )
-        return ""
+        return EmptyResult()
 
-    def admin_set_user_mfa_preference(self) -> str:
+    def admin_set_user_mfa_preference(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         software_token_mfa_settings = self._get_param("SoftwareTokenMfaSettings")
@@ -606,9 +611,9 @@ class CognitoIdpResponse(BaseResponse):
         self.backend.admin_set_user_mfa_preference(
             user_pool_id, username, software_token_mfa_settings, sms_mfa_settings
         )
-        return ""
+        return EmptyResult()
 
-    def admin_set_user_password(self) -> str:
+    def admin_set_user_password(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         username = self._get_param("Username")
         password = self._get_param("Password")
@@ -616,21 +621,21 @@ class CognitoIdpResponse(BaseResponse):
         self.backend.admin_set_user_password(
             user_pool_id, username, password, permanent
         )
-        return ""
+        return EmptyResult()
 
-    def add_custom_attributes(self) -> str:
+    def add_custom_attributes(self) -> ActionResult:
         user_pool_id = self._get_param("UserPoolId")
         custom_attributes = self._get_param("CustomAttributes")
         self.backend.add_custom_attributes(user_pool_id, custom_attributes)
-        return ""
+        return EmptyResult()
 
-    def update_user_attributes(self) -> str:
+    def update_user_attributes(self) -> ActionResult:
         access_token = self._get_param("AccessToken")
         attributes = self._get_param("UserAttributes")
         self._get_region_agnostic_backend().update_user_attributes(
             access_token, attributes
         )
-        return json.dumps({})
+        return EmptyResult()
 
 
 class CognitoIdpJsonWebKeyResponse(BaseResponse):

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -668,7 +668,7 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         )
         status_code, headers, body = action_result.execute_result(context)
         headers.update(self.response_headers)
-        return status_code, self.response_headers, body
+        return status_code, headers, body
 
     def call_action(self) -> TYPE_RESPONSE:
         headers = self.response_headers

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -666,7 +666,9 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
         context = ActionContext(
             service_model, operation_model, serializer_cls, self.__class__
         )
-        return action_result.execute_result(context)
+        status_code, headers, body = action_result.execute_result(context)
+        headers.update(self.response_headers)
+        return status_code, self.response_headers, body
 
     def call_action(self) -> TYPE_RESPONSE:
         headers = self.response_headers

--- a/tests/test_cognitoidp/test_server.py
+++ b/tests/test_cognitoidp/test_server.py
@@ -92,9 +92,7 @@ def test_sign_up_user_without_authentication():
     )
     assert res.status_code == 200
     data = json.loads(res.data)
-    assert data["UserPoolId"] == user_pool_id
     assert data["Username"] == "test@gmail.com"
-    assert data["UserStatus"] == "CONFIRMED"
 
 
 def test_admin_create_user_without_authentication():


### PR DESCRIPTION
This is a minimal viable changeset to integrate the Cognito backend with Moto's new serialization pipeline.  The impetus for this is #9204, which raised the issue of incorrect date serialization in Cognito responses.  The timestamps have been fixed in the Moto models and are now serialized correctly based on the Botocore models.  One test was modified, as it was asserting against attributes that are not present in a real AWS response from Cognito (and are no longer present in the equivalent Moto response).

This PR also contains a minor enhancement to the serializer that allows for custom response headers, in order to support the `x-moto-forgot-password-confirmation-code` workflow.

The Cognito backend in Moto contains multiple `to_json()` methods, which could be refactored out as a result of integrating with the new serializer, but is out of scope for this PR (which is focused on the timestamp serialization issue).

Fixes #9204 