### PR TITLE
Core: normalize request parsing for services using the AWS Query protocol

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -1852,8 +1852,10 @@ class AutoScalingBackend(BaseBackend):
             if f["Name"] == "auto-scaling-group":
                 tags = [t for t in tags if t["ResourceId"] in f["Values"]]
             if f["Name"] == "propagate-at-launch":
-                values = [v.lower() for v in f["Values"]]
-                tags = [t for t in tags if t.get("PropagateAtLaunch", False) in values]
+                values = [v for v in f["Values"]]
+                tags = [
+                    t for t in tags if str(t.get("PropagateAtLaunch", False)) in values
+                ]
             if f["Name"] == "key":
                 tags = [t for t in tags if t["Key"] in f["Values"]]
             if f["Name"] == "value":

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -835,7 +835,7 @@ class CloudFormationBackend(BaseBackend):
                     instance.parameters[parameter["parameter_key"]],
                 )
                 for parameter in incoming_params
-                if parameter.get("use_previous_value") == "true"
+                if parameter.get("use_previous_value", False)
             ]
         )
         parameters.update(previous)

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -118,6 +118,7 @@ class CloudFormationResponse(BaseResponse):
 
     def __init__(self) -> None:
         super().__init__(service_name="cloudformation")
+        self.automated_parameter_parsing = True
 
     @property
     def cloudformation_backend(self) -> CloudFormationBackend:
@@ -127,7 +128,9 @@ class CloudFormationResponse(BaseResponse):
     def cfnresponse(cls, *args: Any, **kwargs: Any) -> Any:  # type: ignore[misc]
         request, full_url, headers = args
         full_url += "&Action=ProcessCfnResponse"
-        return cls.dispatch(request=request, full_url=full_url, headers=headers)
+        cf = CloudFormationResponse()
+        cf.automated_parameter_parsing = False
+        return cf._dispatch(request=request, full_url=full_url, headers=headers)
 
     def _get_stack_from_s3_url(self, template_url: str) -> str:
         return get_stack_from_s3_url(
@@ -150,10 +153,10 @@ class CloudFormationResponse(BaseResponse):
     ) -> Dict[str, Any]:
         result = {}
         for parameter in parameters_list:
-            if parameter.keys() >= {"parameter_key", "parameter_value"}:
+            if set(parameter.keys()) >= {"parameter_key", "parameter_value"}:
                 result[parameter["parameter_key"]] = parameter["parameter_value"]
             elif (
-                parameter.keys() >= {"parameter_key", "use_previous_value"}
+                set(parameter.keys()) >= {"parameter_key", "use_previous_value"}
                 and parameter["parameter_key"] in existing_params
             ):
                 result[parameter["parameter_key"]] = existing_params[
@@ -184,17 +187,16 @@ class CloudFormationResponse(BaseResponse):
         enable_termination_protection = self._get_param("EnableTerminationProtection")
         timeout_in_mins = self._get_param("TimeoutInMinutes")
         stack_policy_body = self._get_param("StackPolicyBody")
-        parameters_list = self._get_list_prefix("Parameters.member")
+        parameters_list = self._get_param("Parameters", [])
         tags = dict(
-            (item["key"], item["value"])
-            for item in self._get_list_prefix("Tags.member")
+            (item["key"], item["value"]) for item in self._get_param("Tags", [])
         )
 
         parameters = self._get_params_from_list(parameters_list)
 
         if template_url:
             stack_body = self._get_stack_from_s3_url(template_url)
-        stack_notification_arns = self._get_multi_param("NotificationARNs.member")
+        stack_notification_arns = self._get_param("NotificationARNs", [])
 
         stack = self.cloudformation_backend.create_stack(
             name=stack_name,
@@ -213,14 +215,14 @@ class CloudFormationResponse(BaseResponse):
     def validate_template_and_stack_body(self) -> None:
         if (
             self._get_param("TemplateBody") or self._get_param("TemplateURL")
-        ) and self._get_param("UsePreviousTemplate", "false").lower() == "true":
+        ) and self._get_bool_param("UsePreviousTemplate", False):
             raise ValidationError(
                 message="An error occurred (ValidationError) when calling the CreateChangeSet operation: You cannot specify both usePreviousTemplate and Template Body/Template URL."
             )
         elif (
             not self._get_param("TemplateBody")
             and not self._get_param("TemplateURL")
-            and self._get_param("UsePreviousTemplate", "false").lower() == "false"
+            and not self._get_bool_param("UsePreviousTemplate", False)
         ):
             raise ValidationError(
                 message="An error occurred (ValidationError) when calling the CreateChangeSet operation: Either Template URL or Template Body must be specified."
@@ -232,26 +234,22 @@ class CloudFormationResponse(BaseResponse):
         stack_body = self._get_param("TemplateBody")
         template_url = self._get_param("TemplateURL")
         update_or_create = self._get_param("ChangeSetType", "CREATE")
-        use_previous_template = (
-            self._get_param("UsePreviousTemplate", "false").lower() == "true"
-        )
+        use_previous_template = self._get_bool_param("UsePreviousTemplate", False)
         if update_or_create == "UPDATE":
             stack = self.cloudformation_backend.get_stack(stack_name)
             self.validate_template_and_stack_body()
-
             if use_previous_template:
                 stack_body = stack.template
         description = self._get_param("Description")
         role_arn = self._get_param("RoleARN")
-        parameters_list = self._get_list_prefix("Parameters.member")
+        parameters_list = self._get_param("Parameters", [])
         tags = dict(
-            (item["key"], item["value"])
-            for item in self._get_list_prefix("Tags.member")
+            (item["key"], item["value"]) for item in self._get_param("Tags", [])
         )
         parameters = {
             param["parameter_key"]: (
                 stack.stack_parameters[param["parameter_key"]]
-                if param.get("use_previous_value", "").lower() == "true"
+                if param.get("use_previous_value", False)
                 else param["parameter_value"]
             )
             for param in parameters_list
@@ -261,7 +259,7 @@ class CloudFormationResponse(BaseResponse):
 
         if template_url:
             stack_body = self._get_stack_from_s3_url(template_url)
-        stack_notification_arns = self._get_multi_param("NotificationARNs.member")
+        stack_notification_arns = self._get_param("NotificationARNs", [])
         change_set_id, stack_id = self.cloudformation_backend.create_change_set(
             stack_name=stack_name,
             change_set_name=change_set_name,
@@ -350,7 +348,7 @@ class CloudFormationResponse(BaseResponse):
         return ActionResult(result)
 
     def list_stacks(self) -> ActionResult:
-        status_filter = self._get_multi_param("StackStatusFilter.member")
+        status_filter = self._get_param("StackStatusFilter", [])
         stacks = self.cloudformation_backend.list_stacks(status_filter)
         result = {"StackSummaries": stacks}
         return ActionResult(result)
@@ -374,9 +372,8 @@ class CloudFormationResponse(BaseResponse):
         return ActionResult(result)
 
     def get_template(self) -> ActionResult:
-        name_or_stack_id = self.querystring.get("StackName")[0]  # type: ignore[index]
+        name_or_stack_id = self._get_param("StackName")
         stack_template = self.cloudformation_backend.get_template(name_or_stack_id)
-
         result = {"TemplateBody": stack_template}
         return ActionResult(result)
 
@@ -429,16 +426,14 @@ class CloudFormationResponse(BaseResponse):
         template_url = self._get_param("TemplateURL")
         stack_body = self._get_param("TemplateBody")
         stack = self.cloudformation_backend.get_stack(stack_name)
-        if self._get_param("UsePreviousTemplate") == "true":
+        if self._get_bool_param("UsePreviousTemplate", False):
             stack_body = stack.template
         elif not stack_body and template_url:
             stack_body = self._get_stack_from_s3_url(template_url)
 
-        incoming_params = self._get_list_prefix("Parameters.member")
+        incoming_params = self._get_param("Parameters", [])
         for param in incoming_params:
-            if param.get("use_previous_value") == "true" and param.get(
-                "parameter_value"
-            ):
+            if param.get("use_previous_value") and param.get("parameter_value"):
                 raise ValidationError(
                     message=f"Invalid input for parameter key {param['parameter_key']}. Cannot specify usePreviousValue as true and non empty value for a parameter"
                 )
@@ -446,8 +441,7 @@ class CloudFormationResponse(BaseResponse):
         # end up containing anything we can use to differentiate between passing an empty value versus not
         # passing anything. so until that changes, moto won't be able to clear tags, only update them.
         tags: Optional[Dict[str, str]] = dict(
-            (item["key"], item["value"])
-            for item in self._get_list_prefix("Tags.member")
+            (item["key"], item["value"]) for item in self._get_param("Tags", [])
         )
         # so that if we don't pass the parameter, we don't clear all the tags accidentally
         if not tags:
@@ -468,8 +462,7 @@ class CloudFormationResponse(BaseResponse):
         return ActionResult(result)
 
     def delete_stack(self) -> ActionResult:
-        name_or_stack_id = self.querystring.get("StackName")[0]  # type: ignore[index]
-
+        name_or_stack_id = self._get_param("StackName")
         self.cloudformation_backend.delete_stack(name_or_stack_id)
         return EmptyResult()
 
@@ -514,13 +507,12 @@ class CloudFormationResponse(BaseResponse):
         stack_body = self._get_param("TemplateBody")
         template_url = self._get_param("TemplateURL")
         permission_model = self._get_param("PermissionModel")
-        parameters_list = self._get_list_prefix("Parameters.member")
+        parameters_list = self._get_param("Parameters", [])
         admin_role = self._get_param("AdministrationRoleARN")
         exec_role = self._get_param("ExecutionRoleName")
         description = self._get_param("Description")
         tags = dict(
-            (item["key"], item["value"])
-            for item in self._get_list_prefix("Tags.member")
+            (item["key"], item["value"]) for item in self._get_param("Tags", [])
         )
 
         # Copy-Pasta - Hack dict-comprehension
@@ -548,9 +540,9 @@ class CloudFormationResponse(BaseResponse):
 
     def create_stack_instances(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
-        accounts = self._get_multi_param("Accounts.member")
-        regions = self._get_multi_param("Regions.member")
-        parameters = self._get_multi_param("ParameterOverrides.member")
+        accounts = self._get_param("Accounts", [])
+        regions = self._get_param("Regions", [])
+        parameters = self._get_param("ParameterOverrides", [])
         deployment_targets = self._get_params().get("DeploymentTargets")
         if deployment_targets and "OrganizationalUnitIds" in deployment_targets:
             for ou_id in deployment_targets.get("OrganizationalUnitIds", []):
@@ -578,8 +570,8 @@ class CloudFormationResponse(BaseResponse):
 
     def delete_stack_instances(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
-        accounts = self._get_multi_param("Accounts.member")
-        regions = self._get_multi_param("Regions.member")
+        accounts = self._get_param("Accounts", [])
+        regions = self._get_param("Regions", [])
         operation = self.cloudformation_backend.delete_stack_instances(
             stackset_name, accounts, regions
         )
@@ -670,17 +662,16 @@ class CloudFormationResponse(BaseResponse):
         description = self._get_param("Description")
         execution_role = self._get_param("ExecutionRoleName")
         admin_role = self._get_param("AdministrationRoleARN")
-        accounts = self._get_multi_param("Accounts.member")
-        regions = self._get_multi_param("Regions.member")
+        accounts = self._get_param("Accounts", [])
+        regions = self._get_param("Regions", [])
         template_body = self._get_param("TemplateBody")
         template_url = self._get_param("TemplateURL")
         if template_url:
             template_body = self._get_stack_from_s3_url(template_url)
         tags = dict(
-            (item["key"], item["value"])
-            for item in self._get_list_prefix("Tags.member")
+            (item["key"], item["value"]) for item in self._get_param("Tags", [])
         )
-        parameters_list = self._get_list_prefix("Parameters.member")
+        parameters_list = self._get_param("Parameters", [])
 
         operation = self.cloudformation_backend.update_stack_set(
             stackset_name=stackset_name,
@@ -700,9 +691,9 @@ class CloudFormationResponse(BaseResponse):
 
     def update_stack_instances(self) -> ActionResult:
         stackset_name = self._get_param("StackSetName")
-        accounts = self._get_multi_param("Accounts.member")
-        regions = self._get_multi_param("Regions.member")
-        parameters = self._get_multi_param("ParameterOverrides.member")
+        accounts = self._get_param("Accounts", [])
+        regions = self._get_param("Regions", [])
+        parameters = self._get_param("ParameterOverrides", [])
         operation = self.cloudformation_backend.update_stack_instances(
             stackset_name, accounts, regions, parameters
         )

--- a/moto/core/parsers.py
+++ b/moto/core/parsers.py
@@ -1,6 +1,8 @@
 # mypy: ignore-errors
+import base64
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
+from typing import Any, Optional
 
 from botocore import xform_name
 from botocore.utils import parse_timestamp
@@ -13,12 +15,21 @@ class QueryParser:
 
     MAP_TYPE = dict
 
-    def __init__(self, timestamp_parser=None, map_type=None):
+    def __init__(self, timestamp_parser=None, blob_parser=None, map_type=None):
         if timestamp_parser is None:
             timestamp_parser = parse_timestamp
         self._timestamp_parser = timestamp_parser
+        if blob_parser is None:
+            blob_parser = self._default_blob_parser
+        self._blob_parser = blob_parser
         if map_type is not None:
             self.MAP_TYPE = map_type
+
+    def _default_blob_parser(self, value):
+        # Blobs are always returned as bytes type (this matters on python3).
+        # We don't decode this to a str because it's entirely possible that the
+        # blob contains binary data that actually can't be decoded.
+        return base64.b64decode(value)
 
     def parse(self, request_dict, operation_model):
         shape = operation_model.input_shape
@@ -61,8 +72,15 @@ class QueryParser:
         if node.get(prefix, UNDEFINED) == "":
             return []
 
-        list_name = shape.member.serialization.get("name", "member")
-        list_prefix = f"{prefix}.{list_name}"
+        if self._is_shape_flattened(shape):
+            list_prefix = prefix
+            if shape.member.serialization.get("name"):
+                name = self._get_serialized_name(shape.member, default_name="")
+                # Replace '.Original' with '.{name}'.
+                list_prefix = ".".join(prefix.split(".")[:-1] + [name])
+        else:
+            list_name = shape.member.serialization.get("name", "member")
+            list_prefix = f"{prefix}.{list_name}"
         parsed_list = []
         i = 1
         while True:
@@ -101,6 +119,13 @@ class QueryParser:
     def _handle_timestamp(self, shape, query_params, prefix=""):
         value = self._default_handle(shape, query_params, prefix)
         return value if value is UNDEFINED else self._timestamp_parser(value)
+
+    def _handle_blob(self, shape, query_params, prefix=""):
+        # Blob args must be base64 encoded.
+        value = self._default_handle(shape, query_params, prefix)
+        if value is UNDEFINED:
+            return value
+        return self._blob_parser(value)
 
     def _handle_boolean(self, shape, query_params, prefix=""):
         value = self._default_handle(shape, query_params, prefix)
@@ -153,7 +178,9 @@ class XFormedDict(MutableMapping):
 
     """
 
-    def __init__(self, data=None, **kwargs):
+    def __init__(
+        self, data: Optional[dict[str, Any]] = None, **kwargs: dict[str, Any]
+    ) -> None:
         self._xform_cache = {}
         self._store = OrderedDict()
         if data is None:
@@ -183,6 +210,16 @@ class XFormedDict(MutableMapping):
     def original_items(self):
         """Like iteritems(), but with all PascalCase keys."""
         return ((keyval[0], keyval[1]) for (_, keyval) in self._store.items())
+
+    def original_dict(self) -> dict[str, Any]:
+        original_dict = {}
+        for _, keyval in self._store.items():
+            key = keyval[0]
+            value = keyval[1]
+            if isinstance(value, XFormedDict):
+                value = value.original_dict()
+            original_dict[key] = value
+        return original_dict
 
     def __eq__(self, other):
         if isinstance(other, Mapping):

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -1072,55 +1072,6 @@ class BaseResponse(_TemplateEnvironmentMixin, ActionAuthenticatorMixin):
 
         return results
 
-    def _get_object_map(
-        self, prefix: str, name: str = "Name", value: str = "Value"
-    ) -> Dict[str, Any]:
-        """
-        Given a query dict like
-        {
-            Prefix.1.Name: [u'event'],
-            Prefix.1.Value.StringValue: [u'order_cancelled'],
-            Prefix.1.Value.DataType: [u'String'],
-            Prefix.2.Name: [u'store'],
-            Prefix.2.Value.StringValue: [u'example_corp'],
-            Prefix.2.Value.DataType [u'String'],
-        }
-
-        returns
-        {
-            'event': {
-                'DataType': 'String',
-                'StringValue': 'example_corp'
-            },
-            'store': {
-                'DataType': 'String',
-                'StringValue': 'order_cancelled'
-            }
-        }
-        """
-        object_map = {}
-        index = 1
-        while True:
-            # Loop through looking for keys representing object name
-            name_key = f"{prefix}.{index}.{name}"
-            obj_name = self.querystring.get(name_key)
-            if not obj_name:
-                # Found all keys
-                break
-
-            obj = {}
-            value_key_prefix = f"{prefix}.{index}.{value}."
-            for k, v in self.querystring.items():
-                if k.startswith(value_key_prefix):
-                    _, value_key = k.split(value_key_prefix, 1)
-                    obj[value_key] = v[0]
-
-            object_map[obj_name[0]] = obj
-
-            index += 1
-
-        return object_map
-
     @property
     def request_json(self) -> bool:
         return "JSON" in self.querystring.get("ContentType", [])

--- a/moto/elasticache/responses.py
+++ b/moto/elasticache/responses.py
@@ -107,7 +107,7 @@ class ElastiCacheResponse(BaseResponse):
         cache_subnet_group_name = self._get_param("CacheSubnetGroupName")
         cache_security_group_names = self._get_param("CacheSecurityGroupNames")
         security_group_ids = self._get_param("SecurityGroupIds")
-        tags = (self._get_multi_param_dict("Tags") or {}).get("Tag", [])
+        tags = self._get_param("Tags", [])
         snapshot_arns = self._get_param("SnapshotArns")
         snapshot_name = self._get_param("SnapshotName")
         preferred_maintenance_window = self._get_param("PreferredMaintenanceWindow")
@@ -190,8 +190,8 @@ class ElastiCacheResponse(BaseResponse):
     def create_cache_subnet_group(self) -> ActionResult:
         cache_subnet_group_name = self._get_param("CacheSubnetGroupName")
         cache_subnet_group_description = self._get_param("CacheSubnetGroupDescription")
-        subnet_ids = self._get_multi_param_dict("SubnetIds").get("SubnetIdentifier", [])
-        tags = (self._get_multi_param_dict("Tags") or {}).get("Tag", [])
+        subnet_ids = self._get_param("SubnetIds", [])
+        tags = self._get_param("Tags", [])
         cache_subnet_group = self.elasticache_backend.create_cache_subnet_group(
             cache_subnet_group_name=cache_subnet_group_name,
             cache_subnet_group_description=cache_subnet_group_description,
@@ -223,22 +223,10 @@ class ElastiCacheResponse(BaseResponse):
         automatic_failover_enabled = self._get_bool_param("AutomaticFailoverEnabled")
         multi_az_enabled = self._get_bool_param("MultiAZEnabled")
         num_cache_clusters = self._get_int_param("NumCacheClusters")
-        preferred_cache_cluster_azs = (
-            self._get_multi_param_dict("PreferredCacheClusterAZs").get(
-                "AvailabilityZone", []
-            )
-            if self._get_multi_param_dict("PreferredCacheClusterAZs")
-            else []
-        )
+        preferred_cache_cluster_azs = self._get_param("PreferredCacheClusterAZs", [])
         num_node_groups = self._get_int_param("NumNodeGroups")
         replicas_per_node_group = self._get_int_param("ReplicasPerNodeGroup")
-        node_group_configuration = (
-            self._get_multi_param_dict("NodeGroupConfiguration").get(
-                "NodeGroupConfiguration", []
-            )
-            if self._get_multi_param_dict("NodeGroupConfiguration")
-            else []
-        )
+        node_group_configuration = self._get_param("NodeGroupConfiguration", [])
         cache_node_type = self._get_param("CacheNodeType")
         engine = self._get_param("Engine")
         engine_version = self._get_param("EngineVersion")
@@ -246,7 +234,7 @@ class ElastiCacheResponse(BaseResponse):
         cache_subnet_group_name = self._get_param("CacheSubnetGroupName")
         cache_security_group_names = self._get_param("CacheSecurityGroupNames")
         security_group_ids = self._get_param("SecurityGroupIds")
-        tags = (self._get_multi_param_dict("Tags") or {}).get("Tag", [])
+        tags = self._get_param("Tags", [])
         snapshot_arns = self._get_param("SnapshotArns")
         snapshot_name = self._get_param("SnapshotName")
         preferred_maintenance_window = self._get_param("PreferredMaintenanceWindow")

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -2389,7 +2389,7 @@ class IAMBackend(BaseBackend):
             policy.tags.pop(ref_key, None)
 
     def create_policy_version(
-        self, policy_arn: str, policy_document: str, set_as_default: str
+        self, policy_arn: str, policy_document: str, set_as_default: bool
     ) -> PolicyVersion:
         iam_policy_document_validator = IAMPolicyDocumentValidator(policy_document)
         iam_policy_document_validator.validate()
@@ -2401,12 +2401,11 @@ class IAMBackend(BaseBackend):
             raise LimitExceededException(
                 "A managed policy can have up to 5 versions. Before you create a new version, you must delete an existing version."
             )
-        _as_default = set_as_default == "true"  # convert it to python bool
-        version = PolicyVersion(policy_arn, policy_document, _as_default)
+        version = PolicyVersion(policy_arn, policy_document, set_as_default)
         policy.versions.append(version)
         version.version_id = f"v{policy.next_version_num}"
         policy.next_version_num += 1
-        if _as_default:
+        if set_as_default:
             policy.update_default_version(version.version_id)
         return version
 

--- a/moto/iam/responses.py
+++ b/moto/iam/responses.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from moto.core.responses import ActionResult, BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 from moto.core.serialize import never_return, return_if_not_empty, url_encode
 
 from .exceptions import NotFoundException
@@ -39,6 +39,7 @@ class IamResponse(BaseResponse):
 
     def __init__(self) -> None:
         super().__init__(service_name="iam")
+        self.automated_parameter_parsing = True
 
     @property
     def backend(self) -> IAMBackend:
@@ -64,44 +65,44 @@ class IamResponse(BaseResponse):
         policy_arn = self._get_param("PolicyArn")
         role_name = self._get_param("RoleName")
         self.backend.attach_role_policy(policy_arn, role_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def detach_role_policy(self) -> ActionResult:
         role_name = self._get_param("RoleName")
         policy_arn = self._get_param("PolicyArn")
         self.backend.detach_role_policy(policy_arn, role_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def attach_group_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         group_name = self._get_param("GroupName")
         self.backend.attach_group_policy(policy_arn, group_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def detach_group_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         group_name = self._get_param("GroupName")
         self.backend.detach_group_policy(policy_arn, group_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def attach_user_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         user_name = self._get_param("UserName")
         self.backend.attach_user_policy(policy_arn, user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def detach_user_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         user_name = self._get_param("UserName")
         self.backend.detach_user_policy(policy_arn, user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_policy(self) -> ActionResult:
         description = self._get_param("Description")
         path = self._get_param("Path")
         policy_document = self._get_param("PolicyDocument")
         policy_name = self._get_param("PolicyName")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
         policy = self.backend.create_policy(
             description, path, policy_document, policy_name, tags
         )
@@ -249,7 +250,7 @@ class IamResponse(BaseResponse):
         policy_arn = self._get_param("PolicyArn")
         version_id = self._get_param("VersionId")
         self.backend.set_default_policy_version(policy_arn, version_id)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_role(self) -> ActionResult:
         role_name = self._get_param("RoleName")
@@ -257,7 +258,7 @@ class IamResponse(BaseResponse):
         assume_role_policy_document = self._get_param("AssumeRolePolicyDocument")
         permissions_boundary = self._get_param("PermissionsBoundary")
         description = self._get_param("Description")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
         max_session_duration = self._get_param("MaxSessionDuration", 3600)
 
         role = self.backend.create_role(
@@ -281,7 +282,7 @@ class IamResponse(BaseResponse):
     def delete_role(self) -> ActionResult:
         role_name = self._get_param("RoleName")
         self.backend.delete_role(role_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def list_role_policies(self) -> ActionResult:
         role_name = self._get_param("RoleName")
@@ -294,13 +295,13 @@ class IamResponse(BaseResponse):
         policy_name = self._get_param("PolicyName")
         policy_document = self._get_param("PolicyDocument")
         self.backend.put_role_policy(role_name, policy_name, policy_document)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_role_policy(self) -> ActionResult:
         role_name = self._get_param("RoleName")
         policy_name = self._get_param("PolicyName")
         self.backend.delete_role_policy(role_name, policy_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def get_role_policy(self) -> ActionResult:
         role_name = self._get_param("RoleName")
@@ -319,7 +320,7 @@ class IamResponse(BaseResponse):
         role_name = self._get_param("RoleName")
         policy_document = self._get_param("PolicyDocument")
         self.backend.update_assume_role_policy(role_name, policy_document)
-        return ActionResult({})
+        return EmptyResult()
 
     def update_role_description(self) -> ActionResult:
         role_name = self._get_param("RoleName")
@@ -333,23 +334,23 @@ class IamResponse(BaseResponse):
         description = self._get_param("Description")
         max_session_duration = self._get_param("MaxSessionDuration", 3600)
         self.backend.update_role(role_name, description, max_session_duration)
-        return ActionResult({})
+        return EmptyResult()
 
     def put_role_permissions_boundary(self) -> ActionResult:
         permissions_boundary = self._get_param("PermissionsBoundary")
         role_name = self._get_param("RoleName")
         self.backend.put_role_permissions_boundary(role_name, permissions_boundary)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_role_permissions_boundary(self) -> ActionResult:
         role_name = self._get_param("RoleName")
         self.backend.delete_role_permissions_boundary(role_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_policy_version(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         policy_document = self._get_param("PolicyDocument")
-        set_as_default = self._get_param("SetAsDefault")
+        set_as_default = self._get_param("SetAsDefault", False)
         policy_version = self.backend.create_policy_version(
             policy_arn, policy_document, set_as_default
         )
@@ -380,31 +381,31 @@ class IamResponse(BaseResponse):
 
     def tag_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
 
         self.backend.tag_policy(policy_arn, tags)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def untag_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
-        tag_keys = self._get_multi_param("TagKeys.member")
+        tag_keys = self._get_param("TagKeys", [])
 
         self.backend.untag_policy(policy_arn, tag_keys)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_policy_version(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         version_id = self._get_param("VersionId")
 
         self.backend.delete_policy_version(policy_arn, version_id)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_instance_profile(self) -> ActionResult:
         profile_name = self._get_param("InstanceProfileName")
         path = self._get_param("Path", "/")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
 
         profile = self.backend.create_instance_profile(
             profile_name, path, role_names=[], tags=tags
@@ -416,7 +417,7 @@ class IamResponse(BaseResponse):
         profile_name = self._get_param("InstanceProfileName")
 
         self.backend.delete_instance_profile(profile_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def get_instance_profile(self) -> ActionResult:
         profile_name = self._get_param("InstanceProfileName")
@@ -430,14 +431,14 @@ class IamResponse(BaseResponse):
         role_name = self._get_param("RoleName")
 
         self.backend.add_role_to_instance_profile(profile_name, role_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def remove_role_from_instance_profile(self) -> ActionResult:
         profile_name = self._get_param("InstanceProfileName")
         role_name = self._get_param("RoleName")
 
         self.backend.remove_role_from_instance_profile(profile_name, role_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def list_roles(self) -> ActionResult:
         path_prefix = self._get_param("PathPrefix", "/")
@@ -520,7 +521,7 @@ class IamResponse(BaseResponse):
     def delete_server_certificate(self) -> ActionResult:
         cert_name = self._get_param("ServerCertificateName")
         self.backend.delete_server_certificate(cert_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
@@ -554,7 +555,7 @@ class IamResponse(BaseResponse):
         policy_name = self._get_param("PolicyName")
         policy_document = self._get_param("PolicyDocument")
         self.backend.put_group_policy(group_name, policy_name, policy_document)
-        return ActionResult({})
+        return EmptyResult()
 
     def list_group_policies(self) -> ActionResult:
         group_name = self._get_param("GroupName")
@@ -577,24 +578,24 @@ class IamResponse(BaseResponse):
         group_name = self._get_param("GroupName")
         policy_name = self._get_param("PolicyName")
         self.backend.delete_group_policy(group_name, policy_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         self.backend.delete_group(group_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def update_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         new_group_name = self._get_param("NewGroupName")
         new_path = self._get_param("NewPath")
         self.backend.update_group(group_name, new_group_name, new_path)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_user(self) -> ActionResult:
         user_name = self._get_param("UserName")
         path = self._get_param("Path")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
         user = self.backend.create_user(
             self.region, user_name=user_name, path=path, tags=tags
         )
@@ -628,7 +629,7 @@ class IamResponse(BaseResponse):
         new_path = self._get_param("NewPath")
         new_user_name = self._get_param("NewUserName")
         self.backend.update_user(user_name, new_path, new_user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_login_profile(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -660,21 +661,21 @@ class IamResponse(BaseResponse):
         password = self._get_param("Password")
         password_reset_required = self._get_param("PasswordResetRequired")
         self.backend.update_login_profile(user_name, password, password_reset_required)
-        return ActionResult({})
+        return EmptyResult()
 
     def add_user_to_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         user_name = self._get_param("UserName")
 
         self.backend.add_user_to_group(group_name, user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def remove_user_from_group(self) -> ActionResult:
         group_name = self._get_param("GroupName")
         user_name = self._get_param("UserName")
 
         self.backend.remove_user_from_group(group_name, user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def get_user_policy(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -706,14 +707,14 @@ class IamResponse(BaseResponse):
         policy_document = self._get_param("PolicyDocument")
 
         self.backend.put_user_policy(user_name, policy_name, policy_document)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_user_policy(self) -> ActionResult:
         user_name = self._get_param("UserName")
         policy_name = self._get_param("PolicyName")
 
         self.backend.delete_user_policy(user_name, policy_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def create_access_key(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -735,7 +736,7 @@ class IamResponse(BaseResponse):
             user_name = access_key["user_name"]
 
         self.backend.update_access_key(user_name, access_key_id, status)
-        return ActionResult({})
+        return EmptyResult()
 
     def get_access_key_last_used(self) -> ActionResult:
         access_key_id = self._get_param("AccessKeyId")
@@ -774,7 +775,7 @@ class IamResponse(BaseResponse):
             user_name = access_key["user_name"]
 
         self.backend.delete_access_key(access_key_id, user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def upload_ssh_public_key(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -805,21 +806,21 @@ class IamResponse(BaseResponse):
         status = self._get_param("Status")
 
         self.backend.update_ssh_public_key(user_name, ssh_public_key_id, status)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_ssh_public_key(self) -> ActionResult:
         user_name = self._get_param("UserName")
         ssh_public_key_id = self._get_param("SSHPublicKeyId")
 
         self.backend.delete_ssh_public_key(user_name, ssh_public_key_id)
-        return ActionResult({})
+        return EmptyResult()
 
     def deactivate_mfa_device(self) -> ActionResult:
         user_name = self._get_param("UserName")
         serial_number = self._get_param("SerialNumber")
 
         self.backend.deactivate_mfa_device(user_name, serial_number)
-        return ActionResult({})
+        return EmptyResult()
 
     def enable_mfa_device(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -830,7 +831,7 @@ class IamResponse(BaseResponse):
         self.backend.enable_mfa_device(
             user_name, serial_number, authentication_code_1, authentication_code_2
         )
-        return ActionResult({})
+        return EmptyResult()
 
     def list_mfa_devices(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -864,7 +865,7 @@ class IamResponse(BaseResponse):
 
         self.backend.delete_virtual_mfa_device(serial_number)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def list_virtual_mfa_devices(self) -> ActionResult:
         assignment_status = self._get_param("AssignmentStatus", "Any")
@@ -885,17 +886,17 @@ class IamResponse(BaseResponse):
     def delete_user(self) -> ActionResult:
         user_name = self._get_param("UserName")
         self.backend.delete_user(user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_policy(self) -> ActionResult:
         policy_arn = self._get_param("PolicyArn")
         self.backend.delete_policy(policy_arn)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_login_profile(self) -> ActionResult:
         user_name = self._get_param("UserName")
         self.backend.delete_login_profile(user_name)
-        return ActionResult({})
+        return EmptyResult()
 
     def generate_credential_report(self) -> ActionResult:
         if self.backend.report_generated():
@@ -925,14 +926,14 @@ class IamResponse(BaseResponse):
     def create_account_alias(self) -> ActionResult:
         alias = self._get_param("AccountAlias")
         self.backend.create_account_alias(alias)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_account_alias(self) -> ActionResult:
         self.backend.delete_account_alias()
-        return ActionResult({})
+        return EmptyResult()
 
     def get_account_authorization_details(self) -> ActionResult:
-        filter_param = self._get_multi_param("Filter.member")
+        filter_param = self._get_param("Filter", [])
         account_details = self.backend.get_account_authorization_details(filter_param)
         result = {
             "UserDetailList": account_details["users"],
@@ -965,7 +966,7 @@ class IamResponse(BaseResponse):
         saml_provider_arn = self._get_param("SAMLProviderArn")
         self.backend.delete_saml_provider(saml_provider_arn)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def list_saml_providers(self) -> ActionResult:
         saml_providers = self.backend.list_saml_providers()
@@ -993,14 +994,14 @@ class IamResponse(BaseResponse):
         status = self._get_param("Status")
 
         self.backend.update_signing_certificate(user_name, cert_id, status)
-        return ActionResult({})
+        return EmptyResult()
 
     def delete_signing_certificate(self) -> ActionResult:
         user_name = self._get_param("UserName")
         cert_id = self._get_param("CertificateId")
 
         self.backend.delete_signing_certificate(user_name, cert_id)
-        return ActionResult({})
+        return EmptyResult()
 
     def list_signing_certificates(self) -> ActionResult:
         user_name = self._get_param("UserName")
@@ -1025,25 +1026,25 @@ class IamResponse(BaseResponse):
 
     def tag_role(self) -> ActionResult:
         role_name = self._get_param("RoleName")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
 
         self.backend.tag_role(role_name, tags)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def untag_role(self) -> ActionResult:
         role_name = self._get_param("RoleName")
-        tag_keys = self._get_multi_param("TagKeys.member")
+        tag_keys = self._get_param("TagKeys", [])
 
         self.backend.untag_role(role_name, tag_keys)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def create_open_id_connect_provider(self) -> ActionResult:
         open_id_provider_url = self._get_param("Url")
-        thumbprint_list = self._get_multi_param("ThumbprintList.member")
-        client_id_list = self._get_multi_param("ClientIDList.member")
-        tags = self._get_multi_param("Tags.member")
+        thumbprint_list = self._get_param("ThumbprintList", [])
+        client_id_list = self._get_param("ClientIDList", [])
+        tags = self._get_param("Tags", [])
 
         open_id_provider = self.backend.create_open_id_connect_provider(
             open_id_provider_url, thumbprint_list, client_id_list, tags
@@ -1054,29 +1055,29 @@ class IamResponse(BaseResponse):
 
     def update_open_id_connect_provider_thumbprint(self) -> ActionResult:
         open_id_provider_arn = self._get_param("OpenIDConnectProviderArn")
-        thumbprint_list = self._get_multi_param("ThumbprintList.member")
+        thumbprint_list = self._get_param("ThumbprintList", [])
 
         self.backend.update_open_id_connect_provider_thumbprint(
             open_id_provider_arn, thumbprint_list
         )
 
-        return ActionResult({})
+        return EmptyResult()
 
     def tag_open_id_connect_provider(self) -> ActionResult:
         open_id_provider_arn = self._get_param("OpenIDConnectProviderArn")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
 
         self.backend.tag_open_id_connect_provider(open_id_provider_arn, tags)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def untag_open_id_connect_provider(self) -> ActionResult:
         open_id_provider_arn = self._get_param("OpenIDConnectProviderArn")
-        tag_keys = self._get_multi_param("TagKeys.member")
+        tag_keys = self._get_param("TagKeys", [])
 
         self.backend.untag_open_id_connect_provider(open_id_provider_arn, tag_keys)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def list_open_id_connect_provider_tags(self) -> ActionResult:
         open_id_provider_arn = self._get_param("OpenIDConnectProviderArn")
@@ -1093,7 +1094,7 @@ class IamResponse(BaseResponse):
 
         self.backend.delete_open_id_connect_provider(open_id_provider_arn)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def get_open_id_connect_provider(self) -> ActionResult:
         open_id_provider_arn = self._get_param("OpenIDConnectProviderArn")
@@ -1141,7 +1142,7 @@ class IamResponse(BaseResponse):
             require_uppercase_characters,
         )
 
-        return ActionResult({})
+        return EmptyResult()
 
     def get_account_password_policy(self) -> ActionResult:
         account_password_policy = self.backend.get_account_password_policy()
@@ -1152,7 +1153,7 @@ class IamResponse(BaseResponse):
     def delete_account_password_policy(self) -> ActionResult:
         self.backend.delete_account_password_policy()
 
-        return ActionResult({})
+        return EmptyResult()
 
     def get_account_summary(self) -> ActionResult:
         account_summary = self.backend.get_account_summary()
@@ -1162,19 +1163,19 @@ class IamResponse(BaseResponse):
 
     def tag_user(self) -> ActionResult:
         name = self._get_param("UserName")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
 
         self.backend.tag_user(name, tags)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def untag_user(self) -> ActionResult:
         name = self._get_param("UserName")
-        tag_keys = self._get_multi_param("TagKeys.member")
+        tag_keys = self._get_param("TagKeys", [])
 
         self.backend.untag_user(name, tag_keys)
 
-        return ActionResult({})
+        return EmptyResult()
 
     def create_service_linked_role(self) -> ActionResult:
         service_name = self._get_param("AWSServiceName")
@@ -1204,20 +1205,20 @@ class IamResponse(BaseResponse):
 
     def tag_instance_profile(self) -> ActionResult:
         instance_profile_name = self._get_param("InstanceProfileName")
-        tags = self._get_multi_param("Tags.member")
+        tags = self._get_param("Tags", [])
 
         self.backend.tag_instance_profile(
             instance_profile_name=instance_profile_name,
             tags=tags,
         )
-        return ActionResult({})
+        return EmptyResult()
 
     def untag_instance_profile(self) -> ActionResult:
         instance_profile_name = self._get_param("InstanceProfileName")
-        tags = self._get_multi_param("TagKeys.member")
+        tags = self._get_param("TagKeys", [])
 
         self.backend.untag_instance_profile(
             instance_profile_name=instance_profile_name,
             tagKeys=tags,
         )
-        return ActionResult({})
+        return EmptyResult()

--- a/moto/sdb/models.py
+++ b/moto/sdb/models.py
@@ -26,7 +26,7 @@ class FakeItem(BaseModel):
         # Lock this, so we know noone else touches this list while we're operating on it
         with self.lock:
             for attr in attributes:
-                if attr.get("replace", "false").lower() == "true":
+                if attr.get("replace", False):
                     self._remove_attributes(attr["name"])
                 self.attributes.append(attr)
 

--- a/moto/sdb/responses.py
+++ b/moto/sdb/responses.py
@@ -6,6 +6,7 @@ from .models import SimpleDBBackend, sdb_backends
 class SimpleDBResponse(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="sdb")
+        self.automated_parameter_parsing = True
 
     @property
     def sdb_backend(self) -> SimpleDBBackend:
@@ -29,7 +30,7 @@ class SimpleDBResponse(BaseResponse):
     def get_attributes(self) -> ActionResult:
         domain_name = self._get_param("DomainName")
         item_name = self._get_param("ItemName")
-        attribute_names = self._get_multi_param("AttributeName.")
+        attribute_names = self._get_param("AttributeNames")
         attributes = self.sdb_backend.get_attributes(
             domain_name=domain_name,
             item_name=item_name,
@@ -41,7 +42,7 @@ class SimpleDBResponse(BaseResponse):
     def put_attributes(self) -> ActionResult:
         domain_name = self._get_param("DomainName")
         item_name = self._get_param("ItemName")
-        attributes = self._get_list_prefix("Attribute")
+        attributes = self._get_param("Attributes")
         self.sdb_backend.put_attributes(
             domain_name=domain_name, item_name=item_name, attributes=attributes
         )

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -93,8 +93,8 @@ class TemplateMessage(BaseModel):
         self,
         message_id: str,
         source: str,
-        template: List[str],
-        template_data: List[str],
+        template: str,
+        template_data: str,
         destinations: Any,
     ):
         self.id = message_id
@@ -109,8 +109,8 @@ class BulkTemplateMessage(BaseModel):
         self,
         message_ids: List[str],
         source: str,
-        template: List[str],
-        template_data: List[str],
+        template: str,
+        template_data: str,
         destinations: Any,
     ):
         self.ids = message_ids
@@ -288,8 +288,8 @@ class SESBackend(BaseBackend):
     def send_bulk_templated_email(
         self,
         source: str,
-        template: List[str],
-        template_data: List[str],
+        template: str,
+        template_data: str,
         destinations: List[Dict[str, Dict[str, List[str]]]],
     ) -> BulkTemplateMessage:
         recipient_count = len(destinations)
@@ -306,8 +306,8 @@ class SESBackend(BaseBackend):
             self.rejected_messages_count += 1
             raise MessageRejectedError(f"Email address not verified {source}")
 
-        if not self.templates.get(template[0]):
-            raise TemplateDoesNotExist(f"Template ({template[0]}) does not exist")
+        if not self.templates.get(template):
+            raise TemplateDoesNotExist(f"Template ({template}) does not exist")
 
         self.__process_sns_feedback__(source, destinations)
 
@@ -324,8 +324,8 @@ class SESBackend(BaseBackend):
     def send_templated_email(
         self,
         source: str,
-        template: List[str],
-        template_data: List[str],
+        template: str,
+        template_data: str,
         destinations: Dict[str, List[str]],
     ) -> TemplateMessage:
         recipient_count = sum(map(len, destinations.values()))
@@ -342,8 +342,8 @@ class SESBackend(BaseBackend):
             if msg is not None:
                 raise InvalidParameterValue(msg)
 
-        if not self.templates.get(template[0]):
-            raise TemplateDoesNotExist(f"Template ({template[0]}) does not exist")
+        if not self.templates.get(template):
+            raise TemplateDoesNotExist(f"Template ({template}) does not exist")
 
         self.__process_sns_feedback__(source, destinations)
 

--- a/moto/sts/responses.py
+++ b/moto/sts/responses.py
@@ -9,6 +9,7 @@ MAX_FEDERATION_TOKEN_POLICY_LENGTH = 2048
 class TokenResponse(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="sts")
+        self.automated_parameter_parsing = True
 
     @property
     def backend(self) -> STSBackend:
@@ -20,7 +21,7 @@ class TokenResponse(BaseResponse):
         return "*"
 
     def get_session_token(self) -> ActionResult:
-        duration = int(self.querystring.get("DurationSeconds", [43200])[0])
+        duration = self._get_int_param("DurationSeconds", 43200)
         token = self.backend.get_session_token(duration=duration)
         result = {
             "Credentials": {
@@ -33,9 +34,8 @@ class TokenResponse(BaseResponse):
         return ActionResult(result)
 
     def get_federation_token(self) -> ActionResult:
-        duration = int(self.querystring.get("DurationSeconds", [43200])[0])
-        policy = self.querystring.get("Policy", [None])[0]
-
+        duration = self._get_int_param("DurationSeconds", 43200)
+        policy = self._get_param("Policy")
         if policy is not None and len(policy) > MAX_FEDERATION_TOKEN_POLICY_LENGTH:
             raise STSValidationError(
                 "1 validation error detected: Value "
@@ -43,8 +43,7 @@ class TokenResponse(BaseResponse):
                 "at 'policy' failed to satisfy constraint: Member must have length less than or "
                 f" equal to {MAX_FEDERATION_TOKEN_POLICY_LENGTH}"
             )
-
-        name = self.querystring.get("Name")[0]  # type: ignore
+        name = self._get_param("Name")
         token = self.backend.get_federation_token(duration=duration, name=name)
         result = {
             "Credentials": {
@@ -62,13 +61,11 @@ class TokenResponse(BaseResponse):
         return ActionResult(result)
 
     def assume_role(self) -> ActionResult:
-        role_session_name = self.querystring.get("RoleSessionName")[0]  # type: ignore
-        role_arn = self.querystring.get("RoleArn")[0]  # type: ignore
-
-        policy = self.querystring.get("Policy", [None])[0]
-        duration = int(self.querystring.get("DurationSeconds", [3600])[0])
-        external_id = self.querystring.get("ExternalId", [None])[0]
-
+        role_session_name = self._get_param("RoleSessionName")
+        role_arn = self._get_param("RoleArn")
+        policy = self._get_param("Policy")
+        duration = self._get_int_param("DurationSeconds", 3600)
+        external_id = self._get_param("ExternalId")
         role = self.backend.assume_role(
             region_name=self.region,
             role_session_name=role_session_name,
@@ -88,13 +85,11 @@ class TokenResponse(BaseResponse):
         return ActionResult(result)
 
     def assume_role_with_web_identity(self) -> ActionResult:
-        role_session_name = self.querystring.get("RoleSessionName")[0]  # type: ignore
-        role_arn = self.querystring.get("RoleArn")[0]  # type: ignore
-
-        policy = self.querystring.get("Policy", [None])[0]
-        duration = int(self.querystring.get("DurationSeconds", [3600])[0])
-        external_id = self.querystring.get("ExternalId", [None])[0]
-
+        role_session_name = self._get_param("RoleSessionName")
+        role_arn = self._get_param("RoleArn")
+        policy = self._get_param("Policy")
+        duration = self._get_int_param("DurationSeconds", 3600)
+        external_id = self._get_param("ExternalId")
         role = self.backend.assume_role_with_web_identity(
             region_name=self.region,
             role_session_name=role_session_name,
@@ -114,10 +109,9 @@ class TokenResponse(BaseResponse):
         return ActionResult(result)
 
     def assume_role_with_saml(self) -> ActionResult:
-        role_arn = self.querystring.get("RoleArn")[0]  # type: ignore
-        principal_arn = self.querystring.get("PrincipalArn")[0]  # type: ignore
-        saml_assertion = self.querystring.get("SAMLAssertion")[0]  # type: ignore
-
+        role_arn = self._get_param("RoleArn")
+        principal_arn = self._get_param("PrincipalArn")
+        saml_assertion = self._get_param("SAMLAssertion")
         role = self.backend.assume_role_with_saml(
             role_arn=role_arn,
             principal_arn=principal_arn,

--- a/tests/test_autoscaling/test_autoscaling_tags.py
+++ b/tests/test_autoscaling/test_autoscaling_tags.py
@@ -220,7 +220,7 @@ def test_describe_tags_filter_by_propgateatlaunch():
     response = client.describe_tags(
         Filters=[{"Name": "propagate-at-launch", "Values": ["True"]}]
     )
-    len(response["Tags"]) == 1
+    assert len(response["Tags"]) == 1
     assert response["Tags"] == [
         {
             "ResourceId": "test_asg",

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -1648,14 +1648,14 @@ def test_put_metric_alarm():
         == f"arn:aws:cloudwatch:{region_name}:{ACCOUNT_ID}:alarm:{alarm_name}"
     )
     assert alarm["AlarmDescription"] == "test alarm"
-    assert alarm["AlarmConfigurationUpdatedTimestamp"].tzinfo == tzutc()
+    assert isinstance(alarm["AlarmConfigurationUpdatedTimestamp"], datetime)
     assert alarm["ActionsEnabled"] is True
     assert alarm["OKActions"] == [sns_topic_arn]
     assert alarm["AlarmActions"] == [sns_topic_arn]
     assert alarm["InsufficientDataActions"] == [sns_topic_arn]
     assert alarm["StateValue"] == "OK"
     assert alarm["StateReason"] == "Unchecked: Initial alarm creation"
-    assert alarm["StateUpdatedTimestamp"].tzinfo == tzutc()
+    assert isinstance(alarm["StateUpdatedTimestamp"], datetime)
     assert alarm["MetricName"] == "5XXError"
     assert alarm["Namespace"] == "AWS/ApiGateway"
     assert alarm["Statistic"] == "Sum"

--- a/tests/test_elb/test_elb.py
+++ b/tests/test_elb/test_elb.py
@@ -627,7 +627,7 @@ def test_register_instances():
     )
     balancer = client.describe_load_balancers()["LoadBalancerDescriptions"][0]
     instance_ids = [instance["InstanceId"] for instance in balancer["Instances"]]
-    assert set(instance_ids) == set([instance_id1, instance_id2])
+    assert set(instance_ids) == {instance_id1, instance_id2}
 
 
 @mock_aws

--- a/tests/test_redshift/test_server.py
+++ b/tests/test_redshift/test_server.py
@@ -325,8 +325,8 @@ def test_create_cluster_with_security_group(is_json):
         "&MasterUsername=masteruser"
         "&MasterUserPassword=12345678Aa"
         "&NodeType=ds2.xlarge"
-        "&ClusterSecurityGroups.member.1=csg1"
-        "&ClusterSecurityGroups.member.2=csg2"
+        "&ClusterSecurityGroups.ClusterSecurityGroupName.1=csg1"
+        "&ClusterSecurityGroups.ClusterSecurityGroupName.2=csg2"
     )
     if is_json:
         create_params += "&ContentType=JSON"


### PR DESCRIPTION
This PR opts all of the Query-protocol-based services in to the new request parsing pipeline.  The dedicated QueryParser obviates the need for many of the existing helper methods (e.g. `_get_multi_param()`, `_get_object_map()`, etc.), which have been replaced with the generic `_get_param()`.  Because the new parsing flow takes parameter type information from the Botocore models into account, some minor Moto model changes were also required (mostly around boolean values that were previously stored as strings).

The changeset for this PR is provided as a series of atomic commits, one for each affected service.