### PR TITLE
Core: handle compressed requests in server mode

### DIFF
--- a/moto/core/request.py
+++ b/moto/core/request.py
@@ -1,21 +1,31 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from botocore.awsrequest import AWSPreparedRequest
 from werkzeug.wrappers import Request
+
+from moto.core.utils import gzip_decompress
+
+if TYPE_CHECKING:
+    from botocore.awsrequest import AWSPreparedRequest
 
 
 def normalize_request(request: AWSPreparedRequest | Request) -> Request:
     if isinstance(request, Request):
         return request
+    body = request.body
+    # Request.from_values() does not automatically handle gzip-encoded bodies,
+    # like the full WSGI server would, so we need to do it manually.
+    if request.headers.get("Content-Encoding") == "gzip":
+        body = gzip_decompress(body)  # type: ignore[arg-type]
     parsed_url = urlparse(request.url)
     normalized_request = Request.from_values(
         method=request.method,
         base_url=f"{parsed_url.scheme}://{parsed_url.netloc}",
         path=parsed_url.path,
         query_string=parsed_url.query,
-        data=request.body,
+        data=body,
         headers=[(k, v) for k, v in request.headers.items()],
     )
     return normalized_request

--- a/moto/moto_server/utilities.py
+++ b/moto/moto_server/utilities.py
@@ -1,7 +1,9 @@
+import gzip
 import json
 from typing import Any, Dict
 from urllib.parse import urlencode
 
+from flask import request
 from flask.testing import FlaskClient
 from werkzeug.routing import BaseConverter
 
@@ -35,3 +37,10 @@ class AWSTestHelper(FlaskClient):
         deserialization of output.
         """
         return json.loads(self.action_data(action_name, **kwargs))
+
+
+def decompress_request_body() -> None:
+    """Intended to be used as a `before_request` handler in the Moto Server Flask app."""
+    if getattr(request, "content_encoding") == "gzip":
+        request.stream = gzip.GzipFile(fileobj=request.stream)  # type: ignore[assignment]
+        request.get_data(parse_form_data=True)

--- a/moto/moto_server/utilities.py
+++ b/moto/moto_server/utilities.py
@@ -3,7 +3,7 @@ import json
 from typing import Any, Dict
 from urllib.parse import urlencode
 
-from flask import request
+from flask import current_app, request
 from flask.testing import FlaskClient
 from werkzeug.routing import BaseConverter
 
@@ -41,6 +41,8 @@ class AWSTestHelper(FlaskClient):
 
 def decompress_request_body() -> None:
     """Intended to be used as a `before_request` handler in the Moto Server Flask app."""
+    if getattr(current_app, "service") == "s3":
+        return
     if getattr(request, "content_encoding") == "gzip":
         request.stream = gzip.GzipFile(fileobj=request.stream)  # type: ignore[assignment]
         request.get_data(parse_form_data=True)

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -22,7 +22,7 @@ from moto.core.base_backend import BackendDict
 from moto.core.utils import convert_to_flask_response
 from moto.settings import DISABLE_GLOBAL_CORS
 
-from .utilities import AWSTestHelper, RegexConverter
+from .utilities import AWSTestHelper, RegexConverter, decompress_request_body
 
 HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH", "OPTIONS"]
 
@@ -275,6 +275,7 @@ def create_backend_app(service: backends.SERVICE_NAMES) -> Flask:
     backend_app = Flask("moto", template_folder=template_dir)
     backend_app.debug = True
     backend_app.service = service  # type: ignore[attr-defined]
+    backend_app.before_request(decompress_request_body)
 
     if not DISABLE_GLOBAL_CORS:
         CORS(backend_app)

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -2,7 +2,6 @@ import copy
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from operator import itemgetter
-from unittest import SkipTest
 from uuid import uuid4
 
 import boto3
@@ -11,7 +10,7 @@ from botocore.exceptions import ClientError
 from dateutil.tz import tzutc
 from freezegun import freeze_time
 
-from moto import mock_aws, settings
+from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.core.utils import utcnow
 

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -62,7 +62,8 @@ def test_put_a_ton_of_metric_data():
             )
 
     cloudwatch.put_metric_data(Namespace="acme", MetricData=metrics)
-    # We don't really need any assertions - we just need to know that the call succeeds
+    resp = cloudwatch.list_metrics(MetricName="TestCWMetrics")
+    assert len(resp["Metrics"]) == 50
 
 
 @mock_aws

--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -34,8 +34,6 @@ def test_put_a_ton_of_metric_data():
     A sufficiently large call with metric data triggers request compression
     Moto should decompress the request if this is the case, and the request should succeed
     """
-    if not settings.TEST_DECORATOR_MODE:
-        raise SkipTest("Can't test large requests in ServerMode")
     cloudwatch = boto3.client("cloudwatch", "us-east-1")
 
     metrics = []


### PR DESCRIPTION
While doing some testing related to CloudWatch's upcoming switch to the JSON protocol, I inadvertently discovered a regression introduced in #9224.  That PR opted all of the Query protocol services into the new request parsing pipeline, which did not handle compressed request bodies.  There was actually a test that covered this, but [it didn't have any assertions](https://github.com/getmoto/moto/blob/152d0e0559829dee48f4efebad7982d824ce2433/tests/test_cloudwatch/test_cloudwatch_boto3.py#L65) and was just failing silently after the merge.  That test was also skipped in server mode.

This PR adds request decompression to the new request parsing pipeline, as well as to requests received in server mode.  It also modifies the existing test, adding assertions and removing the server mode skip.