### PR TITLE
fix: iot:list_things_in_billing_group return Names

### DIFF
--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -990,5 +990,5 @@ class IoTResponse(BaseResponse):
             token=token,
         )
         return json.dumps(
-            dict(things=[thing.to_dict() for thing in things], nextToken=next_token)
+            dict(things=[thing.thing_name for thing in things], nextToken=next_token)
         )

--- a/tests/test_iot/test_iot_billing_groups.py
+++ b/tests/test_iot/test_iot_billing_groups.py
@@ -137,7 +137,7 @@ def test_add_thing_to_billing_group():
 
     response = client.list_things_in_billing_group(billingGroupName=billing_group_name)
     assert len(response["things"]) == 1
-    assert response["things"][0]["thingName"] == thing_name
+    assert thing_name in response["things"]
 
 
 @mock_aws
@@ -178,7 +178,7 @@ def test_remove_thing_from_billing_group_by_arn():
     # Verify the thing is in the billing group
     response = client.list_things_in_billing_group(billingGroupName=billing_group_name)
     assert len(response["things"]) == 1
-    assert response["things"][0]["thingName"] == thing_name
+    assert thing_name in response["things"]
 
     # Get ARNs
     billing_group_arn = create_bg_resp["billingGroupArn"]
@@ -250,7 +250,7 @@ def test_thing_removed_from_billing_group_on_thing_deletion():
     # Verify the thing is in the billing group
     response = client.list_things_in_billing_group(billingGroupName=billing_group_name)
     assert len(response["things"]) == 1
-    assert response["things"][0]["thingName"] == thing_name
+    assert thing_name in response["things"]
 
     # Delete the thing
     client.delete_thing(thingName=thing_name)


### PR DESCRIPTION
iot:list_things_in_billing_group action return only ThingNames, not full Thing descriptions.

Docs for reference:
* https://docs.aws.amazon.com/iot/latest/apireference/API_ListThingsInBillingGroup.html
* https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iot/client/list_things_in_billing_group.html