### PR TITLE
Core: normalize datetime deserialization

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -3,9 +3,6 @@ import math
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable, List, Optional, SupportsFloat, Tuple
 
-from dateutil import parser
-from dateutil.tz import tzutc
-
 from moto.core.base_backend import BaseBackend
 from moto.core.common_models import BackendDict, BaseModel, CloudWatchMetricProvider
 from moto.core.utils import utcnow
@@ -225,7 +222,7 @@ class MetricDatumBase(BaseModel):
     ):
         self.namespace = namespace
         self.name = name
-        self.timestamp = timestamp or utcnow().replace(tzinfo=tzutc())
+        self.timestamp = timestamp or utcnow()
         self.dimensions = [
             Dimension(dimension["Name"], dimension["Value"]) for dimension in dimensions
         ]
@@ -593,8 +590,6 @@ class CloudWatchBackend(BaseBackend):
         for metric_member in metric_data:
             # Preserve "datetime" for get_metric_statistics comparisons
             timestamp = metric_member.get("Timestamp")
-            if timestamp is not None and type(timestamp) is not datetime:
-                timestamp = parser.parse(timestamp)
             metric_name = metric_member["MetricName"]
             dimension = metric_member.get("Dimensions", _EMPTY_LIST)
             unit = metric_member.get("Unit")
@@ -607,9 +602,6 @@ class CloudWatchBackend(BaseBackend):
                 for i in range(0, len(values)):
                     value = values[i]
                     timestamp = metric_member.get("Timestamp")
-                    if timestamp is not None and type(timestamp) is not datetime:
-                        timestamp = parser.parse(timestamp)
-
                     # add the value count[i] times
                     for _ in range(0, int(float(counts[i]))):
                         self.metric_data.append(

--- a/moto/core/parsers.py
+++ b/moto/core/parsers.py
@@ -2,12 +2,23 @@
 import base64
 from collections import OrderedDict
 from collections.abc import Mapping, MutableMapping
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 from botocore import xform_name
-from botocore.utils import parse_timestamp
+from botocore.utils import parse_timestamp as botocore_parse_timestamp
 
 UNDEFINED = object()  # Sentinel to signal the absence of a field in the input
+
+
+def parse_timestamp(value: str) -> datetime:
+    """Parse a timestamp and return a naive datetime object in UTC.
+    This matches Moto's internal representation of timestamps, based
+    on moto.core.utils.utcnow().
+    """
+    parsed = botocore_parse_timestamp(value)
+    as_naive_utc = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return as_naive_utc
 
 
 class QueryParser:

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1862,7 +1862,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
                         {"Name": "StorageType", "Value": "StandardStorage"},
                         {"Name": "BucketName", "Value": name},
                     ],
-                    timestamp=datetime.datetime.now(tz=datetime.timezone.utc).replace(
+                    timestamp=utcnow().replace(
                         hour=0, minute=0, second=0, microsecond=0
                     ),
                     unit="Bytes",
@@ -1877,7 +1877,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
                         {"Name": "StorageType", "Value": "AllStorageTypes"},
                         {"Name": "BucketName", "Value": name},
                     ],
-                    timestamp=datetime.datetime.now(tz=datetime.timezone.utc).replace(
+                    timestamp=utcnow().replace(
                         hour=0, minute=0, second=0, microsecond=0
                     ),
                     unit="Count",


### PR DESCRIPTION
This PR guarantees that all timestamps are normalized as naive `datetime` objects in UTC at the request input boundary.  Importantly, this ensures that all service backends that use `moto.core.utils.utcnow()` for their timestamps and opt in to the new request parsing pipeline, will be able to compare `datetime` objects directly, without the need for any additional parsing or translation.

> [!NOTE]\
> The current recommended approach for working with UTC in Python is to use timezone-aware `datetime` objects. 
> That would be a much bigger change for Moto, but the updates in this PR would ease that transition, should it be deemed necessary in the future. 