### PR TITLE
EC2: Transit Gateway: Improve response parity

### DIFF
--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -38,6 +38,16 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
         self.options = merge_multiple_dicts(self.DEFAULT_OPTIONS, options or {})
         self._created_at = utcnow()
 
+        # creating default route table
+        self.default_route_table = backend.create_transit_gateway_route_table(
+            transit_gateway_id=self.id,
+            tags={},
+            default_association_route_table=True,
+            default_propagation_route_table=True,
+        )
+        self.options["AssociationDefaultRouteTableId"] = self.default_route_table.id
+        self.options["PropagationDefaultRouteTableId"] = self.default_route_table.id
+
     @property
     def tags(self) -> List[Dict[str, str]]:
         return self.get_tags()

--- a/moto/ec2/responses/transit_gateway_attachments.py
+++ b/moto/ec2/responses/transit_gateway_attachments.py
@@ -207,11 +207,12 @@ class TransitGatewayAttachment(EC2BaseResponse):
 CREATE_TRANSIT_GATEWAY_VPC_ATTACHMENT = """<CreateTransitGatewayVpcAttachmentResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
         <requestId>9b5766ac-2af6-4b92-9a8a-4d74ae46ae79</requestId>
         <transitGatewayVpcAttachment>
-            <createTime>{{ transit_gateway_attachment.create_time }}</createTime>
+            <creationTime>{{ transit_gateway_attachment.create_time }}</creationTime>
             <options>
                 <applianceModeSupport>{{ transit_gateway_attachment.options.ApplianceModeSupport }}</applianceModeSupport>
                 <dnsSupport>{{ transit_gateway_attachment.options.DnsSupport }}</dnsSupport>
                 <ipv6Support>{{ transit_gateway_attachment.options.Ipv6Support }}</ipv6Support>
+                <securityGroupReferencingSupport>enable</securityGroupReferencingSupport>
             </options>
             <state>{{ transit_gateway_attachment.state }}</state>
             <subnetIds>
@@ -219,6 +220,7 @@ CREATE_TRANSIT_GATEWAY_VPC_ATTACHMENT = """<CreateTransitGatewayVpcAttachmentRes
                 <item>{{ subnet_id }}</item>
             {% endfor %}
             </subnetIds>
+            {% if transit_gateway_attachment.get_tags() %}
             <tagSet>
             {% for tag in transit_gateway_attachment.get_tags() %}
                 <item>
@@ -227,6 +229,7 @@ CREATE_TRANSIT_GATEWAY_VPC_ATTACHMENT = """<CreateTransitGatewayVpcAttachmentRes
                 </item>
             {% endfor %}
             </tagSet>
+            {% endif %}
             <transitGatewayAttachmentId>{{ transit_gateway_attachment.id }}</transitGatewayAttachmentId>
             <transitGatewayId>{{ transit_gateway_attachment.transit_gateway_id }}</transitGatewayId>
             <vpcId>{{ transit_gateway_attachment.vpc_id }}</vpcId>
@@ -249,6 +252,7 @@ DESCRIBE_TRANSIT_GATEWAY_ATTACHMENTS = """<DescribeTransitGatewayAttachmentsResp
             <resourceOwnerId>{{ transit_gateway_attachment.resource_owner_id }}</resourceOwnerId>
             <resourceType>{{ transit_gateway_attachment.resource_type }}</resourceType>
             <state>{{ transit_gateway_attachment.state }}</state>
+            {% if transit_gateway_attachment.get_tags() %}
             <tagSet>
             {% for tag in transit_gateway_attachment.get_tags() %}
                 <item>
@@ -257,6 +261,7 @@ DESCRIBE_TRANSIT_GATEWAY_ATTACHMENTS = """<DescribeTransitGatewayAttachmentsResp
                 </item>
             {% endfor %}
             </tagSet>
+            {% endif %}
             <transitGatewayAttachmentId>{{ transit_gateway_attachment.id }}</transitGatewayAttachmentId>
             <transitGatewayId>{{ transit_gateway_attachment.transit_gateway_id }}</transitGatewayId>
             <transitGatewayOwnerId>{{ transit_gateway_attachment.resource_owner_id }}</transitGatewayOwnerId>
@@ -272,12 +277,13 @@ DESCRIBE_TRANSIT_GATEWAY_VPC_ATTACHMENTS = """<DescribeTransitGatewayVpcAttachme
         <transitGatewayVpcAttachments>
         {% for transit_gateway_vpc_attachment in transit_gateway_vpc_attachments %}
             <item>
-                <creationTime>2021-07-18T08:57:21.000Z</creationTime>
+                <creationTime>{{ transit_gateway_vpc_attachment.create_time }}</creationTime>
                 {% if transit_gateway_vpc_attachment.options %}
                 <options>
                     <applianceModeSupport>{{ transit_gateway_vpc_attachment.options.ApplianceModeSupport }}</applianceModeSupport>
                     <dnsSupport>{{ transit_gateway_vpc_attachment.options.DnsSupport }}</dnsSupport>
                     <ipv6Support>{{ transit_gateway_vpc_attachment.options.Ipv6Support }}</ipv6Support>
+                    <securityGroupReferencingSupport>enable</securityGroupReferencingSupport>
                 </options>
                 {% endif %}
                 <state>{{ transit_gateway_vpc_attachment.state }}</state>
@@ -286,6 +292,7 @@ DESCRIBE_TRANSIT_GATEWAY_VPC_ATTACHMENTS = """<DescribeTransitGatewayVpcAttachme
                     <item>{{ id }}</item>
                 {% endfor %}
                 </subnetIds>
+                {% if transit_gateway_vpc_attachment.get_tags() %}
                 <tagSet>
                 {% for tag in transit_gateway_vpc_attachment.get_tags() %}
                     <item>
@@ -294,6 +301,7 @@ DESCRIBE_TRANSIT_GATEWAY_VPC_ATTACHMENTS = """<DescribeTransitGatewayVpcAttachme
                     </item>
                 {% endfor %}
                 </tagSet>
+                {% endif %}
                 <transitGatewayAttachmentId>{{ transit_gateway_vpc_attachment.id }}</transitGatewayAttachmentId>
                 <transitGatewayId>{{ transit_gateway_vpc_attachment.transit_gateway_id }}</transitGatewayId>
                 <vpcId>{{ transit_gateway_vpc_attachment.vpc_id }}</vpcId>

--- a/moto/ec2/responses/transit_gateways.py
+++ b/moto/ec2/responses/transit_gateways.py
@@ -15,21 +15,6 @@ class TransitGateways(EC2BaseResponse):
             description=description, options=options, tags=tags
         )
 
-        # creating default route table
-        transit_gateway_route_table = (
-            self.ec2_backend.create_transit_gateway_route_table(
-                transit_gateway_id=transit_gateway.id,
-                tags={},
-                default_association_route_table=True,
-                default_propagation_route_table=True,
-            )
-        )
-        transit_gateway.options["AssociationDefaultRouteTableId"] = (
-            transit_gateway_route_table.id
-        )
-        transit_gateway.options["PropagationDefaultRouteTableId"] = (
-            transit_gateway_route_table.id
-        )
         return ActionResult({"TransitGateway": transit_gateway})
 
     def delete_transit_gateway(self) -> ActionResult:

--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -1,5 +1,6 @@
 from contextlib import nullcontext
 from functools import wraps
+from time import sleep
 from uuid import uuid4
 
 import boto3
@@ -11,6 +12,8 @@ from tests import allow_aws_request
 def ec2_aws_verified(
     create_vpc: bool = False,
     create_sg: bool = False,
+    create_subnet: bool = False,
+    create_transit_gateway: bool = False,
 ):
     """
     Function that is verified to work against AWS.
@@ -27,22 +30,47 @@ def ec2_aws_verified(
             context = nullcontext() if allow_aws_request() else mock_aws()
 
             with context:
-                return _invoke_func(create_vpc, create_sg, func=func, kwargs=kwargs)
+                return _invoke_func(
+                    create_vpc,
+                    create_sg=create_sg,
+                    create_subnet=create_subnet,
+                    create_transit_gateway=create_transit_gateway,
+                    func=func,
+                    kwargs=kwargs,
+                )
 
         return pagination_wrapper
 
     return inner
 
 
-def _invoke_func(create_vpc: bool, create_sg: bool, func, kwargs):
+def _invoke_func(
+    create_vpc: bool,
+    create_sg: bool,
+    create_subnet: bool,
+    create_transit_gateway: bool,
+    func,
+    kwargs,
+):
     ec2_client = boto3.client("ec2", "us-east-1")
     kwargs["ec2_client"] = ec2_client
 
-    vpc_id = sg_id = None
+    vpc_id = sg_id = subnet_id = tg_id = None
     if create_vpc:
-        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/24")
+        vpc = ec2_client.create_vpc(
+            CidrBlock="10.0.0.0/16",
+            TagSpecifications=[
+                {"ResourceType": "vpc", "Tags": [{"Key": "project", "Value": "test"}]}
+            ],
+        )
         vpc_id = vpc["Vpc"]["VpcId"]
         kwargs["vpc_id"] = vpc_id
+
+        if create_subnet:
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/24")[
+                "Subnet"
+            ]["SubnetId"]
+            kwargs["subnet_id"] = subnet_id
 
     if create_sg:
         sg_name = f"test_{str(uuid4())[0:6]}"
@@ -52,10 +80,97 @@ def _invoke_func(create_vpc: bool, create_sg: bool, func, kwargs):
         sg_id = sg["GroupId"]
         kwargs["sg_id"] = sg_id
 
+    if create_transit_gateway:
+        gateway = ec2_client.create_transit_gateway(Description="test")
+        tg_id = gateway["TransitGateway"]["TransitGatewayId"]
+        wait_for_transit_gateway(ec2_client, tg_id=tg_id)
+        kwargs["tg_id"] = tg_id
+
     try:
         func(**kwargs)
     finally:
+        if tg_id:
+            delete_transit_gateway_dependencies(ec2_client, tg_id=tg_id)
+            ec2_client.delete_transit_gateway(TransitGatewayId=tg_id)
+        if subnet_id:
+            ec2_client.delete_subnet(SubnetId=subnet_id)
         if sg_id:
             ec2_client.delete_security_group(GroupId=sg_id)
         if vpc_id:
             ec2_client.delete_vpc(VpcId=vpc_id)
+
+
+def wait_for_transit_gateway(ec2_client, tg_id):
+    for idx in range(10):
+        gateway = ec2_client.describe_transit_gateways(TransitGatewayIds=[tg_id])[
+            "TransitGateways"
+        ][0]
+
+        if gateway["State"] == "available":
+            return
+
+        sleep(5 * idx)
+
+
+def wait_for_transit_gateway_route_table(ec2_client, tg_rt_id):
+    for idx in range(10):
+        route_table = ec2_client.describe_transit_gateway_route_tables(
+            TransitGatewayRouteTableIds=[tg_rt_id]
+        )["TransitGatewayRouteTables"][0]
+
+        if route_table["State"] == "available":
+            return
+
+        sleep(5 * idx)
+
+
+def wait_for_transit_gateway_attachments(ec2_client, tg_attachment_id):
+    for idx in range(10):
+        attachment = ec2_client.describe_transit_gateway_vpc_attachments(
+            TransitGatewayAttachmentIds=[tg_attachment_id]
+        )["TransitGatewayVpcAttachments"][0]
+
+        if attachment["State"] == "available":
+            return
+
+        sleep(5 * idx)
+
+
+def delete_transit_gateway_dependencies(ec2_client, tg_id):
+    for idx in range(10):
+        attachments = ec2_client.describe_transit_gateway_attachments(
+            Filters=[{"Name": "transit-gateway-id", "Values": [tg_id]}]
+        )["TransitGatewayAttachments"]
+
+        if not attachments:
+            return
+
+        for attachment in attachments:
+            if attachment["State"] == "available":
+                ec2_client.delete_transit_gateway_vpc_attachment(
+                    TransitGatewayAttachmentId=attachment["TransitGatewayAttachmentId"]
+                )
+
+        if set(a["State"] for a in attachments) == {"deleted"}:
+            return
+
+        sleep(5 * idx)
+
+    for idx in range(10):
+        route_tables = ec2_client.describe_transit_gateway_route_tables(
+            Filters=[{"Name": "transit-gateway-id", "Values": [tg_id]}]
+        )["TransitGatewayRouteTables"]
+
+        if not route_tables:
+            return
+
+        for table in route_tables:
+            if table["State"] == "available":
+                ec2_client.delete_transit_gateway_route_table(
+                    TransitGatewayRouteTableId=table["TransitGatewayRouteTableId"]
+                )
+
+        if set(rt["State"] for rt in route_tables) == {"deleted"}:
+            return
+
+        sleep(5 * idx)


### PR DESCRIPTION
Some minor parity improvements to the response of EC2's `create_transit_gateway_vpc_attachment` and `describe_transit_gateway_vpc_attachments`:
 - The creation time is now returned correctly
 - Tags are not returned at all if not set
 - The `securityGroupReferencingSupport`-option is now returned (hardcoded for now)

The majority of this changeset is ensuring that we can run any transit gateway tests against AWS, and making sure that it deletes all resources (transit gateways, attachments, route tables, etc) afterwards.