### PR TITLE
Core: enhance logic for request/response protocol selection

### DIFF
--- a/moto/core/request.py
+++ b/moto/core/request.py
@@ -33,10 +33,12 @@ def normalize_request(request: AWSPreparedRequest | Request) -> Request:
     return normalized_request
 
 
-def determine_request_protocol(request: Request, service_model: ServiceModel) -> str:
+def determine_request_protocol(
+    service_model: ServiceModel, content_type: str | None = None
+) -> str:
     protocol = str(service_model.protocol)
     supported_protocols = service_model.metadata.get("protocols", [protocol])
-    content_type = request.content_type if request.content_type else ""
+    content_type = content_type if content_type is not None else ""
     if content_type in JSON_TYPES:
         protocol = "rest-json" if content_type == APPLICATION_JSON else "json"
     elif content_type.startswith("application/x-www-form-urlencoded"):

--- a/moto/core/request.py
+++ b/moto/core/request.py
@@ -6,9 +6,11 @@ from urllib.parse import urlparse
 from werkzeug.wrappers import Request
 
 from moto.core.utils import gzip_decompress
+from moto.utilities.constants import APPLICATION_JSON, JSON_TYPES
 
 if TYPE_CHECKING:
     from botocore.awsrequest import AWSPreparedRequest
+    from botocore.model import ServiceModel
 
 
 def normalize_request(request: AWSPreparedRequest | Request) -> Request:
@@ -29,3 +31,18 @@ def normalize_request(request: AWSPreparedRequest | Request) -> Request:
         headers=[(k, v) for k, v in request.headers.items()],
     )
     return normalized_request
+
+
+def determine_request_protocol(request: Request, service_model: ServiceModel) -> str:
+    protocol = str(service_model.protocol)
+    supported_protocols = service_model.metadata.get("protocols", [protocol])
+    content_type = request.content_type if request.content_type else ""
+    if content_type in JSON_TYPES:
+        protocol = "rest-json" if content_type == APPLICATION_JSON else "json"
+    elif content_type.startswith("application/x-www-form-urlencoded"):
+        protocol = "ec2" if "ec2" in supported_protocols else "query"
+    if protocol not in supported_protocols:
+        raise NotImplementedError(
+            f"Unsupported protocol [{protocol}] for service {service_model.service_name}"
+        )
+    return protocol


### PR DESCRIPTION
Botocore models can now support multiple wire protocols, so this PR adds logic to determine the correct protocol for Moto to use for request parsing/response serialization.

Ref: https://smithy.io/2.0/spec/protocol-traits.html#serialization-and-protocol-traits