### PR TITLE
CloudWatch: support Query/JSON protocols simultaneously

### DIFF
--- a/.github/workflows/test_cloudwatch.yml
+++ b/.github/workflows/test_cloudwatch.yml
@@ -1,0 +1,33 @@
+name: "CloudWatch Protocol Tests"
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/test_cloudwatch.yml"
+      - "moto/core/**"
+      - "moto/cloudwatch/**"
+      - "tests/test_cloudwatch/**"
+jobs:
+  test-cloudwatch-protocols:
+    name: ${{ matrix.botocore-version == 'botocore==1.40.16' && 'Query Protocol' || 'JSON Protocol' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.12" ]
+        botocore-version: [ "botocore-1.39.7-py3-none-any.whl", "botocore==1.40.16" ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install project dependencies
+        run: |
+          curl -L -o Boto3CliV1Artifacts.zip "https://d1l1rpjfz23h36.cloudfront.net/pr2qwos6sy8mfx2/Python_Boto_v3/Boto3CliV1Artifacts.zip"
+          unzip Boto3CliV1Artifacts.zip
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install ${{matrix.botocore-version}}
+      - name: Test CloudWatch
+        run: |
+          pytest -sv tests/test_cloudwatch


### PR DESCRIPTION
In order to ensure that Moto is ready for Botocore's upcoming switch from the Query protocol to the JSON protocol when communicating with CloudWatch (#9195), this PR adds a dedicated workflow to run the CloudWatch test suite using both protocols.  With these tests passing, Moto will be forward- and backward-compatible with the planned Botocore changes.

> [!WARNING]\
> Botocore is switching from the Query protocol to the JSON protocol for CloudWatch, but other SDKs (notably Golang 2.x) will be switching from the Query protocol to the RPC v2 CBOR protocol, for which there is no current (or planned) support in Moto.

It's worth pointing out that Moto is able to simultaneously support both of these protocols _without making a single modification to the CloudWatch backend_, which is remarkable when compared to the [SQS backend](https://github.com/getmoto/moto/blob/d5d203ddd556d88e394131e21d923dc15da16f16/moto/sqs/responses.py), which went through a similar protocol migration and required considerable effort from Moto's maintainer(s) to add support (#6331).  The CloudWatch backend being protocol-agnostic didn't come for free, as a significant amount of recent work has been dedicated to improving Moto's request parsing and response serialization pipeline (#9073), but this is exactly the kind of scenario to highlight the value of these higher-level abstractions: in this case, allowing Moto to quickly adapt to a major change from AWS with very little friction.

> [!TIP]\
> In order to test the new JSON requests/responses, the workflow is currently manually downloading and installing the [public preview version of Botocore](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-protocols-faq.html#getting-started) that implements the CloudWatch protocol changes.  Once these changes are included in a released version of Botocore, we should update the workflow (or simply merge with the [Outdated Dependency Tests](https://github.com/getmoto/moto/blob/d5d203ddd556d88e394131e21d923dc15da16f16/.github/workflows/test_outdated_versions.yml)).