### PR TITLE
[DirectConnect] Updating ARNs to match AWS

### DIFF
--- a/moto/directconnect/models.py
+++ b/moto/directconnect/models.py
@@ -68,7 +68,7 @@ class Connection(BaseModel):
 
     def __post_init__(self) -> None:
         if self.connection_id == "":
-            self.connection_id = f"arn:aws:directconnect:{self.region}:{self.owner_account}:dx-con:dx-moto-{self.connection_name}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+            self.connection_id = f"arn:aws:directconnect:{self.region}:{self.owner_account}:dx-con/dx-moto-{self.connection_name}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
 
     def to_dict(
         self,

--- a/tests/test_directconnect/test_directconnect.py
+++ b/tests/test_directconnect/test_directconnect.py
@@ -18,7 +18,7 @@ def test_create_connection(client):
     connection = client.create_connection(
         location="EqDC2", bandwidth="10Gbps", connectionName="TestConnection"
     )
-    assert connection["connectionId"].startswith("dx-moto")
+    assert "dx-moto" in connection["connectionId"]
     assert connection["connectionState"] == "available"
 
 
@@ -179,13 +179,12 @@ def test_create_lag(client):
         connectionsBandwidth="10Gbps",
         lagName="TestLag0",
     )
-    assert lag["lagId"].startswith("dxlag-moto")
+    assert "dxlag-moto" in lag["lagId"]
     assert lag["lagState"] == "available"
     assert len(lag["connections"]) == 1
     connection = lag["connections"][0]
-    assert connection["connectionName"].startswith(
-        "Requested Connection 1 for Lag dxlag-moto"
-    )
+    assert "Requested Connection 1 for Lag" in connection["connectionName"]
+    assert "dxlag-moto" in connection["connectionName"]
 
 
 def test_describe_lags(client):


### PR DESCRIPTION
This PR looks to address the issue with DirectConnect resources not having proper arn format. Some small changes were made using this [doc](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsdirectconnect.html#awsdirectconnect-dxcon:~:text=arn%3A%24%7BPartition%7D%3Adirectconnect%3A%24%7BRegion%7D%3A%24%7BAccount%7D%3Adxcon/%24%7BConnectionId%7D) as reference for how ARN should be structured. 