### PR TITLE
feat: Handle empty S3 lifecycle configuration

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -8239,7 +8239,7 @@
 - [ ] get_access_point_policy_status_for_object_lambda
 - [ ] get_access_point_scope
 - [ ] get_bucket
-- [ ] get_bucket_lifecycle_configuration
+- [X] get_bucket_lifecycle_configuration
 - [ ] get_bucket_policy
 - [ ] get_bucket_replication
 - [ ] get_bucket_tagging
@@ -8272,7 +8272,7 @@
 - [X] put_access_point_policy
 - [ ] put_access_point_policy_for_object_lambda
 - [ ] put_access_point_scope
-- [ ] put_bucket_lifecycle_configuration
+- [X] put_bucket_lifecycle_configuration
 - [ ] put_bucket_policy
 - [ ] put_bucket_replication
 - [ ] put_bucket_tagging

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -815,10 +815,15 @@ class S3Response(BaseResponse):
             else:
                 return 404, {}, ""
         elif "lifecycle" in querystring:
-            rules = xmltodict.parse(self.body)["LifecycleConfiguration"]["Rule"]
-            if not isinstance(rules, list):
-                # If there is only one rule, xmldict returns just the item
-                rules = [rules]
+            lifecycle_config = xmltodict.parse(self.body)["LifecycleConfiguration"]
+            # Handle empty lifecycle configuration (no rules)
+            if "Rule" not in lifecycle_config:
+                rules = []
+            else:
+                rules = lifecycle_config["Rule"]
+                if not isinstance(rules, list):
+                    # If there is only one rule, xmldict returns just the item
+                    rules = [rules]
             self.backend.put_bucket_lifecycle(bucket_name, rules)
             return ""
         elif "policy" in querystring:


### PR DESCRIPTION
This PR fixes the issue when an empty lifecycle configuration (which is used to delete all lifecycle rules). Moto had a bug in the XML parsing logic that expected a Rule key even when the lifecycle configuration was empty.

A test has been added `Test that empty lifecycle configuration (no rules) works correctly` 

IMPLEMENTATION_COVERAGE.md has also been updated to mention support for `put_bucket_lifecycle_configuration` and `get_bucket_lifecycle_configuration`

https://github.com/getmoto/moto/issues/9271
