### PR TITLE
fix(cognitoidp): aws.cognito.signin.user.admin scope in access token

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -613,6 +613,7 @@ class CognitoIdpUserPool(BaseModel):
         """
         extra_data: Dict[str, Any] = {
             "origin_jti": origin_jti,
+            "scope": "aws.cognito.signin.user.admin",
         }
         user = self._get_user(username)
         if len(user.groups) > 0:


### PR DESCRIPTION
Include the default `aws.cognito.signin.user.admin` scope in access token. This scope is included by default in all access tokens created by `AdminInitiateAuth` and `InitiateAuth`, however it can be stripped by a custom pre-token-generation lambda trigger.

Ref: https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html