### PR TITLE
CloudWatch: fix-ups for datetime asserts in anticipation of protocol change

### DIFF
--- a/tests/test_cloudwatch/test_cloudwatch_boto3.py
+++ b/tests/test_cloudwatch/test_cloudwatch_boto3.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from dateutil.tz import tzutc
 from freezegun import freeze_time
 
 from moto import mock_aws
@@ -1710,11 +1709,11 @@ def test_put_metric_alarm_with_percentile():
         == f"arn:aws:cloudwatch:{region_name}:{ACCOUNT_ID}:alarm:{alarm_name}"
     )
     assert alarm["AlarmDescription"] == "test alarm"
-    assert alarm["AlarmConfigurationUpdatedTimestamp"].tzinfo == tzutc()
+    assert isinstance(alarm["AlarmConfigurationUpdatedTimestamp"], datetime)
     assert alarm["ActionsEnabled"] is True
     assert alarm["StateValue"] == "OK"
     assert alarm["StateReason"] == "Unchecked: Initial alarm creation"
-    assert alarm["StateUpdatedTimestamp"].tzinfo == tzutc()
+    assert isinstance(alarm["StateUpdatedTimestamp"], datetime)
     assert alarm["MetricName"] == "5XXError"
     assert alarm["Namespace"] == "AWS/ApiGateway"
     assert alarm["ExtendedStatistic"] == "p90"
@@ -1781,10 +1780,10 @@ def test_put_metric_alarm_with_anomaly_detection():
         alarm["AlarmArn"]
         == f"arn:aws:cloudwatch:{region_name}:{ACCOUNT_ID}:alarm:{alarm_name}"
     )
-    assert alarm["AlarmConfigurationUpdatedTimestamp"].tzinfo == tzutc()
+    assert isinstance(alarm["AlarmConfigurationUpdatedTimestamp"], datetime)
     assert alarm["StateValue"] == "OK"
     assert alarm["StateReason"] == "Unchecked: Initial alarm creation"
-    assert alarm["StateUpdatedTimestamp"].tzinfo == tzutc()
+    assert isinstance(alarm["StateUpdatedTimestamp"], datetime)
     assert alarm["EvaluationPeriods"] == 2
     assert alarm["ComparisonOperator"] == "GreaterThanOrEqualToThreshold"
     assert alarm["Metrics"] == metrics


### PR DESCRIPTION
In anticipation of CloudWatch switching the wire protocol from Query to JSON in a future version of Botocore, this PR drops the `tzinfo` response asserts.  Botocore parses dates serialized via the Query protocol as UTC always, but the local timezone is used when parsing dates serialized via the JSON protocol.

We didn't catch this with our [dedicated CloudWatch protocol tests](https://github.com/getmoto/moto/blob/192289fb8308caee3849961713cf65ac100d8c30/.github/workflows/test_cloudwatch.yml) because the local time on GitHub Actions runners is Coordinated Universal Time (UTC).

Reported here: https://github.com/getmoto/moto/pull/9253#issuecomment-3268109315