### PR TITLE
CloudWatch: fix `ReturnData` check

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -740,7 +740,7 @@ class CloudWatchBackend(BaseBackend):
                     "status_code": "Complete",
                 }
             )
-            if query.get("ReturnData", "true") == "true":
+            if query.get("ReturnData", True):
                 results_to_return.append(
                     {
                         "id": query["Id"],


### PR DESCRIPTION
CloudWatch was recently migrated to the new request parsing pipeline, which properly deserializes boolean values; but the model was still doing a string comparison.  This PR fixes the bug and adds test coverage.

Closes #9280 