### PR TITLE
Fix: GetPartitions Error Message

### DIFF
--- a/moto/glue/utils.py
+++ b/moto/glue/utils.py
@@ -329,7 +329,8 @@ class _Ident(_Expr):
             if self.ident == key["Name"]:
                 return key["Type"]
 
-        raise InvalidInputException("GetPartitions", f"Unknown column '{self.ident}'")
+        # not a partition column
+        raise InvalidInputException("GetPartitions", "Invalid partition expression!")
 
     def _eval(self, part_keys: List[Dict[str, str]], part_input: Dict[str, Any]) -> Any:
         for key, value in zip(part_keys, part_input["Values"]):
@@ -337,7 +338,7 @@ class _Ident(_Expr):
                 return _cast(key["Type"], value)
 
         # also raised for unpartitioned tables
-        raise InvalidInputException("GetPartitions", f"Unknown column '{self.ident}'")
+        raise InvalidInputException("GetPartitions", "Invalid partition expression!")
 
 
 class _IsNull(_Expr):

--- a/tests/test_glue/test_partition_filter.py
+++ b/tests/test_glue/test_partition_filter.py
@@ -32,7 +32,7 @@ def test_get_partitions_expression_unknown_column():
         )
 
     assert exc.value.response["Error"]["Code"] == "InvalidInputException"
-    assert "Unknown column 'unknown_col'" in exc.value.response["Error"]["Message"]
+    assert exc.value.response["Error"]["Message"] == "Invalid partition expression!"
 
 
 @mock_aws
@@ -200,7 +200,7 @@ def test_get_partitions_expression_string_column():
         client.get_partitions(**kwargs, Expression="unknown_col LIKE 'two'")
 
     assert exc.value.response["Error"]["Code"] == "InvalidInputException"
-    assert "Unknown column 'unknown_col'" in exc.value.response["Error"]["Message"]
+    assert exc.value.response["Error"]["Message"] == "Invalid partition expression!"
 
 
 @mock_aws
@@ -371,7 +371,7 @@ def test_get_partition_expression_warnings_and_exceptions():
         client.get_partitions(**kwargs, Expression="unknown_col = 'test'")
 
     assert exc.value.response["Error"]["Code"] == "InvalidInputException"
-    assert "Unknown column 'unknown_col'" in exc.value.response["Error"]["Message"]
+    assert exc.value.response["Error"]["Message"] == "Invalid partition expression!"
 
     with pytest.raises(ClientError) as exc:
         client.get_partitions(


### PR DESCRIPTION
It seems that when using partition expressions that refer to non-partition columns, the error message has changed.

```python
>>> import boto3
>>> client = boto3.client("glue", region_name="eu-central-1")
>>> parts = client.get_partitions(DatabaseName="existing_database", TableName="existing_table", Expression="existing_column IS NULL")
>>>
>>> parts = client.get_partitions(DatabaseName="existing_database", TableName="existing_table", Expression="non_existing_column IS NULL")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/miniforge3/envs/env/lib/python3.10/site-packages/botocore/client.py", line 602, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/user/miniforge3/envs/env/lib/python3.10/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
  File "/home/user/miniforge3/envs/env/lib/python3.10/site-packages/botocore/client.py", line 1078, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.InvalidInputException: An error occurred (InvalidInputException) when calling the GetPartitions operation: Invalid partition expression!
```

This PR updates `moto` with the new error message and tests.