### PR TITLE
[Macie]Adding support for organization admin accounts and member disassociation

### DIFF
--- a/moto/macie2/models.py
+++ b/moto/macie2/models.py
@@ -177,9 +177,7 @@ class MacieBackend(BaseBackend):
             "updatedAt": now,
         }
 
-    def enable_organization_admin_account(
-        self, admin_account_id: str
-    ) -> None: 
+    def enable_organization_admin_account(self, admin_account_id: str) -> None:
         self.organization_admin_account_id = admin_account_id
 
     def list_organization_admin_accounts(self) -> list[dict[str, str]]:

--- a/moto/macie2/models.py
+++ b/moto/macie2/models.py
@@ -61,6 +61,7 @@ class MacieBackend(BaseBackend):
         self.invitations: Dict[str, Invitation] = {}
         self.members: Dict[str, Member] = {}
         self.administrator_account: Optional[Member] = None
+        self.organization_admin_account_id: Optional[str] = None
         self.macie_session: Optional[Dict[str, Any]] = {
             "createdAt": datetime.utcnow(),
             "findingPublishingFrequency": "FIFTEEN_MINUTES",
@@ -133,6 +134,20 @@ class MacieBackend(BaseBackend):
                 backend.administrator_account = None
                 break
 
+    def disassociate_member(self, member_account_id: str) -> None:
+        if member_account_id not in self.members:
+            raise ResourceNotFoundException(
+                "The request failed because the resource doesn't exist."
+            )
+
+        self.members.pop(member_account_id)
+
+        for backend_dict in macie2_backends.values():
+            backend = backend_dict.get(self.region_name)
+            if backend and backend.account_id == member_account_id:
+                backend.administrator_account = None
+                break
+
     def get_macie_session(self) -> Dict[str, Any]:
         if not self.macie_session:
             raise ResourceNotFoundException(
@@ -161,6 +176,25 @@ class MacieBackend(BaseBackend):
             "status": status,
             "updatedAt": now,
         }
+
+    def enable_organization_admin_account(
+        self, admin_account_id: str
+    ) -> None:  # <-- NEW
+        """
+        Designates a member account as the delegated Amazon Macie
+        administrator account for an organization.
+        """
+        self.organization_admin_account_id = admin_account_id
+
+    def list_organization_admin_accounts(self) -> list[dict[str, str]]:
+        if self.organization_admin_account_id:
+            return [
+                {
+                    "accountId": self.organization_admin_account_id,
+                    "status": "ENABLED",
+                }
+            ]
+        return []
 
     def disable_macie(self) -> None:
         self.invitations.clear()

--- a/moto/macie2/models.py
+++ b/moto/macie2/models.py
@@ -179,11 +179,7 @@ class MacieBackend(BaseBackend):
 
     def enable_organization_admin_account(
         self, admin_account_id: str
-    ) -> None:  # <-- NEW
-        """
-        Designates a member account as the delegated Amazon Macie
-        administrator account for an organization.
-        """
+    ) -> None: 
         self.organization_admin_account_id = admin_account_id
 
     def list_organization_admin_accounts(self) -> list[dict[str, str]]:

--- a/moto/macie2/responses.py
+++ b/moto/macie2/responses.py
@@ -58,6 +58,11 @@ class MacieResponse(BaseResponse):
         self.macie_backend.delete_member(member_account_id)
         return "{}"
 
+    def disassociate_member(self) -> str:
+        member_account_id = self.path.split("/")[-1]
+        self.macie_backend.disassociate_member(member_account_id)
+        return "{}"
+
     def get_macie_session(self) -> str:
         session = self.macie_backend.get_macie_session()
         return json.dumps(session)
@@ -73,3 +78,14 @@ class MacieResponse(BaseResponse):
     def disable_macie(self) -> str:
         self.macie_backend.disable_macie()
         return json.dumps(dict())
+
+    def enable_organization_admin_account(self) -> str:
+        admin_account_id = self._get_param("adminAccountId")
+        self.macie_backend.enable_organization_admin_account(
+            admin_account_id=admin_account_id
+        )
+        return json.dumps({})
+
+    def list_organization_admin_accounts(self) -> str:
+        admin_accounts = self.macie_backend.list_organization_admin_accounts()
+        return json.dumps({"adminAccounts": admin_accounts})

--- a/moto/macie2/urls.py
+++ b/moto/macie2/urls.py
@@ -14,4 +14,6 @@ url_paths = {
     "{0}/administrator$": MacieResponse.dispatch,
     "{0}/macie$": MacieResponse.dispatch,
     "{0}/session$": MacieResponse.dispatch,
+    "{0}/members/disassociate/(?P<id>[^/]+)$": MacieResponse.dispatch,
+    "{0}/admin$": MacieResponse.dispatch,
 }


### PR DESCRIPTION
Updating the current Macie implementation by adding EnableOrganizationAdminAccount and ListOrganizationAdminAccounts to handle the designation and retrieval of a delegated administrator for an AWS Organization.  Also adding DisassociateMember, which correctly removes accounts that were added via direct invitation.