### PR TITLE
[SecurityHub]Adding lifecycle methods in Moto SecurityHub

### DIFF
--- a/moto/securityhub/models.py
+++ b/moto/securityhub/models.py
@@ -69,7 +69,7 @@ class SecurityHubBackend(BaseBackend):
         self,
         enable_default_standards: bool = True,
         tags: Optional[Dict[str, str]] = None,
-    ):
+    ) -> Dict[str, Any]:
         if self.enabled:
             return {}
 

--- a/moto/securityhub/models.py
+++ b/moto/securityhub/models.py
@@ -41,8 +41,8 @@ class SecurityHubBackend(BaseBackend):
         self.findings: List[Finding] = []
         self.region_name = region_name
         self.org_backend = organizations_backends[self.account_id]["aws"]
+        self.enabled_at: Optional[str] = None
         self.enabled = False
-        self.enabled_at = None
 
     def _get_org_config(self) -> Dict[str, Any]:
         """Get organization config for the current account."""

--- a/moto/securityhub/responses.py
+++ b/moto/securityhub/responses.py
@@ -17,7 +17,7 @@ class SecurityHubResponse(BaseResponse):
 
     def enable_security_hub(self) -> str:
         params = json.loads(self.body) if self.body else {}
-        enable_default_standards = (params.get("EnableDefaultStandards", True),)
+        enable_default_standards = params.get("EnableDefaultStandards", True)
         tags = params.get("Tags", {})
 
         self.securityhub_backend.enable_security_hub(

--- a/moto/securityhub/responses.py
+++ b/moto/securityhub/responses.py
@@ -15,6 +15,28 @@ class SecurityHubResponse(BaseResponse):
     def securityhub_backend(self) -> SecurityHubBackend:
         return securityhub_backends[self.current_account][self.region]
 
+    def enable_security_hub(self) -> str:
+        params = json.loads(self.body) if self.body else {}
+        enable_default_standards = (params.get("EnableDefaultStandards", True),)
+        tags = params.get("Tags", {})
+
+        self.securityhub_backend.enable_security_hub(
+            enable_default_standards=enable_default_standards,
+            tags=tags,
+        )
+        return json.dumps({})
+
+    def disable_security_hub(self) -> str:
+        self.securityhub_backend.disable_security_hub()
+        return json.dumps({})
+
+    def describe_hub(self) -> str:
+        params = json.loads(self.body) if self.body else {}
+        hub_arn = params.get("HubArn")
+
+        hub_info = self.securityhub_backend.describe_hub(hub_arn=hub_arn)
+        return json.dumps(hub_info)
+
     def get_findings(self) -> str:
         filters = self._get_param("Filters")
         sort_criteria = self._get_param("SortCriteria")

--- a/moto/securityhub/urls.py
+++ b/moto/securityhub/urls.py
@@ -7,9 +7,14 @@ url_bases = [
 ]
 
 url_paths = {
+    "{0}/accounts$": SecurityHubResponse.dispatch,
+    "{0}/accounts/describe$": SecurityHubResponse.dispatch,
     "{0}/findings$": SecurityHubResponse.dispatch,
     "{0}/findings/import$": SecurityHubResponse.dispatch,
     "{0}/organization/admin/enable$": SecurityHubResponse.dispatch,
     "{0}/organization/configuration$": SecurityHubResponse.dispatch,
     "{0}/administrator$": SecurityHubResponse.dispatch,
+    "{0}/hub$": SecurityHubResponse.dispatch,
+    "{0}/hub/enable$": SecurityHubResponse.dispatch,
+    "{0}/hub/disable$": SecurityHubResponse.dispatch,
 }


### PR DESCRIPTION
This PR adds the following methods:

enable_security_hub – Enables SecurityHub for the account and region. Handles the EnableDefaultStandards parameter.
disable_security_hub – Disables SecurityHub for the account and region.
describe_hub – Returns hub metadata, including the optional HubArn.

Also added tests