### PR TITLE
S3: Support STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER signature in S3 PUT

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -190,10 +190,10 @@ class S3Response(BaseResponse):
         ):
             self.body = self._handle_encoded_body(self.body)
 
-        if (
-            request.headers.get("x-amz-content-sha256")
-            == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
-        ):
+        if request.headers.get("x-amz-content-sha256") in [
+            "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
+            "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER",
+        ]:
             self.body = self._handle_v4_chunk_signatures(
                 self.raw_body, int(request.headers["x-amz-decoded-content-length"])
             )
@@ -1387,6 +1387,10 @@ class S3Response(BaseResponse):
             # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html#sigv4-chunked-body-definition
             # str(hex(chunk-size)) + ";chunk-signature=" + signature + \r\n + chunk-data + \r\n
             chunk_size = int(line[: line.find(b";")].decode("utf8"), 16)
+            if chunk_size == 0:
+                # Signature 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER' will have trailing parts that define the checksum
+                # We can safely ignore those
+                break
             new_body[pos : pos + chunk_size] = body_io.read(chunk_size)
             pos = pos + chunk_size
             body_io.read(2)  # skip trailing \r\n

--- a/other_langs/tests_java/src/test/java/moto/tests/S3Test.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/S3Test.java
@@ -2,14 +2,13 @@ package moto.tests;
 
 import org.junit.Test;
 
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadBucketRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import moto.tests.DependencyFactory;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Unit test for simple App.
@@ -34,8 +33,20 @@ public class S3Test
 
 
         // Upload Object with static data
+        String initialString = "Testing with the {sdk-java}";
         PutObjectRequest put_request = PutObjectRequest.builder().bucket(bucketName).key(keyName).build();
-        s3Client.putObject(put_request, RequestBody.fromString("Testing with the {sdk-java}"));
+        s3Client.putObject(put_request, RequestBody.fromString(initialString));
+
+        GetObjectRequest objectRequest = GetObjectRequest
+                .builder()
+                .key(keyName)
+                .bucket(bucketName)
+                .build();
+
+        ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObject(objectRequest, ResponseTransformer.toBytes());
+        String receivedString = objectBytes.asUtf8String();
+
+        assertEquals(initialString, receivedString);
     }
 
     @Test


### PR DESCRIPTION
Fixes #9263
Fixes #9310 

The Java SDK uses the `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` signature by default, so we can verify this behaviour with a simple `PUT`->`GET` test.