### PR TITLE
EC2: Improve VPN Connections validation

### DIFF
--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -196,7 +196,7 @@ class InvalidCustomerGatewayIdError(EC2ClientError):
     def __init__(self, customer_gateway_id: str):
         super().__init__(
             "InvalidCustomerGatewayID.NotFound",
-            f"The customer gateway ID '{customer_gateway_id}' does not exist",
+            f"The customerGateway ID '{customer_gateway_id}' does not exist",
         )
 
 
@@ -857,6 +857,14 @@ class InvalidCarrierGatewayID(EC2ClientError):
         super().__init__(
             "InvalidCarrierGatewayID.NotFound",
             f"The CarrierGateway ID '{carrier_gateway_id}' does not exist",
+        )
+
+
+class InvalidTransitGatewayID(EC2ClientError):
+    def __init__(self, transit_gateway_id: str):
+        super().__init__(
+            "InvalidTransitGatewayID.NotFound",
+            f"The transitGateway ID '{transit_gateway_id}' does not exist",
         )
 
 

--- a/moto/ec2/models/vpn_connections.py
+++ b/moto/ec2/models/vpn_connections.py
@@ -1,6 +1,10 @@
 from typing import Any, Dict, List, Optional
 
-from ..exceptions import InvalidVpnConnectionIdError
+from ..exceptions import (
+    InvalidParameterValue,
+    InvalidTransitGatewayID,
+    InvalidVpnConnectionIdError,
+)
 from ..utils import generic_filter, random_vpn_connection_id
 from .core import TaggedEC2Resource
 
@@ -45,12 +49,20 @@ class VPNConnectionBackend:
         customer_gateway_id: str,
         vpn_gateway_id: Optional[str] = None,
         transit_gateway_id: Optional[str] = None,
-        static_routes_only: Optional[bool] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> VPNConnection:
+        if vpn_gateway_id and transit_gateway_id:
+            # From the docs (parentheses mine):
+            # Creates a VPN connection between an existing (virtual private gateway or transit gateway) and a customer gateway
+            raise InvalidParameterValue(
+                "The request must not contain both parameter vpnGatewayId and transitGatewayId"
+            )
+        # Validate Gateways exist
+        self.get_customer_gateway(customer_gateway_id=customer_gateway_id)  # type: ignore[attr-defined]
+        if transit_gateway_id and transit_gateway_id not in self.transit_gateways:  # type: ignore[attr-defined]
+            raise InvalidTransitGatewayID(transit_gateway_id)
+
         vpn_connection_id = random_vpn_connection_id()
-        if static_routes_only:
-            pass
         vpn_connection = VPNConnection(
             self,
             vpn_connection_id=vpn_connection_id,

--- a/moto/ec2/responses/vpn_connections.py
+++ b/moto/ec2/responses/vpn_connections.py
@@ -12,14 +12,12 @@ class VPNConnections(EC2BaseResponse):
         cgw_id = self._get_param("CustomerGatewayId")
         vgw_id = self._get_param("VpnGatewayId")
         tgw_id = self._get_param("TransitGatewayId")
-        static_routes = self._get_param("StaticRoutesOnly")
         tags = add_tag_specification(self._get_multi_param("TagSpecification"))
         vpn_connection = self.ec2_backend.create_vpn_connection(
             vpn_conn_type,
             cgw_id,
             vpn_gateway_id=vgw_id,
             transit_gateway_id=tgw_id,
-            static_routes_only=static_routes,
             tags=tags,
         )
         if vpn_connection.transit_gateway_id:

--- a/tests/test_ec2/test_customer_gateways.py
+++ b/tests/test_ec2/test_customer_gateways.py
@@ -3,6 +3,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from tests.test_ec2 import ec2_aws_verified
 
 
 @mock_aws
@@ -93,14 +94,19 @@ def test_delete_customer_gateways():
     assert cgws[0]["State"] == "deleted"
 
 
-@mock_aws
-def test_delete_customer_gateways_bad_id():
-    ec2 = boto3.client("ec2", region_name="us-east-1")
-    with pytest.raises(ClientError) as ex:
-        ec2.delete_customer_gateway(CustomerGatewayId="cgw-0123abcd")
-    assert ex.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
-    assert "RequestId" in ex.value.response["ResponseMetadata"]
-    assert ex.value.response["Error"]["Code"] == "InvalidCustomerGatewayID.NotFound"
+@ec2_aws_verified()
+@pytest.mark.aws_verified
+def test_delete_customer_gateways_bad_id(ec2_client=None):
+    with pytest.raises(ClientError) as exc:
+        ec2_client.delete_customer_gateway(CustomerGatewayId="cgw-0123abcd")
+    response = exc.value.response
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert "RequestId" in response["ResponseMetadata"]
+    assert response["Error"]["Code"] == "InvalidCustomerGatewayID.NotFound"
+    assert (
+        response["Error"]["Message"]
+        == "The customerGateway ID 'cgw-0123abcd' does not exist"
+    )
 
 
 def create_customer_gateway(ec2):

--- a/tests/test_ec2/test_transit_gateway.py
+++ b/tests/test_ec2/test_transit_gateway.py
@@ -216,15 +216,17 @@ def retrieve_all_transit_gateways(ec2):
 def test_create_transit_gateway_vpn_attachment():
     ec2 = boto3.client("ec2", region_name="us-west-1")
 
-    vpn_gateway = ec2.create_vpn_gateway(Type="ipsec.1").get("VpnGateway", {})
+    transit_gateway_id = ec2.create_transit_gateway(Description="my first gatway")[
+        "TransitGateway"
+    ]["TransitGatewayId"]
+
     customer_gateway = ec2.create_customer_gateway(
         Type="ipsec.1", PublicIp="205.251.242.54", BgpAsn=65534
-    ).get("CustomerGateway", {})
+    )["CustomerGateway"]
     vpn_connection = ec2.create_vpn_connection(
         Type="ipsec.1",
-        VpnGatewayId=vpn_gateway["VpnGatewayId"],
         CustomerGatewayId=customer_gateway["CustomerGatewayId"],
-        TransitGatewayId="gateway_id",
+        TransitGatewayId=transit_gateway_id,
     )["VpnConnection"]
     vpn_conn_id = vpn_connection["VpnConnectionId"]
 


### PR DESCRIPTION
## Motivation
I've been wanting to fix #9050 for a while now, but every time I look at it, I discover other bugs/parity issues in our (test) code. This PR should make it easier to improve the TransitGateways, and improves parity in a few areas.

## Changes
 - `create_vpn_connection()` now validates that only one of [VPNGateway|TransitGateway] is provided
 - `create_vpn_connection()` now validates that the provided CustomerGateway and TransitGateway exists
 - Removes reference to the `static_routes_only`-parameter, as that wasn't implemented anyway
 - Adds `aws_verified` tests for all changes