### PR TITLE
DevOps Agent: add service support

### DIFF
--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -63,6 +63,7 @@ backend_url_patterns = [
     ("datapipeline", re.compile("https?://datapipeline\\.(.+)\\.amazonaws\\.com")),
     ("datasync", re.compile("https?://(.*\\.)?(datasync)\\.(.+)\\.amazonaws.com")),
     ("dax", re.compile("https?://dax\\.(.+)\\.amazonaws\\.com")),
+    ("devopsagent", re.compile("https?://(.*\\.)?aidevops\\.(.+)\\.api\\.aws")),
     ("directconnect", re.compile("https?://directconnect\\.(.+)\\.amazonaws\\.com")),
     ("dms", re.compile("https?://dms\\.(.+)\\.amazonaws\\.com")),
     ("ds", re.compile("https?://ds\\.(.+)\\.amazonaws\\.com")),

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from moto.datapipeline.models import DataPipelineBackend
     from moto.datasync.models import DataSyncBackend
     from moto.dax.models import DAXBackend
+    from moto.devopsagent.models import DevOpsAgentBackend
     from moto.directconnect.models import DirectConnectBackend
     from moto.dms.models import DatabaseMigrationServiceBackend
     from moto.ds.models import DirectoryServiceBackend
@@ -242,6 +243,7 @@ SERVICE_NAMES = Union[
     "Literal['datapipeline']",
     "Literal['datasync']",
     "Literal['dax']",
+    "Literal['devopsagent']",
     "Literal['directconnect']",
     "Literal['dms']",
     "Literal['ds']",
@@ -477,6 +479,10 @@ def get_backend(
 def get_backend(name: "Literal['datasync']") -> "BackendDict[DataSyncBackend]": ...
 @overload
 def get_backend(name: "Literal['dax']") -> "BackendDict[DAXBackend]": ...
+@overload
+def get_backend(
+    name: "Literal['devopsagent']",
+) -> "BackendDict[DevOpsAgentBackend]": ...
 @overload
 def get_backend(
     name: "Literal['dms']",

--- a/moto/devopsagent/__init__.py
+++ b/moto/devopsagent/__init__.py
@@ -1,0 +1,1 @@
+from .models import devopsagent_backends  # noqa: F401

--- a/moto/devopsagent/exceptions.py
+++ b/moto/devopsagent/exceptions.py
@@ -1,0 +1,17 @@
+from moto.core.exceptions import ServiceException
+
+
+class DevOpsAgentClientError(ServiceException):
+    pass
+
+
+class ResourceNotFoundException(DevOpsAgentClientError):
+    code = "ResourceNotFoundException"
+
+
+class ConflictException(DevOpsAgentClientError):
+    code = "ConflictException"
+
+
+class ValidationException(DevOpsAgentClientError):
+    code = "ValidationException"

--- a/moto/devopsagent/models.py
+++ b/moto/devopsagent/models.py
@@ -130,6 +130,7 @@ class DevOpsAgentBackend(BaseBackend):
     def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
+
 devopsagent_backends = BackendDict(
     DevOpsAgentBackend,
     "devops-agent",

--- a/moto/devopsagent/models.py
+++ b/moto/devopsagent/models.py
@@ -1,0 +1,134 @@
+from collections import OrderedDict
+from typing import Any, Optional
+
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
+from moto.core.utils import utcnow
+from moto.moto_api._internal import mock_random
+from moto.utilities.tagging_service import TaggingService
+from moto.utilities.utils import get_partition
+
+from .exceptions import ResourceNotFoundException
+
+
+class AgentSpace(BaseModel):
+    def __init__(
+        self,
+        region_name: str,
+        account_id: str,
+        name: str,
+        description: Optional[str],
+        locale: Optional[str],
+        kms_key_arn: Optional[str],
+    ):
+        self.region_name = region_name
+        self.account_id = account_id
+        self.name = name
+        self.description = description or ""
+        self.locale = locale or ""
+        self.kms_key_arn = kms_key_arn or ""
+        self.agent_space_id = f"as-{mock_random.get_random_hex(12)}"
+        self.arn = f"arn:{get_partition(region_name)}:aidevops:{region_name}:{account_id}:agentspace/{self.agent_space_id}"
+        now = utcnow()
+        self.created_at = now
+        self.updated_at = now
+
+    def update(
+        self,
+        name: Optional[str],
+        description: Optional[str],
+        locale: Optional[str],
+    ) -> None:
+        if name is not None:
+            self.name = name
+        if description is not None:
+            self.description = description
+        if locale is not None:
+            self.locale = locale
+        self.updated_at = utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "agentSpaceId": self.agent_space_id,
+            "name": self.name,
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+        }
+        if self.description:
+            result["description"] = self.description
+        if self.locale:
+            result["locale"] = self.locale
+        if self.kms_key_arn:
+            result["kmsKeyArn"] = self.kms_key_arn
+        return result
+
+
+class DevOpsAgentBackend(BaseBackend):
+    def __init__(self, region_name: str, account_id: str):
+        super().__init__(region_name, account_id)
+        self.agent_spaces: OrderedDict[str, AgentSpace] = OrderedDict()
+        self.tagger = TaggingService()
+
+    def create_agent_space(
+        self,
+        name: str,
+        description: Optional[str],
+        locale: Optional[str],
+        kms_key_arn: Optional[str],
+        tags: Optional[dict[str, str]],
+    ) -> AgentSpace:
+        space = AgentSpace(
+            region_name=self.region_name,
+            account_id=self.account_id,
+            name=name,
+            description=description,
+            locale=locale,
+            kms_key_arn=kms_key_arn,
+        )
+        self.agent_spaces[space.agent_space_id] = space
+        if tags:
+            self.tagger.tag_resource(
+                space.arn,
+                [{"Key": k, "Value": v} for k, v in tags.items()],
+            )
+        return space
+
+    def get_agent_space(self, agent_space_id: str) -> AgentSpace:
+        if agent_space_id not in self.agent_spaces:
+            raise ResourceNotFoundException(
+                f"Could not find AgentSpace with ID {agent_space_id}"
+            )
+        return self.agent_spaces[agent_space_id]
+
+    def list_agent_spaces(self) -> list[AgentSpace]:
+        return list(self.agent_spaces.values())
+
+    def update_agent_space(
+        self,
+        agent_space_id: str,
+        name: Optional[str],
+        description: Optional[str],
+        locale: Optional[str],
+    ) -> AgentSpace:
+        space = self.get_agent_space(agent_space_id)
+        space.update(name=name, description=description, locale=locale)
+        return space
+
+    def delete_agent_space(self, agent_space_id: str) -> None:
+        space = self.get_agent_space(agent_space_id)
+        self.tagger.delete_all_tags_for_resource(space.arn)
+        self.agent_spaces.pop(agent_space_id)
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(
+            resource_arn, [{"Key": k, "Value": v} for k, v in tags.items()]
+        )
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
+
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
+        return self.tagger.get_tag_dict_for_resource(resource_arn)
+
+
+devopsagent_backends = BackendDict(DevOpsAgentBackend, "devops-agent")

--- a/moto/devopsagent/models.py
+++ b/moto/devopsagent/models.py
@@ -130,5 +130,21 @@ class DevOpsAgentBackend(BaseBackend):
     def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-
-devopsagent_backends = BackendDict(DevOpsAgentBackend, "devops-agent")
+devopsagent_backends = BackendDict(
+    DevOpsAgentBackend,
+    "devops-agent",
+    use_boto3_regions=False,
+    additional_regions=[
+        "us-east-1",
+        "us-west-2",
+        "ca-central-1",
+        "sa-east-1",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+    ],
+)

--- a/moto/devopsagent/responses.py
+++ b/moto/devopsagent/responses.py
@@ -38,9 +38,7 @@ class DevOpsAgentResponse(BaseResponse):
 
     def list_agent_spaces(self) -> ActionResult:
         spaces = self.backend.list_agent_spaces()
-        return ActionResult(
-            {"agentSpaces": [s.to_dict() for s in spaces]}
-        )
+        return ActionResult({"agentSpaces": [s.to_dict() for s in spaces]})
 
     def update_agent_space(self) -> ActionResult:
         agent_space_id = self._get_param("agentSpaceId")

--- a/moto/devopsagent/responses.py
+++ b/moto/devopsagent/responses.py
@@ -1,0 +1,76 @@
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
+
+from .models import DevOpsAgentBackend, devopsagent_backends
+
+
+class DevOpsAgentResponse(BaseResponse):
+    def __init__(self) -> None:
+        super().__init__(service_name="devops-agent")
+        self.automated_parameter_parsing = True
+
+    @property
+    def backend(self) -> DevOpsAgentBackend:
+        return devopsagent_backends[self.current_account][self.region]
+
+    def create_agent_space(self) -> ActionResult:
+        params = self._get_params()
+        tags = params.get("tags")
+        space = self.backend.create_agent_space(
+            name=params["name"],
+            description=params.get("description"),
+            locale=params.get("locale"),
+            kms_key_arn=params.get("kmsKeyArn"),
+            tags=tags,
+        )
+        result = {"agentSpace": space.to_dict()}
+        if tags:
+            result["tags"] = tags
+        return ActionResult(result)
+
+    def get_agent_space(self) -> ActionResult:
+        agent_space_id = self._get_param("agentSpaceId")
+        space = self.backend.get_agent_space(agent_space_id)
+        tags = self.backend.list_tags_for_resource(space.arn)
+        result = {"agentSpace": space.to_dict()}
+        if tags:
+            result["tags"] = tags
+        return ActionResult(result)
+
+    def list_agent_spaces(self) -> ActionResult:
+        spaces = self.backend.list_agent_spaces()
+        return ActionResult(
+            {"agentSpaces": [s.to_dict() for s in spaces]}
+        )
+
+    def update_agent_space(self) -> ActionResult:
+        agent_space_id = self._get_param("agentSpaceId")
+        params = self._get_params()
+        space = self.backend.update_agent_space(
+            agent_space_id=agent_space_id,
+            name=params.get("name"),
+            description=params.get("description"),
+            locale=params.get("locale"),
+        )
+        return ActionResult({"agentSpace": space.to_dict()})
+
+    def delete_agent_space(self) -> ActionResult:
+        agent_space_id = self._get_param("agentSpaceId")
+        self.backend.delete_agent_space(agent_space_id)
+        return EmptyResult()
+
+    def tag_resource(self) -> ActionResult:
+        resource_arn = self._get_param("resourceArn")
+        params = self._get_params()
+        self.backend.tag_resource(resource_arn, params["tags"])
+        return EmptyResult()
+
+    def untag_resource(self) -> ActionResult:
+        resource_arn = self._get_param("resourceArn")
+        tag_keys = self._get_param("tagKeys", [])
+        self.backend.untag_resource(resource_arn, tag_keys)
+        return EmptyResult()
+
+    def list_tags_for_resource(self) -> ActionResult:
+        resource_arn = self._get_param("resourceArn")
+        tags = self.backend.list_tags_for_resource(resource_arn)
+        return ActionResult({"tags": tags})

--- a/moto/devopsagent/urls.py
+++ b/moto/devopsagent/urls.py
@@ -1,0 +1,9 @@
+from .responses import DevOpsAgentResponse
+
+url_bases = [
+    r"https?://aidevops\.(.+)\.amazonaws\.com",
+]
+
+url_paths = {
+    "{0}/.*$": DevOpsAgentResponse.dispatch,
+}

--- a/moto/devopsagent/urls.py
+++ b/moto/devopsagent/urls.py
@@ -1,7 +1,7 @@
 from .responses import DevOpsAgentResponse
 
 url_bases = [
-    r"https?://aidevops\.(.+)\.amazonaws\.com",
+    r"https?://(.*\.)?aidevops\.(.+)\.api\.aws",
 ]
 
 url_paths = {

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -142,6 +142,8 @@ class DomainDispatcherApplication:
             # All MediaStore API calls have a target header
             # If no target is set, assume we're trying to reach the mediastore-data service
             host = f"data.{service}.{region}.amazonaws.com"
+        elif service == "aidevops":
+            host = f"{service}.{region}.api.aws"
         elif service == "dsql":
             host = f"{service}.{region}.api.aws"
         elif service == "dynamodb":

--- a/tests/test_devopsagent/test_devopsagent.py
+++ b/tests/test_devopsagent/test_devopsagent.py
@@ -15,7 +15,6 @@ def _client():
 def test_crud_round_trip():
     client = _client()
 
-    # Create
     resp = client.create_agent_space(name="my-space", description="A test space")
     space = resp["agentSpace"]
     assert "agentSpaceId" in space
@@ -25,30 +24,24 @@ def test_crud_round_trip():
     assert "updatedAt" in space
     space_id = space["agentSpaceId"]
 
-    # Get
     resp = client.get_agent_space(agentSpaceId=space_id)
     space = resp["agentSpace"]
     assert space["agentSpaceId"] == space_id
     assert space["name"] == "my-space"
 
-    # List
     resp = client.list_agent_spaces()
     assert len(resp["agentSpaces"]) == 1
     assert resp["agentSpaces"][0]["agentSpaceId"] == space_id
 
-    # Update
     resp = client.update_agent_space(agentSpaceId=space_id, name="renamed-space")
     space = resp["agentSpace"]
     assert space["name"] == "renamed-space"
 
-    # Verify update persisted
     resp = client.get_agent_space(agentSpaceId=space_id)
     assert resp["agentSpace"]["name"] == "renamed-space"
 
-    # Delete
     client.delete_agent_space(agentSpaceId=space_id)
 
-    # Verify deleted
     resp = client.list_agent_spaces()
     assert len(resp["agentSpaces"]) == 0
 
@@ -57,7 +50,6 @@ def test_crud_round_trip():
 def test_tagging():
     client = _client()
 
-    # Create with tags
     resp = client.create_agent_space(
         name="tagged-space",
         tags={"env": "test", "team": "platform"},
@@ -65,7 +57,6 @@ def test_tagging():
     space_id = resp["agentSpace"]["agentSpaceId"]
     assert resp.get("tags") == {"env": "test", "team": "platform"}
 
-    # Get should return tags
     resp = client.get_agent_space(agentSpaceId=space_id)
     assert resp["tags"] == {"env": "test", "team": "platform"}
 
@@ -74,16 +65,13 @@ def test_tagging():
     account_id = sts.get_caller_identity()["Account"]
     arn = f"arn:aws:aidevops:{REGION}:{account_id}:agentspace/{space_id}"
 
-    # list_tags_for_resource
     resp = client.list_tags_for_resource(resourceArn=arn)
     assert resp["tags"] == {"env": "test", "team": "platform"}
 
-    # tag_resource — add a new tag
     client.tag_resource(resourceArn=arn, tags={"version": "1"})
     resp = client.list_tags_for_resource(resourceArn=arn)
     assert resp["tags"] == {"env": "test", "team": "platform", "version": "1"}
 
-    # untag_resource
     client.untag_resource(resourceArn=arn, tagKeys=["team"])
     resp = client.list_tags_for_resource(resourceArn=arn)
     assert resp["tags"] == {"env": "test", "version": "1"}

--- a/tests/test_devopsagent/test_devopsagent.py
+++ b/tests/test_devopsagent/test_devopsagent.py
@@ -11,8 +11,18 @@ def _client():
     return boto3.client("devops-agent", region_name=REGION)
 
 
+def _create_agent_space(client, name="my-space", **kwargs):
+    return client.create_agent_space(name=name, **kwargs)["agentSpace"]
+
+
+def _arn_for(space_id):
+    sts = boto3.client("sts", region_name=REGION)
+    account_id = sts.get_caller_identity()["Account"]
+    return f"arn:aws:aidevops:{REGION}:{account_id}:agentspace/{space_id}"
+
+
 @mock_aws
-def test_crud_round_trip():
+def test_create_agent_space():
     client = _client()
 
     resp = client.create_agent_space(name="my-space", description="A test space")
@@ -22,23 +32,63 @@ def test_crud_round_trip():
     assert space["description"] == "A test space"
     assert "createdAt" in space
     assert "updatedAt" in space
-    space_id = space["agentSpaceId"]
+
+
+@mock_aws
+def test_get_agent_space():
+    client = _client()
+    space_id = _create_agent_space(client)["agentSpaceId"]
 
     resp = client.get_agent_space(agentSpaceId=space_id)
     space = resp["agentSpace"]
     assert space["agentSpaceId"] == space_id
     assert space["name"] == "my-space"
 
+
+@mock_aws
+def test_get_agent_space_not_found():
+    client = _client()
+
+    with pytest.raises(ClientError) as exc:
+        client.get_agent_space(agentSpaceId="as-nonexistent")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_list_agent_spaces():
+    client = _client()
+    space_id = _create_agent_space(client)["agentSpaceId"]
+
     resp = client.list_agent_spaces()
     assert len(resp["agentSpaces"]) == 1
     assert resp["agentSpaces"][0]["agentSpaceId"] == space_id
 
+
+@mock_aws
+def test_update_agent_space():
+    client = _client()
+    space_id = _create_agent_space(client)["agentSpaceId"]
+
     resp = client.update_agent_space(agentSpaceId=space_id, name="renamed-space")
-    space = resp["agentSpace"]
-    assert space["name"] == "renamed-space"
+    assert resp["agentSpace"]["name"] == "renamed-space"
 
     resp = client.get_agent_space(agentSpaceId=space_id)
     assert resp["agentSpace"]["name"] == "renamed-space"
+
+
+@mock_aws
+def test_update_agent_space_not_found():
+    client = _client()
+
+    with pytest.raises(ClientError) as exc:
+        client.update_agent_space(agentSpaceId="as-nonexistent", name="x")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_delete_agent_space():
+    client = _client()
+    space_id = _create_agent_space(client)["agentSpaceId"]
 
     client.delete_agent_space(agentSpaceId=space_id)
 
@@ -47,7 +97,16 @@ def test_crud_round_trip():
 
 
 @mock_aws
-def test_tagging():
+def test_delete_agent_space_not_found():
+    client = _client()
+
+    with pytest.raises(ClientError) as exc:
+        client.delete_agent_space(agentSpaceId="as-nonexistent")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_create_agent_space_with_tags():
     client = _client()
 
     resp = client.create_agent_space(
@@ -60,35 +119,39 @@ def test_tagging():
     resp = client.get_agent_space(agentSpaceId=space_id)
     assert resp["tags"] == {"env": "test", "team": "platform"}
 
-    # Build the ARN for tag operations
-    sts = boto3.client("sts", region_name=REGION)
-    account_id = sts.get_caller_identity()["Account"]
-    arn = f"arn:aws:aidevops:{REGION}:{account_id}:agentspace/{space_id}"
 
-    resp = client.list_tags_for_resource(resourceArn=arn)
+@mock_aws
+def test_list_tags_for_resource():
+    client = _client()
+    space_id = _create_agent_space(
+        client, name="tagged-space", tags={"env": "test", "team": "platform"}
+    )["agentSpaceId"]
+
+    resp = client.list_tags_for_resource(resourceArn=_arn_for(space_id))
     assert resp["tags"] == {"env": "test", "team": "platform"}
+
+
+@mock_aws
+def test_tag_resource():
+    client = _client()
+    space_id = _create_agent_space(
+        client, name="tagged-space", tags={"env": "test", "team": "platform"}
+    )["agentSpaceId"]
+    arn = _arn_for(space_id)
 
     client.tag_resource(resourceArn=arn, tags={"version": "1"})
     resp = client.list_tags_for_resource(resourceArn=arn)
     assert resp["tags"] == {"env": "test", "team": "platform", "version": "1"}
 
-    client.untag_resource(resourceArn=arn, tagKeys=["team"])
-    resp = client.list_tags_for_resource(resourceArn=arn)
-    assert resp["tags"] == {"env": "test", "version": "1"}
-
 
 @mock_aws
-def test_not_found():
+def test_untag_resource():
     client = _client()
+    space_id = _create_agent_space(
+        client, name="tagged-space", tags={"env": "test", "team": "platform"}
+    )["agentSpaceId"]
+    arn = _arn_for(space_id)
 
-    with pytest.raises(ClientError) as exc:
-        client.get_agent_space(agentSpaceId="as-nonexistent")
-    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
-
-    with pytest.raises(ClientError) as exc:
-        client.update_agent_space(agentSpaceId="as-nonexistent", name="x")
-    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
-
-    with pytest.raises(ClientError) as exc:
-        client.delete_agent_space(agentSpaceId="as-nonexistent")
-    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    client.untag_resource(resourceArn=arn, tagKeys=["team"])
+    resp = client.list_tags_for_resource(resourceArn=arn)
+    assert resp["tags"] == {"env": "test"}

--- a/tests/test_devopsagent/test_devopsagent.py
+++ b/tests/test_devopsagent/test_devopsagent.py
@@ -25,11 +25,18 @@ def _arn_for(space_id):
 def test_create_agent_space():
     client = _client()
 
-    resp = client.create_agent_space(name="my-space", description="A test space")
+    resp = client.create_agent_space(
+        name="my-space",
+        description="A test space",
+        locale="en_US",
+        kmsKeyArn=f"arn:aws:kms:{REGION}:123456789012:key/test-key",
+    )
     space = resp["agentSpace"]
     assert "agentSpaceId" in space
     assert space["name"] == "my-space"
     assert space["description"] == "A test space"
+    assert space["locale"] == "en_US"
+    assert space["kmsKeyArn"] == f"arn:aws:kms:{REGION}:123456789012:key/test-key"
     assert "createdAt" in space
     assert "updatedAt" in space
 
@@ -69,11 +76,20 @@ def test_update_agent_space():
     client = _client()
     space_id = _create_agent_space(client)["agentSpaceId"]
 
-    resp = client.update_agent_space(agentSpaceId=space_id, name="renamed-space")
+    resp = client.update_agent_space(
+        agentSpaceId=space_id,
+        name="renamed-space",
+        description="Updated description",
+        locale="fr_FR",
+    )
     assert resp["agentSpace"]["name"] == "renamed-space"
+    assert resp["agentSpace"]["description"] == "Updated description"
+    assert resp["agentSpace"]["locale"] == "fr_FR"
 
     resp = client.get_agent_space(agentSpaceId=space_id)
     assert resp["agentSpace"]["name"] == "renamed-space"
+    assert resp["agentSpace"]["description"] == "Updated description"
+    assert resp["agentSpace"]["locale"] == "fr_FR"
 
 
 @mock_aws

--- a/tests/test_devopsagent/test_devopsagent.py
+++ b/tests/test_devopsagent/test_devopsagent.py
@@ -1,0 +1,106 @@
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+
+REGION = "us-east-1"
+
+
+def _client():
+    return boto3.client("devops-agent", region_name=REGION)
+
+
+@mock_aws
+def test_crud_round_trip():
+    client = _client()
+
+    # Create
+    resp = client.create_agent_space(name="my-space", description="A test space")
+    space = resp["agentSpace"]
+    assert "agentSpaceId" in space
+    assert space["name"] == "my-space"
+    assert space["description"] == "A test space"
+    assert "createdAt" in space
+    assert "updatedAt" in space
+    space_id = space["agentSpaceId"]
+
+    # Get
+    resp = client.get_agent_space(agentSpaceId=space_id)
+    space = resp["agentSpace"]
+    assert space["agentSpaceId"] == space_id
+    assert space["name"] == "my-space"
+
+    # List
+    resp = client.list_agent_spaces()
+    assert len(resp["agentSpaces"]) == 1
+    assert resp["agentSpaces"][0]["agentSpaceId"] == space_id
+
+    # Update
+    resp = client.update_agent_space(agentSpaceId=space_id, name="renamed-space")
+    space = resp["agentSpace"]
+    assert space["name"] == "renamed-space"
+
+    # Verify update persisted
+    resp = client.get_agent_space(agentSpaceId=space_id)
+    assert resp["agentSpace"]["name"] == "renamed-space"
+
+    # Delete
+    client.delete_agent_space(agentSpaceId=space_id)
+
+    # Verify deleted
+    resp = client.list_agent_spaces()
+    assert len(resp["agentSpaces"]) == 0
+
+
+@mock_aws
+def test_tagging():
+    client = _client()
+
+    # Create with tags
+    resp = client.create_agent_space(
+        name="tagged-space",
+        tags={"env": "test", "team": "platform"},
+    )
+    space_id = resp["agentSpace"]["agentSpaceId"]
+    assert resp.get("tags") == {"env": "test", "team": "platform"}
+
+    # Get should return tags
+    resp = client.get_agent_space(agentSpaceId=space_id)
+    assert resp["tags"] == {"env": "test", "team": "platform"}
+
+    # Build the ARN for tag operations
+    sts = boto3.client("sts", region_name=REGION)
+    account_id = sts.get_caller_identity()["Account"]
+    arn = f"arn:aws:aidevops:{REGION}:{account_id}:agentspace/{space_id}"
+
+    # list_tags_for_resource
+    resp = client.list_tags_for_resource(resourceArn=arn)
+    assert resp["tags"] == {"env": "test", "team": "platform"}
+
+    # tag_resource — add a new tag
+    client.tag_resource(resourceArn=arn, tags={"version": "1"})
+    resp = client.list_tags_for_resource(resourceArn=arn)
+    assert resp["tags"] == {"env": "test", "team": "platform", "version": "1"}
+
+    # untag_resource
+    client.untag_resource(resourceArn=arn, tagKeys=["team"])
+    resp = client.list_tags_for_resource(resourceArn=arn)
+    assert resp["tags"] == {"env": "test", "version": "1"}
+
+
+@mock_aws
+def test_not_found():
+    client = _client()
+
+    with pytest.raises(ClientError) as exc:
+        client.get_agent_space(agentSpaceId="as-nonexistent")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        client.update_agent_space(agentSpaceId="as-nonexistent", name="x")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+    with pytest.raises(ClientError) as exc:
+        client.delete_agent_space(agentSpaceId="as-nonexistent")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"


### PR DESCRIPTION
  - Add moto mock for the AWS DevOps Agent service (devops-agent)                                                                                                                                         
  - Implement AgentSpace CRUD operations: create, get, list, update, delete                                                                                                                               
  - Implement resource tagging: tag, untag, list tags                                                                                                                                                     
  - Register service in backends.py and backend_index.py with correct api.aws endpoint pattern                                                                                                            
  - Use official supported regions from AWS docs (11 regions) 