### PR TITLE
Fix typos in comments, docstrings, and error messages

### DIFF
--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -381,7 +381,7 @@ class Dashboard(CloudFormationModel):
 
 class Statistics:
     """
-    Helper class to calculate statics for a list of metrics (MetricDatum, or MetricAggregatedDatum)
+    Helper class to calculate statistics for a list of metrics (MetricDatum, or MetricAggregatedDatum)
     """
 
     def __init__(self, stats: list[str], dt: datetime, unit: str | None = None):
@@ -393,7 +393,7 @@ class Statistics:
     def get_statistics_for_type(self, stat: str) -> SupportsFloat | None:
         """Calculates the statistic for the metric_data provided
 
-        :param stat: the statistic that should be returned, case-sensitive (Sum, Average, Minium, Maximum, SampleCount)
+        :param stat: the statistic that should be returned, case-sensitive (Sum, Average, Minimum, Maximum, SampleCount)
         :return: the statistic of the current 'metric_data' in this class, or 0
         """
         if stat == "Sum":

--- a/moto/codebuild/models.py
+++ b/moto/codebuild/models.py
@@ -238,7 +238,7 @@ class CodeBuildBackend(BaseBackend):
 
         self.build_history[project_name].append(build_id)
 
-        # update build histroy with metadata for build id
+        # update build history with metadata for build id
         self.build_metadata_history[project_name].append(
             self.build_metadata[project_name].build_metadata
         )

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -172,7 +172,7 @@ def convert_to_class_args(dict_arg: dict[str, Any]) -> dict[str, Any]:
     """Return dict that can be used to instantiate it's representative class.
 
     Given a dictionary in the incoming API request, convert the keys to
-    snake case to use as arguments when instatiating the representative
+    snake case to use as arguments when instantiating the representative
     class's __init__().
     """
     class_args = {}
@@ -499,7 +499,7 @@ class Scope(ConfigEmptyDictable):
     - combo of one resource type and one resource ID,
     - combo of tag key and value.
 
-    If no scope is specified, evaluations are trigged when any resource
+    If no scope is specified, evaluations are triggered when any resource
     in the recording group changes.
     """
 

--- a/moto/ds/validations.py
+++ b/moto/ds/validations.py
@@ -36,7 +36,7 @@ def validate_args(validators: Any) -> None:
         "remoteDomainName": validate_remote_domain_name,
     }
     err_msgs = []
-    # This eventually could be a switch (python 3.10), elminating the need
+    # This eventually could be a switch (python 3.10), eliminating the need
     # for the above map and individual functions.
     for fieldname, value in validators:
         msg = validation_map[fieldname](value)

--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -924,7 +924,7 @@ class Table(CloudFormationModel):
                 else:
                     processing_previous_page = False
 
-            # Check wether we've reached the limit of our result set
+            # Check whether we've reached the limit of our result set
             # That can be either in number, or in size
             reached_length_limit = len(results) == limit
             reached_size_limit = (result_size + result.size()) > RESULT_SIZE_LIMIT

--- a/moto/dynamodb/parsing/ast_nodes.py
+++ b/moto/dynamodb/parsing/ast_nodes.py
@@ -235,7 +235,7 @@ class ExpressionPathDescender(Node):
 
 
 class ExpressionSelector(LeafNode):
-    """Node identifying selector [selection_index] in expresion"""
+    """Node identifying selector [selection_index] in expression"""
 
     def __init__(self, selection_index):
         try:

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -1942,7 +1942,7 @@ class FakeCrawler(BaseModel):
                 return "STOPPING"
             else:
                 raise RuntimeError(
-                    f"Unexpeected state found for crawler, found state {self.crawls[-1].status}"
+                    f"Unexpected state found for crawler, found state {self.crawls[-1].status}"
                 )
 
 

--- a/moto/lakeformation/models.py
+++ b/moto/lakeformation/models.py
@@ -109,7 +109,7 @@ class PermissionCatalog:
     def add_permission(self, permission: Permission) -> None:
         for existing_permission in self.permissions:
             if permission.equal_principal_and_resouce(existing_permission):
-                # Permission with same principal and resouce, only once of these can exist
+                # Permission with same principal and resource, only once of these can exist
                 existing_permission.merge(permission)
                 return
         # found no match
@@ -118,8 +118,8 @@ class PermissionCatalog:
     def remove_permission(self, permission: Permission) -> None:
         for existing_permission in self.permissions:
             if permission.equal_principal_and_resouce(existing_permission):
-                # Permission with same principal and resouce, only once of these can exist
-                # remove and readd to recalculate the hash value after the diff
+                # Permission with same principal and resource, only once of these can exist
+                # remove and re-add to recalculate the hash value after the diff
                 self.permissions.remove(existing_permission)
                 existing_permission.diff(permission)
                 self.permissions.add(existing_permission)
@@ -231,7 +231,7 @@ class ListPermissionsResource:
             and table is None
             and data_location is None
         ):
-            # Error message is the exact string returned by the AWS-CLI eventhough it is valid
+            # Error message is the exact string returned by the AWS-CLI even though it is valid
             # to not populate the respective fields as long as data_location is given.
             raise InvalidInput(
                 "Resource must have either the catalog, table or database field populated."

--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -565,7 +565,7 @@ class Route53ResolverBackend(BaseBackend):
 
         NOTE: This does not include IPv6 addresses.
         """
-        # only initial endpoint creation requires atleast two ip addresses
+        # only initial endpoint creation requires at least two ip addresses
         if initial:
             if len(ip_addresses) < 2:
                 raise InvalidRequestException(
@@ -740,7 +740,7 @@ class Route53ResolverBackend(BaseBackend):
                 ) from exc
 
         # The boto3 documentation indicates that ResolverEndpoint is
-        # optional, as does the AWS documention.  But if resolver_endpoint_id
+        # optional, as does the AWS documentation.  But if resolver_endpoint_id
         # is set to None or an empty string, it results in boto3 raising
         # a ParamValidationError either regarding the type or len of string.
         if resolver_endpoint_id:

--- a/moto/route53resolver/responses.py
+++ b/moto/route53resolver/responses.py
@@ -57,7 +57,7 @@ class Route53ResolverResponse(BaseResponse):
         return json.dumps({"ResolverEndpoint": resolver_endpoint.description()})
 
     def create_resolver_rule(self) -> str:
-        """Specify which Resolver enpoint the queries will pass through."""
+        """Specify which Resolver endpoint the queries will pass through."""
         creator_request_id = self._get_param("CreatorRequestId")
         name = self._get_param("Name")
         rule_type = self._get_param("RuleType")

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -513,7 +513,7 @@ class S3Response(BaseResponse):
                     self.response_headers["Access-Control-Allow-Origin"] = origin  # type: ignore
                 else:
                     raise AccessForbidden(
-                        "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec."
+                        "CORSResponse: This CORS request is not allowed. This is usually because the evaluation of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec."
                     )
             if cors_rule.allowed_headers is not None:
                 self.response_headers["Access-Control-Allow-Headers"] = _to_string(

--- a/moto/sns/responses.py
+++ b/moto/sns/responses.py
@@ -450,7 +450,7 @@ class SNSResponse(BaseResponse):
 
         # Once Tokens are stored by the `subscribe` endpoint and distributed
         # to the client somehow, then we can check validity of tokens
-        # presented to this method. The following code works, all thats
+        # presented to this method. The following code works, all that's
         # needed is to perform a token check and assign that value to the
         # `already_subscribed` variable.
         #

--- a/moto/wafv2/utils.py
+++ b/moto/wafv2/utils.py
@@ -12,7 +12,7 @@ def make_arn(
         scope = "global"
         # cloudfront global scope is managed from us-east-1 region: https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateIPSet.html#WAF-CreateIPSet-request-Scope
         # base_backend stores global region as "aws": https://github.com/getmoto/moto/blob/d00aa025b6c3d37977508b5d5e81ecad4ca15159/moto/core/base_backend.py#L272
-        # Therefore needs to be overriden here to correctly form the ARN
+        # Therefore needs to be overridden here to correctly form the ARN
         region_name = "us-east-1"
 
     partition = get_partition(region_name)

--- a/moto/workspaces/models.py
+++ b/moto/workspaces/models.py
@@ -164,7 +164,7 @@ class WorkSpaceDirectory(BaseModel):
             ),
             "EnableMaintenanceMode": True,
         }
-        # modify creation properites
+        # modify creation properties
         self.workspace_creation_properties = workspace_creation_properties
         self.ip_group_ids = ""  # create_ip_group
         # Default values for workspace access properties
@@ -515,7 +515,7 @@ class WorkSpacesBackend(BaseBackend, TaggableResourcesMixin):
     def modify_workspace_creation_properties(
         self, resource_id: str, workspace_creation_properties: dict[str, Any]
     ) -> None:
-        # Raise Exception if Directory doesnot exist.
+        # Raise Exception if Directory does not exist.
         if resource_id not in self.workspace_directories:
             raise ValidationException("The request is invalid.")
 


### PR DESCRIPTION
This PR fixes a set of genuine spelling typos found across comments, docstrings, and a couple of user-facing error message strings in the moto source. No code identifiers, public API names, test fixtures, or generated files were touched — only prose.

For the S3 CORS and Glue crawler error strings, the corrected spelling also better matches the wording AWS itself returns.

| File | Before | After |
|------|--------|-------|
| `moto/cloudwatch/models.py` | calculate `statics` for a list | calculate `statistics` for a list |
| `moto/cloudwatch/models.py` | Sum, Average, `Minium`, Maximum | Sum, Average, `Minimum`, Maximum |
| `moto/codebuild/models.py` | update build `histroy` | update build `history` |
| `moto/config/models.py` | when `instatiating` the representative | when `instantiating` the representative |
| `moto/config/models.py` | evaluations are `trigged` | evaluations are `triggered` |
| `moto/ds/validations.py` | `elminating` the need | `eliminating` the need |
| `moto/dynamodb/models/table.py` | Check `wether` we've reached | Check `whether` we've reached |
| `moto/dynamodb/parsing/ast_nodes.py` | in `expresion` | in `expression` |
| `moto/glue/models.py` | `Unexpeected` state found for crawler | `Unexpected` state found for crawler |
| `moto/lakeformation/models.py` | same principal and `resouce` (comments) | same principal and `resource` |
| `moto/lakeformation/models.py` | remove and `readd` | remove and `re-add` |
| `moto/lakeformation/models.py` | `eventhough` it is valid | `even though` it is valid |
| `moto/route53resolver/models.py` | requires `atleast` two ip addresses | requires `at least` two ip addresses |
| `moto/route53resolver/models.py` | as does the AWS `documention` | as does the AWS `documentation` |
| `moto/route53resolver/responses.py` | which Resolver `enpoint` | which Resolver `endpoint` |
| `moto/s3/responses.py` | because the `evalution` of Origin | because the `evaluation` of Origin |
| `moto/sns/responses.py` | all `thats` needed | all `that's` needed |
| `moto/wafv2/utils.py` | needs to be `overriden` here | needs to be `overridden` here |
| `moto/workspaces/models.py` | modify creation `properites` | modify creation `properties` |
| `moto/workspaces/models.py` | if Directory `doesnot` exist | if Directory `does not` exist |

The `equal_principal_and_resouce` method name was intentionally left unchanged to avoid touching identifiers.