### PR TITLE
fix: wire JSONata evaluator to jsonata-python engine

### DIFF
--- a/moto/stepfunctions/parser/asl/jsonata/jsonata.py
+++ b/moto/stepfunctions/parser/asl/jsonata/jsonata.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable
 from typing import Any, Final
+
+import jsonata
 
 from moto.stepfunctions.parser.asl.utils.encoding import to_json_str
 
@@ -81,17 +82,11 @@ class _JSONataJVMBridge:
             raise JSONataException("UNKNOWN", str(ex))
 
 
-# Lazy initialization of the `eval_jsonata` function pointer.
-# This ensures the JVM is only started when JSONata functionality is needed.
-_eval_jsonata: Callable[[JSONataExpression], Any] | None = None
-
-
 def eval_jsonata_expression(jsonata_expression: JSONataExpression) -> Any:
-    global _eval_jsonata
-    if _eval_jsonata is None:
-        # Initialize _eval_jsonata only when invoked for the first time using the Singleton pattern.
-        _eval_jsonata = None
-    return _eval_jsonata(jsonata_expression)
+    try:
+        return jsonata.Jsonata(jsonata_expression).evaluate(None)
+    except Exception as ex:
+        raise JSONataException("UNKNOWN", str(ex))
 
 
 class IllegalJSONataVariableReference(ValueError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -228,6 +228,7 @@ ssm =
 ssoadmin =
 stepfunctions =
     antlr4-python3-runtime
+    jsonata-python
     jsonpath_ng
 sts =
 support =

--- a/setup.cfg
+++ b/setup.cfg
@@ -229,6 +229,7 @@ ssm =
 ssoadmin =
 stepfunctions =
     antlr4-python3-runtime
+    jsonata-python
     jsonpath_ng
 sts =
 support =

--- a/tests/test_stepfunctions/parser/test_jsonata.py
+++ b/tests/test_stepfunctions/parser/test_jsonata.py
@@ -1,0 +1,39 @@
+import json
+from time import sleep
+from uuid import uuid4
+
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_jsonata_pass_state():
+    sfn = boto3.client("stepfunctions", region_name="us-east-1")
+    definition = {
+        "QueryLanguage": "JSONata",
+        "StartAt": "Add",
+        "States": {
+            "Add": {
+                "Type": "Pass",
+                "Output": {"sum": "{% 1 + 1 %}"},
+                "End": True,
+            }
+        },
+    }
+    arn = sfn.create_state_machine(
+        name=f"jsonata-test-{str(uuid4())[:6]}",
+        definition=json.dumps(definition),
+        roleArn="arn:aws:iam::123456789012:role/sf",
+    )["stateMachineArn"]
+
+    execution_arn = sfn.start_execution(stateMachineArn=arn)["executionArn"]
+
+    for _ in range(30):
+        execution = sfn.describe_execution(executionArn=execution_arn)
+        if execution["status"] != "RUNNING":
+            break
+        sleep(0.1)
+
+    assert execution["status"] == "SUCCEEDED"
+    assert json.loads(execution["output"]) == {"sum": 2}


### PR DESCRIPTION
Fixes #10105

Wires eval_jsonata_expression to the pure-Python jsonata-python engine instead of the uninitialized JVM bridge, so JSONata state machines can run under the parser backend. Adds jsonata-python to the stepfunctions extra dependencies and a regression test.