### PR TITLE
CleanRoomsService: initial implementation

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1323,6 +1323,112 @@
 - [X] update_cost_category_definition
 </details>
 
+## cleanrooms
+<details>
+<summary>19% implemented</summary>
+
+- [ ] batch_get_collaboration_analysis_template
+- [ ] batch_get_schema
+- [ ] batch_get_schema_analysis_rule
+- [ ] create_analysis_template
+- [X] create_collaboration
+- [ ] create_collaboration_change_request
+- [ ] create_configured_audience_model_association
+- [X] create_configured_table
+- [ ] create_configured_table_analysis_rule
+- [ ] create_configured_table_association
+- [ ] create_configured_table_association_analysis_rule
+- [ ] create_id_mapping_table
+- [ ] create_id_namespace_association
+- [ ] create_intermediate_table
+- [ ] create_intermediate_table_analysis_rule
+- [X] create_membership
+- [ ] create_privacy_budget_template
+- [ ] delete_analysis_template
+- [X] delete_collaboration
+- [ ] delete_configured_audience_model_association
+- [X] delete_configured_table
+- [ ] delete_configured_table_analysis_rule
+- [ ] delete_configured_table_association
+- [ ] delete_configured_table_association_analysis_rule
+- [ ] delete_id_mapping_table
+- [ ] delete_id_namespace_association
+- [ ] delete_intermediate_table
+- [ ] delete_intermediate_table_analysis_rule
+- [ ] delete_member
+- [X] delete_membership
+- [ ] delete_privacy_budget_template
+- [ ] disallow_intermediate_table
+- [ ] get_analysis_template
+- [X] get_collaboration
+- [ ] get_collaboration_analysis_template
+- [ ] get_collaboration_change_request
+- [ ] get_collaboration_configured_audience_model_association
+- [ ] get_collaboration_id_namespace_association
+- [ ] get_collaboration_privacy_budget_template
+- [ ] get_configured_audience_model_association
+- [X] get_configured_table
+- [ ] get_configured_table_analysis_rule
+- [ ] get_configured_table_association
+- [ ] get_configured_table_association_analysis_rule
+- [ ] get_id_mapping_table
+- [ ] get_id_namespace_association
+- [ ] get_intermediate_table
+- [ ] get_intermediate_table_analysis_rule
+- [X] get_membership
+- [ ] get_privacy_budget_template
+- [ ] get_protected_job
+- [ ] get_protected_query
+- [ ] get_schema
+- [ ] get_schema_analysis_rule
+- [ ] list_analysis_templates
+- [ ] list_collaboration_analysis_templates
+- [ ] list_collaboration_change_requests
+- [ ] list_collaboration_configured_audience_model_associations
+- [ ] list_collaboration_id_namespace_associations
+- [ ] list_collaboration_privacy_budget_templates
+- [ ] list_collaboration_privacy_budgets
+- [X] list_collaborations
+- [ ] list_configured_audience_model_associations
+- [ ] list_configured_table_associations
+- [X] list_configured_tables
+- [ ] list_id_mapping_tables
+- [ ] list_id_namespace_associations
+- [ ] list_intermediate_table_versions
+- [ ] list_intermediate_tables
+- [X] list_members
+- [X] list_memberships
+- [ ] list_privacy_budget_templates
+- [ ] list_privacy_budgets
+- [ ] list_protected_jobs
+- [ ] list_protected_queries
+- [ ] list_schemas
+- [X] list_tags_for_resource
+- [ ] populate_id_mapping_table
+- [ ] populate_intermediate_table
+- [ ] preview_privacy_impact
+- [ ] start_protected_job
+- [ ] start_protected_query
+- [X] tag_resource
+- [X] untag_resource
+- [ ] update_analysis_template
+- [X] update_collaboration
+- [ ] update_collaboration_change_request
+- [ ] update_configured_audience_model_association
+- [X] update_configured_table
+- [ ] update_configured_table_analysis_rule
+- [ ] update_configured_table_association
+- [ ] update_configured_table_association_analysis_rule
+- [ ] update_id_mapping_table
+- [ ] update_id_namespace_association
+- [ ] update_intermediate_table
+- [ ] update_intermediate_table_analysis_rule
+- [X] update_membership
+- [ ] update_privacy_budget_template
+- [ ] update_protected_job
+- [ ] update_protected_query
+</details>
+
 ## clouddirectory
 <details>
 <summary>19% implemented</summary>

--- a/docs/docs/services/cleanrooms.rst
+++ b/docs/docs/services/cleanrooms.rst
@@ -1,0 +1,119 @@
+.. _implementedservice_cleanrooms:
+
+.. |start-h3| raw:: html
+
+    <h3>
+
+.. |end-h3| raw:: html
+
+    </h3>
+
+==========
+cleanrooms
+==========
+
+.. autoclass:: moto.cleanrooms.models.CleanRoomsBackend
+
+|start-h3| Implemented features for this service |end-h3|
+
+- [ ] batch_get_collaboration_analysis_template
+- [ ] batch_get_schema
+- [ ] batch_get_schema_analysis_rule
+- [ ] create_analysis_template
+- [X] create_collaboration
+- [ ] create_collaboration_change_request
+- [ ] create_configured_audience_model_association
+- [X] create_configured_table
+- [ ] create_configured_table_analysis_rule
+- [ ] create_configured_table_association
+- [ ] create_configured_table_association_analysis_rule
+- [ ] create_id_mapping_table
+- [ ] create_id_namespace_association
+- [ ] create_intermediate_table
+- [ ] create_intermediate_table_analysis_rule
+- [X] create_membership
+- [ ] create_privacy_budget_template
+- [ ] delete_analysis_template
+- [X] delete_collaboration
+- [ ] delete_configured_audience_model_association
+- [X] delete_configured_table
+- [ ] delete_configured_table_analysis_rule
+- [ ] delete_configured_table_association
+- [ ] delete_configured_table_association_analysis_rule
+- [ ] delete_id_mapping_table
+- [ ] delete_id_namespace_association
+- [ ] delete_intermediate_table
+- [ ] delete_intermediate_table_analysis_rule
+- [ ] delete_member
+- [X] delete_membership
+- [ ] delete_privacy_budget_template
+- [ ] disallow_intermediate_table
+- [ ] get_analysis_template
+- [X] get_collaboration
+- [ ] get_collaboration_analysis_template
+- [ ] get_collaboration_change_request
+- [ ] get_collaboration_configured_audience_model_association
+- [ ] get_collaboration_id_namespace_association
+- [ ] get_collaboration_privacy_budget_template
+- [ ] get_configured_audience_model_association
+- [X] get_configured_table
+- [ ] get_configured_table_analysis_rule
+- [ ] get_configured_table_association
+- [ ] get_configured_table_association_analysis_rule
+- [ ] get_id_mapping_table
+- [ ] get_id_namespace_association
+- [ ] get_intermediate_table
+- [ ] get_intermediate_table_analysis_rule
+- [X] get_membership
+- [ ] get_privacy_budget_template
+- [ ] get_protected_job
+- [ ] get_protected_query
+- [ ] get_schema
+- [ ] get_schema_analysis_rule
+- [ ] list_analysis_templates
+- [ ] list_collaboration_analysis_templates
+- [ ] list_collaboration_change_requests
+- [ ] list_collaboration_configured_audience_model_associations
+- [ ] list_collaboration_id_namespace_associations
+- [ ] list_collaboration_privacy_budget_templates
+- [ ] list_collaboration_privacy_budgets
+- [X] list_collaborations
+- [ ] list_configured_audience_model_associations
+- [ ] list_configured_table_associations
+- [X] list_configured_tables
+- [ ] list_id_mapping_tables
+- [ ] list_id_namespace_associations
+- [ ] list_intermediate_table_versions
+- [ ] list_intermediate_tables
+- [X] list_members
+- [X] list_memberships
+- [ ] list_privacy_budget_templates
+- [ ] list_privacy_budgets
+- [ ] list_protected_jobs
+- [ ] list_protected_queries
+- [ ] list_schemas
+- [X] list_tags_for_resource
+- [ ] populate_id_mapping_table
+- [ ] populate_intermediate_table
+- [ ] preview_privacy_impact
+- [ ] start_protected_job
+- [ ] start_protected_query
+- [X] tag_resource
+- [X] untag_resource
+- [ ] update_analysis_template
+- [X] update_collaboration
+- [ ] update_collaboration_change_request
+- [ ] update_configured_audience_model_association
+- [X] update_configured_table
+- [ ] update_configured_table_analysis_rule
+- [ ] update_configured_table_association
+- [ ] update_configured_table_association_analysis_rule
+- [ ] update_id_mapping_table
+- [ ] update_id_namespace_association
+- [ ] update_intermediate_table
+- [ ] update_intermediate_table_analysis_rule
+- [X] update_membership
+- [ ] update_privacy_budget_template
+- [ ] update_protected_job
+- [ ] update_protected_query
+

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -38,6 +38,7 @@ backend_url_patterns = [
     ("bedrockruntime", re.compile("https?://bedrock-runtime\\.(.+)\\.amazonaws\\.com")),
     ("budgets", re.compile("https?://budgets\\.amazonaws\\.com")),
     ("ce", re.compile("https?://ce\\.(.+)\\.amazonaws\\.com")),
+    ("cleanrooms", re.compile("https?://cleanrooms\\.(.+)\\.amazonaws\\.com")),
     ("clouddirectory", re.compile("https?://clouddirectory\\.(.+)\\.amazonaws\\.com")),
     ("cloudformation", re.compile("https?://cloudformation\\.(.+)\\.amazonaws\\.com")),
     ("cloudfront", re.compile("https?://cloudfront\\.amazonaws\\.com")),

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from moto.bedrockruntime.models import BedrockRuntimeBackend
     from moto.budgets.models import BudgetsBackend
     from moto.ce.models import CostExplorerBackend
+    from moto.cleanrooms.models import CleanRoomsBackend
     from moto.clouddirectory.models import CloudDirectoryBackend
     from moto.cloudformation.models import CloudFormationBackend
     from moto.cloudfront.models import CloudFrontBackend
@@ -223,6 +224,7 @@ SERVICE_NAMES = Union[
     "Literal['bedrock-runtime']",
     "Literal['budgets']",
     "Literal['ce']",
+    "Literal['cleanrooms']",
     "Literal['clouddirectory']",
     "Literal['cloudformation']",
     "Literal['cloudfront']",
@@ -427,6 +429,8 @@ def get_backend(
 def get_backend(name: "Literal['budgets']") -> "BackendDict[BudgetsBackend]": ...
 @overload
 def get_backend(name: "Literal['ce']") -> "BackendDict[CostExplorerBackend]": ...
+@overload
+def get_backend(name: "Literal['cleanrooms']") -> "BackendDict[CleanRoomsBackend]": ...
 @overload
 def get_backend(
     name: "Literal['clouddirectory']",

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from moto.bedrockruntime.models import BedrockRuntimeBackend
     from moto.budgets.models import BudgetsBackend
     from moto.ce.models import CostExplorerBackend
+    from moto.cleanrooms.models import CleanRoomsBackend
     from moto.clouddirectory.models import CloudDirectoryBackend
     from moto.cloudformation.models import CloudFormationBackend
     from moto.cloudfront.models import CloudFrontBackend
@@ -224,6 +225,7 @@ SERVICE_NAMES = Union[
     "Literal['bedrock-runtime']",
     "Literal['budgets']",
     "Literal['ce']",
+    "Literal['cleanrooms']",
     "Literal['clouddirectory']",
     "Literal['cloudformation']",
     "Literal['cloudfront']",
@@ -429,6 +431,8 @@ def get_backend(
 def get_backend(name: "Literal['budgets']") -> "BackendDict[BudgetsBackend]": ...
 @overload
 def get_backend(name: "Literal['ce']") -> "BackendDict[CostExplorerBackend]": ...
+@overload
+def get_backend(name: "Literal['cleanrooms']") -> "BackendDict[CleanRoomsBackend]": ...
 @overload
 def get_backend(
     name: "Literal['clouddirectory']",

--- a/moto/cleanrooms/__init__.py
+++ b/moto/cleanrooms/__init__.py
@@ -1,0 +1,1 @@
+from .models import cleanrooms_backends  # noqa: F401

--- a/moto/cleanrooms/exceptions.py
+++ b/moto/cleanrooms/exceptions.py
@@ -10,9 +10,17 @@ class CleanRoomsException(JsonRESTError):
 
 
 class ResourceNotFoundException(CleanRoomsException):
+    code = 404
+
     def __init__(self, resource_type: str, resource_id: str):
         super().__init__(
             "ResourceNotFoundException",
             f"Could not find {resource_type} with id {resource_id}",
         )
-        self.description = json.dumps({"message": self.message})
+        self.description = json.dumps(
+            {
+                "message": self.message,
+                "resourceId": resource_id,
+                "resourceType": resource_type.upper().replace(" ", "_"),
+            }
+        )

--- a/moto/cleanrooms/exceptions.py
+++ b/moto/cleanrooms/exceptions.py
@@ -1,0 +1,18 @@
+"""Exceptions raised by the cleanrooms service."""
+
+import json
+
+from moto.core.exceptions import JsonRESTError
+
+
+class CleanRoomsException(JsonRESTError):
+    pass
+
+
+class ResourceNotFoundException(CleanRoomsException):
+    def __init__(self, resource_type: str, resource_id: str):
+        super().__init__(
+            "ResourceNotFoundException",
+            f"Could not find {resource_type} with id {resource_id}",
+        )
+        self.description = json.dumps({"message": self.message})

--- a/moto/cleanrooms/models.py
+++ b/moto/cleanrooms/models.py
@@ -1,0 +1,429 @@
+"""CleanRoomsBackend class with methods for supported APIs."""
+
+from typing import Any
+
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
+from moto.core.utils import unix_time
+from moto.moto_api._internal import mock_random
+from moto.utilities.paginator import paginate
+from moto.utilities.tagging_service import TaggingService
+from moto.utilities.utils import get_partition
+
+from .exceptions import ResourceNotFoundException
+
+DEFAULT_PAYMENT_CONFIGURATION = {"queryCompute": {"isResponsible": True}}
+
+
+class Collaboration(BaseModel):
+    def __init__(
+        self,
+        account_id: str,
+        region_name: str,
+        name: str,
+        description: str,
+        creator_display_name: str,
+        creator_member_abilities: list[str],
+        query_log_status: str,
+        members: list[dict[str, Any]],
+        data_encryption_metadata: dict[str, Any] | None,
+        analytics_engine: str | None,
+    ):
+        self.id = str(mock_random.uuid4())
+        self.arn = f"arn:{get_partition(region_name)}:cleanrooms:{region_name}:{account_id}:collaboration/{self.id}"
+        self.name = name
+        self.description = description
+        self.creator_account_id = account_id
+        self.creator_display_name = creator_display_name
+        self.creator_member_abilities = creator_member_abilities
+        self.query_log_status = query_log_status
+        self.members = members
+        self.data_encryption_metadata = data_encryption_metadata
+        self.analytics_engine = analytics_engine
+        self.create_time = unix_time()
+        self.update_time = self.create_time
+        # The creator only becomes an active member once they create a
+        # membership for this collaboration
+        self.member_status = "INVITED"
+        self.membership_id: str | None = None
+        self.membership_arn: str | None = None
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        summary = {
+            "id": self.id,
+            "arn": self.arn,
+            "name": self.name,
+            "creatorAccountId": self.creator_account_id,
+            "creatorDisplayName": self.creator_display_name,
+            "createTime": self.create_time,
+            "updateTime": self.update_time,
+            "memberStatus": self.member_status,
+            "membershipId": self.membership_id,
+            "membershipArn": self.membership_arn,
+            "analyticsEngine": self.analytics_engine,
+        }
+        return {k: v for k, v in summary.items() if v is not None}
+
+    def to_dict(self) -> dict[str, Any]:
+        dct = {
+            **self.to_summary_dict(),
+            "description": self.description,
+            "queryLogStatus": self.query_log_status,
+            "dataEncryptionMetadata": self.data_encryption_metadata,
+        }
+        return {k: v for k, v in dct.items() if v is not None}
+
+    def member_summaries(self) -> list[dict[str, Any]]:
+        creator = {
+            "accountId": self.creator_account_id,
+            "status": self.member_status,
+            "displayName": self.creator_display_name,
+            "abilities": self.creator_member_abilities,
+            "createTime": self.create_time,
+            "updateTime": self.update_time,
+            "membershipId": self.membership_id,
+            "membershipArn": self.membership_arn,
+            "paymentConfiguration": DEFAULT_PAYMENT_CONFIGURATION,
+        }
+        summaries = [{k: v for k, v in creator.items() if v is not None}]
+        for member in self.members:
+            summaries.append(
+                {
+                    "accountId": member["accountId"],
+                    "status": "INVITED",
+                    "displayName": member["displayName"],
+                    "abilities": member["memberAbilities"],
+                    "createTime": self.create_time,
+                    "updateTime": self.update_time,
+                    "paymentConfiguration": member.get(
+                        "paymentConfiguration", DEFAULT_PAYMENT_CONFIGURATION
+                    ),
+                }
+            )
+        return summaries
+
+
+class Membership(BaseModel):
+    def __init__(
+        self,
+        account_id: str,
+        region_name: str,
+        collaboration: Collaboration,
+        query_log_status: str,
+        payment_configuration: dict[str, Any] | None,
+        default_result_configuration: dict[str, Any] | None,
+    ):
+        self.id = str(mock_random.uuid4())
+        self.arn = f"arn:{get_partition(region_name)}:cleanrooms:{region_name}:{account_id}:membership/{self.id}"
+        self.collaboration_arn = collaboration.arn
+        self.collaboration_id = collaboration.id
+        self.collaboration_creator_account_id = collaboration.creator_account_id
+        self.collaboration_creator_display_name = collaboration.creator_display_name
+        self.collaboration_name = collaboration.name
+        self.status = "ACTIVE"
+        self.member_abilities = collaboration.creator_member_abilities
+        self.query_log_status = query_log_status
+        self.payment_configuration = (
+            payment_configuration or DEFAULT_PAYMENT_CONFIGURATION
+        )
+        self.default_result_configuration = default_result_configuration
+        self.create_time = unix_time()
+        self.update_time = self.create_time
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "arn": self.arn,
+            "collaborationArn": self.collaboration_arn,
+            "collaborationId": self.collaboration_id,
+            "collaborationCreatorAccountId": self.collaboration_creator_account_id,
+            "collaborationCreatorDisplayName": self.collaboration_creator_display_name,
+            "collaborationName": self.collaboration_name,
+            "createTime": self.create_time,
+            "updateTime": self.update_time,
+            "status": self.status,
+            "memberAbilities": self.member_abilities,
+            "paymentConfiguration": self.payment_configuration,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        dct = {
+            **self.to_summary_dict(),
+            "queryLogStatus": self.query_log_status,
+            "defaultResultConfiguration": self.default_result_configuration,
+        }
+        return {k: v for k, v in dct.items() if v is not None}
+
+
+class ConfiguredTable(BaseModel):
+    def __init__(
+        self,
+        account_id: str,
+        region_name: str,
+        name: str,
+        description: str | None,
+        table_reference: dict[str, Any],
+        allowed_columns: list[str],
+        analysis_method: str,
+        selected_analysis_methods: list[str] | None,
+    ):
+        self.id = str(mock_random.uuid4())
+        self.arn = f"arn:{get_partition(region_name)}:cleanrooms:{region_name}:{account_id}:configuredtable/{self.id}"
+        self.name = name
+        self.description = description
+        self.table_reference = table_reference
+        self.allowed_columns = allowed_columns
+        self.analysis_method = analysis_method
+        self.selected_analysis_methods = selected_analysis_methods
+        self.analysis_rule_types: list[str] = []
+        self.create_time = unix_time()
+        self.update_time = self.create_time
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        summary = {
+            "id": self.id,
+            "arn": self.arn,
+            "name": self.name,
+            "createTime": self.create_time,
+            "updateTime": self.update_time,
+            "analysisRuleTypes": self.analysis_rule_types,
+            "analysisMethod": self.analysis_method,
+            "selectedAnalysisMethods": self.selected_analysis_methods,
+        }
+        return {k: v for k, v in summary.items() if v is not None}
+
+    def to_dict(self) -> dict[str, Any]:
+        dct = {
+            **self.to_summary_dict(),
+            "description": self.description,
+            "tableReference": self.table_reference,
+            "allowedColumns": self.allowed_columns,
+        }
+        return {k: v for k, v in dct.items() if v is not None}
+
+
+class CleanRoomsBackend(BaseBackend):
+    """Implementation of CleanRoomsService APIs."""
+
+    PAGINATION_MODEL = {
+        "list_collaborations": {
+            "input_token": "next_token",
+            "limit_key": "max_results",
+            "limit_default": 100,
+            "unique_attribute": "id",
+        },
+        "list_members": {
+            "input_token": "next_token",
+            "limit_key": "max_results",
+            "limit_default": 100,
+            "unique_attribute": "accountId",
+        },
+        "list_memberships": {
+            "input_token": "next_token",
+            "limit_key": "max_results",
+            "limit_default": 100,
+            "unique_attribute": "id",
+        },
+        "list_configured_tables": {
+            "input_token": "next_token",
+            "limit_key": "max_results",
+            "limit_default": 100,
+            "unique_attribute": "id",
+        },
+    }
+
+    def __init__(self, region_name: str, account_id: str):
+        super().__init__(region_name, account_id)
+        self.collaborations: dict[str, Collaboration] = {}
+        self.memberships: dict[str, Membership] = {}
+        self.configured_tables: dict[str, ConfiguredTable] = {}
+        self.tagger = TaggingService()
+
+    def create_collaboration(
+        self,
+        name: str,
+        description: str,
+        creator_display_name: str,
+        creator_member_abilities: list[str],
+        query_log_status: str,
+        members: list[dict[str, Any]],
+        data_encryption_metadata: dict[str, Any] | None,
+        analytics_engine: str | None,
+        tags: dict[str, str] | None,
+    ) -> Collaboration:
+        collaboration = Collaboration(
+            account_id=self.account_id,
+            region_name=self.region_name,
+            name=name,
+            description=description,
+            creator_display_name=creator_display_name,
+            creator_member_abilities=creator_member_abilities,
+            query_log_status=query_log_status,
+            members=members,
+            data_encryption_metadata=data_encryption_metadata,
+            analytics_engine=analytics_engine,
+        )
+        self.collaborations[collaboration.id] = collaboration
+        if tags:
+            self.tag_resource(collaboration.arn, tags)
+        return collaboration
+
+    def get_collaboration(self, collaboration_identifier: str) -> Collaboration:
+        if collaboration_identifier not in self.collaborations:
+            raise ResourceNotFoundException("collaboration", collaboration_identifier)
+        return self.collaborations[collaboration_identifier]
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_collaborations(self) -> list[Collaboration]:
+        return list(self.collaborations.values())
+
+    def update_collaboration(
+        self,
+        collaboration_identifier: str,
+        name: str | None,
+        description: str | None,
+    ) -> Collaboration:
+        collaboration = self.get_collaboration(collaboration_identifier)
+        if name is not None:
+            collaboration.name = name
+        if description is not None:
+            collaboration.description = description
+        collaboration.update_time = unix_time()
+        return collaboration
+
+    def delete_collaboration(self, collaboration_identifier: str) -> None:
+        self.get_collaboration(collaboration_identifier)
+        del self.collaborations[collaboration_identifier]
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_members(  # type: ignore[misc]
+        self, collaboration_identifier: str
+    ) -> list[dict[str, Any]]:
+        collaboration = self.get_collaboration(collaboration_identifier)
+        return collaboration.member_summaries()
+
+    def create_membership(
+        self,
+        collaboration_identifier: str,
+        query_log_status: str,
+        payment_configuration: dict[str, Any] | None,
+        default_result_configuration: dict[str, Any] | None,
+        tags: dict[str, str] | None,
+    ) -> Membership:
+        collaboration = self.get_collaboration(collaboration_identifier)
+        membership = Membership(
+            account_id=self.account_id,
+            region_name=self.region_name,
+            collaboration=collaboration,
+            query_log_status=query_log_status,
+            payment_configuration=payment_configuration,
+            default_result_configuration=default_result_configuration,
+        )
+        self.memberships[membership.id] = membership
+        collaboration.member_status = "ACTIVE"
+        collaboration.membership_id = membership.id
+        collaboration.membership_arn = membership.arn
+        if tags:
+            self.tag_resource(membership.arn, tags)
+        return membership
+
+    def get_membership(self, membership_identifier: str) -> Membership:
+        if membership_identifier not in self.memberships:
+            raise ResourceNotFoundException("membership", membership_identifier)
+        return self.memberships[membership_identifier]
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_memberships(self) -> list[Membership]:
+        return list(self.memberships.values())
+
+    def update_membership(
+        self, membership_identifier: str, query_log_status: str | None
+    ) -> Membership:
+        membership = self.get_membership(membership_identifier)
+        if query_log_status is not None:
+            membership.query_log_status = query_log_status
+        membership.update_time = unix_time()
+        return membership
+
+    def delete_membership(self, membership_identifier: str) -> None:
+        membership = self.get_membership(membership_identifier)
+        collaboration = self.collaborations.get(membership.collaboration_id)
+        if collaboration and collaboration.membership_id == membership.id:
+            collaboration.member_status = "LEFT"
+            collaboration.membership_id = None
+            collaboration.membership_arn = None
+        del self.memberships[membership_identifier]
+
+    def create_configured_table(
+        self,
+        name: str,
+        description: str | None,
+        table_reference: dict[str, Any],
+        allowed_columns: list[str],
+        analysis_method: str,
+        selected_analysis_methods: list[str] | None,
+        tags: dict[str, str] | None,
+    ) -> ConfiguredTable:
+        configured_table = ConfiguredTable(
+            account_id=self.account_id,
+            region_name=self.region_name,
+            name=name,
+            description=description,
+            table_reference=table_reference,
+            allowed_columns=allowed_columns,
+            analysis_method=analysis_method,
+            selected_analysis_methods=selected_analysis_methods,
+        )
+        self.configured_tables[configured_table.id] = configured_table
+        if tags:
+            self.tag_resource(configured_table.arn, tags)
+        return configured_table
+
+    def get_configured_table(self, configured_table_identifier: str) -> ConfiguredTable:
+        if configured_table_identifier not in self.configured_tables:
+            raise ResourceNotFoundException(
+                "configured table", configured_table_identifier
+            )
+        return self.configured_tables[configured_table_identifier]
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_configured_tables(self) -> list[ConfiguredTable]:
+        return list(self.configured_tables.values())
+
+    def update_configured_table(
+        self,
+        configured_table_identifier: str,
+        name: str | None,
+        description: str | None,
+        analysis_method: str | None,
+        selected_analysis_methods: list[str] | None,
+    ) -> ConfiguredTable:
+        configured_table = self.get_configured_table(configured_table_identifier)
+        if name is not None:
+            configured_table.name = name
+        if description is not None:
+            configured_table.description = description
+        if analysis_method is not None:
+            configured_table.analysis_method = analysis_method
+        if selected_analysis_methods is not None:
+            configured_table.selected_analysis_methods = selected_analysis_methods
+        configured_table.update_time = unix_time()
+        return configured_table
+
+    def delete_configured_table(self, configured_table_identifier: str) -> None:
+        self.get_configured_table(configured_table_identifier)
+        del self.configured_tables[configured_table_identifier]
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(
+            resource_arn, TaggingService.convert_dict_to_tags_input(tags)
+        )
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
+
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
+        return self.tagger.get_tag_dict_for_resource(resource_arn)
+
+
+cleanrooms_backends = BackendDict(CleanRoomsBackend, "cleanrooms")

--- a/moto/cleanrooms/responses.py
+++ b/moto/cleanrooms/responses.py
@@ -1,0 +1,191 @@
+"""Handles incoming cleanrooms requests, invokes methods, returns responses."""
+
+import json
+from typing import Any
+from urllib.parse import unquote
+
+from moto.core.responses import BaseResponse
+
+from .models import CleanRoomsBackend, cleanrooms_backends
+
+
+class CleanRoomsResponse(BaseResponse):
+    """Handler for CleanRoomsService requests and responses."""
+
+    def __init__(self) -> None:
+        super().__init__(service_name="cleanrooms")
+
+    @property
+    def cleanrooms_backend(self) -> CleanRoomsBackend:
+        return cleanrooms_backends[self.current_account][self.region]
+
+    def create_collaboration(self) -> str:
+        params = json.loads(self.body)
+        collaboration = self.cleanrooms_backend.create_collaboration(
+            name=params.get("name"),
+            description=params.get("description"),
+            creator_display_name=params.get("creatorDisplayName"),
+            creator_member_abilities=params.get("creatorMemberAbilities"),
+            query_log_status=params.get("queryLogStatus"),
+            members=params.get("members") or [],
+            data_encryption_metadata=params.get("dataEncryptionMetadata"),
+            analytics_engine=params.get("analyticsEngine"),
+            tags=params.get("tags"),
+        )
+        return json.dumps({"collaboration": collaboration.to_dict()})
+
+    def get_collaboration(self) -> str:
+        collaboration_identifier = self._get_param("collaborationIdentifier")
+        collaboration = self.cleanrooms_backend.get_collaboration(
+            collaboration_identifier
+        )
+        return json.dumps({"collaboration": collaboration.to_dict()})
+
+    def list_collaborations(self) -> str:
+        max_results = self._get_int_param("maxResults")
+        next_token = self._get_param("nextToken")
+        collaborations, next_token = self.cleanrooms_backend.list_collaborations(
+            max_results=max_results, next_token=next_token
+        )
+        response: dict[str, Any] = {
+            "collaborationList": [c.to_summary_dict() for c in collaborations]
+        }
+        if next_token:
+            response["nextToken"] = next_token
+        return json.dumps(response)
+
+    def update_collaboration(self) -> str:
+        params = json.loads(self.body)
+        collaboration = self.cleanrooms_backend.update_collaboration(
+            collaboration_identifier=self._get_param("collaborationIdentifier"),
+            name=params.get("name"),
+            description=params.get("description"),
+        )
+        return json.dumps({"collaboration": collaboration.to_dict()})
+
+    def delete_collaboration(self) -> str:
+        collaboration_identifier = self._get_param("collaborationIdentifier")
+        self.cleanrooms_backend.delete_collaboration(collaboration_identifier)
+        return json.dumps({})
+
+    def list_members(self) -> str:
+        collaboration_identifier = self._get_param("collaborationIdentifier")
+        max_results = self._get_int_param("maxResults")
+        next_token = self._get_param("nextToken")
+        members, next_token = self.cleanrooms_backend.list_members(
+            collaboration_identifier=collaboration_identifier,
+            max_results=max_results,
+            next_token=next_token,
+        )
+        response: dict[str, Any] = {"memberSummaries": members}
+        if next_token:
+            response["nextToken"] = next_token
+        return json.dumps(response)
+
+    def create_membership(self) -> str:
+        params = json.loads(self.body)
+        membership = self.cleanrooms_backend.create_membership(
+            collaboration_identifier=params.get("collaborationIdentifier"),
+            query_log_status=params.get("queryLogStatus"),
+            payment_configuration=params.get("paymentConfiguration"),
+            default_result_configuration=params.get("defaultResultConfiguration"),
+            tags=params.get("tags"),
+        )
+        return json.dumps({"membership": membership.to_dict()})
+
+    def get_membership(self) -> str:
+        membership_identifier = self._get_param("membershipIdentifier")
+        membership = self.cleanrooms_backend.get_membership(membership_identifier)
+        return json.dumps({"membership": membership.to_dict()})
+
+    def list_memberships(self) -> str:
+        max_results = self._get_int_param("maxResults")
+        next_token = self._get_param("nextToken")
+        memberships, next_token = self.cleanrooms_backend.list_memberships(
+            max_results=max_results, next_token=next_token
+        )
+        response: dict[str, Any] = {
+            "membershipSummaries": [m.to_summary_dict() for m in memberships]
+        }
+        if next_token:
+            response["nextToken"] = next_token
+        return json.dumps(response)
+
+    def update_membership(self) -> str:
+        params = json.loads(self.body)
+        membership = self.cleanrooms_backend.update_membership(
+            membership_identifier=self._get_param("membershipIdentifier"),
+            query_log_status=params.get("queryLogStatus"),
+        )
+        return json.dumps({"membership": membership.to_dict()})
+
+    def delete_membership(self) -> str:
+        membership_identifier = self._get_param("membershipIdentifier")
+        self.cleanrooms_backend.delete_membership(membership_identifier)
+        return json.dumps({})
+
+    def create_configured_table(self) -> str:
+        params = json.loads(self.body)
+        configured_table = self.cleanrooms_backend.create_configured_table(
+            name=params.get("name"),
+            description=params.get("description"),
+            table_reference=params.get("tableReference"),
+            allowed_columns=params.get("allowedColumns"),
+            analysis_method=params.get("analysisMethod"),
+            selected_analysis_methods=params.get("selectedAnalysisMethods"),
+            tags=params.get("tags"),
+        )
+        return json.dumps({"configuredTable": configured_table.to_dict()})
+
+    def get_configured_table(self) -> str:
+        configured_table_identifier = self._get_param("configuredTableIdentifier")
+        configured_table = self.cleanrooms_backend.get_configured_table(
+            configured_table_identifier
+        )
+        return json.dumps({"configuredTable": configured_table.to_dict()})
+
+    def list_configured_tables(self) -> str:
+        max_results = self._get_int_param("maxResults")
+        next_token = self._get_param("nextToken")
+        configured_tables, next_token = self.cleanrooms_backend.list_configured_tables(
+            max_results=max_results, next_token=next_token
+        )
+        response: dict[str, Any] = {
+            "configuredTableSummaries": [t.to_summary_dict() for t in configured_tables]
+        }
+        if next_token:
+            response["nextToken"] = next_token
+        return json.dumps(response)
+
+    def update_configured_table(self) -> str:
+        params = json.loads(self.body)
+        configured_table = self.cleanrooms_backend.update_configured_table(
+            configured_table_identifier=self._get_param("configuredTableIdentifier"),
+            name=params.get("name"),
+            description=params.get("description"),
+            analysis_method=params.get("analysisMethod"),
+            selected_analysis_methods=params.get("selectedAnalysisMethods"),
+        )
+        return json.dumps({"configuredTable": configured_table.to_dict()})
+
+    def delete_configured_table(self) -> str:
+        configured_table_identifier = self._get_param("configuredTableIdentifier")
+        self.cleanrooms_backend.delete_configured_table(configured_table_identifier)
+        return json.dumps({})
+
+    def tag_resource(self) -> str:
+        resource_arn = unquote(self._get_param("resourceArn"))
+        tags = json.loads(self.body).get("tags") or {}
+        self.cleanrooms_backend.tag_resource(resource_arn, tags)
+        return json.dumps({})
+
+    def untag_resource(self) -> str:
+        resource_arn = unquote(self._get_param("resourceArn"))
+        tag_keys = self.querystring.get("tagKeys", [])
+        self.cleanrooms_backend.untag_resource(resource_arn, tag_keys)
+        return json.dumps({})
+
+    def list_tags_for_resource(self) -> str:
+        resource_arn = unquote(self._get_param("resourceArn"))
+        tags = self.cleanrooms_backend.list_tags_for_resource(resource_arn)
+        return json.dumps({"tags": tags})

--- a/moto/cleanrooms/urls.py
+++ b/moto/cleanrooms/urls.py
@@ -1,0 +1,18 @@
+"""cleanrooms base URL and path."""
+
+from .responses import CleanRoomsResponse
+
+url_bases = [
+    r"https?://cleanrooms\.(.+)\.amazonaws\.com",
+]
+
+url_paths = {
+    "{0}/collaborations$": CleanRoomsResponse.dispatch,
+    "{0}/collaborations/(?P<collaborationIdentifier>[^/]+)$": CleanRoomsResponse.dispatch,
+    "{0}/collaborations/(?P<collaborationIdentifier>[^/]+)/members$": CleanRoomsResponse.dispatch,
+    "{0}/memberships$": CleanRoomsResponse.dispatch,
+    "{0}/memberships/(?P<membershipIdentifier>[^/]+)$": CleanRoomsResponse.dispatch,
+    "{0}/configuredTables$": CleanRoomsResponse.dispatch,
+    "{0}/configuredTables/(?P<configuredTableIdentifier>[^/]+)$": CleanRoomsResponse.dispatch,
+    "{0}/tags/(?P<resourceArn>.+)$": CleanRoomsResponse.dispatch,
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -106,6 +106,7 @@ batch = docker>=3.0.0
 batch_simple =
 budgets =
 ce =
+cleanrooms =
 cloudformation =
     joserfc>=0.9.0
     docker>=3.0.0

--- a/tests/test_cleanrooms/test_cleanrooms.py
+++ b/tests/test_cleanrooms/test_cleanrooms.py
@@ -1,0 +1,427 @@
+"""Unit tests for cleanrooms-supported APIs."""
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+
+REGION = "us-east-2"
+UNKNOWN_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def create_collaboration(client, name="test-collaboration", **kwargs):
+    params = {
+        "name": name,
+        "description": "A test collaboration",
+        "creatorDisplayName": "Creator",
+        "creatorMemberAbilities": ["CAN_QUERY", "CAN_RECEIVE_RESULTS"],
+        "queryLogStatus": "ENABLED",
+        "members": [
+            {
+                "accountId": "111111111111",
+                "memberAbilities": ["CAN_QUERY"],
+                "displayName": "Invited Member",
+            }
+        ],
+        **kwargs,
+    }
+    return client.create_collaboration(**params)["collaboration"]
+
+
+def create_configured_table(client, name="test-table", **kwargs):
+    params = {
+        "name": name,
+        "description": "A test configured table",
+        "tableReference": {
+            "glue": {"tableName": "test-table", "databaseName": "test-db"}
+        },
+        "allowedColumns": ["column1", "column2"],
+        "analysisMethod": "DIRECT_QUERY",
+        **kwargs,
+    }
+    return client.create_configured_table(**params)["configuredTable"]
+
+
+@mock_aws
+def test_create_collaboration():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    collaboration = create_collaboration(client)
+
+    assert (
+        collaboration["arn"]
+        == f"arn:aws:cleanrooms:{REGION}:{ACCOUNT_ID}:collaboration/{collaboration['id']}"
+    )
+    assert collaboration["name"] == "test-collaboration"
+    assert collaboration["description"] == "A test collaboration"
+    assert collaboration["creatorAccountId"] == ACCOUNT_ID
+    assert collaboration["creatorDisplayName"] == "Creator"
+    assert collaboration["memberStatus"] == "INVITED"
+    assert collaboration["queryLogStatus"] == "ENABLED"
+    assert "createTime" in collaboration
+    assert "updateTime" in collaboration
+
+
+@mock_aws
+def test_get_collaboration():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_collaboration(client)
+
+    collaboration = client.get_collaboration(collaborationIdentifier=created["id"])[
+        "collaboration"
+    ]
+
+    assert collaboration["id"] == created["id"]
+    assert collaboration["arn"] == created["arn"]
+    assert collaboration["name"] == "test-collaboration"
+
+
+@mock_aws
+def test_get_collaboration_unknown():
+    client = boto3.client("cleanrooms", region_name=REGION)
+
+    with pytest.raises(ClientError) as exc:
+        client.get_collaboration(collaborationIdentifier=UNKNOWN_ID)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
+    assert err["Message"] == f"Could not find collaboration with id {UNKNOWN_ID}"
+
+
+@mock_aws
+def test_list_collaborations():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    create_collaboration(client, name="collaboration-1")
+    create_collaboration(client, name="collaboration-2")
+
+    collaborations = client.list_collaborations()["collaborationList"]
+
+    assert len(collaborations) == 2
+    assert {c["name"] for c in collaborations} == {
+        "collaboration-1",
+        "collaboration-2",
+    }
+    for summary in collaborations:
+        assert "id" in summary
+        assert "arn" in summary
+        assert "creatorAccountId" in summary
+        assert "updateTime" in summary
+        assert "description" not in summary
+
+
+@mock_aws
+def test_list_collaborations_pagination():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    for idx in range(3):
+        create_collaboration(client, name=f"collaboration-{idx}")
+
+    page1 = client.list_collaborations(maxResults=2)
+    assert len(page1["collaborationList"]) == 2
+    assert "nextToken" in page1
+
+    page2 = client.list_collaborations(maxResults=2, nextToken=page1["nextToken"])
+    assert len(page2["collaborationList"]) == 1
+    assert "nextToken" not in page2
+
+
+@mock_aws
+def test_update_collaboration():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_collaboration(client)
+
+    updated = client.update_collaboration(
+        collaborationIdentifier=created["id"],
+        name="updated-name",
+        description="updated description",
+    )["collaboration"]
+
+    assert updated["name"] == "updated-name"
+    assert updated["description"] == "updated description"
+    assert updated["updateTime"] >= updated["createTime"]
+
+
+@mock_aws
+def test_delete_collaboration():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_collaboration(client)
+
+    client.delete_collaboration(collaborationIdentifier=created["id"])
+
+    assert client.list_collaborations()["collaborationList"] == []
+    with pytest.raises(ClientError) as exc:
+        client.delete_collaboration(collaborationIdentifier=created["id"])
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_list_members():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_collaboration(client)
+
+    members = client.list_members(collaborationIdentifier=created["id"])[
+        "memberSummaries"
+    ]
+
+    assert len(members) == 2
+    creator = next(m for m in members if m["accountId"] == ACCOUNT_ID)
+    assert creator["status"] == "INVITED"
+    assert creator["displayName"] == "Creator"
+    assert creator["abilities"] == ["CAN_QUERY", "CAN_RECEIVE_RESULTS"]
+    invited = next(m for m in members if m["accountId"] == "111111111111")
+    assert invited["status"] == "INVITED"
+    assert invited["displayName"] == "Invited Member"
+    assert invited["abilities"] == ["CAN_QUERY"]
+
+
+@mock_aws
+def test_create_membership():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_collaboration(client)
+
+    membership = client.create_membership(
+        collaborationIdentifier=created["id"], queryLogStatus="DISABLED"
+    )["membership"]
+
+    assert (
+        membership["arn"]
+        == f"arn:aws:cleanrooms:{REGION}:{ACCOUNT_ID}:membership/{membership['id']}"
+    )
+    assert membership["collaborationId"] == created["id"]
+    assert membership["collaborationArn"] == created["arn"]
+    assert membership["collaborationName"] == "test-collaboration"
+    assert membership["collaborationCreatorAccountId"] == ACCOUNT_ID
+    assert membership["status"] == "ACTIVE"
+    assert membership["memberAbilities"] == ["CAN_QUERY", "CAN_RECEIVE_RESULTS"]
+    assert membership["queryLogStatus"] == "DISABLED"
+    assert membership["paymentConfiguration"] == {
+        "queryCompute": {"isResponsible": True}
+    }
+
+    # The creator becomes an active member of the collaboration
+    collaboration = client.get_collaboration(collaborationIdentifier=created["id"])[
+        "collaboration"
+    ]
+    assert collaboration["memberStatus"] == "ACTIVE"
+    assert collaboration["membershipId"] == membership["id"]
+    assert collaboration["membershipArn"] == membership["arn"]
+
+
+@mock_aws
+def test_create_membership_unknown_collaboration():
+    client = boto3.client("cleanrooms", region_name=REGION)
+
+    with pytest.raises(ClientError) as exc:
+        client.create_membership(
+            collaborationIdentifier=UNKNOWN_ID, queryLogStatus="ENABLED"
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_get_membership():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    collaboration = create_collaboration(client)
+    created = client.create_membership(
+        collaborationIdentifier=collaboration["id"], queryLogStatus="ENABLED"
+    )["membership"]
+
+    membership = client.get_membership(membershipIdentifier=created["id"])["membership"]
+
+    assert membership["id"] == created["id"]
+    assert membership["collaborationId"] == collaboration["id"]
+
+    with pytest.raises(ClientError) as exc:
+        client.get_membership(membershipIdentifier=UNKNOWN_ID)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_list_memberships():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    for idx in range(2):
+        collaboration = create_collaboration(client, name=f"collaboration-{idx}")
+        client.create_membership(
+            collaborationIdentifier=collaboration["id"], queryLogStatus="ENABLED"
+        )
+
+    memberships = client.list_memberships()["membershipSummaries"]
+
+    assert len(memberships) == 2
+    assert {m["collaborationName"] for m in memberships} == {
+        "collaboration-0",
+        "collaboration-1",
+    }
+    for summary in memberships:
+        assert "id" in summary
+        assert "arn" in summary
+        assert "updateTime" in summary
+        assert summary["status"] == "ACTIVE"
+
+
+@mock_aws
+def test_update_membership():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    collaboration = create_collaboration(client)
+    created = client.create_membership(
+        collaborationIdentifier=collaboration["id"], queryLogStatus="ENABLED"
+    )["membership"]
+
+    updated = client.update_membership(
+        membershipIdentifier=created["id"], queryLogStatus="DISABLED"
+    )["membership"]
+
+    assert updated["queryLogStatus"] == "DISABLED"
+    assert updated["updateTime"] >= updated["createTime"]
+
+
+@mock_aws
+def test_delete_membership():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    collaboration = create_collaboration(client)
+    created = client.create_membership(
+        collaborationIdentifier=collaboration["id"], queryLogStatus="ENABLED"
+    )["membership"]
+
+    client.delete_membership(membershipIdentifier=created["id"])
+
+    assert client.list_memberships()["membershipSummaries"] == []
+    updated_collaboration = client.get_collaboration(
+        collaborationIdentifier=collaboration["id"]
+    )["collaboration"]
+    assert updated_collaboration["memberStatus"] == "LEFT"
+    assert "membershipId" not in updated_collaboration
+
+
+@mock_aws
+def test_create_configured_table():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    configured_table = create_configured_table(client)
+
+    assert (
+        configured_table["arn"]
+        == f"arn:aws:cleanrooms:{REGION}:{ACCOUNT_ID}:configuredtable/{configured_table['id']}"
+    )
+    assert configured_table["name"] == "test-table"
+    assert configured_table["description"] == "A test configured table"
+    assert configured_table["tableReference"] == {
+        "glue": {"tableName": "test-table", "databaseName": "test-db"}
+    }
+    assert configured_table["allowedColumns"] == ["column1", "column2"]
+    assert configured_table["analysisMethod"] == "DIRECT_QUERY"
+    assert configured_table["analysisRuleTypes"] == []
+
+
+@mock_aws
+def test_get_configured_table():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_configured_table(client)
+
+    configured_table = client.get_configured_table(
+        configuredTableIdentifier=created["id"]
+    )["configuredTable"]
+
+    assert configured_table["id"] == created["id"]
+    assert configured_table["name"] == "test-table"
+
+    with pytest.raises(ClientError) as exc:
+        client.get_configured_table(configuredTableIdentifier=UNKNOWN_ID)
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_list_configured_tables():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    create_configured_table(client, name="table-1")
+    create_configured_table(client, name="table-2")
+
+    configured_tables = client.list_configured_tables()["configuredTableSummaries"]
+
+    assert len(configured_tables) == 2
+    assert {t["name"] for t in configured_tables} == {"table-1", "table-2"}
+    for summary in configured_tables:
+        assert "id" in summary
+        assert "arn" in summary
+        assert "updateTime" in summary
+        assert "tableReference" not in summary
+
+
+@mock_aws
+def test_update_configured_table():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_configured_table(client)
+
+    updated = client.update_configured_table(
+        configuredTableIdentifier=created["id"],
+        name="updated-table",
+        description="updated description",
+    )["configuredTable"]
+
+    assert updated["name"] == "updated-table"
+    assert updated["description"] == "updated description"
+    assert updated["updateTime"] >= updated["createTime"]
+
+
+@mock_aws
+def test_delete_configured_table():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    created = create_configured_table(client)
+
+    client.delete_configured_table(configuredTableIdentifier=created["id"])
+
+    assert client.list_configured_tables()["configuredTableSummaries"] == []
+    with pytest.raises(ClientError) as exc:
+        client.delete_configured_table(configuredTableIdentifier=created["id"])
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_tags_on_create():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    collaboration = create_collaboration(client, tags={"env": "test"})
+    configured_table = create_configured_table(client, tags={"team": "data"})
+    membership = client.create_membership(
+        collaborationIdentifier=collaboration["id"],
+        queryLogStatus="ENABLED",
+        tags={"owner": "me"},
+    )["membership"]
+
+    assert client.list_tags_for_resource(resourceArn=collaboration["arn"])["tags"] == {
+        "env": "test"
+    }
+    assert client.list_tags_for_resource(resourceArn=configured_table["arn"])[
+        "tags"
+    ] == {"team": "data"}
+    assert client.list_tags_for_resource(resourceArn=membership["arn"])["tags"] == {
+        "owner": "me"
+    }
+
+
+@mock_aws
+def test_tag_and_untag_resource():
+    client = boto3.client("cleanrooms", region_name=REGION)
+    collaboration = create_collaboration(client)
+
+    client.tag_resource(
+        resourceArn=collaboration["arn"], tags={"env": "test", "team": "data"}
+    )
+    assert client.list_tags_for_resource(resourceArn=collaboration["arn"])["tags"] == {
+        "env": "test",
+        "team": "data",
+    }
+
+    client.untag_resource(resourceArn=collaboration["arn"], tagKeys=["env"])
+    assert client.list_tags_for_resource(resourceArn=collaboration["arn"])["tags"] == {
+        "team": "data"
+    }
+
+
+@mock_aws
+def test_collaborations_are_region_specific():
+    client_use2 = boto3.client("cleanrooms", region_name=REGION)
+    client_euw1 = boto3.client("cleanrooms", region_name="eu-west-1")
+    create_collaboration(client_use2)
+
+    collaboration = create_collaboration(client_euw1, name="eu-collaboration")
+
+    assert collaboration["arn"].startswith(f"arn:aws:cleanrooms:eu-west-1:{ACCOUNT_ID}")
+    assert len(client_euw1.list_collaborations()["collaborationList"]) == 1

--- a/tests/test_cleanrooms/test_cleanrooms.py
+++ b/tests/test_cleanrooms/test_cleanrooms.py
@@ -86,6 +86,9 @@ def test_get_collaboration_unknown():
     err = exc.value.response["Error"]
     assert err["Code"] == "ResourceNotFoundException"
     assert err["Message"] == f"Could not find collaboration with id {UNKNOWN_ID}"
+    assert exc.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+    assert exc.value.response["resourceId"] == UNKNOWN_ID
+    assert exc.value.response["resourceType"] == "COLLABORATION"
 
 
 @mock_aws

--- a/tests/test_cleanrooms/test_server.py
+++ b/tests/test_cleanrooms/test_server.py
@@ -1,0 +1,15 @@
+"""Test different server responses."""
+
+import json
+
+import moto.server as server
+
+
+def test_cleanrooms_list_collaborations():
+    backend = server.create_backend_app("cleanrooms")
+    test_client = backend.test_client()
+
+    resp = test_client.get("/collaborations")
+
+    assert resp.status_code == 200
+    assert "collaborationList" in json.loads(resp.data)


### PR DESCRIPTION
This PR adds initial support for the CleanRooms service (collaborations, memberships, configured tables)

  Implemented:
  - Collaborations: `create`, `get`, `list`, `update`, `delete`, `list_members`
  - Memberships: `create`, `get`, `list`, `update`, `delete`
  - Configured tables: `create`, `get`, `list`, `update`, `delete`
  - Tagging: `tag_resource`, `untag_resource`, `list_tags_for_resource`