### PR TITLE
Fix describe_instances group-id filter for instances in multiple security groups

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -348,10 +348,12 @@ def get_object_value(obj: Any, attr: str) -> Any:
         elif isinstance(val, dict):
             val = val[key]
         elif isinstance(val, list):
-            for item in val:
-                item_val = get_object_value(item, key)
-                if item_val:
-                    return item_val
+            # Collect the value from every element (e.g. all of an instance's
+            # security groups), not just the first, so a filter matches when the
+            # requested value belongs to any element. The caller
+            # (instance_value_in_filter_values) already intersects lists.
+            values = [get_object_value(item, key) for item in val]
+            return [value for value in values if value is not None]
         elif key == "owner_id" and hasattr(val, "account_id"):
             val = val.account_id
         else:

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -798,6 +798,46 @@ def test_get_instances_filtering_by_instance_group_id():
 
 
 @mock_aws
+def test_get_instances_filtering_by_group_id_multiple_security_groups():
+    # An instance can belong to several security groups; a group-id/group-name
+    # filter must match it via ANY of them, not only the first one attached.
+    client = boto3.client("ec2", region_name="us-east-1")
+    vpc_id = client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+    sg1 = client.create_security_group(
+        Description="test", GroupName=str(uuid4())[0:6], VpcId=vpc_id
+    )["GroupId"]
+    sg2 = client.create_security_group(
+        Description="test", GroupName="second-group", VpcId=vpc_id
+    )["GroupId"]
+    subnet_id = client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/24")["Subnet"][
+        "SubnetId"
+    ]
+    instance_id = client.run_instances(
+        ImageId=EXAMPLE_AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        SubnetId=subnet_id,
+        SecurityGroupIds=[sg1, sg2],
+    )["Instances"][0]["InstanceId"]
+
+    def instances_for(filter_name, value):
+        reservations = client.describe_instances(
+            Filters=[{"Name": filter_name, "Values": [value]}]
+        )["Reservations"]
+        return [i["InstanceId"] for r in reservations for i in r["Instances"]]
+
+    # Matches via the first and the (previously ignored) second security group.
+    assert instances_for("group-id", sg1) == [instance_id]
+    assert instances_for("group-id", sg2) == [instance_id]
+    assert instances_for("instance.group-name", "second-group") == [instance_id]
+    # A group the instance is not in must not match.
+    other = client.create_security_group(
+        Description="test", GroupName="other", VpcId=vpc_id
+    )["GroupId"]
+    assert instances_for("group-id", other) == []
+
+
+@mock_aws
 def test_get_instances_filtering_by_subnet_id():
     client = boto3.client("ec2", region_name="us-east-1")
 


### PR DESCRIPTION
Fixes #10114.

### Problem
`describe_instances` filtered by `group-id` / `instance.group-id` / `instance.group-name` only matches an instance's **first** security group, so an instance in several groups is wrongly excluded when filtered by any of its other groups (repro in #10114). Real AWS matches via any attached group.

### Cause
`get_object_value` (`moto/ec2/utils.py`), when a filter attribute traverses a list (`security_groups.id`), returned the first element's value instead of all of them.

### Fix
Collect the value from every list element. `instance_value_in_filter_values` already intersects lists, so the requested group now matches via any of the instance's security groups; `passes_igw_filter_dict` never traverses a list, so it is unaffected.

### Tests
Added `test_get_instances_filtering_by_group_id_multiple_security_groups` (matches via first + second SG + group-name; a non-member group returns nothing). Fails before, passes after; `test_instances.py` filter tests stay green (25 passed).
