### PR TITLE
CloudTrail: Fix start_logging/stop_logging to accept trail ARN

### DIFF
--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -335,11 +335,11 @@ class CloudTrailBackend(BaseBackend):
         return self.describe_trails(include_shadow_trails=True)
 
     def start_logging(self, name: str) -> None:
-        trail = self.trails[name]
+        trail = self.get_trail(name_or_arn=name)
         trail.start_logging()
 
     def stop_logging(self, name: str) -> None:
-        trail = self.trails[name]
+        trail = self.get_trail(name_or_arn=name)
         trail.stop_logging()
 
     def delete_trail(self, name: str) -> None:

--- a/tests/test_cloudtrail/test_cloudtrail.py
+++ b/tests/test_cloudtrail/test_cloudtrail.py
@@ -309,6 +309,31 @@ def test_get_trail_status_after_starting_and_stopping():
 
 
 @mock_aws
+def test_start_and_stop_logging_by_arn():
+    client = boto3.client("cloudtrail", region_name="eu-west-3")
+    _, resp, trail_name = create_trail_simple(region_name="eu-west-3")
+    trail_arn = resp["TrailARN"]
+
+    client.start_logging(Name=trail_arn)
+    status = client.get_trail_status(Name=trail_name)
+    assert status["IsLogging"] is True
+
+    client.stop_logging(Name=trail_arn)
+    status = client.get_trail_status(Name=trail_name)
+    assert status["IsLogging"] is False
+
+
+@pytest.mark.parametrize("method", ["start_logging", "stop_logging"])
+@mock_aws
+def test_start_and_stop_logging_unknown_trail(method):
+    client = boto3.client("cloudtrail", region_name="eu-west-3")
+    with pytest.raises(ClientError) as exc:
+        getattr(client, method)(Name="does-not-exist")
+    err = exc.value.response["Error"]
+    assert err["Code"] == "TrailNotFoundException"
+
+
+@mock_aws
 def test_get_trail_status_multi_region_not_from_the_home_region():
     # CloudTrail client
     client_us_east_1 = boto3.client("cloudtrail", region_name="us-east-1")


### PR DESCRIPTION
CloudTrail: Fix start_logging/stop_logging to accept trail ARN

Closes [#10107](https://github.com/getmoto/moto/issues/10107)

start_logging/stop_logging did a raw self.trails[name] dict lookup, which raises KeyError when called with a trail ARN; AWS accepts both name and ARN for these operations, and get_trail_status already handles this correctly. Routes both methods through the existing ARN-tolerant get_trail() helper instead, matching the pattern already used by update_trail, put_event_selectors, etc. Unknown trails now correctly raise TrailNotFoundException.

Added tests covering start/stop by ARN and the not-found case for both methods. The full test_cloudtrail suite (45 tests) passes, and the ruff check/ruff format --check/mypy all clean.