### PR TITLE
S3: Fix duplicate response headers when overriding via response-* que…

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2011,6 +2011,12 @@ class S3Response(BaseResponse):
 
         for param_name, header_name in ALLOWED_HEADER_OVERRIDES.items():
             if param_name in self.querystring:
+                # Remove any existing header with the same name but different casing
+                # (e.g. object metadata stores "content-disposition" lowercase, while
+                # this override uses "Content-Disposition") to avoid duplicate headers.
+                for existing in list(response_headers.keys()):
+                    if existing.lower() == header_name.lower():
+                        del response_headers[existing]
                 response_headers[header_name] = self.querystring[param_name][0]
 
         part_number = self._get_int_param("partNumber")

--- a/tests/test_s3/test_server.py
+++ b/tests/test_s3/test_server.py
@@ -112,6 +112,45 @@ def test_s3_server_ignore_subdomain_for_bucketnames():
         assert "mybucket" in res.headers.get("Location")
 
 
+def test_s3_server_get_object_does_not_duplicate_overridden_headers():
+    # github.com/getmoto/moto/issues/10116
+    # Object metadata set at PutObject-time (e.g. Content-Disposition, Cache-Control)
+    # must be *replaced* by the response-* query overrides on GetObject, not duplicated
+    # alongside them - a plain dict lookup on res.headers hides this, since it only
+    # surfaces one of the two differently-cased entries.
+    thread = ThreadedMotoServer(port=0, verbose=False)
+    thread.start()
+    _, port = thread.get_host_and_port()
+    auth = {"Authorization": "Any authorization header"}
+    base_url = f"http://localhost:{port}/duplicate-header-bucket"
+    try:
+        requests.put(base_url, headers=auth)
+        requests.put(
+            f"{base_url}/file.txt",
+            data=b"ABCD",
+            headers={
+                **auth,
+                "Content-Disposition": 'inline; filename="orig.png"',
+                "Cache-Control": "max-age=1",
+            },
+        )
+        res = requests.get(
+            f"{base_url}/file.txt",
+            params={
+                "response-content-disposition": 'attachment; filename="foo.jpg"',
+                "response-cache-control": "max-age=74",
+            },
+            headers=auth,
+        )
+        assert res.status_code == 200
+        assert res.raw.headers.getlist("Content-Disposition") == [
+            'attachment; filename="foo.jpg"'
+        ]
+        assert res.raw.headers.getlist("Cache-Control") == ["max-age=74"]
+    finally:
+        thread.stop()
+
+
 def test_s3_server_bucket_versioning():
     test_client = authenticated_client()
 


### PR DESCRIPTION
Closes #10116
get_object's response-content-disposition (and similar response-* query overrides) added a differently-cased header key alongside any value already set from the object's own metadata (e.g. stored lowercase 'content-disposition' + override's capitalized 'Content-Disposition'), producing two header lines in the actual HTTP response and breaking browsers. Strip any existing header with the same name case-insensitively before applying the override.

Verified via ThreadedMotoServer (the in-process mock_aws decorator's CaseInsensitiveDict silently hides this bug, so the regression test uses a real server instead).