### PR TITLE
SNS: Fixing tag format in AWS Config resource items

### DIFF
--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -1272,6 +1272,7 @@ class SNSBackend(BaseBackend, TaggableResourcesMixin):
             "arn": topic.arn,
             "awsRegion": self.region_name,
             "availabilityZone": "Not Applicable",
+            "tags": dict(topic._tags),
             "configuration": {
                 "topicArn": topic.arn,
                 "displayName": topic.display_name,
@@ -1284,7 +1285,7 @@ class SNSBackend(BaseBackend, TaggableResourcesMixin):
             },
             "supplementaryConfiguration": {
                 "Tags": json.dumps(
-                    [{"Key": k, "Value": v} for k, v in topic._tags.items()]
+                    [{"key": k, "value": v} for k, v in topic._tags.items()]
                 )
             },
             "configurationItemMD5Hash": "",

--- a/tests/test_sns/test_topics.py
+++ b/tests/test_sns/test_topics.py
@@ -711,7 +711,12 @@ def test_get_config_resource():
     assert configuration["fifoTopic"] is True
     assert configuration["contentBasedDeduplication"] is True
     tags = json.loads(config_item["supplementaryConfiguration"]["Tags"])
-    assert tags == [{"Key": "Environment", "Value": "Test"}]
+    assert tags == [{"key": "Environment", "value": "Test"}]
+
+    history = config_client.get_resource_config_history(
+        resourceType="AWS::SNS::Topic", resourceId=topic_arn
+    )
+    assert history["configurationItems"][0]["tags"] == {"Environment": "Test"}
 
     response = config_client.batch_get_resource_config(
         resourceKeys=[


### PR DESCRIPTION
Tags on SNS topics came back as null when read through moto's AWS Config integration (tested with Cloud Custodian policies with source: config).

  The config item from get_config_resource didn't match real AWS Config output:
  - missing the top-level tags map
  - supplementaryConfiguration.Tags used uppercase Key/Value instead of lowercase key/value