### PR TITLE
RDS: Raise InvalidParameterCombination on monitoring parameters mismatch

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1138,6 +1138,8 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         manage_master_user_password: bool | None = False,
         master_user_secret_kms_key_id: str | None = None,
         storage_throughput: int | None = None,
+        monitoring_interval: int = 0,
+        monitoring_role_arn: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(backend)
@@ -1194,6 +1196,16 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self.tags = tags or []
         self.deletion_protection = deletion_protection
         self.enabled_cloudwatch_logs_exports = enable_cloudwatch_logs_exports or []
+        self.monitoring_role_arn = monitoring_role_arn
+        self.monitoring_interval = monitoring_interval
+        if self.monitoring_role_arn is not None and self.monitoring_interval == 0:
+            raise InvalidParameterCombination(
+                "You must specify a MonitoringInterval value other than 0 when you specify a MonitoringRoleARN value."
+            )
+        if self.monitoring_role_arn is None and self.monitoring_interval != 0:
+            raise InvalidParameterCombination(
+                "A MonitoringRoleARN value is required if you specify a MonitoringInterval value other than 0."
+            )
         self.db_cluster_identifier = db_cluster_identifier
         if self.db_cluster_identifier is None:
             self.vpc_security_group_ids = vpc_security_group_ids or []

--- a/tests/test_rds/test_rds.py
+++ b/tests/test_rds/test_rds.py
@@ -3817,3 +3817,29 @@ def test_add_role_to_db_instance_in_invalid_state_throws_InvalidDBInstanceStateF
         ex.value.response["Error"]["Message"]
         == "Instance db-master-1 should be in a valid state to add role."
     )
+
+
+@mock_aws
+def test_create_database_with_monitoring_role_and_no_interval_throws_InvalidParameterCombination():
+    with pytest.raises(ClientError) as ex:
+        create_db_instance(MonitoringRoleArn="monitoring-role", MonitoringInterval=0)
+
+    assert ex.value.operation_name == "CreateDBInstance"
+    assert ex.value.response["Error"]["Code"] == "InvalidParameterCombination"
+    assert (
+        ex.value.response["Error"]["Message"]
+        == "You must specify a MonitoringInterval value other than 0 when you specify a MonitoringRoleARN value."
+    )
+
+
+@mock_aws
+def test_create_database_without_monitoring_role_and_with_interval_throws_InvalidParameterCombination():
+    with pytest.raises(ClientError) as ex:
+        create_db_instance(MonitoringInterval=60)
+
+    assert ex.value.operation_name == "CreateDBInstance"
+    assert ex.value.response["Error"]["Code"] == "InvalidParameterCombination"
+    assert (
+        ex.value.response["Error"]["Message"]
+        == "A MonitoringRoleARN value is required if you specify a MonitoringInterval value other than 0."
+    )


### PR DESCRIPTION
`create_db_instance` should fail if we provide `MonitoringRoleArn` without providing `MonitoringInterval` or when we provide `MonitoringInterval` without providing `MonitoringRoleArn`.

From boto3 docs: https://docs.aws.amazon.com/boto3/latest/reference/services/rds/client/create_db_instance.html

> If MonitoringRoleArn is specified, then you must set MonitoringInterval to a value other than 0.
> If MonitoringInterval is set to a value other than 0, then you must supply a MonitoringRoleArn value.