### PR TITLE
Firehose: interpolate the destination id in the not-found message

### DIFF
--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -645,7 +645,7 @@ class FirehoseBackend(BaseBackend, TaggableResourcesMixin):
                 break
             destination_idx += 1
         else:
-            raise InvalidArgumentException("Destination Id {destination_id} not found")
+            raise InvalidArgumentException(f"Destination Id {destination_id} not found")
 
         # Switching between Amazon ES and other services is not supported.
         # For an Amazon ES destination, you can only update to another Amazon

--- a/tests/test_firehose/test_firehose.py
+++ b/tests/test_firehose/test_firehose.py
@@ -490,6 +490,18 @@ def test_update_destination():
         "supported at this time"
     ) in err["Message"]
 
+    # An unknown destination id is reported back with the id that was given.
+    with pytest.raises(ClientError) as exc:
+        client.update_destination(
+            DeliveryStreamName=stream_name,
+            CurrentDeliveryStreamVersionId="1",
+            DestinationId="destinationId-000000000009",
+            ExtendedS3DestinationUpdate=s3_dest_config,
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidArgumentException"
+    assert "Destination Id destinationId-000000000009 not found" in err["Message"]
+
 
 @mock_aws
 def test_lookup_name_from_arn():


### PR DESCRIPTION
`update_destination()` reports an unknown destination id with a missing `f` prefix, so the caller gets the placeholder text rather than the id they passed:

```python
>>> client.update_destination(
...     DeliveryStreamName="my-stream",
...     CurrentDeliveryStreamVersionId="1",
...     DestinationId="destinationId-000000000009",
...     ExtendedS3DestinationUpdate=s3_config,
... )
InvalidArgumentException: Destination Id {destination_id} not found
```

The `raise` immediately above it in the same method uses f-strings, and every other braced string in `moto/firehose/models.py` is an f-string, so this looks like a slip rather than an intentional literal.

Added the unknown-id case to `test_update_destination`, which previously only ever passed the id that exists. Without the one-character change it fails with:

```
assert 'Destination Id destinationId-000000000009 not found' in 'Destination Id {destination_id} not found'
```

`tests/test_firehose` passes (31), and `ruff format` is clean. `ruff check moto/firehose tests/test_firehose` reports the same 5 findings before and after my change, and the one mypy finding in this file (`models.py:443`) is also present on an unmodified checkout, so I have left both alone.

One thing I did not verify: the exact wording real Firehose uses for this error. I only changed the interpolation, not the text, so if AWS words it differently that is a separate question.
