### PR TITLE
Transfer: raise ServerNotFound instead of building it

### DIFF
--- a/moto/transfer/models.py
+++ b/moto/transfer/models.py
@@ -126,13 +126,13 @@ class TransferBackend(BaseBackend):
 
     def describe_server(self, server_id: str) -> Server:
         if server_id not in self.servers:
-            ServerNotFound(server_id=server_id)
+            raise ServerNotFound(server_id=server_id)
         server = self.servers[server_id]
         return server
 
     def delete_server(self, server_id: str) -> None:
         if server_id not in self.servers:
-            ServerNotFound(server_id=server_id)
+            raise ServerNotFound(server_id=server_id)
         del self.servers[server_id]
         return
 
@@ -150,7 +150,7 @@ class TransferBackend(BaseBackend):
         user_name: str,
     ) -> tuple[str, str]:
         if server_id not in self.servers:
-            ServerNotFound(server_id=server_id)
+            raise ServerNotFound(server_id=server_id)
         user = User(
             region_name=self.region_name,
             account_id=self.account_id,

--- a/tests/test_transfer/test_transfer.py
+++ b/tests/test_transfer/test_transfer.py
@@ -156,6 +156,27 @@ def test_create_describe_and_delete_server(client, server):
     assert server_id not in connection
 
 
+def test_server_not_found(client):
+    """An unknown server id must surface as ServerNotFound, not a KeyError."""
+    unknown_server_id = "s-1234567890abcdef0"
+
+    with pytest.raises(ClientError) as exc:
+        client.describe_server(ServerId=unknown_server_id)
+    assert exc.value.response["Error"]["Code"] == "ServerNotFound"
+
+    with pytest.raises(ClientError) as exc:
+        client.delete_server(ServerId=unknown_server_id)
+    assert exc.value.response["Error"]["Code"] == "ServerNotFound"
+
+    with pytest.raises(ClientError) as exc:
+        client.create_user(
+            ServerId=unknown_server_id,
+            UserName="test_user",
+            Role="TransferFamilyAdministrator",
+        )
+    assert exc.value.response["Error"]["Code"] == "ServerNotFound"
+
+
 def test_create_describe_and_delete_user(client, server):
     connection = client.create_user(
         HomeDirectory="/Users/mock_user",


### PR DESCRIPTION
`describe_server`, `delete_server` and `create_user` each build a `ServerNotFound` without raising it:

```python
def describe_server(self, server_id: str) -> Server:
    if server_id not in self.servers:
        ServerNotFound(server_id=server_id)
    server = self.servers[server_id]
```

The object is constructed and discarded, so the guard has no effect and the next line runs anyway. Callers get a bare `KeyError` for the missing id rather than the AWS error:

```pycon
>>> client.describe_server(ServerId="s-1234567890abcdef0")
KeyError: 's-1234567890abcdef0'
>>> client.delete_server(ServerId="s-1234567890abcdef0")
KeyError: 's-1234567890abcdef0'
>>> client.create_user(ServerId="s-1234567890abcdef0", UserName="alice", Role="...")
KeyError: 's-1234567890abcdef0'
```

`describe_user` in the same file raises it properly and returns `ServerNotFound` with "There are no transfer protocol-enabled servers with ID ...", so the intended behaviour is already demonstrated next door. After adding the `raise`, all three match it.

`create_user` is the one with a side effect worth noting: without the raise it goes on to build a `User` for a server that does not exist before hitting the `KeyError`.

Added `test_server_not_found` covering the three operations. It fails without the change with `KeyError: 's-1234567890abcdef0'` raised at `moto/transfer/models.py:130`.

`tests/test_transfer` passes (19, previously 18), `ruff format` is clean and mypy reports nothing. `ruff check moto/transfer` reports the same single pre-existing `PLR1711` about a useless `return` in `delete_server` before and after my change; I left it alone since it is unrelated, though I am happy to remove it while I am in there if you would prefer.
