### PR TITLE
S3Tables: raise TableAlreadyExists instead of building it

### DIFF
--- a/moto/s3tables/models.py
+++ b/moto/s3tables/models.py
@@ -285,7 +285,7 @@ class S3TablesBackend(BaseBackend):
 
         ns = bucket.namespaces[namespace]
         if name in ns.tables:
-            TableAlreadyExists()
+            raise TableAlreadyExists()
         table = Table(
             name=name,
             account_id=self.account_id,

--- a/tests/test_s3tables/test_s3tables.py
+++ b/tests/test_s3tables/test_s3tables.py
@@ -144,6 +144,22 @@ def test_create_table():
 
 
 @mock_aws
+def test_create_table_with_an_existing_name():
+    client = boto3.client("s3tables", region_name="us-east-2")
+    arn = client.create_table_bucket(name="foo")["arn"]
+    client.create_namespace(tableBucketARN=arn, namespace=["bar"])
+    client.create_table(
+        tableBucketARN=arn, namespace="bar", name="baz", format="ICEBERG"
+    )
+
+    with pytest.raises(client.exceptions.ConflictException) as exc:
+        client.create_table(
+            tableBucketARN=arn, namespace="bar", name="baz", format="ICEBERG"
+        )
+    assert exc.match("A table with an identical name already exists in the namespace.")
+
+
+@mock_aws
 def test_get_table():
     client = boto3.client("s3tables", region_name="us-east-2")
     arn = client.create_table_bucket(name="foo")["arn"]


### PR DESCRIPTION
`create_table` builds `TableAlreadyExists` without raising it, so the duplicate-name guard has no effect:

```python
if name in ns.tables:
    TableAlreadyExists()
table = Table(...)
ns.tables[name] = table
```

The two `raise NotFoundException(...)` guards a few lines above are correct, which is what makes this one stand out.

The result is that creating a table with a name that already exists succeeds and replaces the existing table rather than being rejected:

```pycon
>>> client.create_table(tableBucketARN=arn, namespace="ns", name="t", format="ICEBERG")
>>> client.get_table(tableBucketARN=arn, namespace="ns", name="t")["versionToken"]
'2558ff5603108fb4f052'
>>> client.create_table(tableBucketARN=arn, namespace="ns", name="t", format="ICEBERG")   # accepted
>>> client.get_table(tableBucketARN=arn, namespace="ns", name="t")["versionToken"]
'0897d5495b52d1cac9ff'
```

Both `versionToken` and `createdAt` change, so it is a replacement rather than a no-op, and `list_tables` still reports one table. Any state the first table had is gone.

Adding the `raise` makes it return the `ConflictException` that the existing `TableAlreadyExists` class was already written for, with its message "A table with an identical name already exists in the namespace.".

Added `test_create_table_with_an_existing_name`, which fails without the change with `Failed: DID NOT RAISE ConflictException`. It follows the `client.exceptions.<Name>` style already used in this file.

`tests/test_s3tables` passes (37), `ruff format` is clean, mypy reports nothing, and `ruff check moto/s3tables tests/test_s3tables` finds the same 4 pre-existing issues before and after my change.

I did not verify the exact wording or code that real S3 Tables returns for this. The message and exception class are moto's own, already present in `moto/s3tables/exceptions.py`; I only made the existing guard effective.
