### PR TITLE
fix(cognitoidp): do not invent an AccountRecoverySetting for pools created without one

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -381,13 +381,15 @@ DEFAULT_USER_POOL_CONFIG: dict[str, Any] = {
         "EmailSubject": "Your verification code",
         "DefaultEmailOption": "CONFIRM_WITH_CODE",
     },
-    "AccountRecoverySetting": {
-        "RecoveryMechanisms": [
-            {"Priority": 1, "Name": "verified_email"},
-            {"Priority": 2, "Name": "verified_phone_number"},
-        ]
-    },
 }
+
+# AWS does not apply an AccountRecoverySetting when the user pool was created
+# without one. It instead falls back to "the legacy behavior to determine the
+# recovery method where SMS is preferred through email".
+LEGACY_ACCOUNT_RECOVERY_MECHANISMS = [
+    {"Priority": 1, "Name": "verified_phone_number"},
+    {"Priority": 2, "Name": "verified_email"},
+]
 
 
 class CognitoIdpUserPool(BaseModel):
@@ -1784,7 +1786,9 @@ class CognitoIdpBackend(BaseBackend):
         """
         for user_pool in self.user_pools.values():
             if client_id in user_pool.clients:
-                recovery_settings = user_pool.extended_config["AccountRecoverySetting"]
+                recovery_settings = user_pool.extended_config.get(
+                    "AccountRecoverySetting"
+                )
                 user = user_pool._get_user(username)
                 break
         else:
@@ -1809,8 +1813,11 @@ class CognitoIdpBackend(BaseBackend):
     def _get_code_delivery_details(
         self, recovery_settings: Any, user: CognitoIdpUser | None, username: str
     ) -> dict[str, str]:
+        recovery_mechanisms = (recovery_settings or {}).get(
+            "RecoveryMechanisms"
+        ) or LEGACY_ACCOUNT_RECOVERY_MECHANISMS
         selected_recovery = min(
-            recovery_settings["RecoveryMechanisms"],
+            recovery_mechanisms,
             key=lambda recovery_mechanism: recovery_mechanism["Priority"],
         )
         if selected_recovery["Name"] == "admin_only":
@@ -2010,7 +2017,7 @@ class CognitoIdpBackend(BaseBackend):
             or "phone_number" in verified_attributes
         )
         if (has_email and email_verified) or (has_phone and phone_verified):
-            recovery_settings = user_pool.extended_config["AccountRecoverySetting"]
+            recovery_settings = user_pool.extended_config.get("AccountRecoverySetting")
             details = self._get_code_delivery_details(
                 recovery_settings=recovery_settings, user=user, username=user.username
             )

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -891,7 +891,9 @@ def test_update_user_pool():
     assert (
         updated_user_pool_details["UserPool"]["VerificationMessageTemplate"] is not None
     )
-    assert updated_user_pool_details["UserPool"]["AccountRecoverySetting"] is not None
+    # This pool was created without an AccountRecoverySetting, so AWS does not
+    # report one back.
+    assert "AccountRecoverySetting" not in updated_user_pool_details["UserPool"]
 
 
 @mock_aws
@@ -3621,9 +3623,11 @@ def test_forgot_password():
         UserPoolId=user_pool_id, ClientName=str(uuid.uuid4())
     )["UserPoolClient"]["ClientId"]
     result = conn.forgot_password(ClientId=client_id, Username=str(uuid.uuid4()))
+    # No AccountRecoverySetting on this pool, so the legacy SMS-first behavior
+    # applies.
     assert result["CodeDeliveryDetails"]["Destination"] is not None
-    assert result["CodeDeliveryDetails"]["DeliveryMedium"] == "EMAIL"
-    assert result["CodeDeliveryDetails"]["AttributeName"] == "email"
+    assert result["CodeDeliveryDetails"]["DeliveryMedium"] == "SMS"
+    assert result["CodeDeliveryDetails"]["AttributeName"] == "phone_number"
 
 
 @mock_aws
@@ -3691,6 +3695,35 @@ def test_forgot_password_user_with_all_recovery_attributes():
         AccountRecoverySetting={
             "RecoveryMechanisms": [{"Name": "verified_phone_number", "Priority": 1}]
         },
+    )
+
+    result = conn.forgot_password(ClientId=client_id, Username=username)
+
+    assert result["CodeDeliveryDetails"]["Destination"] == "555555555"
+    assert result["CodeDeliveryDetails"]["DeliveryMedium"] == "SMS"
+    assert result["CodeDeliveryDetails"]["AttributeName"] == "phone_number"
+
+
+@mock_aws
+def test_forgot_password_without_account_recovery_setting():
+    # A pool created without an AccountRecoverySetting does not get one, and
+    # recovery falls back to the legacy behavior, which prefers SMS over email.
+    conn = boto3.client("cognito-idp", "us-west-2")
+    user_pool = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]
+
+    assert "AccountRecoverySetting" not in user_pool
+
+    client_id = conn.create_user_pool_client(
+        UserPoolId=user_pool["Id"], ClientName=str(uuid.uuid4())
+    )["UserPoolClient"]["ClientId"]
+    username = str(uuid.uuid4())
+    conn.admin_create_user(
+        UserPoolId=user_pool["Id"],
+        Username=username,
+        UserAttributes=[
+            {"Name": "email", "Value": "test@m***"},
+            {"Name": "phone_number", "Value": "555555555"},
+        ],
     )
 
     result = conn.forgot_password(ClientId=client_id, Username=username)


### PR DESCRIPTION
## Problem

`DEFAULT_USER_POOL_CONFIG` includes an `AccountRecoverySetting`:

```python
"AccountRecoverySetting": {
    "RecoveryMechanisms": [
        {"Priority": 1, "Name": "verified_email"},
        {"Priority": 2, "Name": "verified_phone_number"},
    ]
},
```

and `update_extended_config` starts from `DEFAULT_USER_POOL_CONFIG.copy()`, so this is merged into **every** pool. Two consequences:

1. `describe_user_pool` reports an `AccountRecoverySetting` for a pool created without one.
2. `_get_code_delivery_details` takes the lowest `Priority`, so `forgot_password` and `sign_up` always resolve to `DeliveryMedium: EMAIL` on such a pool.

## Why this is wrong

The cognito-idp model documents the absence case explicitly, on `CreateUserPoolRequest`, `UpdateUserPoolRequest` and `UserPoolType` alike:

> In the absence of this setting, Amazon Cognito uses the legacy behavior to determine the recovery method where SMS is preferred through email.

So absence is a real, modeled state, and the fallback is **SMS-first**. moto's injected default is both present when AWS would report nothing, and backwards when it is applied.

This is observable: code under test that inspects `AccountRecoverySetting` to decide whether a pool is configured cannot distinguish "unset" from "set to email-first" under moto, and gets the opposite of AWS's actual recovery preference.

## Change

- Drop `AccountRecoverySetting` from `DEFAULT_USER_POOL_CONFIG`.
- Read it with `.get()` at the two call sites (`forgot_password`, and the `sign_up` path).
- In `_get_code_delivery_details`, fall back to a `LEGACY_ACCOUNT_RECOVERY_MECHANISMS` constant (phone first, then email) when the pool has no setting.

Pools that *do* specify `AccountRecoverySetting` are unaffected.

## Tests

New: `test_forgot_password_without_account_recovery_setting` — a pool created without the setting reports no `AccountRecoverySetting`, and `forgot_password` for a user with both a verified phone and email returns SMS/`phone_number`.

Two existing tests asserted the injected default and are updated. Calling these out explicitly since they are behavior changes, not cosmetic:

- `test_update_user_pool:894` asserted `AccountRecoverySetting is not None` on a pool created without one — now asserts the key is absent.
- `test_forgot_password:3627` asserted `EMAIL`/`email` on a pool created without one — now asserts `SMS`/`phone_number`, which is the documented legacy order.

## Verification

`pytest tests/test_cognitoidp/ --ignore=tests/test_cognitoidp/test_server.py` → **222 passed**.

`ruff check` and `ruff format --check` clean on both changed files with the pinned `ruff==0.14.10`.

`tests/test_cognitoidp/test_server.py` has 4 failures on my machine (`ConnectionError` binding to `0.0.0.0`), but they reproduce identically on a clean checkout of master — Windows-specific and unrelated to this change.