### PR TITLE
EventBridge: honour NextToken/Limit in list_event_buses

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1691,6 +1691,7 @@ class EventsBackend(BaseBackend, TaggableResourcesMixin):
 
         return self.event_buses[name]
 
+    @paginate(pagination_model=PAGINATION_MODEL)
     def list_event_buses(self, name_prefix: str | None) -> list[EventBus]:
         if name_prefix:
             return [

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -280,10 +280,15 @@ class EventsHandler(BaseResponse):
 
     def list_event_buses(self) -> tuple[str, dict[str, Any]]:
         name_prefix = self._get_param("NamePrefix")
-        # ToDo: add 'NextToken' & 'Limit' parameters
+        next_token = self._get_param("NextToken")
+        limit = self._get_param("Limit")
+
+        event_buses, token = self.events_backend.list_event_buses(
+            name_prefix, next_token=next_token, limit=limit
+        )
 
         response = []
-        for event_bus in self.events_backend.list_event_buses(name_prefix):
+        for event_bus in event_buses:
             event_bus_response = {"Name": event_bus.name, "Arn": event_bus.arn}
 
             if event_bus.policy:
@@ -291,7 +296,10 @@ class EventsHandler(BaseResponse):
 
             response.append(event_bus_response)
 
-        return json.dumps({"EventBuses": response}), self.response_headers
+        return (
+            json.dumps({"EventBuses": response, "NextToken": token}),
+            self.response_headers,
+        )
 
     def delete_event_bus(self) -> tuple[str, dict[str, Any]]:
         name = self._get_param("Name")

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -47,6 +47,13 @@ PAGINATION_MODEL = {
         "unique_attribute": "Arn",
         "fail_on_invalid_token": False,
     },
+    "list_event_buses": {
+        "input_token": "next_token",
+        "limit_key": "limit",
+        "limit_default": 50,
+        "unique_attribute": "arn",
+        "fail_on_invalid_token": False,
+    },
 }
 
 _BASE_EVENT_MESSAGE: EventMessageType = {

--- a/tests/test_events/test_events.py
+++ b/tests/test_events/test_events.py
@@ -983,6 +983,54 @@ def test_list_event_buses():
 
 
 @mock_aws
+def test_list_event_buses_with_token():
+    client = boto3.client("events", "us-east-1")
+    for name in ["test-bus-1", "test-bus-2", "other-bus-1", "other-bus-2"]:
+        client.create_event_bus(Name=name)
+
+    response = client.list_event_buses()
+    assert "NextToken" not in response
+    assert len(response["EventBuses"]) == 5
+    #
+    response = client.list_event_buses(Limit=2)
+    assert "NextToken" in response
+    names = [b["Name"] for b in response["EventBuses"]]
+    assert len(names) == 2
+    #
+    response = client.list_event_buses(NextToken=response["NextToken"])
+    assert "NextToken" not in response
+    names += [b["Name"] for b in response["EventBuses"]]
+    assert len(response["EventBuses"]) == 3
+    # every bus is returned exactly once across the pages
+    assert sorted(names) == [
+        "default",
+        "other-bus-1",
+        "other-bus-2",
+        "test-bus-1",
+        "test-bus-2",
+    ]
+
+
+@mock_aws
+def test_list_event_buses_with_prefix_and_token():
+    client = boto3.client("events", "us-east-1")
+    for name in ["test-bus-1", "other-bus-1", "other-bus-2"]:
+        client.create_event_bus(Name=name)
+
+    response = client.list_event_buses(NamePrefix="other-bus", Limit=1)
+    assert "NextToken" in response
+    names = [b["Name"] for b in response["EventBuses"]]
+    assert len(names) == 1
+    #
+    response = client.list_event_buses(
+        NamePrefix="other-bus", NextToken=response["NextToken"]
+    )
+    assert "NextToken" not in response
+    names += [b["Name"] for b in response["EventBuses"]]
+    assert names == ["other-bus-1", "other-bus-2"]
+
+
+@mock_aws
 def test_delete_event_bus():
     client = boto3.client("events", "us-east-1")
     client.create_event_bus(Name="test-bus")


### PR DESCRIPTION
### Problem

`ListEventBuses` takes `NamePrefix`, **`NextToken`** and **`Limit`**, and returns **`NextToken`** alongside `EventBuses`. Moto only honoured `NamePrefix` — the other three were dropped on the floor, with a `# ToDo` marking the gap:

https://github.com/getmoto/moto/blob/master/moto/events/responses.py#L283

So a client asking for a page got the whole list instead:

```python
@mock_aws
def run():
    c = boto3.client("events", region_name="us-east-1")
    for i in range(5):
        c.create_event_bus(Name=f"bus-{i}")

    r = c.list_event_buses(Limit=2)
    print(len(r["EventBuses"]), "NextToken" in r)
```

```
before:  6 False      <- Limit ignored, no token
after:   2 True
```

That's a silent wrong answer rather than an error, so calling code that loops on `NextToken` just processes the first oversized page and stops.

### Fix

`list_rules`, `list_rule_names_by_target` and `list_targets_by_rule` are already wired through the shared `@paginate` helper in this module. This does the same for `list_event_buses` — an entry in `PAGINATION_MODEL` keyed on `arn`, the decorator on the backend method, and the token threaded back through the response. No new machinery.

`NamePrefix` filtering happens in the backend method, so it still applies before paging and composes with `Limit`.

### Tests

`test_list_event_buses_with_token` and `test_list_event_buses_with_prefix_and_token`, written to match the existing `test_list_rules_with_token` / `test_list_rules_with_prefix_and_token` pair. Beyond the page sizes they assert that walking the pages yields every bus **exactly once** and that the last page carries no `NextToken`, since a token that never clears is the failure mode that hangs a client.

The existing `test_list_event_buses` is untouched and still passes — an unparameterised call returns everything with no `NextToken`, exactly as before. (`json.dumps` emits `"NextToken": null` on the last page and botocore drops it, which is the same thing `list_rules` does today.)

I checked the new tests actually bite by mutating the patch three ways:

| Mutation | Result |
|---|---|
| revert the production change, keep the tests | both new tests fail; `test_list_event_buses` still passes |
| drop `NextToken` from the response body | both fail |
| pass `limit=None` into the backend | both fail |

`tests/test_events/` shows an identical set of results before and after the change (the 7 failures on my machine are pre-existing environment gaps — `openapi_spec_validator` missing, and the Docker-backed lambda-trigger test). `ruff check`, `ruff format --check` and `mypy moto/events/` are all clean.