### PR TITLE
EC2: match all security groups when filtering describe_instances

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -348,10 +348,12 @@ def get_object_value(obj: Any, attr: str) -> Any:
         elif isinstance(val, dict):
             val = val[key]
         elif isinstance(val, list):
+            item_values = []
             for item in val:
                 item_val = get_object_value(item, key)
                 if item_val:
-                    return item_val
+                    item_values.append(item_val)
+            return item_values or None
         elif key == "owner_id" and hasattr(val, "account_id"):
             val = val.account_id
         else:

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -798,6 +798,45 @@ def test_get_instances_filtering_by_instance_group_id():
 
 
 @mock_aws
+def test_get_instances_filtering_by_secondary_instance_group():
+    client = boto3.client("ec2", region_name="us-east-1")
+    first_group_name = str(uuid4())[0:6]
+    second_group_name = str(uuid4())[0:6]
+    first_group_id = client.create_security_group(
+        Description="test", GroupName=first_group_name
+    )["GroupId"]
+    second_group_id = client.create_security_group(
+        Description="test", GroupName=second_group_name
+    )["GroupId"]
+    instance_id = client.run_instances(
+        ImageId=EXAMPLE_AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        SecurityGroups=[first_group_name, second_group_name],
+    )["Instances"][0]["InstanceId"]
+
+    for filter_name, filter_value in [
+        ("instance.group-id", second_group_id),
+        ("group-id", second_group_id),
+        ("instance.group-name", second_group_name),
+    ]:
+        reservations = client.describe_instances(
+            Filters=[{"Name": filter_name, "Values": [filter_value]}]
+        )["Reservations"]
+        assert [i["InstanceId"] for r in reservations for i in r["Instances"]] == [
+            instance_id
+        ]
+
+    # the first group must keep matching too
+    reservations = client.describe_instances(
+        Filters=[{"Name": "instance.group-id", "Values": [first_group_id]}]
+    )["Reservations"]
+    assert [i["InstanceId"] for r in reservations for i in r["Instances"]] == [
+        instance_id
+    ]
+
+
+@mock_aws
 def test_get_instances_filtering_by_subnet_id():
     client = boto3.client("ec2", region_name="us-east-1")
 


### PR DESCRIPTION
Closes #10114

`describe_instances` filtered by `group-id`, `instance.group-id` or `instance.group-name` only matched an instance's *first* security group, so an instance in several groups was wrongly excluded when filtered by any of the others.

`get_object_value()` returned as soon as the first list element produced a value, so for a list-valued attribute like `security_groups` only that element's value reached `instance_value_in_filter_values()`. It now collects the value of every element and returns the full list (or `None` when empty), which the filter comparison already handles via its list branch.

`test_get_instances_filtering_by_secondary_instance_group` covers the three affected filters plus the first group; it fails on master and passes with the fix.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
