### PR TITLE
Implement IoT list_principal_things_v2 action

### DIFF
--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -2220,6 +2220,9 @@ class IoTBackend(BaseBackend):
         ]
         return thing_names
 
+    def list_principal_things_v2(self, principal_arn: str) -> list[str]:
+        return self.list_principal_things(principal_arn)
+
     def list_thing_principals(self, thing_name: str) -> list[str]:
         things = [_ for _ in self.things.values() if _.thing_name == thing_name]
         if len(things) == 0:

--- a/moto/iot/responses.py
+++ b/moto/iot/responses.py
@@ -569,6 +569,15 @@ class IoTResponse(BaseResponse):
         next_token = None
         return ActionResult({"things": things, "nextToken": next_token})
 
+    def list_principal_things_v2(self) -> ActionResult:
+        principal = self.headers.get("x-amzn-principal")
+        thing_names = self.iot_backend.list_principal_things_v2(principal_arn=principal)
+
+        # V2 requires a "list of objects" format, not the original "list of strings".
+        principal_thing_objects = [{"thingName": name} for name in thing_names]
+
+        return ActionResult({"principalThingObjects": principal_thing_objects})
+
     def list_thing_principals(self) -> ActionResult:
         thing_name = self._get_param("thingName")
         principals = self.iot_backend.list_thing_principals(thing_name=thing_name)

--- a/tests/test_iot/test_iot.py
+++ b/tests/test_iot/test_iot.py
@@ -169,3 +169,22 @@ def test_list_thing_principals_v2():
 
     # Verify if Principal is correct.
     assert results[0]["principal"] == cert_arn
+
+
+@mock_aws
+def test_list_principal_things_v2():
+    client = boto3.client("iot", region_name="us-east-1")
+    thing_name = "my-test-thing"
+    client.create_thing(thingName=thing_name)
+
+    cert = client.create_keys_and_certificate(setAsActive=True)
+    cert_arn = cert["certificateArn"]
+    client.attach_thing_principal(thingName=thing_name, principal=cert_arn)
+
+    response = client.list_principal_things_v2(principal=cert_arn)
+
+    assert "principalThingObjects" in response
+    results = response["principalThingObjects"]
+    assert len(results) == 1
+    assert isinstance(results[0], dict)
+    assert results[0]["thingName"] == thing_name


### PR DESCRIPTION
Closes #10138.

Adds the `list_principal_things_v2` handler for IoT, mirroring the existing `list_thing_principals_v2` implementation (models.py + responses.py), plus a test in `tests/test_iot/test_iot.py`.

Response shape (`principalThingObjects` -> list of `{thingName}`) matches the `PrincipalThingObject` shape in the botocore IoT service model.