### PR TITLE
APIGateway: add get_tags support for stages

### DIFF
--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -425,6 +425,13 @@ class APIGatewayResponse(BaseResponse):
         )
         return json.dumps(stage_response.to_json())
 
+    def get_tags(self) -> str:
+        url_path_parts = unquote(self.path.split("/tags/")[1]).split("/")
+        function_id = url_path_parts[-3]
+        stage_name = url_path_parts[-1]
+        stage = self.backend.get_stage(function_id, stage_name)
+        return json.dumps({"tags": stage.tags or {}})
+
     def tag_resource(self) -> str:
         url_path_parts = unquote(self.path.split("/tags/")[1]).split("/")
         function_id = url_path_parts[-3]

--- a/tests/test_apigateway/test_apigateway_get_tags.py
+++ b/tests/test_apigateway/test_apigateway_get_tags.py
@@ -1,0 +1,27 @@
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_get_tags_returns_stage_tags():
+    client = boto3.client("apigateway", region_name="us-east-1")
+    api_id = client.create_rest_api(name="my-api")["id"]
+    root_id = client.get_resources(restApiId=api_id)["items"][0]["id"]
+    client.put_method(
+        restApiId=api_id, resourceId=root_id, httpMethod="GET", authorizationType="NONE"
+    )
+    client.put_integration(
+        restApiId=api_id, resourceId=root_id, httpMethod="GET", type="MOCK"
+    )
+    client.create_deployment(restApiId=api_id, stageName="dev")
+    deployment_id = client.get_deployments(restApiId=api_id)["items"][0]["id"]
+    client.create_stage(
+        restApiId=api_id,
+        stageName="test",
+        deploymentId=deployment_id,
+        tags={"env": "prod", "team": "backend"},
+    )
+    arn = f"arn:aws:apigateway:us-east-1::/restapis/{api_id}/stages/test"
+    resp = client.get_tags(resourceArn=arn)
+    assert resp["tags"] == {"env": "prod", "team": "backend"}


### PR DESCRIPTION
This adds `get_tags` for API Gateway, completing the existing `tag_resource` / `untag_resource` pair (which were already implemented for stages). Calling `get_tags` on a stage ARN now returns its tags.

- New `get_tags` handler in `moto/apigateway/responses.py`, consistent with the existing stage-based `tag_resource` / `untag_resource`.
- Added `tests/test_apigateway/test_apigateway_get_tags.py`.

Tested locally: full `tests/test_apigateway/` suite passes (153), `ruff` + `mypy` clean.
