### PR TITLE
StepFunctions: fix apigateway:invoke task parameters being dropped

### DIFF
--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
@@ -18,6 +18,9 @@ from moto.stepfunctions.parser.asl.component.common.error_name.custom_error_name
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
     FailureEvent,
 )
+from moto.stepfunctions.parser.asl.component.state.exec.state_task.credentials import (
+    StateCredentials,
+)
 from moto.stepfunctions.parser.asl.component.state.exec.state_task.service.resource import (
     ResourceCondition,
     ResourceRuntimePart,
@@ -262,7 +265,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         env: Environment,
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
-        task_credentials: Any,
+        state_credentials: StateCredentials,
     ):
         task_parameters: TaskParameters = normalised_parameters
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
@@ -103,7 +103,17 @@ class SfnGatewayException(Exception):
 
 class StateTaskServiceApiGateway(StateTaskServiceCallback):
     _SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {
-        SupportedApiCalls.invoke: {"ApiEndpoint", "Method"}
+        SupportedApiCalls.invoke: {
+            "ApiEndpoint",
+            "Method",
+            "Headers",
+            "Stage",
+            "Path",
+            "QueryParameters",
+            "RequestBody",
+            "AllowNullValues",
+            "AuthType",
+        }
     }
 
     _FORBIDDEN_HTTP_HEADERS_PREFIX: Final[set[str]] = {"X-Forwarded", "X-Amz", "X-Amzn"}
@@ -154,19 +164,19 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         query_parameters = parameters.get("QueryParameters")
         # TODO: add support for AllowNullValues.
         if query_parameters is not None:
-            for key, value in list(query_parameters.items()):
-                if value:
-                    query_parameters[key] = value[-1]
-                else:
-                    query_parameters[key] = ""
-            query_str = f"?{urlencode(query_parameters)}"
+            normalised = {
+                key: "" if value in (None, []) else value
+                for key, value in query_parameters.items()
+            }
+            query_str = f"?{urlencode(normalised, doseq=True)}"
         return query_str
 
     @staticmethod
     def _headers_of(parameters: TaskParameters) -> dict | None:
-        headers = parameters.get("Headers", {})
-        if headers:
-            for key in headers.keys():
+        given_headers = parameters.get("Headers") or {}
+        headers = {}
+        if given_headers:
+            for key, value in given_headers.items():
                 # TODO: the following check takes place at parse time.
                 if key in StateTaskServiceApiGateway._FORBIDDEN_HTTP_HEADERS:
                     raise ValueError(
@@ -179,7 +189,11 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
                         raise ValueError(
                             f"The 'Headers' field contains unsupported values: {key}"
                         )
-            if "RequestBody" in parameters:
+                if isinstance(value, list):
+                    headers[key] = f"[{','.join(value)}]"
+                else:
+                    headers[key] = value
+            if parameters.get("RequestBody") is not None:
                 headers[HEADER_CONTENT_TYPE] = APPLICATION_JSON
         headers["Accept"] = APPLICATION_JSON
         return headers
@@ -193,9 +207,9 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         # http://localhost:4566/restapis/<api-id>/<stage>/_user_request_/<path>(?<query-parameters>)?
         url_tail = "/".join(
             [
-                parameters.get("Stage", ""),
+                parameters.get("Stage") or "",
                 PATH_USER_REQUEST,
-                parameters.get("Path", ""),
+                parameters.get("Path") or "",
                 StateTaskServiceApiGateway._query_parameters_of(parameters) or "",
             ]
         )
@@ -220,7 +234,8 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         if "date" in headers:
             headers["Date"] = [headers.pop("date")]
         headers[HEADER_CONTENT_TYPE] = [APPLICATION_JSON]
-        headers["Content-Length"] = [headers["Content-Length"]]
+        if "Content-Length" in headers:
+            headers["Content-Length"] = [headers["Content-Length"]]
         # TODO: add support for the following generated fields.
         headers["Connection"] = ["keep-alive"]
         headers["x-amz-apigw-id"] = [str(mock_random.uuid4())]
@@ -268,6 +283,15 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         state_credentials: StateCredentials,
     ):
         task_parameters: TaskParameters = normalised_parameters
+
+        auth_type = task_parameters.get("AuthType")
+        if auth_type is not None and auth_type != AuthType.NO_AUTH:
+            LOG.warning(
+                "AuthType '%s' is not supported for apigateway:invoke; the request will be sent without authentication",
+                auth_type,
+            )
+        if task_parameters.get("AllowNullValues"):
+            LOG.warning("AllowNullValues is not supported for apigateway:invoke")
 
         method = task_parameters["Method"]
         invoke_url = self._invoke_url_of(task_parameters)

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
@@ -244,6 +244,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
             error_name = f"ApiGateway.{ex_name}"
             cause = str(ex)
         return FailureEvent(
+            env=env,
             error_name=CustomErrorName(error_name),
             event_type=HistoryEventType.TaskFailed,
             event_details=EventDetails(

--- a/tests/test_stepfunctions/parser/templates/services/apigw_invoke.json
+++ b/tests/test_stepfunctions/parser/templates/services/apigw_invoke.json
@@ -1,0 +1,19 @@
+{
+  "StartAt": "Call",
+  "States": {
+    "Call": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::apigateway:invoke",
+      "Parameters": {
+        "ApiEndpoint.$": "$.ApiEndpoint",
+        "Method": "POST",
+        "Stage": "prod",
+        "Path": "/things",
+        "QueryParameters": {"mode": ["fast", "slow"], "limit": "10", "flag": 0},
+        "RequestBody.$": "$.RequestBody",
+        "Headers": {"Content-Type": ["application/json"], "X-Custom": ["a", "b"]}
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/test_stepfunctions/parser/templates/services/apigw_invoke_dynamic.json
+++ b/tests/test_stepfunctions/parser/templates/services/apigw_invoke_dynamic.json
@@ -1,0 +1,16 @@
+{
+  "StartAt": "Call",
+  "States": {
+    "Call": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::apigateway:invoke",
+      "Parameters": {
+        "ApiEndpoint.$": "$.ApiEndpoint",
+        "Method.$": "$.Method",
+        "Headers.$": "$.Headers",
+        "RequestBody.$": "$.RequestBody"
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/test_stepfunctions/parser/templates/services/apigw_invoke_get.json
+++ b/tests/test_stepfunctions/parser/templates/services/apigw_invoke_get.json
@@ -1,0 +1,18 @@
+{
+  "StartAt": "Call",
+  "States": {
+    "Call": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::apigateway:invoke",
+      "Parameters": {
+        "ApiEndpoint.$": "$.ApiEndpoint",
+        "Method": "GET",
+        "AuthType": "IAM_ROLE",
+        "AllowNullValues": true,
+        "QueryParameters": {"name": "moto", "empty": []},
+        "Headers": {"X-Custom": "single"}
+      },
+      "End": true
+    }
+  }
+}

--- a/tests/test_stepfunctions/parser/test_stepfunctions_apigateway_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_apigateway_integration.py
@@ -9,6 +9,68 @@ from . import verify_execution_result
 
 
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_state_machine_calling_apigateway_invoke():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("No point in testing this in ServerMode")
+
+    received = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            body = self.rfile.read(length) if length else b""
+            received.append(
+                {
+                    "path": self.path,
+                    "body": body.decode(),
+                    "x_custom": self.headers.get("X-Custom"),
+                }
+            )
+            payload = b'{"ok": true}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = SimpleServer(Handler)
+    server.start()
+    _, port = server.get_host_and_port()
+
+    try:
+        exec_input = {
+            "ApiEndpoint": f"http://127.0.0.1:{port}",
+            "RequestBody": {"hello": "world"},
+        }
+
+        def _verify_result(client, execution, execution_arn):
+            output = json.loads(execution["output"])
+            assert output["StatusCode"] == 200
+            assert output["ResponseBody"] == {"ok": True}
+            return True
+
+        verify_execution_result(
+            _verify_result,
+            "SUCCEEDED",
+            "services/apigw_invoke",
+            exec_input=json.dumps(exec_input),
+        )
+
+        assert received == [
+            {
+                "path": "/prod/_user_request_/things/?mode=fast&mode=slow&limit=10&flag=0",
+                "body": '{"hello": "world"}',
+                "x_custom": "[a,b]",
+            }
+        ]
+    finally:
+        server.stop()
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
 def test_state_machine_calling_apigateway_invoke_error():
     if not settings.TEST_DECORATOR_MODE:
         raise SkipTest("No point in testing this in ServerMode")

--- a/tests/test_stepfunctions/parser/test_stepfunctions_apigateway_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_apigateway_integration.py
@@ -2,6 +2,8 @@ import json
 from http.server import BaseHTTPRequestHandler
 from unittest import SkipTest
 
+import pytest
+
 from moto import mock_aws, settings
 from tests.test_core.utilities import SimpleServer
 
@@ -49,7 +51,11 @@ def test_state_machine_calling_apigateway_invoke():
         def _verify_result(client, execution, execution_arn):
             output = json.loads(execution["output"])
             assert output["StatusCode"] == 200
+            assert output["StatusText"] == "OK"
             assert output["ResponseBody"] == {"ok": True}
+            assert output["Headers"]["Content-Type"] == ["application/json"]
+            assert output["Headers"]["Content-Length"] == ["12"]
+            assert "x-amzn-RequestId" in output["Headers"]
             return True
 
         verify_execution_result(
@@ -68,6 +74,93 @@ def test_state_machine_calling_apigateway_invoke():
         ]
     finally:
         server.stop()
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_state_machine_calling_apigateway_invoke_get_without_stage_or_path():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("No point in testing this in ServerMode")
+
+    received = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            received.append(
+                {"path": self.path, "x_custom": self.headers.get("X-Custom")}
+            )
+            payload = b"not json"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = SimpleServer(Handler)
+    server.start()
+    _, port = server.get_host_and_port()
+
+    try:
+        exec_input = {"ApiEndpoint": f"http://127.0.0.1:{port}"}
+
+        def _verify_result(client, execution, execution_arn):
+            output = json.loads(execution["output"])
+            assert output["StatusCode"] == 200
+            assert output["StatusText"] == "OK"
+            assert output["ResponseBody"] == "not json"
+            # The response has no Content-Length, which used to raise a KeyError
+            assert "Content-Length" not in output["Headers"]
+            return True
+
+        verify_execution_result(
+            _verify_result,
+            "SUCCEEDED",
+            "services/apigw_invoke_get",
+            exec_input=json.dumps(exec_input),
+        )
+
+        assert received == [
+            {"path": "/_user_request_//?name=moto&empty=", "x_custom": "single"}
+        ]
+    finally:
+        server.stop()
+
+
+@pytest.mark.parametrize(
+    "method,headers",
+    [
+        ("POST", {"Authorization": "Bearer token"}),
+        ("POST", {"X-Amz-Custom": "value"}),
+        ("GET", {}),
+    ],
+    ids=["forbidden_header", "forbidden_header_prefix", "body_with_get"],
+)
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_state_machine_calling_apigateway_invoke_with_invalid_parameters(
+    method, headers
+):
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("No point in testing this in ServerMode")
+
+    exec_input = {
+        # The request is rejected before it is sent, so this endpoint is never called
+        "ApiEndpoint": "http://127.0.0.1:1",
+        "Method": method,
+        "Headers": headers,
+        "RequestBody": {"hello": "world"},
+    }
+
+    def _verify_result(client, execution, execution_arn):
+        assert execution["error"] == "ApiGateway.ValueError"
+        return True
+
+    verify_execution_result(
+        _verify_result,
+        "FAILED",
+        "services/apigw_invoke_dynamic",
+        exec_input=json.dumps(exec_input),
+    )
 
 
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
@@ -101,7 +194,8 @@ def test_state_machine_calling_apigateway_invoke_error():
         }
 
         def _verify_result(client, execution, execution_arn):
-            assert execution["error"].startswith("ApiGateway.")
+            assert execution["error"] == "ApiGateway.500"
+            assert json.loads(execution["cause"]) == {"message": "broken"}
             return True
 
         verify_execution_result(

--- a/tests/test_stepfunctions/parser/test_stepfunctions_apigateway_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_apigateway_integration.py
@@ -1,0 +1,52 @@
+import json
+from http.server import BaseHTTPRequestHandler
+from unittest import SkipTest
+
+from moto import mock_aws, settings
+from tests.test_core.utilities import SimpleServer
+
+from . import verify_execution_result
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_state_machine_calling_apigateway_invoke_error():
+    if not settings.TEST_DECORATOR_MODE:
+        raise SkipTest("No point in testing this in ServerMode")
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            if length:
+                self.rfile.read(length)
+            payload = b'{"message": "broken"}'
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = SimpleServer(Handler)
+    server.start()
+    _, port = server.get_host_and_port()
+
+    try:
+        exec_input = {
+            "ApiEndpoint": f"http://127.0.0.1:{port}",
+            "RequestBody": {"hello": "world"},
+        }
+
+        def _verify_result(client, execution, execution_arn):
+            assert execution["error"].startswith("ApiGateway.")
+            return True
+
+        verify_execution_result(
+            _verify_result,
+            "FAILED",
+            "services/apigw_invoke",
+            exec_input=json.dumps(exec_input),
+        )
+    finally:
+        server.stop()


### PR DESCRIPTION
## Overview

Closes #10163 

The parser-based StepFunctions implementation only accepted `ApiEndpoint` and `Method` for `apigateway:invoke` tasks, rejecting all other documented parameters.

This PR:
- Accepts the optional request params `Headers`, `Stage`, `Path`, `QueryParameters`, `RequestBody`, `AllowNullValues`, and `AuthType` according to the [docs](https://docs.aws.amazon.com/step-functions/latest/dg/connect-api-gateway.html)
- Preserves multi-value query parameters and headers instead of dropping all but the last value
- Fixes a `KeyError` when the API response has no `Content-Length`, and a `TypeError` (`FailureEvent` missing `env`) that masked real task failures

Added integration tests for the success and failure paths.