### PR TITLE
fix: group-id/group-name filters only matched an instance's first security group

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -348,10 +348,12 @@ def get_object_value(obj: Any, attr: str) -> Any:
         elif isinstance(val, dict):
             val = val[key]
         elif isinstance(val, list):
+            values = []
             for item in val:
                 item_val = get_object_value(item, key)
                 if item_val:
-                    return item_val
+                    values.append(item_val)
+            return values
         elif key == "owner_id" and hasattr(val, "account_id"):
             val = val.account_id
         else:

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -781,6 +781,27 @@ def test_get_instances_filtering_by_instance_group_name():
 
 
 @mock_aws
+def test_get_instances_filtering_by_instance_group_name_multiple_groups():
+    # https://github.com/getmoto/moto/issues/10114
+    # An instance in multiple security groups should be matched by a
+    # group-name filter naming any of its groups, not just the first one.
+    client = boto3.client("ec2", region_name="us-east-1")
+    name1 = str(uuid4())[0:6]
+    name2 = str(uuid4())[0:6]
+    client.create_security_group(Description="test", GroupName=name1)
+    client.create_security_group(Description="test", GroupName=name2)
+    client.run_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, SecurityGroups=[name1, name2]
+    )
+
+    for name in (name1, name2):
+        reservations = client.describe_instances(
+            Filters=[{"Name": "instance.group-name", "Values": [name]}]
+        )["Reservations"]
+        assert len(reservations[0]["Instances"]) == 1
+
+
+@mock_aws
 def test_get_instances_filtering_by_instance_group_id():
     client = boto3.client("ec2", region_name="us-east-1")
     sec_group_name = str(uuid4())[0:6]
@@ -795,6 +816,32 @@ def test_get_instances_filtering_by_instance_group_id():
         Filters=[{"Name": "instance.group-id", "Values": [group_id]}]
     )["Reservations"]
     assert len(reservations[0]["Instances"]) == 1
+
+
+@mock_aws
+def test_get_instances_filtering_by_instance_group_id_multiple_groups():
+    # https://github.com/getmoto/moto/issues/10114
+    # An instance in multiple security groups should be matched by a
+    # group-id filter naming any of its groups, not just the first one.
+    client = boto3.client("ec2", region_name="us-east-1")
+    sg1 = client.create_security_group(Description="test", GroupName=str(uuid4())[0:6])[
+        "GroupId"
+    ]
+    sg2 = client.create_security_group(Description="test", GroupName=str(uuid4())[0:6])[
+        "GroupId"
+    ]
+    client.run_instances(
+        ImageId=EXAMPLE_AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        SecurityGroupIds=[sg1, sg2],
+    )
+
+    for group_id in (sg1, sg2):
+        reservations = client.describe_instances(
+            Filters=[{"Name": "group-id", "Values": [group_id]}]
+        )["Reservations"]
+        assert len(reservations[0]["Instances"]) == 1
 
 
 @mock_aws


### PR DESCRIPTION
get_object_value() in moto/ec2/utils.py returns early on the first
match when walking a list attribute (e.g. an instance's security
groups), so filtering describe_instances by group-id or group-name
only ever matched an instance's first security group. Instances in
multiple groups were silently excluded when filtered by any group
other than the first.

Fixed it to collect all matches into a list instead of returning
early - the calling code (instance_value_in_filter_values) already
expected a list back.

Added tests for both group-id and group-name filters with an
instance in multiple security groups. Confirmed both fail against
the old code (IndexError) and pass with the fix.

Fixes #10114