### PR TITLE
Fix docstring :param: names that do not match the signatures

### DIFF
--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -1452,9 +1452,8 @@ class ConfigBackend(BaseBackend):
         The listing function must exist for the resource backend.
 
         :param resource_type:
-        :param backend_region:
-        :param ids:
-        :param name:
+        :param resource_ids:
+        :param resource_name:
         :param limit:
         :param next_token:
         :return:

--- a/moto/rds/utils.py
+++ b/moto/rds/utils.py
@@ -265,7 +265,7 @@ def valid_preferred_maintenance_window(
 ) -> str | None:
     """Determines validity of preferred_maintenance_window
 
-    :param maintenance_windown:
+    :param maintenance_window:
         type DDD:HH24:MM-DDD:HH24:MM
     :param backup_window:
         type HH24:MM-HH24:MM

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -856,7 +856,6 @@ class LifecycleRule(BaseModel):
     def to_config_dict(self) -> dict[str, Any]:
         """Converts the object to the AWS Config data dict.
 
-        :param kwargs:
         :return:
         """
 


### PR DESCRIPTION
Five `:param:` fields name something the function does not take.

`ConfigBackend.list_discovered_resources` documents `backend_region`, `ids` and `name`. The signature is `(resource_type, resource_ids, resource_name, limit, next_token)` — so `ids` and `name` became `resource_ids` and `resource_name`, and `backend_region` is gone entirely.

`valid_preferred_maintenance_window` documents `maintenance_windown` — one letter off from `maintenance_window`.

`LifecycleRule.to_config_dict` documents `kwargs`; it takes only `self`.

Docstrings only. `ruff check` reports nothing new on the three files, and `ruff format --check` is clean.

Worth noting: #10098 also touches `moto/config/models.py`, but at lines 172 and 499 — no overlap with this change at 1455.
