### PR TITLE
Fix: make create_stack_instances idempotent for existing targets

### DIFF
--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -347,6 +347,14 @@ class StackInstances(BaseModel):
 
         new_instances = []
         for region, account in targets:
+            # Real AWS is idempotent here: creating an instance for an
+            # account/region that the StackSet already targets is a no-op,
+            # not an error - see the CreateStackInstances docs. Without this
+            # guard, a second create_stack_instances() call for an existing
+            # target collides on the underlying stack name and raises
+            # AlreadyExistsException instead of silently skipping it.
+            if self.get_instance(account, region) is not None:
+                continue
             instance = StackInstance(
                 account_id=account,
                 region_name=region,

--- a/tests/test_cloudformation/test_cloudformation_multi_accounts.py
+++ b/tests/test_cloudformation/test_cloudformation_multi_accounts.py
@@ -224,6 +224,31 @@ class TestSelfManagedStacks(TestStackSetMultipleAccounts):
         self._verify_queues(self.acct22, [], region="us-east-2")
         self._verify_queues(DEFAULT_ACCOUNT_ID, [], region="us-east-2")
 
+    def test_create_instances__is_idempotent_for_existing_targets(self):
+        # Real AWS does not error when create_stack_instances() is called
+        # again for an account/region the StackSet already targets - it's a
+        # common pattern to call update_stack_instances() for existing
+        # targets and create_stack_instances() for the full target list,
+        # relying on AWS to skip the ones that already exist.
+        self.client.create_stack_instances(
+            StackSetName=self.name, Accounts=[self.acct01], Regions=["us-east-2"]
+        )
+
+        # Calling this again for the same account/region must not raise
+        # AlreadyExistsException, and must not create a second stack.
+        self.client.create_stack_instances(
+            StackSetName=self.name, Accounts=[self.acct01], Regions=["us-east-2"]
+        )
+
+        self._verify_stack_instance(self.acct01, region="us-east-2")
+        assert len(cf_backends[self.acct01]["us-east-2"].stacks) == 1
+        self._verify_queues(self.acct01, ["testqueue"], region="us-east-2")
+
+        instances = self.client.list_stack_instances(StackSetName=self.name)[
+            "Summaries"
+        ]
+        assert len(instances) == 1
+
     def test_create_instances__multiple_accounts(self):
         self.client.create_stack_instances(
             StackSetName=self.name,


### PR DESCRIPTION
## Bug

Calling `create_stack_instances()` a second time for an account/region a StackSet already targets raises `AlreadyExistsException` instead of being a no-op, as it is on real AWS. This happens because `SELF_MANAGED` StackSets internally call `create_stack(name=f"StackSet:{name}", ...)`, and the second call collides on the same underlying stack name.

Repro (from the issue):
```python
import boto3
from moto import mock_aws

@mock_aws
def test_repro():
    client = boto3.client("cloudformation", region_name="us-east-1")
    client.create_stack_set(StackSetName="my-set", TemplateBody="...")
    client.create_stack_instances(StackSetName="my-set", Accounts=["123456789012"], Regions=["us-east-1"])
    # Second call for the same account/region should be a no-op, but raises:
    client.create_stack_instances(StackSetName="my-set", Accounts=["123456789012"], Regions=["us-east-1"])
```

Per the [CreateStackInstances docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStackInstances.html), it's a common pattern to call `create_stack_instances()` for a full target list and rely on AWS to silently skip targets that already exist.

## Fix

In `StackInstances.create_instances()` (`moto/cloudformation/models.py`), skip any `(account, region)` pair that already has an instance via the existing `get_instance()` lookup, rather than unconditionally creating (and re-creating) a `StackInstance`/underlying stack for it. Scoped narrowly to match the issue's exact repro (idempotency across separate `create_stack_instances()` calls).

## Testing

Added `test_create_instances__is_idempotent_for_existing_targets` to `TestSelfManagedStacks` in `tests/test_cloudformation/test_cloudformation_multi_accounts.py`, asserting a second `create_stack_instances()` call for an existing target does not raise, does not create a second underlying stack, and `list_stack_instances` still reports exactly one instance.

- Confirmed the new test fails against the unfixed code with `AlreadyExistsException: An error occurred (AlreadyExistsException) when calling the CreateStackInstances operation: Stack StackSet:... already exists`.
- Confirmed all 10 tests in `tests/test_cloudformation/test_cloudformation_multi_accounts.py` pass with the fix applied.
- `ruff check` / `ruff format --check` on both changed files report no issues introduced by this change (the 3 pre-existing findings on `master` are unrelated to this diff).

Closes #10171