### PR TITLE
fix(dynamodb): validate Select and honor Scan COUNT

### DIFF
--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -36,6 +36,12 @@ from .exceptions import (
 )
 
 TRANSACTION_MAX_ITEMS = 25
+SELECT_VALUES = [
+    "SPECIFIC_ATTRIBUTES",
+    "COUNT",
+    "ALL_ATTRIBUTES",
+    "ALL_PROJECTED_ATTRIBUTES",
+]
 
 
 def include_consumed_capacity(
@@ -164,6 +170,58 @@ def validate_attributes_used(
         if name not in names_used:
             raise MockValidationException(
                 f"Value provided in ExpressionAttribute{provided_attr} unused in expressions: keys: {{{name}}}"
+            )
+
+
+def validate_select(
+    *,
+    operation: str,
+    select: str | None,
+    projection_expression: str | None,
+    attributes_to_get: list[str] | None,
+    table: Table,
+    index_name: str | None,
+) -> None:
+    if select is None:
+        return
+
+    if select not in SELECT_VALUES:
+        raise MockValidationException(
+            f"1 validation error detected: Value '{select}' at 'select' failed to satisfy constraint: Member must satisfy enum value set: [{', '.join(SELECT_VALUES)}]"
+        )
+
+    validation_prefix = "1 validation error detected: " if operation == "Query" else ""
+
+    if select == "SPECIFIC_ATTRIBUTES" and not (
+        projection_expression or attributes_to_get
+    ):
+        raise MockValidationException(
+            f"{validation_prefix}Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES"
+        )
+
+    if select != "SPECIFIC_ATTRIBUTES":
+        selection_description = "only the Count" if select == "COUNT" else select
+        if projection_expression:
+            raise MockValidationException(
+                f"{validation_prefix}Cannot specify the ProjectionExpression when choosing to get {selection_description}"
+            )
+        if attributes_to_get:
+            raise MockValidationException(
+                f"{validation_prefix}Cannot specify the AttributesToGet when choosing to get {selection_description}"
+            )
+
+    if select == "ALL_PROJECTED_ATTRIBUTES" and index_name is None:
+        raise MockValidationException(
+            f"{validation_prefix}ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName"
+        )
+
+    if select == "ALL_ATTRIBUTES" and index_name:
+        global_index = next(
+            (index for index in table.global_indexes if index.name == index_name), None
+        )
+        if global_index and global_index.projection.get("ProjectionType") != "ALL":
+            raise MockValidationException(
+                f"One or more parameter values were invalid: Select type ALL_ATTRIBUTES is not supported for global secondary index {index_name} because its projection type is not ALL"
             )
 
 
@@ -962,6 +1020,15 @@ class DynamoHandler(BaseResponse):
         scan_index_forward = self.body.get("ScanIndexForward", True)
         consistent_read = self.body.get("ConsistentRead", False)
 
+        validate_select(
+            operation="Query",
+            select=self.body.get("Select"),
+            projection_expression=projection_expression,
+            attributes_to_get=self.body.get("AttributesToGet"),
+            table=self.dynamodb_backend.get_table(name),
+            index_name=index_name,
+        )
+
         items, scanned_count, last_evaluated_key = self.dynamodb_backend.query(
             name,
             hash_key,
@@ -986,7 +1053,7 @@ class DynamoHandler(BaseResponse):
             "ScannedCount": scanned_count,
         }
 
-        if self.body.get("Select", "").upper() != "COUNT":
+        if self.body.get("Select") != "COUNT":
             result["Items"] = [item.attrs for item in items]
 
         if last_evaluated_key is not None:
@@ -1056,6 +1123,15 @@ class DynamoHandler(BaseResponse):
             expression_attribute_names, expression_attribute_names_used
         )
 
+        validate_select(
+            operation="Scan",
+            select=self.body.get("Select"),
+            projection_expression=projection_expression,
+            attributes_to_get=self.body.get("AttributesToGet"),
+            table=self.dynamodb_backend.get_table(name),
+            index_name=index_name,
+        )
+
         try:
             items, scanned_count, last_evaluated_key = self.dynamodb_backend.scan(
                 name,
@@ -1073,11 +1149,12 @@ class DynamoHandler(BaseResponse):
         except ValueError as err:
             raise MockValidationException(f"Bad Filter Expression: {err}")
 
-        result = {
+        result: dict[str, Any] = {
             "Count": len(items),
-            "Items": [item.attrs for item in items],
             "ScannedCount": scanned_count,
         }
+        if self.body.get("Select") != "COUNT":
+            result["Items"] = [item.attrs for item in items]
         if last_evaluated_key is not None:
             result["LastEvaluatedKey"] = last_evaluated_key
         return DynamoResult(result)

--- a/tests/test_dynamodb/__init__.py
+++ b/tests/test_dynamodb/__init__.py
@@ -14,6 +14,7 @@ def dynamodb_aws_verified(
     add_gsi: bool = False,
     add_gsi_range: bool = False,
     gsi_projection_type: str = "ALL",
+    gsi_non_key_attributes: list[str] | None = None,
     add_lsi: bool = False,
     lsi_projection_type: str = "ALL",
     numeric_gsi_range: bool = False,
@@ -46,6 +47,14 @@ def dynamodb_aws_verified(
                 range_type = "N" if numeric_range else "S"
                 gsi_range_type = "N" if numeric_gsi_range else "S"
                 lsi_range_type = "N" if numeric_lsi_range else "S"
+                gsi_projection = {
+                    "ProjectionType": gsi_projection_type,
+                    **(
+                        {"NonKeyAttributes": gsi_non_key_attributes}
+                        if gsi_non_key_attributes
+                        else {}
+                    ),
+                }
 
                 db_kwargs = {
                     "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
@@ -67,7 +76,7 @@ def dynamodb_aws_verified(
                             "KeySchema": [
                                 {"AttributeName": "gsi_pk", "KeyType": "HASH"},
                             ],
-                            "Projection": {"ProjectionType": gsi_projection_type},
+                            "Projection": gsi_projection,
                             "ProvisionedThroughput": {
                                 "ReadCapacityUnits": 1,
                                 "WriteCapacityUnits": 1,
@@ -85,7 +94,7 @@ def dynamodb_aws_verified(
                                 {"AttributeName": "gsi_pk", "KeyType": "HASH"},
                                 {"AttributeName": "gsi_sk", "KeyType": "RANGE"},
                             ],
-                            "Projection": {"ProjectionType": gsi_projection_type},
+                            "Projection": gsi_projection,
                             "ProvisionedThroughput": {
                                 "ReadCapacityUnits": 1,
                                 "WriteCapacityUnits": 1,
@@ -107,7 +116,7 @@ def dynamodb_aws_verified(
                                 {"AttributeName": "gsi_sk", "KeyType": "RANGE"},
                                 {"AttributeName": "gsi_sk2", "KeyType": "RANGE"},
                             ],
-                            "Projection": {"ProjectionType": gsi_projection_type},
+                            "Projection": gsi_projection,
                             "ProvisionedThroughput": {
                                 "ReadCapacityUnits": 1,
                                 "WriteCapacityUnits": 1,

--- a/tests/test_dynamodb/test_dynamodb_select.py
+++ b/tests/test_dynamodb/test_dynamodb_select.py
@@ -1,0 +1,300 @@
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from . import dynamodb_aws_verified
+
+
+def _read(client, operation, table_name, index_name=None, **kwargs):
+    request = {"TableName": table_name, **kwargs}
+    if index_name:
+        request["IndexName"] = index_name
+
+    if operation == "query":
+        key_name = "gsi_pk" if index_name == "test_gsi" else "pk"
+        request["KeyConditionExpression"] = f"{key_name} = :key"
+        request["ExpressionAttributeValues"] = {":key": {"S": "value"}}
+        return client.query(**request)
+
+    return client.scan(**request)
+
+
+def _validation_error(exc):
+    error = exc.value.response["Error"]
+    assert error["Code"] == "ValidationException"
+    return error["Message"]
+
+
+def _assert_validation_error(exc, expected_message):
+    assert _validation_error(exc) == expected_message
+
+
+def _assert_all_attributes_rejected_for_gsi(operation, table_name):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    response = _read(
+        client,
+        operation,
+        table_name,
+        index_name="test_lsi",
+        Select="ALL_ATTRIBUTES",
+    )
+    assert response["Count"] == 0
+
+    response = _read(
+        client,
+        operation,
+        table_name,
+        index_name="test_gsi",
+        Select="ALL_PROJECTED_ATTRIBUTES",
+    )
+    assert response["Count"] == 0
+
+    with pytest.raises(ClientError) as exc:
+        _read(
+            client,
+            operation,
+            table_name,
+            index_name="test_gsi",
+            Select="ALL_ATTRIBUTES",
+        )
+
+    _assert_validation_error(
+        exc,
+        "One or more parameter values were invalid: Select type ALL_ATTRIBUTES "
+        "is not supported for global secondary index test_gsi because its projection "
+        "type is not ALL",
+    )
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified(
+    add_range=True,
+    add_gsi=True,
+    gsi_projection_type="KEYS_ONLY",
+    add_lsi=True,
+    lsi_projection_type="KEYS_ONLY",
+)
+@pytest.mark.parametrize("operation", ["query", "scan"])
+def test_all_attributes_rejected_for_keys_only_gsi(operation, table_name=None):
+    _assert_all_attributes_rejected_for_gsi(operation, table_name)
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified(
+    add_range=True,
+    add_gsi=True,
+    gsi_projection_type="INCLUDE",
+    gsi_non_key_attributes=["projected"],
+    add_lsi=True,
+    lsi_projection_type="KEYS_ONLY",
+)
+@pytest.mark.parametrize("operation", ["query", "scan"])
+def test_all_attributes_rejected_for_include_gsi(operation, table_name=None):
+    _assert_all_attributes_rejected_for_gsi(operation, table_name)
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified(add_gsi=True)
+@pytest.mark.parametrize(
+    "operation, expected_message",
+    [
+        (
+            "query",
+            (
+                "1 validation error detected: ALL_PROJECTED_ATTRIBUTES can be used only "
+                "when Querying using an IndexName"
+            ),
+        ),
+        (
+            "scan",
+            "ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName",
+        ),
+    ],
+)
+def test_all_projected_attributes_rejected_for_table(
+    operation, expected_message, table_name=None
+):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    response = _read(
+        client,
+        operation,
+        table_name,
+        index_name="test_gsi",
+        Select="ALL_PROJECTED_ATTRIBUTES",
+    )
+    assert response["Count"] == 0
+
+    with pytest.raises(ClientError) as exc:
+        _read(client, operation, table_name, Select="ALL_PROJECTED_ATTRIBUTES")
+
+    _assert_validation_error(exc, expected_message)
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified()
+@pytest.mark.parametrize(
+    "operation, expected_message",
+    [
+        (
+            "query",
+            (
+                "1 validation error detected: Must specify the AttributesToGet or "
+                "ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES"
+            ),
+        ),
+        (
+            "scan",
+            (
+                "Must specify the AttributesToGet or ProjectionExpression when choosing "
+                "to get SPECIFIC_ATTRIBUTES"
+            ),
+        ),
+    ],
+)
+def test_specific_attributes_requires_attribute_selection(
+    operation, expected_message, table_name=None
+):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    response = _read(
+        client,
+        operation,
+        table_name,
+        Select="SPECIFIC_ATTRIBUTES",
+        ProjectionExpression="pk",
+    )
+    assert response["Count"] == 0
+
+    with pytest.raises(ClientError) as exc:
+        _read(client, operation, table_name, Select="SPECIFIC_ATTRIBUTES")
+
+    _assert_validation_error(exc, expected_message)
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified(add_gsi=True)
+@pytest.mark.parametrize(
+    "select, selection_description",
+    [
+        ("ALL_ATTRIBUTES", "ALL_ATTRIBUTES"),
+        ("ALL_PROJECTED_ATTRIBUTES", "ALL_PROJECTED_ATTRIBUTES"),
+        ("COUNT", "only the Count"),
+    ],
+)
+@pytest.mark.parametrize(
+    "operation, message_prefix",
+    [("query", "1 validation error detected: "), ("scan", "")],
+)
+def test_projection_expression_rejected_for_non_specific_select(
+    select, selection_description, operation, message_prefix, table_name=None
+):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    response = _read(
+        client,
+        operation,
+        table_name,
+        index_name="test_gsi",
+        Select=select,
+    )
+    assert response["Count"] == 0
+
+    with pytest.raises(ClientError) as exc:
+        _read(
+            client,
+            operation,
+            table_name,
+            index_name="test_gsi",
+            Select=select,
+            ProjectionExpression="gsi_pk",
+        )
+
+    _assert_validation_error(
+        exc,
+        f"{message_prefix}Cannot specify the ProjectionExpression when choosing "
+        f"to get {selection_description}",
+    )
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified(add_gsi=True)
+@pytest.mark.parametrize(
+    "operation, message_prefix",
+    [("query", "1 validation error detected: "), ("scan", "")],
+)
+def test_attributes_to_get_rejected_for_non_specific_select(
+    operation, message_prefix, table_name=None
+):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    request = {
+        "TableName": table_name,
+        "IndexName": "test_gsi",
+        "AttributesToGet": ["gsi_pk"],
+    }
+    if operation == "query":
+        request["KeyConditions"] = {
+            "gsi_pk": {
+                "ComparisonOperator": "EQ",
+                "AttributeValueList": [{"S": "value"}],
+            }
+        }
+
+    response = getattr(client, operation)(Select="SPECIFIC_ATTRIBUTES", **request)
+    assert response["Count"] == 0
+
+    for select, selection_description in [
+        ("ALL_ATTRIBUTES", "ALL_ATTRIBUTES"),
+        ("ALL_PROJECTED_ATTRIBUTES", "ALL_PROJECTED_ATTRIBUTES"),
+        ("COUNT", "only the Count"),
+    ]:
+        with pytest.raises(ClientError) as exc:
+            getattr(client, operation)(Select=select, **request)
+
+        _assert_validation_error(
+            exc,
+            f"{message_prefix}Cannot specify the AttributesToGet when choosing "
+            f"to get {selection_description}",
+        )
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified()
+@pytest.mark.parametrize("operation", ["query", "scan"])
+def test_select_values_are_case_sensitive(operation, table_name=None):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    response = _read(client, operation, table_name, Select="COUNT")
+    assert response["Count"] == 0
+    assert "Items" not in response
+
+    with pytest.raises(ClientError) as exc:
+        _read(client, operation, table_name, Select="count")
+
+    _assert_validation_error(
+        exc,
+        "1 validation error detected: Value 'count' at 'select' failed to satisfy "
+        "constraint: Member must satisfy enum value set: [SPECIFIC_ATTRIBUTES, "
+        "COUNT, ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES]",
+    )
+
+
+@pytest.mark.aws_verified
+@dynamodb_aws_verified()
+def test_scan_count_omits_items_and_preserves_pagination(table_name=None):
+    client = boto3.client("dynamodb", region_name="us-east-1")
+    client.put_item(TableName=table_name, Item={"pk": {"S": "first"}})
+    client.put_item(TableName=table_name, Item={"pk": {"S": "second"}})
+
+    response = client.scan(
+        TableName=table_name,
+        Select="COUNT",
+        Limit=1,
+        ConsistentRead=True,
+    )
+
+    assert response["Count"] == 1
+    assert response["ScannedCount"] == 1
+    assert "Items" not in response
+    assert "LastEvaluatedKey" in response


### PR DESCRIPTION
DynamoDB enforces validation rules for `Select` on `Query` and `Scan`, but Moto silently accepts invalid combinations and includes `Items` in `Scan` responses when `Select="COUNT"`.

This PR adds 19 AWS-verified test cases covering GSI projection restrictions, invalid `ProjectionExpression` and `AttributesToGet` combinations, case-sensitive `Select` values, and `COUNT` response handling. Each case was confirmed to fail against Moto and pass against DynamoDB before the implementation was updated. The shared validation and response-handling changes make those same cases pass against Moto.

Fixes #10174.