### PR TITLE
Core: guard against duplicate references in `BackendDict._instances`

### DIFF
--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -376,6 +376,7 @@ class BackendDict(dict[str, AccountSpecificBackend[SERVICE_BACKEND]]):
                     use_boto3_regions=self._use_boto3_regions,
                     additional_regions=self._additional_regions,
                 )
+            if self not in BackendDict._instances:  # type: ignore[misc]
                 BackendDict._instances.append(self)  # type: ignore[misc]
 
     def iter_backends(self) -> Iterator[tuple[str, str, BaseBackend]]:

--- a/tests/test_core/test_resource_tagging.py
+++ b/tests/test_core/test_resource_tagging.py
@@ -1,8 +1,10 @@
+from collections.abc import Iterator
 from unittest import SkipTest
 
 import pytest
 
 from moto import mock_aws, settings
+from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.resource_tagging import (
     TaggableResourcesMixin,
     TaggedResource,
@@ -85,6 +87,34 @@ def test_iter_taggable_backends_skips_untouched_accounts() -> None:
     # Account that's never been touched by any service should yield nothing.
     other_account = list(iter_taggable_backends("999999999999", "us-east-1"))
     assert other_account == []
+
+
+@mock_aws
+def test_iter_taggable_backends_does_not_duplicates_after_second_account() -> None:
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("No direct access to backends in Server Mode")
+
+    class FakeBackend(BaseBackend, TaggableResourcesMixin):
+        SERVICE_NAMESPACE = "fake"
+
+        def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+            yield TaggedResource(
+                arn=f"arn:aws:fake:{self.region_name}:{self.account_id}:thing/1",
+                tags={},
+                resource_type="fake:thing",
+            )
+
+    fake_backends = BackendDict(
+        FakeBackend, "fake", use_boto3_regions=False, additional_regions=["us-east-1"]
+    )
+
+    fake_backends["111111111111"]["us-east-1"]
+    assert len(list(iter_taggable_backends("111111111111", "us-east-1"))) == 1
+
+    # A second, unrelated account touching the same service shouln't corrupt
+    # first account's results.
+    fake_backends["222222222222"]["us-east-1"]
+    assert len(list(iter_taggable_backends("111111111111", "us-east-1"))) == 2
 
 
 def test_default_owns_arn() -> None:

--- a/tests/test_core/test_resource_tagging.py
+++ b/tests/test_core/test_resource_tagging.py
@@ -114,7 +114,7 @@ def test_iter_taggable_backends_does_not_duplicates_after_second_account() -> No
     # A second, unrelated account touching the same service shouln't corrupt
     # first account's results.
     fake_backends["222222222222"]["us-east-1"]
-    assert len(list(iter_taggable_backends("111111111111", "us-east-1"))) == 2
+    assert len(list(iter_taggable_backends("111111111111", "us-east-1"))) == 1
 
 
 def test_default_owns_arn() -> None:


### PR DESCRIPTION
Adds a regression test for #10167. Every service backend registers itself in a global list (BackendDict._instances) the first time each AWS account uses it, but nothing checks whether it's already there. Once a second account has touched a service within a long-lived moto_server process, resourcegroupstaggingapi.get_resources() returns every other account's resources twice. This only shows up in server mode, since @mock_aws resets that list before and after every test. 