### PR TITLE
dynamodb: fix Number attribute size calculation to use significant digits

### DIFF
--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -22,6 +22,24 @@ deserializer = TypeDeserializer()
 serializer = TypeSerializer()
 
 
+def _number_size(raw_value: str) -> int:
+    """
+    Approximate the on-disk size of a DynamoDB Number attribute, matching
+    AWS's documented item-size rules:
+    https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CapacityUnitCalculations.html
+
+    "The size of a number is approximately (1 byte per two significant
+    digits) + (1 byte)." Leading and trailing zeroes are trimmed before
+    counting significant digits, 0 itself has no significant digits, and
+    negative numbers use an extra byte for the sign.
+    """
+    is_negative = raw_value.startswith("-")
+    digits_only = raw_value.lstrip("-").replace(".", "")
+    significant_digits = digits_only.strip("0")
+    digit_count = len(significant_digits)
+    return -(-digit_count // 2) + (2 if is_negative else 1)
+
+
 class DDBType:
     """
     Official documentation at https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html
@@ -214,7 +232,7 @@ class DynamoType:
 
     def size(self) -> int:
         if self.is_number():
-            value_size = len(str(self.value))
+            value_size = _number_size(str(self.value))
         elif self.is_set():
             sub_type = self.type[0]
             value_size = sum([DynamoType({sub_type: v}).size() for v in self.value])

--- a/tests/test_dynamodb/models/test_dynamo_type_size.py
+++ b/tests/test_dynamodb/models/test_dynamo_type_size.py
@@ -1,0 +1,52 @@
+import pytest
+
+from moto.dynamodb.models.dynamo_type import DynamoType, _number_size
+
+
+class TestNumberSize:
+    """
+    DynamoDB's Number attribute size is documented at
+    https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CapacityUnitCalculations.html
+    as "approximately (1 byte per two significant digits) + (1 byte)", with
+    leading/trailing zeroes trimmed before counting significant digits.
+
+    Regression coverage for a bug where `DynamoType.size()` used
+    `len(str(value))` -- the length of the raw decimal string -- instead of
+    this compact, significant-digit-based encoding. That overcounted the
+    size of any Number attribute whose string form is longer than its
+    significant-digit encoding (which is most numbers), making moto's 400KB
+    item-size check stricter than real DynamoDB and rejecting items that
+    DynamoDB itself would accept.
+    """
+
+    @pytest.mark.parametrize(
+        "raw_value,expected_size",
+        [
+            # Worked examples from AWS's own documentation/blog writeups.
+            ("27", 2),
+            ("-27", 3),
+            ("461", 3),
+            ("0", 1),
+            # A 10-significant-digit Unix timestamp: the old `len(str(value))`
+            # behavior returned 10 here instead of the documented 6.
+            ("1786461547", 6),
+            # Leading/trailing zeroes are trimmed before counting digits.
+            ("100", 2),
+            ("00042", 2),
+            ("0.5", 2),
+            ("-0.010", 3),
+            # 38 significant digits is DynamoDB's documented maximum.
+            ("1" * 38, 20),
+        ],
+    )
+    def test_number_size_matches_documented_formula(self, raw_value, expected_size):
+        assert _number_size(raw_value) == expected_size
+
+    def test_dynamo_type_number_uses_significant_digit_encoding(self):
+        # Same timestamp as the reported bug: previously sized as 10 bytes
+        # (len of the decimal string) instead of the correct 6.
+        assert DynamoType({"N": "1786461547"}).size() == 6
+
+    def test_dynamo_type_number_set_sums_member_sizes(self):
+        number_set = DynamoType({"NS": ["27", "-27", "461"]})
+        assert number_set.size() == 2 + 3 + 3


### PR DESCRIPTION
Found this one while poking around moto's DynamoDB code, seemed like a good self-contained bug to learn the item-size logic a bit better.

Issue: #10176

## What I changed

`DynamoType.size()` was computing a Number attribute's size as `len(str(value))`, basically just the length of the decimal string. Real DynamoDB actually uses a more compact encoding based on significant digits, roughly 1 byte per two significant digits plus 1 byte, with leading and trailing zeros trimmed first. This is documented here: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/CapacityUnitCalculations.html

So moto was overcounting the size of most numbers, which made its 400KB item-size check stricter than the real thing and could reject items that real DynamoDB would accept. The issue's example was a 10-digit timestamp like `1786461547`, sized as 10 bytes by moto instead of the documented 6.

I added a small `_number_size()` helper that strips the sign, drops the decimal point, trims leading/trailing zeros, and applies the "1 byte per 2 significant digits + 1 byte" formula, and swapped it in for the old `len(str(value))` call.

## Testing

- Added `tests/test_dynamodb/models/test_dynamo_type_size.py` with parametrized cases checked against AWS's own worked examples (27 -> 2 bytes, -27 -> 3 bytes, 461 -> 3 bytes, zero-trimming cases, the 38-significant-digit max), plus a direct regression test for the timestamp from the issue and a NumberSet sum-of-members check. 12 new tests, all passing.
- Ran the full `tests/test_dynamodb/` suite (718 tests) locally, all still passing, including the existing `test_item_size_is_under_400KB` test.
- `ruff check` / `ruff format --check` on the touched files come back clean (double-checked the pre-existing lint warnings elsewhere in `dynamo_type.py` are unrelated to this change, they're on upstream master too).
- `mypy` on the touched file: no issues.

One honest caveat: I didn't try to reproduce the exact `put_item` call from the issue end-to-end, since moto intentionally sets its internal size cap a bit below the real 400KB/409600-byte limit as a safety margin (there's a comment in `LimitedSizeDict` about this), so the issue's specific byte counts don't line up perfectly with moto's cap either way. The actual bug, the wrong Number size formula, is what I focused on fixing and testing directly.

Let me know if I should tweak anything, still getting familiar with this codebase.
