### PR TITLE
Fix RuntimeError in get_block_device_mapping

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -316,7 +316,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
 
     @property
     def get_block_device_mapping(self) -> ItemsView[str, Any]:  # type: ignore[misc]
-        return self.block_device_mapping.items()
+        return list(self.block_device_mapping.items())
 
     @staticmethod
     def get_block_device_status(volume_status: str) -> str:


### PR DESCRIPTION
In a multi-threaded situation, the block_device_mapping dictionary can change in one thread while another thread is iterating over it using get_block_device_mapping.  Fix that by returning a list instead of an iterator (as we do for the network_interfaces property below).

Last few lines of a sample traceback:

```
  File "/home/zuul/src/opendev.org/zuul/zuul/.nox/tests-3-14/lib/python3.14/site-packages/moto/core/serialize.py", line 1282, in __call__
    value = get_value(obj, possible_key, MISSING)
  File "/home/zuul/src/opendev.org/zuul/zuul/.nox/tests-3-14/lib/python3.14/site-packages/moto/core/utils.py", line 483, in get_value
    return _get_value_for_key(obj, key, default)
  File "/home/zuul/src/opendev.org/zuul/zuul/.nox/tests-3-14/lib/python3.14/site-packages/moto/core/utils.py", line 496, in _get_value_for_key
    return getattr(obj, str(key), default)
  File "/home/zuul/src/opendev.org/zuul/zuul/.nox/tests-3-14/lib/python3.14/site-packages/moto/ec2/models/instances.py", line 334, in block_device_mappings
    for device_name, block in self.get_block_device_mapping:
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

RuntimeError: dictionary changed size during iteration
```