### PR TITLE
fix(dynamodb): BETWEEN filter incorrectly excludes attribute value 0

### DIFF
--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -1229,16 +1229,17 @@ class FuncBetween(Func):
         start = self.start.expr(item)
         attr = self.attr.expr(item)
         end = self.end.expr(item)
-        # Need to verify whether start has a valid value
-        # Can't just check  'if start', because start could be 0, which is a valid number
+        # Need to verify whether start/attr/end have a valid value
+        # Can't just check 'if start', because start could be 0, which is a valid number
         start_has_value = start is not None and (isinstance(start, Decimal) or start)
+        attr_has_value = attr is not None and (isinstance(attr, Decimal) or attr)
         end_has_value = end is not None and (isinstance(end, Decimal) or end)
-        if start_has_value and attr and end_has_value:
+        if start_has_value and attr_has_value and end_has_value:
             return start <= attr <= end
         elif start is None and attr is None:
             # None is between None and None as well as None is between None and any number
             return True
-        elif start is None and attr and end:
+        elif start is None and attr_has_value and end_has_value:
             return attr <= end
         else:
             return False

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -1403,6 +1403,30 @@ def test_filter_expression():
     )
     assert filter_expr.expr(row1) is True
 
+    # BETWEEN test where the attribute itself is exactly 0 -- regression test.
+    # 0 is a valid Decimal value and must not be treated as "no value" via
+    # bare truthiness (bool(Decimal("0")) is False), the same way start/end
+    # already correctly special-case 0. Item with Id=0 must be included in
+    # a BETWEEN 0 AND 10 (and BETWEEN -5 AND 10) range.
+    row_zero = moto.dynamodb.models.Item(
+        hash_key=None,
+        range_key=None,
+        attrs={"Id": {"N": "0"}},
+    )
+    filter_expr = moto.dynamodb.comparisons.get_filter_expression(
+        "Id BETWEEN :v0 AND :v1", {}, {":v0": {"N": "0"}, ":v1": {"N": "10"}}
+    )
+    assert filter_expr.expr(row_zero) is True
+    filter_expr = moto.dynamodb.comparisons.get_filter_expression(
+        "Id BETWEEN :v0 AND :v1", {}, {":v0": {"N": "-5"}, ":v1": {"N": "10"}}
+    )
+    assert filter_expr.expr(row_zero) is True
+    # And it must still correctly exclude 0 when it falls outside the range.
+    filter_expr = moto.dynamodb.comparisons.get_filter_expression(
+        "Id BETWEEN :v0 AND :v1", {}, {":v0": {"N": "1"}, ":v1": {"N": "10"}}
+    )
+    assert filter_expr.expr(row_zero) is False
+
     # PAREN test
     filter_expr = moto.dynamodb.comparisons.get_filter_expression(
         "Id = :v0 AND (Subs = :v0 OR Subs = :v1)",


### PR DESCRIPTION
## Bug

DynamoDB `BETWEEN` filtering incorrectly excludes items whose attribute
value is exactly `0`, even when `0` is within the specified range.

## Root cause

`FuncBetween.expr()` checked the tested attribute using bare Python
truthiness (`and attr`). Since `Decimal("0")` is falsy, an attribute
whose value is zero was incorrectly treated as having no value.

The `start` and `end` operands already use zero-safe checks for this
exact case.

## Fix

Apply the same zero-safe value check to the attribute being tested.

## Testing

- Added regression coverage for attribute value `0`
- Confirmed the regression test fails on the unfixed code
- Confirmed the targeted tests pass after the fix
- `3/3` relevant tests pass
- `git diff --check` passes
