### PR TITLE
EMRServerless: add `executionRole` to `GetJobRun` response

### DIFF
--- a/moto/emrserverless/models.py
+++ b/moto/emrserverless/models.py
@@ -134,6 +134,10 @@ class JobRun(BaseModel):
 
         self.tags = tags
 
+    @property
+    def execution_role(self) -> str:
+        return self.execution_role_arn
+
 
 class EMRServerlessBackend(BaseBackend):
     """Implementation of EMRServerless APIs."""

--- a/tests/test_emrserverless/test_emrserverless.py
+++ b/tests/test_emrserverless/test_emrserverless.py
@@ -776,6 +776,10 @@ class TestGetJobRun:
                 assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
                 assert resp["jobRun"]["applicationId"] == app_id
                 assert resp["jobRun"]["jobRunId"] == run_id
+                assert re.match(
+                    r"arn:(.*?):role/emr-serverless-role",
+                    resp["jobRun"]["executionRole"],
+                )
 
     def test_invalid_application_id(self):
         for _, run_ids in self.job_run_lookup.items():


### PR DESCRIPTION
Fixes #10188 