### PR TITLE
Payment Cryptography: add full control plane support

### DIFF
--- a/docs/docs/services/payment-cryptography.rst
+++ b/docs/docs/services/payment-cryptography.rst
@@ -1,0 +1,48 @@
+.. _implementedservice_payment-cryptography:
+
+====================
+payment-cryptography
+====================
+
+.. autoclass:: moto.paymentcryptography.models.PaymentCryptographyControlPlaneBackend
+
+Implemented features
+--------------------
+
+- [X] add_key_replication_regions
+- [X] associate_mpa_team
+- [X] create_alias
+- [X] create_key
+- [X] delete_alias
+- [X] delete_key
+- [X] delete_resource_policy
+- [X] disable_default_key_replication_regions
+- [X] disassociate_mpa_team
+- [X] enable_default_key_replication_regions
+- [X] export_key
+- [X] get_alias
+- [X] get_certificate_signing_request
+- [X] get_default_key_replication_regions
+- [X] get_key
+- [X] get_mpa_team_association
+- [X] get_parameters_for_export
+- [X] get_parameters_for_import
+- [X] get_public_key_certificate
+- [X] get_resource_policy
+- [X] import_key
+- [X] list_aliases
+- [X] list_keys
+- [X] list_tags_for_resource
+- [X] put_resource_policy
+- [X] remove_key_replication_regions
+- [X] restore_key
+- [X] start_key_usage
+- [X] stop_key_usage
+- [X] tag_resource
+- [X] untag_resource
+- [X] update_alias
+
+The control plane stores key material only to preserve coherent state for future
+data-plane support. Import and export responses are suitable for mocked workflows;
+they do not emulate an AWS hardware security module or provide TR-31/TR-34
+interoperability guarantees.

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -168,6 +168,12 @@ backend_url_patterns = [
     ("opensearchserverless", re.compile("https?://aoss\\.(.+)\\.amazonaws\\.com")),
     ("organizations", re.compile("https?://organizations\\.(.+)\\.amazonaws\\.com")),
     ("osis", re.compile("https?://osis\\.(.+)\\.amazonaws\\.com")),
+    (
+        "paymentcryptography",
+        re.compile(
+            "https?://controlplane\\.payment-cryptography\\.(.+)\\.amazonaws\\.com"
+        ),
+    ),
     ("personalize", re.compile("https?://personalize\\.(.+)\\.amazonaws\\.com")),
     ("pinpoint", re.compile("https?://pinpoint\\.(.+)\\.amazonaws\\.com")),
     ("pipes", re.compile("https?://pipes\\.(.+)\\.amazonaws\\.com")),

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -49,6 +49,7 @@ SIGNING_ALIASES = {
     "execute-api": "iot",
     "iotdata": "data.iot",
     "mobiletargeting": "pinpoint",
+    "payment-cryptography": "controlplane.payment-cryptography",
 }
 
 # Some services are only recognizable by the version

--- a/moto/paymentcryptography/__init__.py
+++ b/moto/paymentcryptography/__init__.py
@@ -1,0 +1,1 @@
+from .models import paymentcryptography_backends  # noqa: F401

--- a/moto/paymentcryptography/exceptions.py
+++ b/moto/paymentcryptography/exceptions.py
@@ -1,0 +1,27 @@
+from moto.core.exceptions import JsonRESTError
+
+
+class PaymentCryptographyError(JsonRESTError):
+    code = 400
+
+    def __init__(self, error_type: str, message: str):
+        super().__init__(error_type, message)
+
+
+class ConflictException(PaymentCryptographyError):
+    code = 409
+
+    def __init__(self, message: str):
+        super().__init__("ConflictException", message)
+
+
+class ResourceNotFoundException(PaymentCryptographyError):
+    code = 404
+
+    def __init__(self, message: str):
+        super().__init__("ResourceNotFoundException", message)
+
+
+class ValidationException(PaymentCryptographyError):
+    def __init__(self, message: str):
+        super().__init__("ValidationException", message)

--- a/moto/paymentcryptography/models.py
+++ b/moto/paymentcryptography/models.py
@@ -9,8 +9,11 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+from cryptography.hazmat.primitives import cmac, hashes, hmac, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.ciphers import Cipher, modes
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.x509.oid import NameOID
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -51,6 +54,51 @@ def _material_size(algorithm: str) -> int:
     return sizes.get(algorithm, 32)
 
 
+def _private_key(algorithm: str) -> Any:
+    rsa_sizes = {"RSA_2048": 2048, "RSA_3072": 3072, "RSA_4096": 4096}
+    curves = {
+        "ECC_NIST_P256": ec.SECP256R1,
+        "ECC_NIST_P384": ec.SECP384R1,
+        "ECC_NIST_P521": ec.SECP521R1,
+    }
+    if algorithm in rsa_sizes:
+        return rsa.generate_private_key(
+            public_exponent=65537, key_size=rsa_sizes[algorithm]
+        )
+    if algorithm in curves:
+        return ec.generate_private_key(curves[algorithm]())
+    return None
+
+
+def _calculate_kcv(
+    material: bytes, algorithm: str, kcv_algorithm: str, private_key: Any = None
+) -> str:
+    if algorithm.startswith("AES") and kcv_algorithm == "CMAC":
+        cmac_calculator = cmac.CMAC(AES(material))
+        cmac_calculator.update(bytes(16))
+        return cmac_calculator.finalize()[:3].hex().upper()
+    if algorithm.startswith("TDES") and kcv_algorithm == "ANSI_X9_24":
+        encryptor = Cipher(TripleDES(material), modes.ECB()).encryptor()
+        return encryptor.update(bytes(8))[:3].hex().upper()
+    if algorithm.startswith("HMAC") and kcv_algorithm == "HMAC":
+        digest = {
+            "HMAC_SHA224": hashes.SHA224,
+            "HMAC_SHA256": hashes.SHA256,
+            "HMAC_SHA384": hashes.SHA384,
+            "HMAC_SHA512": hashes.SHA512,
+        }.get(algorithm, hashes.SHA256)
+        digest_algorithm = digest()
+        hmac_calculator = hmac.HMAC(material, digest_algorithm)
+        hmac_calculator.update(bytes(digest_algorithm.digest_size))
+        return hmac_calculator.finalize()[:3].hex().upper()
+    if private_key is not None:
+        material = private_key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    return hashlib.sha1(material).hexdigest().upper()[:6]  # noqa: S324
+
+
 class Key:
     def __init__(
         self,
@@ -75,13 +123,39 @@ class Key:
         self.exportable = exportable
         self.enabled = enabled
         self.origin = origin
-        self.material = material or os.urandom(
-            _material_size(attributes.get("KeyAlgorithm", ""))
+        algorithm = attributes.get("KeyAlgorithm", "")
+        expected_class = (
+            "ASYMMETRIC_KEY_PAIR"
+            if algorithm.startswith(("RSA", "ECC"))
+            and origin == "AWS_PAYMENT_CRYPTOGRAPHY"
+            else None
         )
+        if expected_class and attributes.get("KeyClass") != expected_class:
+            raise ValidationException(
+                f"{algorithm} requires KeyClass {expected_class} when creating a key"
+            )
+        self.private_key: Any = _private_key(algorithm) if material is None else None
+        if material is not None:
+            self.material = material
+        elif self.private_key is not None:
+            self.material = self.private_key.private_bytes(
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        else:
+            self.material = os.urandom(_material_size(algorithm))
         self.kcv_algorithm = kcv_algorithm or _default_kcv_algorithm(
             attributes.get("KeyAlgorithm", "")
         )
-        self.kcv = hashlib.sha256(self.material).hexdigest().upper()[:6]
+        expected_kcv = _default_kcv_algorithm(algorithm)
+        if self.kcv_algorithm != expected_kcv:
+            raise ValidationException(
+                f"{self.kcv_algorithm} is not valid for {algorithm}; expected {expected_kcv}"
+            )
+        self.kcv = _calculate_kcv(
+            self.material, algorithm, self.kcv_algorithm, self.private_key
+        )
         self.state = "CREATE_COMPLETE"
         self.created = utcnow()
         self.usage_start = self.created if enabled else None
@@ -94,7 +168,6 @@ class Key:
         self.replication_status: dict[str, dict[str, str]] | None = None
         self.using_defaults: bool | None = None
         self.public_certificate: str | None = None
-        self.private_key: Any = None
         self.mpa_status: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -148,6 +221,28 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
             if identifier in (key.arn, key.key_id):
                 return key
         raise ResourceNotFoundException(f"Key {identifier} was not found")
+
+    def _related_keys(self, key: Key) -> list[Key]:
+        related = []
+        for backend in paymentcryptography_backends[self.account_id].values():
+            for candidate in backend.keys.values():
+                if candidate.key_id == key.key_id:
+                    related.append(candidate)
+        return related
+
+    def _update_related(self, key: Key, **values: Any) -> None:
+        for related in self._related_keys(key):
+            for name, value in values.items():
+                setattr(related, name, value)
+
+    def _require_mode(self, identifier: str, mode: str) -> Key:
+        key = self._resolve(identifier)
+        if not key.enabled or key.state != "CREATE_COMPLETE":
+            raise ConflictException("The wrapping key is not enabled")
+        modes_of_use = key.attributes.get("KeyModesOfUse", {})
+        if not (modes_of_use.get(mode) or modes_of_use.get("NoRestrictions")):
+            raise ValidationException(f"The key does not permit {mode.lower()}")
+        return key
 
     def _paginate(
         self, values: list[Any], token: str | None, limit: int | None
@@ -235,32 +330,40 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
 
     def delete_key(self, key_identifier: str, days: int | None) -> dict[str, Any]:
         key = self._resolve(key_identifier)
-        key.enabled = False
-        key.state = "DELETE_PENDING"
-        key.usage_stop = utcnow()
-        key.delete_pending = utcnow() + timedelta(days=days or 7)
+        if key.state == "DELETE_PENDING":
+            raise ConflictException("The key is already pending deletion")
+        usage_stop = utcnow()
+        delete_pending = usage_stop + timedelta(days=days or 7)
+        self._update_related(
+            key,
+            enabled=False,
+            state="DELETE_PENDING",
+            usage_stop=usage_stop,
+            delete_pending=delete_pending,
+        )
         return key.to_dict()
 
     def restore_key(self, key_identifier: str) -> dict[str, Any]:
         key = self._resolve(key_identifier)
         if key.state != "DELETE_PENDING":
             raise ConflictException("Only a key pending deletion can be restored")
-        key.state = "CREATE_COMPLETE"
-        key.delete_pending = None
+        self._update_related(key, state="CREATE_COMPLETE", delete_pending=None)
         return key.to_dict()
 
     def start_key_usage(self, key_identifier: str) -> dict[str, Any]:
         key = self._resolve(key_identifier)
         if key.state == "DELETE_PENDING":
             raise ConflictException("A key pending deletion cannot be enabled")
-        key.enabled = True
-        key.usage_start = utcnow()
+        if not key.enabled:
+            self._update_related(key, enabled=True, usage_start=utcnow())
         return key.to_dict()
 
     def stop_key_usage(self, key_identifier: str) -> dict[str, Any]:
         key = self._resolve(key_identifier)
-        key.enabled = False
-        key.usage_stop = utcnow()
+        if key.state == "DELETE_PENDING":
+            raise ConflictException("A key pending deletion cannot be disabled")
+        if key.enabled:
+            self._update_related(key, enabled=False, usage_stop=utcnow())
         return key.to_dict()
 
     def create_alias(self, alias_name: str, key_arn: str | None) -> dict[str, Any]:
@@ -380,11 +483,9 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         return key.to_dict()
 
     def _certificate(self, algorithm: str, common_name: str) -> tuple[Any, str]:
-        private = (
-            ec.generate_private_key(ec.SECP256R1())
-            if algorithm.startswith("ECC")
-            else rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        )
+        private = _private_key(algorithm)
+        if private is None:
+            raise ValidationException(f"{algorithm} is not an asymmetric key algorithm")
         subject = issuer = x509.Name(
             [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
         )
@@ -405,11 +506,17 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
     ) -> dict[str, Any]:
         store = self.import_tokens if kind == "Import" else self.export_tokens
         last = self.last_import_token if kind == "Import" else self.last_export_token
-        if reuse and last and store[last]["expires"] > utcnow():
+        if (
+            reuse
+            and last
+            and store[last]["expires"] > utcnow()
+            and store[last]["algorithm"] == algorithm
+            and store[last]["material_type"] == material_type
+        ):
             token = last
             item = store[token]
         else:
-            token = str(uuid.uuid4())
+            token = f"{kind.lower()}-token-{uuid.uuid4().hex}"
             _, certificate = self._certificate(
                 algorithm, f"Moto Payment Cryptography {kind}"
             )
@@ -433,6 +540,57 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
             "ParametersValidUntilTimestamp": item["expires"],
         }
 
+    def _validate_token(
+        self, token: str, kind: str, expected_material_type: str
+    ) -> dict[str, Any]:
+        store = self.import_tokens if kind == "Import" else self.export_tokens
+        if token not in store:
+            raise ValidationException(f"The {kind.lower()} token is not valid")
+        item = store[token]
+        if item["expires"] <= utcnow():
+            raise ValidationException(f"The {kind.lower()} token has expired")
+        if item["material_type"] != expected_material_type:
+            raise ValidationException(
+                f"The {kind.lower()} token is not valid for {expected_material_type}"
+            )
+        return item
+
+    def _wrapped_payload(self, key: Key, variant: str) -> str:
+        payload = json.dumps(
+            {
+                "attributes": key.attributes,
+                "derive_key_usage": key.derive_key_usage,
+                "exportable": key.exportable,
+                "material": base64.b64encode(key.material).decode(),
+            },
+            separators=(",", ":"),
+        ).encode()
+        if variant in {"Tr31KeyBlock", "DiffieHellmanTr31KeyBlock"}:
+            return "MOTO1" + base64.b32encode(payload).decode().rstrip("=")
+        return payload.hex().upper()
+
+    def _decode_wrapped_payload(
+        self, variant: str, value: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        wrapped = value.get("WrappedKeyBlock") or value.get("WrappedKeyCryptogram")
+        if not wrapped:
+            return None
+        try:
+            if variant in {"Tr31KeyBlock", "DiffieHellmanTr31KeyBlock"}:
+                if not wrapped.startswith("MOTO1"):
+                    return None
+                encoded = wrapped[5:]
+                encoded += "=" * (-len(encoded) % 8)
+                raw = base64.b32decode(encoded)
+            else:
+                raw = bytes.fromhex(wrapped)
+            payload = json.loads(raw)
+            if not {"attributes", "exportable", "material"}.issubset(payload):
+                return None
+            return payload
+        except (ValueError, TypeError, json.JSONDecodeError):
+            return None
+
     def get_parameters_for_import(
         self, material_type: str, algorithm: str, reuse: bool
     ) -> dict[str, Any]:
@@ -445,8 +603,25 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
 
     def import_key(self, key_material: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         variant, value = next(iter(key_material.items()))
-        attrs = value.get("KeyAttributes")
-        exportable = value.get("Exportable", False)
+        material_types = {
+            "Tr31KeyBlock": "TR31_KEY_BLOCK",
+            "DiffieHellmanTr31KeyBlock": "TR31_KEY_BLOCK",
+            "Tr34KeyBlock": "TR34_KEY_BLOCK",
+            "KeyCryptogram": "KEY_CRYPTOGRAM",
+        }
+        token = value.get("ImportToken")
+        if token:
+            self._validate_token(token, "Import", material_types.get(variant, ""))
+        elif variant == "KeyCryptogram":
+            raise ValidationException("ImportToken is required for KeyCryptogram")
+        wrapping_identifier = value.get("WrappingKeyIdentifier")
+        if wrapping_identifier:
+            self._require_mode(wrapping_identifier, "Unwrap")
+        payload = self._decode_wrapped_payload(variant, value)
+        attrs = payload["attributes"] if payload else value.get("KeyAttributes")
+        exportable = (
+            payload["exportable"] if payload else value.get("Exportable", False)
+        )
         if attrs is None and variant == "As2805KeyCryptogram":
             attrs = {
                 "KeyUsage": value["As2805KeyVariant"],
@@ -462,12 +637,29 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
                 "KeyAlgorithm": "TDES_3KEY",
                 "KeyModesOfUse": {"NoRestrictions": True},
             }
-        raw = (
-            value.get("WrappedKeyBlock")
-            or value.get("WrappedKeyCryptogram")
-            or value.get("PublicKeyCertificate")
-            or str(uuid.uuid4())
-        ).encode()
+        public_certificate = value.get("PublicKeyCertificate")
+        if payload:
+            raw = base64.b64decode(payload["material"])
+        elif public_certificate:
+            try:
+                certificate = x509.load_pem_x509_certificate(
+                    public_certificate.encode()
+                )
+                raw = certificate.public_key().public_bytes(
+                    serialization.Encoding.DER,
+                    serialization.PublicFormat.SubjectPublicKeyInfo,
+                )
+            except ValueError:
+                raise ValidationException(
+                    "PublicKeyCertificate is not a valid certificate"
+                )
+        else:
+            wrapped = value.get("WrappedKeyBlock") or value.get("WrappedKeyCryptogram")
+            if not wrapped:
+                raise ValidationException("KeyMaterial does not contain key material")
+            raw = hashlib.sha256(wrapped.encode()).digest()[
+                : _material_size(attrs["KeyAlgorithm"])
+            ]
         key = Key(
             self.account_id,
             self.region_name,
@@ -476,10 +668,11 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
             kwargs.get("enabled", True),
             kwargs.get("key_check_value_algorithm"),
             "EXTERNAL",
-            hashlib.sha256(raw).digest()[: _material_size(attrs["KeyAlgorithm"])],
+            raw,
+            derive_key_usage=(payload or {}).get("derive_key_usage"),
         )
-        if "PublicKeyCertificate" in value:
-            key.public_certificate = value["PublicKeyCertificate"]
+        if public_certificate:
+            key.public_certificate = public_certificate
         self.keys[key.arn] = key
         self.tags[key.arn] = {t["Key"]: t["Value"] for t in kwargs.get("tags") or []}
         if kwargs.get("replication_regions"):
@@ -496,12 +689,17 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         if not key.exportable:
             raise ConflictException("The key is not exportable")
         variant, spec = next(iter(key_material.items()))
+        if variant == "Tr34KeyBlock" and spec.get("ExportToken"):
+            self._validate_token(spec["ExportToken"], "Export", "TR34_KEY_BLOCK")
         wrapping_identifier = (
             spec.get("WrappingKeyIdentifier")
             or spec.get("CertificateAuthorityPublicKeyIdentifier")
             or identifier
         )
-        wrapping_arn = self._resolve(wrapping_identifier).arn
+        if spec.get("WrappingKeyIdentifier"):
+            wrapping_arn = self._require_mode(wrapping_identifier, "Wrap").arn
+        else:
+            wrapping_arn = self._resolve(wrapping_identifier).arn
         formats = {
             "Tr31KeyBlock": "TR31_KEY_BLOCK",
             "Tr34KeyBlock": "TR34_KEY_BLOCK",
@@ -512,7 +710,7 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         return {
             "WrappingKeyArn": wrapping_arn,
             "WrappedKeyMaterialFormat": formats[variant],
-            "KeyMaterial": base64.b64encode(key.material).decode(),
+            "KeyMaterial": self._wrapped_payload(key, variant),
             "KeyCheckValue": key.kcv,
             "KeyCheckValueAlgorithm": (export_attributes or {}).get(
                 "KeyCheckValueAlgorithm", key.kcv_algorithm
@@ -521,10 +719,32 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
 
     def get_public_key_certificate(self, identifier: str) -> dict[str, str]:
         key = self._resolve(identifier)
+        if key.attributes.get("KeyClass") not in {
+            "ASYMMETRIC_KEY_PAIR",
+            "PUBLIC_KEY",
+        }:
+            raise ValidationException("The key must be an asymmetric key")
         if not key.public_certificate:
-            key.private_key, key.public_certificate = self._certificate(
-                key.attributes.get("KeyAlgorithm", "RSA_2048"), key.key_id
+            if key.private_key is None:
+                raise ConflictException(
+                    "No public certificate is available for this key"
+                )
+            subject = issuer = x509.Name(
+                [x509.NameAttribute(NameOID.COMMON_NAME, key.key_id)]
             )
+            certificate = (
+                x509.CertificateBuilder()
+                .subject_name(subject)
+                .issuer_name(issuer)
+                .public_key(key.private_key.public_key())
+                .serial_number(x509.random_serial_number())
+                .not_valid_before(utcnow())
+                .not_valid_after(utcnow() + timedelta(days=365))
+                .sign(key.private_key, hashes.SHA256())
+            )
+            key.public_certificate = certificate.public_bytes(
+                serialization.Encoding.PEM
+            ).decode()
         return {
             "KeyCertificate": key.public_certificate,
             "KeyCertificateChain": key.public_certificate,
@@ -534,10 +754,10 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         self, identifier: str, signing_algorithm: str, subject: dict[str, str]
     ) -> str:
         key = self._resolve(identifier)
-        if not key.private_key:
-            key.private_key, key.public_certificate = self._certificate(
-                key.attributes.get("KeyAlgorithm", "RSA_2048"), key.key_id
-            )
+        if key.attributes.get("KeyClass") != "ASYMMETRIC_KEY_PAIR":
+            raise ValidationException("The key must be an asymmetric key pair")
+        if key.private_key is None:
+            raise ConflictException("The private key is not available")
         names = {
             "CommonName": NameOID.COMMON_NAME,
             "OrganizationUnit": NameOID.ORGANIZATIONAL_UNIT_NAME,
@@ -550,10 +770,16 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         csr_subject = x509.Name(
             [x509.NameAttribute(names[k], v) for k, v in subject.items() if k in names]
         )
+        signing_hash: Any = {
+            "SHA224": hashes.SHA224,
+            "SHA256": hashes.SHA256,
+            "SHA384": hashes.SHA384,
+            "SHA512": hashes.SHA512,
+        }[signing_algorithm]()
         return (
             x509.CertificateSigningRequestBuilder()
             .subject_name(csr_subject)
-            .sign(key.private_key, hashes.SHA256())
+            .sign(key.private_key, signing_hash)
             .public_bytes(serialization.Encoding.PEM)
             .decode()
         )
@@ -579,7 +805,7 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
     def disassociate_mpa_team(self, action: str, comment: str | None) -> dict[str, Any]:
         association = self.get_mpa_team_association(action).copy()
         association["AssociationState"] = "DELETE_PENDING"
-        del self.mpa_associations[action]
+        self.mpa_associations[action] = association
         return association
 
 

--- a/moto/paymentcryptography/models.py
+++ b/moto/paymentcryptography/models.py
@@ -1,0 +1,625 @@
+"""Models for the AWS Payment Cryptography control plane."""
+
+import base64
+import hashlib
+import json
+import os
+import uuid
+from datetime import datetime, timedelta
+from typing import Any
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.utils import utcnow
+
+from .exceptions import (
+    ConflictException,
+    ResourceNotFoundException,
+    ValidationException,
+)
+
+
+def _id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _default_kcv_algorithm(algorithm: str) -> str:
+    if algorithm.startswith("AES"):
+        return "CMAC"
+    if algorithm.startswith("HMAC"):
+        return "HMAC"
+    if algorithm.startswith("TDES"):
+        return "ANSI_X9_24"
+    return "SHA_1"
+
+
+def _material_size(algorithm: str) -> int:
+    sizes = {
+        "AES_128": 16,
+        "AES_192": 24,
+        "AES_256": 32,
+        "TDES_2KEY": 16,
+        "TDES_3KEY": 24,
+        "HMAC_SHA256": 32,
+        "HMAC_SHA384": 48,
+        "HMAC_SHA512": 64,
+    }
+    return sizes.get(algorithm, 32)
+
+
+class Key:
+    def __init__(
+        self,
+        account_id: str,
+        region: str,
+        attributes: dict[str, Any],
+        exportable: bool,
+        enabled: bool = True,
+        kcv_algorithm: str | None = None,
+        origin: str = "AWS_PAYMENT_CRYPTOGRAPHY",
+        material: bytes | None = None,
+        derive_key_usage: str | None = None,
+        key_id: str | None = None,
+    ):
+        self.key_id = key_id or _id()
+        self.account_id = account_id
+        self.region = region
+        self.arn = (
+            f"arn:aws:payment-cryptography:{region}:{account_id}:key/{self.key_id}"
+        )
+        self.attributes = attributes
+        self.exportable = exportable
+        self.enabled = enabled
+        self.origin = origin
+        self.material = material or os.urandom(
+            _material_size(attributes.get("KeyAlgorithm", ""))
+        )
+        self.kcv_algorithm = kcv_algorithm or _default_kcv_algorithm(
+            attributes.get("KeyAlgorithm", "")
+        )
+        self.kcv = hashlib.sha256(self.material).hexdigest().upper()[:6]
+        self.state = "CREATE_COMPLETE"
+        self.created = utcnow()
+        self.usage_start = self.created if enabled else None
+        self.usage_stop = self.created if not enabled else None
+        self.delete_pending: datetime | None = None
+        self.delete_timestamp: datetime | None = None
+        self.derive_key_usage = derive_key_usage
+        self.multi_region_type: str | None = None
+        self.primary_region: str | None = None
+        self.replication_status: dict[str, dict[str, str]] | None = None
+        self.using_defaults: bool | None = None
+        self.public_certificate: str | None = None
+        self.private_key: Any = None
+        self.mpa_status: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "KeyArn": self.arn,
+            "KeyAttributes": self.attributes,
+            "KeyCheckValue": self.kcv,
+            "KeyCheckValueAlgorithm": self.kcv_algorithm,
+            "Enabled": self.enabled,
+            "Exportable": self.exportable,
+            "KeyState": self.state,
+            "KeyOrigin": self.origin,
+            "CreateTimestamp": self.created,
+        }
+        optional = {
+            "UsageStartTimestamp": self.usage_start,
+            "UsageStopTimestamp": self.usage_stop,
+            "DeletePendingTimestamp": self.delete_pending,
+            "DeleteTimestamp": self.delete_timestamp,
+            "DeriveKeyUsage": self.derive_key_usage,
+            "MultiRegionKeyType": self.multi_region_type,
+            "PrimaryRegion": self.primary_region,
+            "ReplicationStatus": self.replication_status,
+            "UsingDefaultReplicationRegions": self.using_defaults,
+            "MpaStatus": self.mpa_status,
+        }
+        result.update({k: v for k, v in optional.items() if v is not None})
+        return result
+
+
+class PaymentCryptographyControlPlaneBackend(BaseBackend):
+    """Implementation of Payment Cryptography control-plane APIs."""
+
+    def __init__(self, region_name: str, account_id: str):
+        super().__init__(region_name, account_id)
+        self.keys: dict[str, Key] = {}
+        self.aliases: dict[str, str | None] = {}
+        self.tags: dict[str, dict[str, str]] = {}
+        self.policies: dict[str, str] = {}
+        self.default_replication_regions: list[str] = []
+        self.import_tokens: dict[str, dict[str, Any]] = {}
+        self.export_tokens: dict[str, dict[str, Any]] = {}
+        self.last_import_token: str | None = None
+        self.last_export_token: str | None = None
+        self.mpa_associations: dict[str, dict[str, Any]] = {}
+
+    def _resolve(self, identifier: str) -> Key:
+        if identifier.startswith("alias/"):
+            identifier = self.aliases.get(identifier) or ""
+        for key in self.keys.values():
+            if identifier in (key.arn, key.key_id):
+                return key
+        raise ResourceNotFoundException(f"Key {identifier} was not found")
+
+    def _paginate(
+        self, values: list[Any], token: str | None, limit: int | None
+    ) -> tuple[list[Any], str | None]:
+        try:
+            start = (
+                int(base64.urlsafe_b64decode(token.encode()).decode()) if token else 0
+            )
+        except Exception:
+            raise ValidationException("Invalid pagination token")
+        size = limit or 100
+        end = start + size
+        next_token = (
+            base64.urlsafe_b64encode(str(end).encode()).decode()
+            if end < len(values)
+            else None
+        )
+        return values[start:end], next_token
+
+    def _replicate(
+        self, key: Key, regions: list[str], using_defaults: bool = False
+    ) -> None:
+        key.multi_region_type = "PRIMARY"
+        key.primary_region = self.region_name
+        key.replication_status = key.replication_status or {}
+        key.using_defaults = using_defaults
+        for region in regions:
+            if region == self.region_name:
+                raise ValidationException(
+                    "A key cannot be replicated to its primary region"
+                )
+            target = paymentcryptography_backends[self.account_id][region]
+            replica = Key(
+                self.account_id,
+                region,
+                key.attributes.copy(),
+                key.exportable,
+                key.enabled,
+                key.kcv_algorithm,
+                key.origin,
+                key.material,
+                key.derive_key_usage,
+                key.key_id,
+            )
+            replica.created = key.created
+            replica.kcv = key.kcv
+            replica.multi_region_type = "REPLICA"
+            replica.primary_region = self.region_name
+            replica.public_certificate = key.public_certificate
+            replica.private_key = key.private_key
+            target.keys[replica.arn] = replica
+            target.tags[replica.arn] = self.tags.get(key.arn, {}).copy()
+            key.replication_status[region] = {"Status": "SYNCHRONIZED"}
+
+    def create_key(self, **kwargs: Any) -> dict[str, Any]:
+        key = Key(
+            self.account_id,
+            self.region_name,
+            kwargs["key_attributes"],
+            kwargs["exportable"],
+            kwargs.get("enabled", True),
+            kwargs.get("key_check_value_algorithm"),
+            derive_key_usage=kwargs.get("derive_key_usage"),
+        )
+        self.keys[key.arn] = key
+        self.tags[key.arn] = {t["Key"]: t["Value"] for t in kwargs.get("tags") or []}
+        regions = kwargs.get("replication_regions")
+        using_defaults = regions is None and bool(self.default_replication_regions)
+        regions = self.default_replication_regions if regions is None else regions
+        if regions:
+            self._replicate(key, regions, using_defaults)
+        return key.to_dict()
+
+    def get_key(self, key_identifier: str) -> dict[str, Any]:
+        return self._resolve(key_identifier).to_dict()
+
+    def list_keys(
+        self, key_state: str | None, next_token: str | None, max_results: int | None
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        values = sorted(self.keys.values(), key=lambda k: k.arn)
+        if key_state:
+            values = [k for k in values if k.state == key_state]
+        page, token = self._paginate(values, next_token, max_results)
+        return [k.to_dict() for k in page], token
+
+    def delete_key(self, key_identifier: str, days: int | None) -> dict[str, Any]:
+        key = self._resolve(key_identifier)
+        key.enabled = False
+        key.state = "DELETE_PENDING"
+        key.usage_stop = utcnow()
+        key.delete_pending = utcnow() + timedelta(days=days or 7)
+        return key.to_dict()
+
+    def restore_key(self, key_identifier: str) -> dict[str, Any]:
+        key = self._resolve(key_identifier)
+        if key.state != "DELETE_PENDING":
+            raise ConflictException("Only a key pending deletion can be restored")
+        key.state = "CREATE_COMPLETE"
+        key.delete_pending = None
+        return key.to_dict()
+
+    def start_key_usage(self, key_identifier: str) -> dict[str, Any]:
+        key = self._resolve(key_identifier)
+        if key.state == "DELETE_PENDING":
+            raise ConflictException("A key pending deletion cannot be enabled")
+        key.enabled = True
+        key.usage_start = utcnow()
+        return key.to_dict()
+
+    def stop_key_usage(self, key_identifier: str) -> dict[str, Any]:
+        key = self._resolve(key_identifier)
+        key.enabled = False
+        key.usage_stop = utcnow()
+        return key.to_dict()
+
+    def create_alias(self, alias_name: str, key_arn: str | None) -> dict[str, Any]:
+        if alias_name in self.aliases:
+            raise ConflictException(f"Alias {alias_name} already exists")
+        if key_arn:
+            key_arn = self._resolve(key_arn).arn
+        self.aliases[alias_name] = key_arn
+        return self._alias(alias_name)
+
+    def _alias(self, name: str) -> dict[str, Any]:
+        result: dict[str, Any] = {"AliasName": name}
+        if self.aliases[name]:
+            result["KeyArn"] = self.aliases[name]
+        return result
+
+    def get_alias(self, alias_name: str) -> dict[str, Any]:
+        if alias_name not in self.aliases:
+            raise ResourceNotFoundException(f"Alias {alias_name} was not found")
+        return self._alias(alias_name)
+
+    def list_aliases(
+        self, key_arn: str | None, next_token: str | None, max_results: int | None
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        names = sorted(self.aliases)
+        if key_arn:
+            key_arn = self._resolve(key_arn).arn
+            names = [n for n in names if self.aliases[n] == key_arn]
+        page, token = self._paginate(names, next_token, max_results)
+        return [self._alias(n) for n in page], token
+
+    def update_alias(self, alias_name: str, key_arn: str | None) -> dict[str, Any]:
+        if alias_name not in self.aliases:
+            raise ResourceNotFoundException(f"Alias {alias_name} was not found")
+        self.aliases[alias_name] = self._resolve(key_arn).arn if key_arn else None
+        return self._alias(alias_name)
+
+    def delete_alias(self, alias_name: str) -> None:
+        if alias_name not in self.aliases:
+            raise ResourceNotFoundException(f"Alias {alias_name} was not found")
+        del self.aliases[alias_name]
+
+    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
+        key = self._resolve(resource_arn)
+        current = self.tags.setdefault(key.arn, {})
+        current.update({t["Key"]: t["Value"] for t in tags})
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        key = self._resolve(resource_arn)
+        for name in tag_keys:
+            self.tags.setdefault(key.arn, {}).pop(name, None)
+
+    def list_tags_for_resource(
+        self, resource_arn: str, next_token: str | None, max_results: int | None
+    ) -> tuple[list[dict[str, str]], str | None]:
+        key = self._resolve(resource_arn)
+        values = [
+            {"Key": k, "Value": v}
+            for k, v in sorted(self.tags.get(key.arn, {}).items())
+        ]
+        return self._paginate(values, next_token, max_results)
+
+    def put_resource_policy(self, resource_arn: str, policy: str) -> dict[str, str]:
+        arn = self._resolve(resource_arn).arn
+        try:
+            json.loads(policy)
+        except ValueError:
+            raise ValidationException("The resource policy is not valid JSON")
+        self.policies[arn] = policy
+        return {"ResourceArn": arn, "Policy": policy}
+
+    def get_resource_policy(self, resource_arn: str) -> dict[str, str]:
+        arn = self._resolve(resource_arn).arn
+        return {"ResourceArn": arn, "Policy": self.policies.get(arn, "{}")}
+
+    def delete_resource_policy(self, resource_arn: str) -> None:
+        arn = self._resolve(resource_arn).arn
+        self.policies.pop(arn, None)
+
+    def enable_default_key_replication_regions(self, regions: list[str]) -> list[str]:
+        self.default_replication_regions = sorted(
+            set(self.default_replication_regions + regions)
+        )
+        return self.default_replication_regions
+
+    def disable_default_key_replication_regions(self, regions: list[str]) -> list[str]:
+        self.default_replication_regions = [
+            r for r in self.default_replication_regions if r not in regions
+        ]
+        return self.default_replication_regions
+
+    def get_default_key_replication_regions(self) -> list[str]:
+        return self.default_replication_regions
+
+    def add_key_replication_regions(
+        self, key_identifier: str, regions: list[str]
+    ) -> dict[str, Any]:
+        key = self._resolve(key_identifier)
+        if key.multi_region_type == "REPLICA":
+            raise ConflictException(
+                "Replication regions can only be changed on a primary key"
+            )
+        self._replicate(key, regions)
+        return key.to_dict()
+
+    def remove_key_replication_regions(
+        self, key_identifier: str, regions: list[str]
+    ) -> dict[str, Any]:
+        key = self._resolve(key_identifier)
+        for region in regions:
+            paymentcryptography_backends[self.account_id][region].keys.pop(
+                f"arn:aws:payment-cryptography:{region}:{self.account_id}:key/{key.key_id}",
+                None,
+            )
+            if key.replication_status:
+                key.replication_status.pop(region, None)
+        return key.to_dict()
+
+    def _certificate(self, algorithm: str, common_name: str) -> tuple[Any, str]:
+        private = (
+            ec.generate_private_key(ec.SECP256R1())
+            if algorithm.startswith("ECC")
+            else rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        )
+        subject = issuer = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, common_name)]
+        )
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(private.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(utcnow())
+            .not_valid_after(utcnow() + timedelta(days=365))
+            .sign(private, hashes.SHA256())
+        )
+        return private, cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    def _parameters(
+        self, kind: str, material_type: str, algorithm: str, reuse: bool
+    ) -> dict[str, Any]:
+        store = self.import_tokens if kind == "Import" else self.export_tokens
+        last = self.last_import_token if kind == "Import" else self.last_export_token
+        if reuse and last and store[last]["expires"] > utcnow():
+            token = last
+            item = store[token]
+        else:
+            token = str(uuid.uuid4())
+            _, certificate = self._certificate(
+                algorithm, f"Moto Payment Cryptography {kind}"
+            )
+            item = {
+                "certificate": certificate,
+                "algorithm": algorithm,
+                "material_type": material_type,
+                "expires": utcnow() + timedelta(days=30),
+            }
+            store[token] = item
+            if kind == "Import":
+                self.last_import_token = token
+            else:
+                self.last_export_token = token
+        prefix = "Wrapping" if kind == "Import" else "Signing"
+        return {
+            f"{prefix}KeyCertificate": item["certificate"],
+            f"{prefix}KeyCertificateChain": item["certificate"],
+            f"{prefix}KeyAlgorithm": item["algorithm"],
+            f"{kind}Token": token,
+            "ParametersValidUntilTimestamp": item["expires"],
+        }
+
+    def get_parameters_for_import(
+        self, material_type: str, algorithm: str, reuse: bool
+    ) -> dict[str, Any]:
+        return self._parameters("Import", material_type, algorithm, reuse)
+
+    def get_parameters_for_export(
+        self, material_type: str, algorithm: str, reuse: bool
+    ) -> dict[str, Any]:
+        return self._parameters("Export", material_type, algorithm, reuse)
+
+    def import_key(self, key_material: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        variant, value = next(iter(key_material.items()))
+        attrs = value.get("KeyAttributes")
+        exportable = value.get("Exportable", False)
+        if attrs is None and variant == "As2805KeyCryptogram":
+            attrs = {
+                "KeyUsage": value["As2805KeyVariant"],
+                "KeyClass": "SYMMETRIC_KEY",
+                "KeyAlgorithm": value["KeyAlgorithm"],
+                "KeyModesOfUse": value["KeyModesOfUse"],
+            }
+            exportable = value["Exportable"]
+        if attrs is None:
+            attrs = {
+                "KeyUsage": "TR31_K0_KEY_ENCRYPTION_KEY",
+                "KeyClass": "SYMMETRIC_KEY",
+                "KeyAlgorithm": "TDES_3KEY",
+                "KeyModesOfUse": {"NoRestrictions": True},
+            }
+        raw = (
+            value.get("WrappedKeyBlock")
+            or value.get("WrappedKeyCryptogram")
+            or value.get("PublicKeyCertificate")
+            or str(uuid.uuid4())
+        ).encode()
+        key = Key(
+            self.account_id,
+            self.region_name,
+            attrs,
+            exportable,
+            kwargs.get("enabled", True),
+            kwargs.get("key_check_value_algorithm"),
+            "EXTERNAL",
+            hashlib.sha256(raw).digest()[: _material_size(attrs["KeyAlgorithm"])],
+        )
+        if "PublicKeyCertificate" in value:
+            key.public_certificate = value["PublicKeyCertificate"]
+        self.keys[key.arn] = key
+        self.tags[key.arn] = {t["Key"]: t["Value"] for t in kwargs.get("tags") or []}
+        if kwargs.get("replication_regions"):
+            self._replicate(key, kwargs["replication_regions"])
+        return key.to_dict()
+
+    def export_key(
+        self,
+        key_material: dict[str, Any],
+        identifier: str,
+        export_attributes: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        key = self._resolve(identifier)
+        if not key.exportable:
+            raise ConflictException("The key is not exportable")
+        variant, spec = next(iter(key_material.items()))
+        wrapping_identifier = (
+            spec.get("WrappingKeyIdentifier")
+            or spec.get("CertificateAuthorityPublicKeyIdentifier")
+            or identifier
+        )
+        wrapping_arn = self._resolve(wrapping_identifier).arn
+        formats = {
+            "Tr31KeyBlock": "TR31_KEY_BLOCK",
+            "Tr34KeyBlock": "TR34_KEY_BLOCK",
+            "KeyCryptogram": "KEY_CRYPTOGRAM",
+            "DiffieHellmanTr31KeyBlock": "TR31_KEY_BLOCK",
+            "As2805KeyCryptogram": "KEY_CRYPTOGRAM",
+        }
+        return {
+            "WrappingKeyArn": wrapping_arn,
+            "WrappedKeyMaterialFormat": formats[variant],
+            "KeyMaterial": base64.b64encode(key.material).decode(),
+            "KeyCheckValue": key.kcv,
+            "KeyCheckValueAlgorithm": (export_attributes or {}).get(
+                "KeyCheckValueAlgorithm", key.kcv_algorithm
+            ),
+        }
+
+    def get_public_key_certificate(self, identifier: str) -> dict[str, str]:
+        key = self._resolve(identifier)
+        if not key.public_certificate:
+            key.private_key, key.public_certificate = self._certificate(
+                key.attributes.get("KeyAlgorithm", "RSA_2048"), key.key_id
+            )
+        return {
+            "KeyCertificate": key.public_certificate,
+            "KeyCertificateChain": key.public_certificate,
+        }
+
+    def get_certificate_signing_request(
+        self, identifier: str, signing_algorithm: str, subject: dict[str, str]
+    ) -> str:
+        key = self._resolve(identifier)
+        if not key.private_key:
+            key.private_key, key.public_certificate = self._certificate(
+                key.attributes.get("KeyAlgorithm", "RSA_2048"), key.key_id
+            )
+        names = {
+            "CommonName": NameOID.COMMON_NAME,
+            "OrganizationUnit": NameOID.ORGANIZATIONAL_UNIT_NAME,
+            "Organization": NameOID.ORGANIZATION_NAME,
+            "City": NameOID.LOCALITY_NAME,
+            "Country": NameOID.COUNTRY_NAME,
+            "StateOrProvince": NameOID.STATE_OR_PROVINCE_NAME,
+            "EmailAddress": NameOID.EMAIL_ADDRESS,
+        }
+        csr_subject = x509.Name(
+            [x509.NameAttribute(names[k], v) for k, v in subject.items() if k in names]
+        )
+        return (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(csr_subject)
+            .sign(key.private_key, hashes.SHA256())
+            .public_bytes(serialization.Encoding.PEM)
+            .decode()
+        )
+
+    def associate_mpa_team(
+        self, action: str, team_arn: str, comment: str | None
+    ) -> dict[str, Any]:
+        if action in self.mpa_associations:
+            raise ConflictException(f"An MPA team is already associated with {action}")
+        association = {
+            "Action": action,
+            "MpaTeamArn": team_arn,
+            "AssociationState": "ACTIVE",
+        }
+        self.mpa_associations[action] = association
+        return association
+
+    def get_mpa_team_association(self, action: str) -> dict[str, Any]:
+        if action not in self.mpa_associations:
+            raise ResourceNotFoundException(f"No MPA team is associated with {action}")
+        return self.mpa_associations[action]
+
+    def disassociate_mpa_team(self, action: str, comment: str | None) -> dict[str, Any]:
+        association = self.get_mpa_team_association(action).copy()
+        association["AssociationState"] = "DELETE_PENDING"
+        del self.mpa_associations[action]
+        return association
+
+
+paymentcryptography_backends = BackendDict(
+    PaymentCryptographyControlPlaneBackend,
+    "payment-cryptography",
+    additional_regions=[
+        "af-south-1",
+        "ap-east-1",
+        "ap-east-2",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-northeast-3",
+        "ap-south-1",
+        "ap-south-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-southeast-3",
+        "ap-southeast-4",
+        "ap-southeast-5",
+        "ap-southeast-6",
+        "ap-southeast-7",
+        "ca-central-1",
+        "ca-west-1",
+        "eu-central-1",
+        "eu-central-2",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-south-2",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "il-central-1",
+        "me-central-1",
+        "me-south-1",
+        "mx-central-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+    ],
+)

--- a/moto/paymentcryptography/responses.py
+++ b/moto/paymentcryptography/responses.py
@@ -1,0 +1,286 @@
+"""Responses for the AWS Payment Cryptography control plane."""
+
+from typing import Any
+
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
+
+from .models import (
+    PaymentCryptographyControlPlaneBackend,
+    paymentcryptography_backends,
+)
+
+
+class PaymentCryptographyControlPlaneResponse(BaseResponse):
+    def __init__(self) -> None:
+        super().__init__(service_name="payment-cryptography")
+        self.automated_parameter_parsing = True
+
+    @property
+    def backend(self) -> PaymentCryptographyControlPlaneBackend:
+        return paymentcryptography_backends[self.current_account][self.region]
+
+    def create_key(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            {
+                "Key": self.backend.create_key(
+                    key_attributes=p["KeyAttributes"],
+                    exportable=p["Exportable"],
+                    enabled=p.get("Enabled", True),
+                    key_check_value_algorithm=p.get("KeyCheckValueAlgorithm"),
+                    tags=p.get("Tags"),
+                    derive_key_usage=p.get("DeriveKeyUsage"),
+                    replication_regions=p.get("ReplicationRegions"),
+                )
+            }
+        )
+
+    def get_key(self) -> ActionResult:
+        return ActionResult(
+            {"Key": self.backend.get_key(self._get_param("KeyIdentifier"))}
+        )
+
+    def list_keys(self) -> ActionResult:
+        p = self._get_params()
+        values, token = self.backend.list_keys(
+            p.get("KeyState"), p.get("NextToken"), p.get("MaxResults")
+        )
+        result: dict[str, Any] = {"Keys": values}
+        if token:
+            result["NextToken"] = token
+        return ActionResult(result)
+
+    def delete_key(self) -> ActionResult:
+        return ActionResult(
+            {
+                "Key": self.backend.delete_key(
+                    self._get_param("KeyIdentifier"), self._get_param("DeleteKeyInDays")
+                )
+            }
+        )
+
+    def restore_key(self) -> ActionResult:
+        return ActionResult(
+            {"Key": self.backend.restore_key(self._get_param("KeyIdentifier"))}
+        )
+
+    def start_key_usage(self) -> ActionResult:
+        return ActionResult(
+            {"Key": self.backend.start_key_usage(self._get_param("KeyIdentifier"))}
+        )
+
+    def stop_key_usage(self) -> ActionResult:
+        return ActionResult(
+            {"Key": self.backend.stop_key_usage(self._get_param("KeyIdentifier"))}
+        )
+
+    def create_alias(self) -> ActionResult:
+        return ActionResult(
+            {
+                "Alias": self.backend.create_alias(
+                    self._get_param("AliasName"), self._get_param("KeyArn")
+                )
+            }
+        )
+
+    def get_alias(self) -> ActionResult:
+        return ActionResult(
+            {"Alias": self.backend.get_alias(self._get_param("AliasName"))}
+        )
+
+    def list_aliases(self) -> ActionResult:
+        p = self._get_params()
+        values, token = self.backend.list_aliases(
+            p.get("KeyArn"), p.get("NextToken"), p.get("MaxResults")
+        )
+        result: dict[str, Any] = {"Aliases": values}
+        if token:
+            result["NextToken"] = token
+        return ActionResult(result)
+
+    def update_alias(self) -> ActionResult:
+        return ActionResult(
+            {
+                "Alias": self.backend.update_alias(
+                    self._get_param("AliasName"), self._get_param("KeyArn")
+                )
+            }
+        )
+
+    def delete_alias(self) -> EmptyResult:
+        self.backend.delete_alias(self._get_param("AliasName"))
+        return EmptyResult()
+
+    def tag_resource(self) -> EmptyResult:
+        self.backend.tag_resource(
+            self._get_param("ResourceArn"), self._get_param("Tags")
+        )
+        return EmptyResult()
+
+    def untag_resource(self) -> EmptyResult:
+        self.backend.untag_resource(
+            self._get_param("ResourceArn"), self._get_param("TagKeys")
+        )
+        return EmptyResult()
+
+    def list_tags_for_resource(self) -> ActionResult:
+        p = self._get_params()
+        values, token = self.backend.list_tags_for_resource(
+            p["ResourceArn"], p.get("NextToken"), p.get("MaxResults")
+        )
+        result: dict[str, Any] = {"Tags": values}
+        if token:
+            result["NextToken"] = token
+        return ActionResult(result)
+
+    def put_resource_policy(self) -> ActionResult:
+        return ActionResult(
+            self.backend.put_resource_policy(
+                self._get_param("ResourceArn"), self._get_param("Policy")
+            )
+        )
+
+    def get_resource_policy(self) -> ActionResult:
+        return ActionResult(
+            self.backend.get_resource_policy(self._get_param("ResourceArn"))
+        )
+
+    def delete_resource_policy(self) -> EmptyResult:
+        self.backend.delete_resource_policy(self._get_param("ResourceArn"))
+        return EmptyResult()
+
+    def enable_default_key_replication_regions(self) -> ActionResult:
+        return ActionResult(
+            {
+                "EnabledReplicationRegions": self.backend.enable_default_key_replication_regions(
+                    self._get_param("ReplicationRegions")
+                )
+            }
+        )
+
+    def disable_default_key_replication_regions(self) -> ActionResult:
+        return ActionResult(
+            {
+                "EnabledReplicationRegions": self.backend.disable_default_key_replication_regions(
+                    self._get_param("ReplicationRegions")
+                )
+            }
+        )
+
+    def get_default_key_replication_regions(self) -> ActionResult:
+        return ActionResult(
+            {
+                "EnabledReplicationRegions": self.backend.get_default_key_replication_regions()
+            }
+        )
+
+    def add_key_replication_regions(self) -> ActionResult:
+        return ActionResult(
+            {
+                "Key": self.backend.add_key_replication_regions(
+                    self._get_param("KeyIdentifier"),
+                    self._get_param("ReplicationRegions"),
+                )
+            }
+        )
+
+    def remove_key_replication_regions(self) -> ActionResult:
+        return ActionResult(
+            {
+                "Key": self.backend.remove_key_replication_regions(
+                    self._get_param("KeyIdentifier"),
+                    self._get_param("ReplicationRegions"),
+                )
+            }
+        )
+
+    def get_parameters_for_import(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            self.backend.get_parameters_for_import(
+                p["KeyMaterialType"],
+                p["WrappingKeyAlgorithm"],
+                p.get("ReuseLastGeneratedToken", False),
+            )
+        )
+
+    def get_parameters_for_export(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            self.backend.get_parameters_for_export(
+                p["KeyMaterialType"],
+                p["SigningKeyAlgorithm"],
+                p.get("ReuseLastGeneratedToken", False),
+            )
+        )
+
+    def import_key(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            {
+                "Key": self.backend.import_key(
+                    p["KeyMaterial"],
+                    key_check_value_algorithm=p.get("KeyCheckValueAlgorithm"),
+                    enabled=p.get("Enabled", True),
+                    tags=p.get("Tags"),
+                    replication_regions=p.get("ReplicationRegions"),
+                    requester_comment=p.get("RequesterComment"),
+                )
+            }
+        )
+
+    def export_key(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            {
+                "WrappedKey": self.backend.export_key(
+                    p["KeyMaterial"],
+                    p["ExportKeyIdentifier"],
+                    p.get("ExportAttributes"),
+                )
+            }
+        )
+
+    def get_public_key_certificate(self) -> ActionResult:
+        return ActionResult(
+            self.backend.get_public_key_certificate(self._get_param("KeyIdentifier"))
+        )
+
+    def get_certificate_signing_request(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            {
+                "CertificateSigningRequest": self.backend.get_certificate_signing_request(
+                    p["KeyIdentifier"], p["SigningAlgorithm"], p["CertificateSubject"]
+                )
+            }
+        )
+
+    def associate_mpa_team(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            {
+                "MpaTeamAssociation": self.backend.associate_mpa_team(
+                    p["Action"], p["MpaTeamArn"], p.get("RequesterComment")
+                )
+            }
+        )
+
+    def get_mpa_team_association(self) -> ActionResult:
+        return ActionResult(
+            {
+                "MpaTeamAssociation": self.backend.get_mpa_team_association(
+                    self._get_param("Action")
+                )
+            }
+        )
+
+    def disassociate_mpa_team(self) -> ActionResult:
+        p = self._get_params()
+        return ActionResult(
+            {
+                "MpaTeamAssociation": self.backend.disassociate_mpa_team(
+                    p["Action"], p.get("RequesterComment")
+                )
+            }
+        )

--- a/moto/paymentcryptography/urls.py
+++ b/moto/paymentcryptography/urls.py
@@ -1,0 +1,4 @@
+from .responses import PaymentCryptographyControlPlaneResponse
+
+url_bases = [r"https?://controlplane\.payment-cryptography\.(.+)\.amazonaws\.com"]
+url_paths = {"{0}/$": PaymentCryptographyControlPlaneResponse.dispatch}

--- a/tests/test_paymentcryptography/test_control_plane.py
+++ b/tests/test_paymentcryptography/test_control_plane.py
@@ -5,9 +5,16 @@ import pytest
 from botocore import xform_name
 from botocore.exceptions import ClientError
 from botocore.session import Session
+from cryptography import x509
+from cryptography.hazmat.primitives import cmac
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
 
 from moto import mock_aws
-from moto.paymentcryptography.models import PaymentCryptographyControlPlaneBackend
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.paymentcryptography.models import (
+    PaymentCryptographyControlPlaneBackend,
+    paymentcryptography_backends,
+)
 from moto.paymentcryptography.responses import PaymentCryptographyControlPlaneResponse
 
 ATTRIBUTES = {
@@ -22,6 +29,20 @@ PUBLIC_ATTRIBUTES = {
     "KeyClass": "PUBLIC_KEY",
     "KeyAlgorithm": "RSA_2048",
     "KeyModesOfUse": {"Verify": True},
+}
+
+PAIR_ATTRIBUTES = {
+    "KeyUsage": "TR31_S0_ASYMMETRIC_KEY_FOR_DIGITAL_SIGNATURE",
+    "KeyClass": "ASYMMETRIC_KEY_PAIR",
+    "KeyAlgorithm": "RSA_2048",
+    "KeyModesOfUse": {"Sign": True, "Verify": True},
+}
+
+WRAPPING_ATTRIBUTES = {
+    "KeyUsage": "TR31_K0_KEY_ENCRYPTION_KEY",
+    "KeyClass": "SYMMETRIC_KEY",
+    "KeyAlgorithm": "AES_128",
+    "KeyModesOfUse": {"Wrap": True, "Unwrap": True},
 }
 
 
@@ -132,6 +153,18 @@ def test_default_and_per_key_replication():
         ]
         == "REPLICA"
     )
+    east.stop_key_usage(KeyIdentifier=key["KeyArn"])
+    assert (
+        client("us-west-2").get_key(KeyIdentifier=replica_arn)["Key"]["Enabled"]
+        is False
+    )
+    east.start_key_usage(KeyIdentifier=key["KeyArn"])
+    east.delete_key(KeyIdentifier=key["KeyArn"])
+    assert (
+        client("us-west-2").get_key(KeyIdentifier=replica_arn)["Key"]["KeyState"]
+        == "DELETE_PENDING"
+    )
+    east.restore_key(KeyIdentifier=key["KeyArn"])
     east.remove_key_replication_regions(
         KeyIdentifier=key["KeyArn"], ReplicationRegions=["us-west-2"]
     )
@@ -163,8 +196,9 @@ def test_import_export_certificates_and_token_reuse():
     )["Key"]
     certificate = pc.get_public_key_certificate(KeyIdentifier=imported["KeyArn"])
     assert certificate["KeyCertificate"].startswith("-----BEGIN CERTIFICATE-----")
+    signing_key = pc.create_key(KeyAttributes=PAIR_ATTRIBUTES, Exportable=False)["Key"]
     csr = pc.get_certificate_signing_request(
-        KeyIdentifier=imported["KeyArn"],
+        KeyIdentifier=signing_key["KeyArn"],
         SigningAlgorithm="SHA256",
         CertificateSubject={"CommonName": "moto.example", "Country": "US"},
     )["CertificateSigningRequest"]
@@ -182,11 +216,69 @@ def test_import_export_certificates_and_token_reuse():
         == export_parameters["ExportToken"]
     )
     exportable = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+    wrapping = pc.create_key(KeyAttributes=WRAPPING_ATTRIBUTES, Exportable=True)["Key"]
     wrapped = pc.export_key(
-        KeyMaterial={"Tr31KeyBlock": {"WrappingKeyIdentifier": exportable["KeyArn"]}},
+        KeyMaterial={"Tr31KeyBlock": {"WrappingKeyIdentifier": wrapping["KeyArn"]}},
         ExportKeyIdentifier=exportable["KeyArn"],
     )["WrappedKey"]
     assert wrapped["WrappedKeyMaterialFormat"] == "TR31_KEY_BLOCK"
+    reimported = pc.import_key(
+        KeyMaterial={
+            "Tr31KeyBlock": {
+                "WrappingKeyIdentifier": wrapping["KeyArn"],
+                "WrappedKeyBlock": wrapped["KeyMaterial"],
+            }
+        }
+    )["Key"]
+    assert reimported["KeyAttributes"] == exportable["KeyAttributes"]
+    assert reimported["KeyCheckValue"] == exportable["KeyCheckValue"]
+
+
+@mock_aws
+def test_kcv_matches_aes_cmac():
+    pc = client()
+    key = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+    backend_key = paymentcryptography_backends[DEFAULT_ACCOUNT_ID]["us-east-1"].keys[
+        key["KeyArn"]
+    ]
+    calculator = cmac.CMAC(AES(backend_key.material))
+    calculator.update(bytes(16))
+    assert key["KeyCheckValue"] == calculator.finalize()[:3].hex().upper()
+
+
+@mock_aws
+def test_import_token_is_bound_to_material_type():
+    pc = client()
+    token = pc.get_parameters_for_import(
+        KeyMaterialType="TR31_KEY_BLOCK", WrappingKeyAlgorithm="RSA_2048"
+    )["ImportToken"]
+    with pytest.raises(ClientError) as error:
+        pc.import_key(
+            KeyMaterial={
+                "KeyCryptogram": {
+                    "KeyAttributes": ATTRIBUTES,
+                    "Exportable": True,
+                    "WrappedKeyCryptogram": "00" * 16,
+                    "ImportToken": token,
+                }
+            }
+        )
+    assert error.value.response["Error"]["Code"] == "ValidationException"
+
+
+@mock_aws
+def test_csr_uses_requested_key_size_and_hash():
+    pc = client()
+    attributes = {**PAIR_ATTRIBUTES, "KeyAlgorithm": "RSA_3072"}
+    key = pc.create_key(KeyAttributes=attributes, Exportable=False)["Key"]
+    pem = pc.get_certificate_signing_request(
+        KeyIdentifier=key["KeyArn"],
+        SigningAlgorithm="SHA384",
+        CertificateSubject={"CommonName": "moto.example"},
+    )["CertificateSigningRequest"]
+    csr = x509.load_pem_x509_csr(pem.encode())
+    assert csr.public_key().key_size == 3072
+    assert csr.signature_hash_algorithm.name == "sha384"
 
 
 @mock_aws
@@ -203,6 +295,7 @@ def test_mpa_team_association_lifecycle():
     )
     removed = pc.disassociate_mpa_team(Action=action)["MpaTeamAssociation"]
     assert removed["AssociationState"] == "DELETE_PENDING"
+    assert pc.get_mpa_team_association(Action=action)["MpaTeamAssociation"] == removed
 
 
 @mock_aws

--- a/tests/test_paymentcryptography/test_control_plane.py
+++ b/tests/test_paymentcryptography/test_control_plane.py
@@ -311,3 +311,26 @@ def test_missing_key_raises_resource_not_found():
     with pytest.raises(ClientError) as exc:
         client().get_key(KeyIdentifier="0000000000000000")
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_control_plane_validation_errors():
+    pc = client()
+    key = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+
+    pc.create_alias(AliasName="alias/duplicate", KeyArn=key["KeyArn"])
+    with pytest.raises(ClientError) as error:
+        pc.create_alias(AliasName="alias/duplicate", KeyArn=key["KeyArn"])
+    assert error.value.response["Error"]["Code"] == "ConflictException"
+
+    with pytest.raises(ClientError) as error:
+        pc.list_keys(NextToken="not-a-pagination-token")
+    assert error.value.response["Error"]["Code"] == "ValidationException"
+
+    with pytest.raises(ClientError) as error:
+        pc.put_resource_policy(ResourceArn=key["KeyArn"], Policy="not-json")
+    assert error.value.response["Error"]["Code"] == "ValidationException"
+
+    with pytest.raises(ClientError) as error:
+        pc.get_public_key_certificate(KeyIdentifier=key["KeyArn"])
+    assert error.value.response["Error"]["Code"] == "ValidationException"

--- a/tests/test_paymentcryptography/test_control_plane.py
+++ b/tests/test_paymentcryptography/test_control_plane.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 import boto3
@@ -231,13 +232,23 @@ def test_import_export_certificates_and_token_reuse():
 
 
 @mock_aws
-def test_kcv_matches_aes_cmac(monkeypatch):
-    material = bytes(range(16))
-    monkeypatch.setattr(
-        "moto.paymentcryptography.models.os.urandom", lambda size: material[:size]
-    )
+def test_kcv_matches_aes_cmac():
     pc = client()
-    key = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+    wrapped = "00" * 16
+    token = pc.get_parameters_for_import(
+        KeyMaterialType="KEY_CRYPTOGRAM", WrappingKeyAlgorithm="RSA_2048"
+    )["ImportToken"]
+    key = pc.import_key(
+        KeyMaterial={
+            "KeyCryptogram": {
+                "KeyAttributes": ATTRIBUTES,
+                "Exportable": True,
+                "WrappedKeyCryptogram": wrapped,
+                "ImportToken": token,
+            }
+        }
+    )["Key"]
+    material = hashlib.sha256(wrapped.encode()).digest()[:16]
     calculator = cmac.CMAC(AES(material))
     calculator.update(bytes(16))
     assert key["KeyCheckValue"] == calculator.finalize()[:3].hex().upper()

--- a/tests/test_paymentcryptography/test_control_plane.py
+++ b/tests/test_paymentcryptography/test_control_plane.py
@@ -1,0 +1,212 @@
+import json
+
+import boto3
+import pytest
+from botocore import xform_name
+from botocore.exceptions import ClientError
+from botocore.session import Session
+
+from moto import mock_aws
+from moto.paymentcryptography.models import PaymentCryptographyControlPlaneBackend
+from moto.paymentcryptography.responses import PaymentCryptographyControlPlaneResponse
+
+ATTRIBUTES = {
+    "KeyUsage": "TR31_D0_SYMMETRIC_DATA_ENCRYPTION_KEY",
+    "KeyClass": "SYMMETRIC_KEY",
+    "KeyAlgorithm": "AES_128",
+    "KeyModesOfUse": {"Encrypt": True, "Decrypt": True},
+}
+
+PUBLIC_ATTRIBUTES = {
+    "KeyUsage": "TR31_K2_TR34_ASYMMETRIC_KEY",
+    "KeyClass": "PUBLIC_KEY",
+    "KeyAlgorithm": "RSA_2048",
+    "KeyModesOfUse": {"Verify": True},
+}
+
+
+def client(region: str = "us-east-1"):
+    return boto3.client("payment-cryptography", region_name=region)
+
+
+def test_all_botocore_operations_are_implemented():
+    service = Session().get_service_model("payment-cryptography")
+    operations = {xform_name(name) for name in service.operation_names}
+    assert len(operations) == 32
+    assert not {
+        operation
+        for operation in operations
+        if not hasattr(PaymentCryptographyControlPlaneBackend, operation)
+    }
+    assert not {
+        operation
+        for operation in operations
+        if not hasattr(PaymentCryptographyControlPlaneResponse, operation)
+    }
+
+
+@mock_aws
+def test_key_alias_lifecycle_and_pagination():
+    pc = client()
+    first = pc.create_key(
+        KeyAttributes=ATTRIBUTES,
+        Exportable=True,
+        Enabled=True,
+        Tags=[{"Key": "team", "Value": "payments"}],
+    )["Key"]
+    second = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=False)["Key"]
+
+    page = pc.list_keys(MaxResults=1)
+    assert len(page["Keys"]) == 1
+    assert len(pc.list_keys(MaxResults=1, NextToken=page["NextToken"])["Keys"]) == 1
+    assert pc.get_key(KeyIdentifier=first["KeyArn"])["Key"] == first
+
+    alias = pc.create_alias(AliasName="alias/current", KeyArn=first["KeyArn"])["Alias"]
+    assert pc.get_alias(AliasName="alias/current")["Alias"] == alias
+    pc.update_alias(AliasName="alias/current", KeyArn=second["KeyArn"])
+    assert (
+        pc.list_aliases(KeyArn=second["KeyArn"])["Aliases"][0]["AliasName"]
+        == "alias/current"
+    )
+    pc.delete_alias(AliasName="alias/current")
+    assert pc.list_aliases()["Aliases"] == []
+
+    stopped = pc.stop_key_usage(KeyIdentifier=first["KeyArn"])["Key"]
+    assert stopped["Enabled"] is False
+    assert pc.start_key_usage(KeyIdentifier=first["KeyArn"])["Key"]["Enabled"] is True
+    assert (
+        pc.delete_key(KeyIdentifier=first["KeyArn"], DeleteKeyInDays=8)["Key"][
+            "KeyState"
+        ]
+        == "DELETE_PENDING"
+    )
+    assert (
+        pc.restore_key(KeyIdentifier=first["KeyArn"])["Key"]["KeyState"]
+        == "CREATE_COMPLETE"
+    )
+
+
+@mock_aws
+def test_tags_and_resource_policy():
+    pc = client()
+    arn = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]["KeyArn"]
+    pc.tag_resource(
+        ResourceArn=arn, Tags=[{"Key": "a", "Value": "1"}, {"Key": "b", "Value": "2"}]
+    )
+    assert len(pc.list_tags_for_resource(ResourceArn=arn, MaxResults=1)["Tags"]) == 1
+    pc.untag_resource(ResourceArn=arn, TagKeys=["a"])
+    assert pc.list_tags_for_resource(ResourceArn=arn)["Tags"] == [
+        {"Key": "b", "Value": "2"}
+    ]
+
+    policy = json.dumps({"Version": "2012-10-17", "Statement": []})
+    assert pc.put_resource_policy(ResourceArn=arn, Policy=policy)["Policy"] == policy
+    assert pc.get_resource_policy(ResourceArn=arn)["Policy"] == policy
+    pc.delete_resource_policy(ResourceArn=arn)
+    assert pc.get_resource_policy(ResourceArn=arn)["Policy"] == "{}"
+
+
+@mock_aws
+def test_default_and_per_key_replication():
+    east = client()
+    assert east.enable_default_key_replication_regions(
+        ReplicationRegions=["us-west-2"]
+    )["EnabledReplicationRegions"] == ["us-west-2"]
+    assert east.get_default_key_replication_regions()["EnabledReplicationRegions"] == [
+        "us-west-2"
+    ]
+    default_key = east.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+    assert default_key["UsingDefaultReplicationRegions"] is True
+
+    east.disable_default_key_replication_regions(ReplicationRegions=["us-west-2"])
+    key = east.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+    primary = east.add_key_replication_regions(
+        KeyIdentifier=key["KeyArn"], ReplicationRegions=["us-west-2"]
+    )["Key"]
+    assert primary["ReplicationStatus"]["us-west-2"]["Status"] == "SYNCHRONIZED"
+    key_id = key["KeyArn"].rsplit("/", 1)[1]
+    replica_arn = f"arn:aws:payment-cryptography:us-west-2:123456789012:key/{key_id}"
+    assert (
+        client("us-west-2").get_key(KeyIdentifier=replica_arn)["Key"][
+            "MultiRegionKeyType"
+        ]
+        == "REPLICA"
+    )
+    east.remove_key_replication_regions(
+        KeyIdentifier=key["KeyArn"], ReplicationRegions=["us-west-2"]
+    )
+    with pytest.raises(ClientError):
+        client("us-west-2").get_key(KeyIdentifier=replica_arn)
+
+
+@mock_aws
+def test_import_export_certificates_and_token_reuse():
+    pc = client()
+    import_parameters = pc.get_parameters_for_import(
+        KeyMaterialType="ROOT_PUBLIC_KEY_CERTIFICATE", WrappingKeyAlgorithm="RSA_2048"
+    )
+    reused = pc.get_parameters_for_import(
+        KeyMaterialType="ROOT_PUBLIC_KEY_CERTIFICATE",
+        WrappingKeyAlgorithm="RSA_2048",
+        ReuseLastGeneratedToken=True,
+    )
+    assert reused["ImportToken"] == import_parameters["ImportToken"]
+
+    imported = pc.import_key(
+        KeyMaterial={
+            "RootCertificatePublicKey": {
+                "KeyAttributes": PUBLIC_ATTRIBUTES,
+                "PublicKeyCertificate": import_parameters["WrappingKeyCertificate"],
+            }
+        },
+        Enabled=True,
+    )["Key"]
+    certificate = pc.get_public_key_certificate(KeyIdentifier=imported["KeyArn"])
+    assert certificate["KeyCertificate"].startswith("-----BEGIN CERTIFICATE-----")
+    csr = pc.get_certificate_signing_request(
+        KeyIdentifier=imported["KeyArn"],
+        SigningAlgorithm="SHA256",
+        CertificateSubject={"CommonName": "moto.example", "Country": "US"},
+    )["CertificateSigningRequest"]
+    assert csr.startswith("-----BEGIN CERTIFICATE REQUEST-----")
+
+    export_parameters = pc.get_parameters_for_export(
+        KeyMaterialType="TR34_KEY_BLOCK", SigningKeyAlgorithm="RSA_2048"
+    )
+    assert (
+        pc.get_parameters_for_export(
+            KeyMaterialType="TR34_KEY_BLOCK",
+            SigningKeyAlgorithm="RSA_2048",
+            ReuseLastGeneratedToken=True,
+        )["ExportToken"]
+        == export_parameters["ExportToken"]
+    )
+    exportable = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
+    wrapped = pc.export_key(
+        KeyMaterial={"Tr31KeyBlock": {"WrappingKeyIdentifier": exportable["KeyArn"]}},
+        ExportKeyIdentifier=exportable["KeyArn"],
+    )["WrappedKey"]
+    assert wrapped["WrappedKeyMaterialFormat"] == "TR31_KEY_BLOCK"
+
+
+@mock_aws
+def test_mpa_team_association_lifecycle():
+    pc = client()
+    action = "IMPORT_ROOT_PUBLIC_KEY_CERTIFICATE"
+    team = "arn:aws:mpa:us-east-1:123456789012:approval-team/moto"
+    association = pc.associate_mpa_team(Action=action, MpaTeamArn=team)[
+        "MpaTeamAssociation"
+    ]
+    assert association["AssociationState"] == "ACTIVE"
+    assert (
+        pc.get_mpa_team_association(Action=action)["MpaTeamAssociation"] == association
+    )
+    removed = pc.disassociate_mpa_team(Action=action)["MpaTeamAssociation"]
+    assert removed["AssociationState"] == "DELETE_PENDING"
+
+
+@mock_aws
+def test_missing_key_raises_resource_not_found():
+    with pytest.raises(ClientError) as exc:
+        client().get_key(KeyIdentifier="0000000000000000")
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"

--- a/tests/test_paymentcryptography/test_control_plane.py
+++ b/tests/test_paymentcryptography/test_control_plane.py
@@ -10,11 +10,7 @@ from cryptography.hazmat.primitives import cmac
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 
 from moto import mock_aws
-from moto.core import DEFAULT_ACCOUNT_ID
-from moto.paymentcryptography.models import (
-    PaymentCryptographyControlPlaneBackend,
-    paymentcryptography_backends,
-)
+from moto.paymentcryptography.models import PaymentCryptographyControlPlaneBackend
 from moto.paymentcryptography.responses import PaymentCryptographyControlPlaneResponse
 
 ATTRIBUTES = {
@@ -235,13 +231,14 @@ def test_import_export_certificates_and_token_reuse():
 
 
 @mock_aws
-def test_kcv_matches_aes_cmac():
+def test_kcv_matches_aes_cmac(monkeypatch):
+    material = bytes(range(16))
+    monkeypatch.setattr(
+        "moto.paymentcryptography.models.os.urandom", lambda size: material[:size]
+    )
     pc = client()
     key = pc.create_key(KeyAttributes=ATTRIBUTES, Exportable=True)["Key"]
-    backend_key = paymentcryptography_backends[DEFAULT_ACCOUNT_ID]["us-east-1"].keys[
-        key["KeyArn"]
-    ]
-    calculator = cmac.CMAC(AES(backend_key.material))
+    calculator = cmac.CMAC(AES(material))
     calculator.update(bytes(16))
     assert key["KeyCheckValue"] == calculator.finalize()[:3].hex().upper()
 

--- a/tests/test_paymentcryptography/test_server.py
+++ b/tests/test_paymentcryptography/test_server.py
@@ -1,0 +1,17 @@
+import json
+
+import moto.server as server
+from moto import mock_aws
+
+
+@mock_aws
+def test_control_plane_server_dispatch():
+    app = server.create_backend_app("paymentcryptography")
+    response = app.test_client().post(
+        "/",
+        headers={"X-Amz-Target": "PaymentCryptographyControlPlane.ListKeys"},
+        data=json.dumps({}),
+        content_type="application/x-amz-json-1.0",
+    )
+    assert response.status_code == 200
+    assert json.loads(response.data) == {"Keys": []}


### PR DESCRIPTION
 ## Summary

  This PR adds Moto support for all 32 AWS Payment Cryptography control-plane operations.
  The implementation provides a complete control-plane foundation for testing infrastructure-management tools such as Cloud Custodian.

  ## What’s included

  - Key creation, retrieval, listing, deletion, restoration, and usage state
  - Alias creation, retrieval, listing, updating, and deletion
  - Resource tagging and untagging
  - Resource policy management
  - Default and per-key multi-Region replication
  - Import and export parameters and stateful mock round trips
  - Public-key certificates and certificate signing requests
  - MPA team association lifecycle
  - Pagination and common validation errors
  - Moto server-mode routing
  - Service documentation listing all supported operations

  The implementation also includes:

  - Algorithm-appropriate key material and key-check-value calculation
  - Import and export token validation
  - Preservation of key attributes and material across mock export/import workflows
  - Requested RSA key sizes and CSR signing hashes
  - Lifecycle propagation between primary and replica keys
  - Persistent MPA deletion state

  ## Scope and limitations

  This PR targets stateful control-plane mocking and does not add Payment Cryptography Data Plane operations.

  Import and export behavior supports coherent Moto-generated workflows, but it does not provide wire-compatible TR-31/TR-34 processing, emulate AWS HSM cryptography, or claim exact AWS behavioral parity for every validation edge case.

  ## Testing

  - pytest -q tests/test_paymentcryptography
  - make lint
  - Moto server-mode dispatch

  All 32 boto3 control-plane operations are checked for both backend and response-layer implementations.