### PR TITLE
DynamoDB: Bring parity with AWS in error messages

### DIFF
--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -122,8 +122,12 @@ class ExpressionAttributeValueNotDefined(InvalidUpdateExpression):
 
 
 class ExpressionAttributeValuesEmpty(MockValidationException):
-    def __init__(self) -> None:
-        super().__init__("ExpressionAttributeValues must not be empty")
+    def __init__(self, validation_error_prefix: bool = False) -> None:
+        msg = "ExpressionAttributeValues must not be empty"
+        if validation_error_prefix:
+            # Error messages are inconsistent - some operations have this prefix, others (like Transact* operations) do not
+            msg = f"1 validation error detected: {msg}"
+        super().__init__(msg)
 
 
 class UpdateExprSyntaxError(InvalidUpdateExpression):
@@ -216,7 +220,7 @@ class ConditionalCheckFailed(DynamodbException):
                     "__type": ConditionalCheckFailed.error_type,
                     # Note the uppercase Message
                     # This ensures the message is only part of the 'error': {'message': .., 'code': ..}
-                    "Message": _msg,
+                    "message": _msg,
                     "Item": item,
                 }
             )
@@ -299,24 +303,24 @@ class InvalidAttributeTypeError(MockValidationException):
         super().__init__(self.msg.format(name, expected_type, actual_type))
 
 
-class DuplicateUpdateExpression(InvalidUpdateExpression):
+class DuplicateUpdateExpression(MockValidationException):
     def __init__(self, name_1: str, name_2: str):
         super().__init__(
-            f"Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{', '.join(name_1.split('.'))}], path two: [{', '.join(name_2.split('.'))}]"
+            f"1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{', '.join(name_1.split('.'))}], path two: [{', '.join(name_2.split('.'))}]"
         )
 
 
 class InvalidProjectionExpression(MockValidationException):
     def __init__(self, path_1: str, path_2: str):
         super().__init__(
-            f"Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{', '.join(path_1.split('.'))}], path two: [{', '.join(path_2.split('.'))}]"
+            f"1 validation error detected: Invalid ProjectionExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [{', '.join(path_1.split('.'))}], path two: [{', '.join(path_2.split('.'))}]"
         )
 
 
-class TooManyClauses(InvalidUpdateExpression):
+class TooManyClauses(MockValidationException):
     def __init__(self, _type: str) -> None:
         super().__init__(
-            f'The "{_type}" section can only be used once in an update expression;'
+            f'1 validation error detected: Invalid UpdateExpression: The "{_type}" section can only be used once in an update expression;'
         )
 
 

--- a/moto/dynamodb/parsing/executors.py
+++ b/moto/dynamodb/parsing/executors.py
@@ -227,7 +227,7 @@ class AddExecutor(NodeExecutor):
             if value_to_add.is_set():
                 if len(value_to_add.value) == 0:
                     raise MockValidationException(
-                        "ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An string set  may not be empty"
+                        "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty"
                     )
                 try:
                     current_string_set = self.get_item_at_end_of_path(item)

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -137,7 +137,7 @@ def validate_put_has_empty_attrs(field_updates: dict[str, Any], table: Table) ->
         for set_type, error in [("NS", "number"), ("SS", "string")]:
             if set_type in attr and attr[set_type] == []:
                 raise MockValidationException(
-                    f"One or more parameter values were invalid: An {error} set  may not be empty"
+                    f"1 validation error detected: One or more parameter values were invalid: An {error} set  may not be empty"
                 )
 
         else:
@@ -165,12 +165,14 @@ def validate_attributes_used(
     attribute_names: dict[str, Any] | None,
     names_used: list[str],
     provided_attr: str = "Names",
+    validation_error_prefix: bool = True,
 ) -> None:
     for name in attribute_names or []:
         if name not in names_used:
-            raise MockValidationException(
-                f"Value provided in ExpressionAttribute{provided_attr} unused in expressions: keys: {{{name}}}"
-            )
+            msg = f"Value provided in ExpressionAttribute{provided_attr} unused in expressions: keys: {{{name}}}"
+            if validation_error_prefix:
+                msg = f"1 validation error detected: {msg}"
+            raise MockValidationException(msg)
 
 
 def validate_select(
@@ -809,7 +811,9 @@ class DynamoHandler(BaseResponse):
         projection_expressions = parser.parse()
 
         validate_attributes_used(
-            expression_attribute_names, parser.expr_attr_names_found
+            expression_attribute_names,
+            parser.expr_attr_names_found,
+            validation_error_prefix=False,
         )
 
         item = self.dynamodb_backend.get_item(name, key, projection_expressions)
@@ -864,7 +868,9 @@ class DynamoHandler(BaseResponse):
             )
             projection_expressions = parser.parse()
             validate_attributes_used(
-                expression_attribute_names, parser.expr_attr_names_found
+                expression_attribute_names,
+                parser.expr_attr_names_found,
+                validation_error_prefix=False,
             )
 
             results["Responses"][table_name] = []
@@ -1012,7 +1018,9 @@ class DynamoHandler(BaseResponse):
                 filter_kwargs.update(query_filters)
 
         validate_attributes_used(
-            expression_attribute_names, expression_attribute_names_used
+            expression_attribute_names,
+            expression_attribute_names_used,
+            validation_error_prefix=False,
         )
         index_name = self.body.get("IndexName")
         exclusive_start_key = self.body.get("ExclusiveStartKey")
@@ -1120,7 +1128,9 @@ class DynamoHandler(BaseResponse):
             )
 
         validate_attributes_used(
-            expression_attribute_names, expression_attribute_names_used
+            expression_attribute_names,
+            expression_attribute_names_used,
+            validation_error_prefix=False,
         )
 
         validate_select(
@@ -1227,7 +1237,7 @@ class DynamoHandler(BaseResponse):
             update_expression = update_expression.strip()
             if update_expression == "":
                 raise MockValidationException(
-                    "Invalid UpdateExpression: The expression can not be empty;"
+                    "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;"
                 )
             update_expression_ast = UpdateExpressionParser.make(update_expression)
             attr_name_clauses = update_expression_ast.find_clauses(
@@ -1341,7 +1351,7 @@ class DynamoHandler(BaseResponse):
         if values is None:
             return {}
         if len(values) == 0:
-            raise ExpressionAttributeValuesEmpty
+            raise ExpressionAttributeValuesEmpty(validation_error_prefix=True)
         for key in values:
             if not key.startswith(":"):
                 raise MockValidationException(
@@ -1349,7 +1359,7 @@ class DynamoHandler(BaseResponse):
                 )
             if values[key] == {"NS": []}:
                 raise MockValidationException(
-                    f"ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An number set  may not be empty for key {key}"
+                    "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty"
                 )
         return values
 
@@ -1512,7 +1522,9 @@ class DynamoHandler(BaseResponse):
                 ]
 
             validate_attributes_used(
-                expression_attribute_names, expression_attribute_names_used
+                expression_attribute_names,
+                expression_attribute_names_used,
+                validation_error_prefix=False,
             )
 
         self.dynamodb_backend.transact_write_items(transact_items)

--- a/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_exceptions.py
@@ -281,7 +281,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
         assert err["Code"] == "ValidationException"
         assert (
             err["Message"]
-            == 'Invalid UpdateExpression: The "ADD" section can only be used once in an update expression;'
+            == '1 validation error detected: Invalid UpdateExpression: The "ADD" section can only be used once in an update expression;'
         )
 
     def test_multiple_remove_clauses(self):
@@ -296,7 +296,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
         assert err["Code"] == "ValidationException"
         assert (
             err["Message"]
-            == 'Invalid UpdateExpression: The "REMOVE" section can only be used once in an update expression;'
+            == '1 validation error detected: Invalid UpdateExpression: The "REMOVE" section can only be used once in an update expression;'
         )
 
     def test_multiple_set_clauses(self):
@@ -310,7 +310,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
         assert err["Code"] == "ValidationException"
         assert (
             err["Message"]
-            == 'Invalid UpdateExpression: The "SET" section can only be used once in an update expression;'
+            == '1 validation error detected: Invalid UpdateExpression: The "SET" section can only be used once in an update expression;'
         )
 
     def test_delete_and_add_on_same_set(self):
@@ -323,7 +323,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert exc.value.response["Error"]["Message"].startswith(
-            "Invalid UpdateExpression: Two document paths overlap with each other;"
+            "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
     def test_remove_and_add_on_same_set(self):
@@ -336,7 +336,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert exc.value.response["Error"]["Message"].startswith(
-            "Invalid UpdateExpression: Two document paths overlap with each other;"
+            "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
     def test_set_and_remove_on_overlapping_paths(self):
@@ -348,7 +348,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert exc.value.response["Error"]["Message"].startswith(
-            "Invalid UpdateExpression: Two document paths overlap with each other;"
+            "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
     def test_set_path_overlap(self):
@@ -360,7 +360,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert exc.value.response["Error"]["Message"].startswith(
-            "Invalid UpdateExpression: Two document paths overlap with each other;"
+            "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
     def test_path_overlap_error_uses_expression_attribute_name(self):
@@ -374,7 +374,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert (
             exc.value.response["Error"]["Message"]
-            == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set]"
+            == "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set], path two: [string_set]"
         )
 
     def test_path_overlap_error_splits_paths(self):
@@ -387,7 +387,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert (
             exc.value.response["Error"]["Message"]
-            == "Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set, nested], path two: [string_set, nested]"
+            == "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other; must remove or rewrite one of these paths; path one: [string_set, nested], path two: [string_set, nested]"
         )
 
     # pretty weird AWS behavior with the next two tests, seems like a bug
@@ -416,7 +416,7 @@ class TestUpdateExpressionClausesWithClashingExpressions(BaseTest):
             )
         assert exc.value.response["Error"]["Code"] == "ValidationException"
         assert exc.value.response["Error"]["Message"].startswith(
-            "Invalid UpdateExpression: Two document paths overlap with each other;"
+            "1 validation error detected: Invalid UpdateExpression: Two document paths overlap with each other;"
         )
 
     def test_update_item_with_shared_root_but_different_overall(self):
@@ -471,7 +471,7 @@ def test_update_item_unused_attributes(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
+        == "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
     )
 
     # Unused Name (count) only
@@ -486,7 +486,7 @@ def test_update_item_unused_attributes(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
+        == "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
     )
 
     # Unused Value (countChange)
@@ -501,7 +501,7 @@ def test_update_item_unused_attributes(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "Value provided in ExpressionAttributeValues unused in expressions: keys: {:countChange}"
+        == "1 validation error detected: Value provided in ExpressionAttributeValues unused in expressions: keys: {:countChange}"
     )
 
     # Used value in ConditionExpression
@@ -531,7 +531,7 @@ def test_update_item_unused_attributes(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An number set  may not be empty for key :one"
+        == "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty"
     )
 
 
@@ -552,7 +552,7 @@ def test_put_item_unused_attributes(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
+        == "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
     )
 
 
@@ -640,7 +640,7 @@ def test_delete_unused_attribute_name(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
+        == "1 validation error detected: Value provided in ExpressionAttributeNames unused in expressions: keys: {#count}"
     )
 
 
@@ -1374,7 +1374,7 @@ def test_put_item_empty_set(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "One or more parameter values were invalid: An number set  may not be empty"
+        == "1 validation error detected: One or more parameter values were invalid: An number set  may not be empty"
     )
 
     with pytest.raises(ClientError) as exc:
@@ -1385,7 +1385,7 @@ def test_put_item_empty_set(table_name=None):
     assert err["Code"] == "ValidationException"
     assert (
         err["Message"]
-        == "One or more parameter values were invalid: An string set  may not be empty"
+        == "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty"
     )
 
 
@@ -1811,15 +1811,16 @@ def test_list_append_errors_for_unknown_attribute_value():
     )
 
 
-@mock_aws
-def test_query_with_empty_filter_expression():
-    ddb = boto3.resource("dynamodb", region_name="us-east-1")
-    table = ddb.create_table(
-        TableName=f"T{uuid4()}", BillingMode="PAY_PER_REQUEST", **table_schema
-    )
+@pytest.mark.aws_verified
+@dynamodb_aws_verified()
+def test_query_with_empty_filter_expression(table_name=None):
+    table = boto3.resource("dynamodb", region_name="us-east-1").Table(table_name)
+
     with pytest.raises(ClientError) as exc:
         table.query(
-            KeyConditionExpression="partitionKey = sth", ProjectionExpression=""
+            KeyConditionExpression="pk = :pk",
+            ExpressionAttributeValues={":pk": "pk"},
+            ProjectionExpression="",
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
@@ -1940,7 +1941,7 @@ class TestReturnValuesOnConditionCheckFailure(BaseTest):
             "Message": "The conditional request failed",
             "Code": "ConditionalCheckFailedException",
         }
-        assert "message" not in resp
+        assert resp["message"] == "The conditional request failed"
         assert resp["Item"] == {
             "pk": {"S": "the-key"},
             "body": {"S": "some test msg"},

--- a/tests/test_dynamodb/exceptions/test_dynamodb_transactions.py
+++ b/tests/test_dynamodb/exceptions/test_dynamodb_transactions.py
@@ -151,9 +151,12 @@ def test_transact_write_items__update_with_multiple_set_clauses(table_name=None)
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
+    # In AWS, this is the full error message
+    # Moto prefixes this error with '1 validation error detected', as that is what other methods also return.
+    # Hopefully AWS streamlines the error messages soon to include that prefix everywhere
     assert (
-        err["Message"]
-        == 'Invalid UpdateExpression: The "SET" section can only be used once in an update expression;'
+        'Invalid UpdateExpression: The "SET" section can only be used once in an update expression;'
+        in err["Message"]
     )
 
     # Note that we can do this by simply separating the statements with a comma

--- a/tests/test_dynamodb/test_dynamodb.py
+++ b/tests/test_dynamodb/test_dynamodb.py
@@ -4039,28 +4039,23 @@ def test_error_when_providing_expression_and_nonexpression_params():
     )
 
 
-@mock_aws
-def test_error_when_providing_empty_update_expression():
-    client = boto3.client("dynamodb", "eu-central-1")
-    table_name = f"T{uuid4()}"
-    client.create_table(
-        TableName=table_name,
-        KeySchema=[{"AttributeName": "pkey", "KeyType": "HASH"}],
-        AttributeDefinitions=[{"AttributeName": "pkey", "AttributeType": "S"}],
-        BillingMode="PAY_PER_REQUEST",
-    )
+@pytest.mark.aws_verified
+@dynamodb_aws_verified()
+def test_error_when_providing_empty_update_expression(table_name=None):
+    client = boto3.client("dynamodb", "us-east-1")
 
     with pytest.raises(ClientError) as ex:
         client.update_item(
             TableName=table_name,
-            Key={"pkey": {"S": "testrecord"}},
+            Key={"pk": {"S": "testrecord"}},
             UpdateExpression="",
             ExpressionAttributeValues={":order": {"SS": ["item"]}},
         )
     err = ex.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
-        err["Message"] == "Invalid UpdateExpression: The expression can not be empty;"
+        err["Message"]
+        == "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;"
     )
 
 

--- a/tests/test_dynamodb/test_dynamodb_update_expressions.py
+++ b/tests/test_dynamodb/test_dynamodb_update_expressions.py
@@ -176,8 +176,8 @@ def test_update_item_add_empty_set(table_name=None):
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
-        "ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An string set  may not be empty"
-        in err["Message"]
+        err["Message"]
+        == "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty"
     )
 
     assert dynamodb.scan(TableName=table_name)["Items"] == [{"pk": {"S": "foo"}}]
@@ -196,8 +196,8 @@ def test_update_item_add_empty_set(table_name=None):
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
-        "ExpressionAttributeValues contains invalid value: One or more parameter values were invalid: An string set  may not be empty"
-        in err["Message"]
+        err["Message"]
+        == "1 validation error detected: One or more parameter values were invalid: An string set  may not be empty"
     )
 
     assert dynamodb.scan(TableName=table_name)["Items"] == [
@@ -221,7 +221,10 @@ def test_update_item_with_empty_values(table_name=None):
         )
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
-    assert err["Message"] == "ExpressionAttributeValues must not be empty"
+    assert (
+        err["Message"]
+        == "1 validation error detected: ExpressionAttributeValues must not be empty"
+    )
 
 
 @pytest.mark.aws_verified
@@ -239,7 +242,8 @@ def test_update_item_with_empty_expression(table_name=None):
     err = exc.value.response["Error"]
     assert err["Code"] == "ValidationException"
     assert (
-        err["Message"] == "Invalid UpdateExpression: The expression can not be empty;"
+        err["Message"]
+        == "1 validation error detected: Invalid UpdateExpression: The expression can not be empty;"
     )
 
 


### PR DESCRIPTION
AWS changed the format of quite a few error messages, breaking our parity test suite. This changes the relevant error messages in Moto, bringing parity back with how AWS behaves.

Successful run against AWS: https://github.com/getmoto/moto/actions/runs/32587019036/job/97064848374