### PR TITLE
CloudFormation: don't propagate stack tags to launch templates

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -32,6 +32,7 @@ from moto.datapipeline import models as data_models  # noqa
 from moto.dynamodb import models as ddb_models  # noqa
 from moto.ec2 import models as ec2_models
 from moto.ec2.models.core import TaggedEC2Resource
+from moto.ec2.models.launch_templates import LaunchTemplate
 from moto.ecr import models as ecr_models  # noqa
 from moto.ecs import models as ecs_models  # noqa
 from moto.efs import models as efs_models  # noqa
@@ -752,7 +753,12 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
         all_resources_ready = True
         for resource in self.__get_resources_in_dependency_order():
             instance = self[resource]
-            if isinstance(instance, TaggedEC2Resource):
+            # LaunchTemplate's CFN schema exposes tags via TagSpecifications
+            # (nested under LaunchTemplateData), not a top-level Tags property,
+            # so CloudFormation does not auto-propagate the stack tags to it.
+            if isinstance(instance, TaggedEC2Resource) and not isinstance(
+                instance, LaunchTemplate
+            ):
                 self.tags["aws:cloudformation:logical-id"] = resource
                 backend = ec2_models.ec2_backends[self._account_id][self._region_name]
                 backend.create_tags([instance.physical_resource_id], self.tags)

--- a/tests/test_ec2/test_ec2_cloudformation.py
+++ b/tests/test_ec2/test_ec2_cloudformation.py
@@ -1002,16 +1002,22 @@ def test_launch_template_does_not_receive_stack_tags():
     assert lt_tags == []
 
     # Sanity check: a resource that *does* support the Tags property still
-    # gets the stack tags, so we know tagging itself isn't broken.
-    vpc = ec2.describe_vpcs(Filters=[{"Name": "cidr", "Values": ["10.0.0.0/16"]}])[
-        "Vpcs"
+    # gets the stack tags, so we know tagging itself isn't broken. Look the
+    # VPC up by its stack resource id (not by CidrBlock) since server-mode
+    # tests share one long-lived backend across the whole suite, and other
+    # tests may use the same generic CIDR.
+    resources = cf.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
+    vpc_id = [
+        r["PhysicalResourceId"]
+        for r in resources
+        if r["LogicalResourceId"] == "TestVpc"
     ][0]
-    vpc_tags = ec2.describe_tags(
-        Filters=[{"Name": "resource-id", "Values": [vpc["VpcId"]]}]
-    )["Tags"]
+    vpc_tags = ec2.describe_tags(Filters=[{"Name": "resource-id", "Values": [vpc_id]}])[
+        "Tags"
+    ]
     assert {
         "Key": "aws:cloudformation:logical-id",
-        "ResourceId": vpc["VpcId"],
+        "ResourceId": vpc_id,
         "ResourceType": "vpc",
         "Value": "TestVpc",
     } in vpc_tags

--- a/tests/test_ec2/test_ec2_cloudformation.py
+++ b/tests/test_ec2/test_ec2_cloudformation.py
@@ -955,3 +955,63 @@ def test_launch_template_delete():
         err["Message"]
         == "At least one of the launch templates specified in the request does not exist."
     )
+
+
+@mock_aws
+def test_launch_template_does_not_receive_stack_tags():
+    cf = boto3.client("cloudformation", region_name="us-west-1")
+    ec2 = boto3.client("ec2", region_name="us-west-1")
+
+    launch_template_name = str(uuid4())[0:6]
+    logical_id = str(uuid4())[0:6]
+    stack_name = str(uuid4())[0:6]
+
+    template_json = json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Resources": {
+                logical_id: {
+                    "Type": "AWS::EC2::LaunchTemplate",
+                    "Properties": {
+                        "LaunchTemplateName": launch_template_name,
+                        "LaunchTemplateData": {
+                            "ImageId": EXAMPLE_AMI_ID,
+                            "InstanceType": "t2.micro",
+                        },
+                    },
+                },
+                "TestVpc": {
+                    "Type": "AWS::EC2::VPC",
+                    "Properties": {"CidrBlock": "10.0.0.0/16"},
+                },
+            },
+        }
+    )
+    cf.create_stack(StackName=stack_name, TemplateBody=template_json)
+
+    launch_template = ec2.describe_launch_templates(
+        LaunchTemplateNames=[launch_template_name]
+    )["LaunchTemplates"][0]
+    lt_tags = ec2.describe_tags(
+        Filters=[
+            {"Name": "resource-id", "Values": [launch_template["LaunchTemplateId"]]}
+        ]
+    )["Tags"]
+    # AWS::EC2::LaunchTemplate exposes tags via TagSpecifications, not a
+    # top-level Tags property, so CloudFormation does not auto-tag it
+    assert lt_tags == []
+
+    # Sanity check: a resource that *does* support the Tags property still
+    # gets the stack tags, so we know tagging itself isn't broken.
+    vpc = ec2.describe_vpcs(Filters=[{"Name": "cidr", "Values": ["10.0.0.0/16"]}])[
+        "Vpcs"
+    ][0]
+    vpc_tags = ec2.describe_tags(
+        Filters=[{"Name": "resource-id", "Values": [vpc["VpcId"]]}]
+    )["Tags"]
+    assert {
+        "Key": "aws:cloudformation:logical-id",
+        "ResourceId": vpc["VpcId"],
+        "ResourceType": "vpc",
+        "Value": "TestVpc",
+    } in vpc_tags


### PR DESCRIPTION
Closes #10168.

`AWS::EC2::LaunchTemplate` exposes tags via `TagSpecifications` (nested under `LaunchTemplateData`), not a top-level `Tags` property, so real CloudFormation does not auto-propagate the stack's tags to it the way it does for other taggable EC2 resources ([AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-resource-tags.html#cfn-resource-tags-key)).

Root cause: `LaunchTemplate` inherits `TaggedEC2Resource`, so the generic tag-propagation loop in `ResourceMap.create()` (`moto/cloudformation/parsing.py`) was calling `create_tags(...)` on it just like any other taggable EC2 resource. Excludes `LaunchTemplate` from that loop.

Note: `describe_launch_templates`'s `Tags` field wasn't actually showing the leak (it's a snapshot taken at construction time, before the CFN tag loop runs), the leaked tags were only visible via the generic `describe_tags` API on the launch template's resource id. Test reflects that, and also verifies a normal taggable resource (VPC) still gets stack tags as a regression guard.