### PR TITLE
KMS: implement MessageType=DIGEST for Sign and Verify

### DIFF
--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -288,9 +288,9 @@ class Key(CloudFormationModel):
             }
         }
         if key_dict["KeyMetadata"]["MultiRegion"]:
-            key_dict["KeyMetadata"]["MultiRegionConfiguration"] = (
-                self.multi_region_configuration
-            )
+            key_dict["KeyMetadata"][
+                "MultiRegionConfiguration"
+            ] = self.multi_region_configuration
         if self.key_state == "PendingDeletion":
             key_dict["KeyMetadata"]["DeletionDate"] = unix_time(self.deletion_date)
         return key_dict
@@ -753,7 +753,11 @@ class KmsBackend(BaseBackend, TaggableResourcesMixin):
             )
 
     def sign(
-        self, key_id: str, message: bytes, signing_algorithm: str
+        self,
+        key_id: str,
+        message: bytes,
+        signing_algorithm: str,
+        message_type: str = "RAW",
     ) -> tuple[str, bytes, str]:
         """
         Sign message using generated private key.
@@ -765,18 +769,22 @@ class KmsBackend(BaseBackend, TaggableResourcesMixin):
         self.__ensure_valid_sign_and_verify_key(key)
         self.__ensure_valid_signing_algorithm(key, signing_algorithm)
 
-        signature = key.private_key.sign(message, signing_algorithm)
+        signature = key.private_key.sign(message, signing_algorithm, message_type)
 
         return key.arn, signature, signing_algorithm
 
     def verify(
-        self, key_id: str, message: bytes, signature: bytes, signing_algorithm: str
+        self,
+        key_id: str,
+        message: bytes,
+        signature: bytes,
+        signing_algorithm: str,
+        message_type: str = "RAW",
     ) -> tuple[str, bool, str]:
         """
         Verify message using public key from generated private key.
 
         - grant_tokens are not implemented
-        - The MessageType-parameter DIGEST is not yet implemented
         """
         key = self.describe_key(key_id)
 
@@ -792,7 +800,7 @@ class KmsBackend(BaseBackend, TaggableResourcesMixin):
 
         return (
             key.arn,
-            key.private_key.verify(message, signature, signing_algorithm),
+            key.private_key.verify(message, signature, signing_algorithm, message_type),
             signing_algorithm,
         )
 

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -645,6 +645,21 @@ class KmsResponse(BaseResponse):
 
         return json.dumps({"Plaintext": response_entropy})
 
+    def _validate_message_type(self, message_type: str) -> None:
+        if message_type not in ("RAW", "DIGEST", "EXTERNAL_MU"):
+            raise ValidationException(
+                f"1 validation error detected: Value '{message_type}' at 'MessageType' failed "
+                "to satisfy constraint: Member must satisfy enum value set: "
+                "[RAW, DIGEST, EXTERNAL_MU]"
+            )
+        if message_type == "EXTERNAL_MU":
+            # Valid enum value, but only meaningful for ML-DSA keys, which moto does not
+            # implement yet.
+            raise ValidationException(
+                "MessageType EXTERNAL_MU is only supported for ML-DSA keys, "
+                "which are not yet implemented in moto"
+            )
+
     def sign(self) -> str:
         key_id = self._get_param("KeyId")
         message = self._get_param("Message")
@@ -664,10 +679,13 @@ class KmsResponse(BaseResponse):
         if not message_type:
             message_type = "RAW"
 
+        self._validate_message_type(message_type)
+
         key_id, signature, signing_algorithm = self.kms_backend.sign(
             key_id=key_id,
             message=message,
             signing_algorithm=signing_algorithm,
+            message_type=message_type,
         )
 
         signature_blob_response = base64.b64encode(signature).decode("utf-8")
@@ -710,11 +728,14 @@ class KmsResponse(BaseResponse):
                 "1 validation error detected: Value at 'Signature' failed to satisfy constraint: Member must have length greater than or equal to 1"
             )
 
+        self._validate_message_type(message_type)
+
         key_arn, signature_valid, signing_algorithm = self.kms_backend.verify(
             key_id=key_id,
             message=message,
             signature=signature,
             signing_algorithm=signing_algorithm,
+            message_type=message_type,
         )
 
         return json.dumps(

--- a/moto/kms/utils.py
+++ b/moto/kms/utils.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives._asymmetric import AsymmetricPadding
 from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from moto.moto_api._internal import mock_random
@@ -143,11 +144,19 @@ def generate_master_key() -> bytes:
 
 class AbstractPrivateKey(metaclass=ABCMeta):
     @abstractmethod
-    def sign(self, message: bytes, signing_algorithm: str) -> bytes:
+    def sign(
+        self, message: bytes, signing_algorithm: str, message_type: str = "RAW"
+    ) -> bytes:
         raise NotImplementedError
 
     @abstractmethod
-    def verify(self, message: bytes, signature: bytes, signing_algorithm: str) -> bool:
+    def verify(
+        self,
+        message: bytes,
+        signature: bytes,
+        signing_algorithm: str,
+        message_type: str = "RAW",
+    ) -> bool:
         raise NotImplementedError
 
     @abstractmethod
@@ -162,6 +171,18 @@ def validate_signing_algorithm(
         raise ValidationException(
             "1 validation error detected: Value at 'signing_algorithm' failed"
             f"to satisfy constraint: Member must satisfy enum value set: {valid_algorithms}"
+        )
+
+
+def validate_digest_length(
+    digest: bytes, hash_algorithm: hashes.HashAlgorithm, signing_algorithm: str
+) -> None:
+    # For MessageType=DIGEST, the Message must be the digest itself: "the length of the
+    # Message value must match the length of hashed messages for the specified signing
+    # algorithm" (API_Sign.html). The same constraint applies to Verify.
+    if len(digest) != hash_algorithm.digest_size:
+        raise ValidationException(
+            f"Digest is invalid length for algorithm {signing_algorithm}"
         )
 
 
@@ -217,19 +238,38 @@ class RSAPrivateKey(AbstractPrivateKey):
             algorithm = hashes.SHA512()
         return pad, algorithm
 
-    def sign(self, message: bytes, signing_algorithm: str) -> bytes:
+    def sign(
+        self, message: bytes, signing_algorithm: str, message_type: str = "RAW"
+    ) -> bytes:
         validate_signing_algorithm(
             signing_algorithm, SigningAlgorithm.rsa_signing_algorithms()
         )
         pad, hash_algorithm = self.__padding_and_hash_algorithm(signing_algorithm)
+        if message_type == "DIGEST":
+            # The caller has already hashed the message; sign the digest as-is.
+            validate_digest_length(message, hash_algorithm, signing_algorithm)
+            return self.private_key.sign(message, pad, Prehashed(hash_algorithm))
         return self.private_key.sign(message, pad, hash_algorithm)
 
-    def verify(self, message: bytes, signature: bytes, signing_algorithm: str) -> bool:
+    def verify(
+        self,
+        message: bytes,
+        signature: bytes,
+        signing_algorithm: str,
+        message_type: str = "RAW",
+    ) -> bool:
         validate_signing_algorithm(
             signing_algorithm, SigningAlgorithm.rsa_signing_algorithms()
         )
         pad, hash_algorithm = self.__padding_and_hash_algorithm(signing_algorithm)
         public_key = self.private_key.public_key()
+        if message_type == "DIGEST":
+            validate_digest_length(message, hash_algorithm, signing_algorithm)
+            try:
+                public_key.verify(signature, message, pad, Prehashed(hash_algorithm))
+                return True
+            except InvalidSignature:
+                return False
         try:
             public_key.verify(signature, message, pad, hash_algorithm)
             return True
@@ -272,15 +312,36 @@ class ECDSAPrivateKey(AbstractPrivateKey):
             algorithm = hashes.SHA512()
         return algorithm
 
-    def sign(self, message: bytes, signing_algorithm: str) -> bytes:
+    def sign(
+        self, message: bytes, signing_algorithm: str, message_type: str = "RAW"
+    ) -> bytes:
         validate_signing_algorithm(signing_algorithm, self.valid_signing_algorithms)
         hash_algorithm = self.__hash_algorithm(signing_algorithm)
+        if message_type == "DIGEST":
+            # The caller has already hashed the message; sign the digest as-is.
+            validate_digest_length(message, hash_algorithm, signing_algorithm)
+            return self.private_key.sign(message, ec.ECDSA(Prehashed(hash_algorithm)))
         return self.private_key.sign(message, ec.ECDSA(hash_algorithm))
 
-    def verify(self, message: bytes, signature: bytes, signing_algorithm: str) -> bool:
+    def verify(
+        self,
+        message: bytes,
+        signature: bytes,
+        signing_algorithm: str,
+        message_type: str = "RAW",
+    ) -> bool:
         validate_signing_algorithm(signing_algorithm, self.valid_signing_algorithms)
         hash_algorithm = self.__hash_algorithm(signing_algorithm)
         public_key = self.private_key.public_key()
+        if message_type == "DIGEST":
+            validate_digest_length(message, hash_algorithm, signing_algorithm)
+            try:
+                public_key.verify(
+                    signature, message, ec.ECDSA(Prehashed(hash_algorithm))
+                )
+                return True
+            except InvalidSignature:
+                return False
         try:
             public_key.verify(signature, message, ec.ECDSA(hash_algorithm))
             return True

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -1344,6 +1344,14 @@ def test_sign_and_verify_ignoring_grant_tokens():
     assert verify_response["SignatureValid"] is True
 
 
+def _hash_for_signing_algorithm(signing_algorithm):
+    return {
+        "SHA_256": hashes.SHA256(),
+        "SHA_384": hashes.SHA384(),
+        "SHA_512": hashes.SHA512(),
+    }["SHA_" + signing_algorithm.rsplit("SHA_", 1)[-1]]
+
+
 @mock_aws
 @pytest.mark.parametrize(
     "key_spec, signing_algorithm",
@@ -1369,7 +1377,9 @@ def test_sign_and_verify_digest_message_type_RSA(key_spec, signing_algorithm):
     )
     key_id = key["KeyMetadata"]["KeyId"]
 
-    digest = hashes.Hash(hashes.SHA256())
+    # The digest must be produced by the hash of the signing algorithm: with
+    # MessageType=DIGEST, AWS requires the message length to match that hash's length.
+    digest = hashes.Hash(_hash_for_signing_algorithm(signing_algorithm))
     digest.update(b"this works")
     digest.update(b"as well")
     message = digest.finalize()
@@ -1386,6 +1396,7 @@ def test_sign_and_verify_digest_message_type_RSA(key_spec, signing_algorithm):
         Message=message,
         Signature=sign_response["Signature"],
         SigningAlgorithm=signing_algorithm,
+        MessageType="DIGEST",
     )
 
     assert verify_response["SignatureValid"] is True
@@ -1410,7 +1421,7 @@ def test_fail_verify_digest_message_type_RSA(
     )
     key_id = key["KeyMetadata"]["KeyId"]
 
-    digest = hashes.Hash(hashes.SHA256())
+    digest = hashes.Hash(_hash_for_signing_algorithm(signing_algorithm))
     digest.update(b"this works")
     digest.update(b"as well")
     falsified_digest = digest.copy()
@@ -1431,15 +1442,22 @@ def test_fail_verify_digest_message_type_RSA(
         Message=falsified_message,
         Signature=sign_response["Signature"],
         SigningAlgorithm=signing_algorithm,
+        MessageType="DIGEST",
     )
     assert verify_response["SignatureValid"] is False
 
-    # Verification fails if a different signing algorithm is used than the one used in signature.
+    # Verification fails under a different signing algorithm than the one that signed —
+    # the digest must be re-computed with the other algorithm's hash, since DIGEST
+    # messages must match that hash's length.
+    other_digest = hashes.Hash(_hash_for_signing_algorithm(another_signing_algorithm))
+    other_digest.update(b"this works")
+    other_digest.update(b"as well")
     verify_response = client.verify(
         KeyId=key_id,
-        Message=message,
+        Message=other_digest.finalize(),
         Signature=sign_response["Signature"],
         SigningAlgorithm=another_signing_algorithm,
+        MessageType="DIGEST",
     )
 
     assert verify_response["SignatureValid"] is False
@@ -1463,7 +1481,7 @@ def test_sign_and_verify_digest_message_type_ECDSA(key_spec, signing_algorithm):
     )
     key_id = key["KeyMetadata"]["KeyId"]
 
-    digest = hashes.Hash(hashes.SHA256())
+    digest = hashes.Hash(_hash_for_signing_algorithm(signing_algorithm))
     digest.update(b"this works")
     digest.update(b"as well")
     message = digest.finalize()
@@ -1480,6 +1498,7 @@ def test_sign_and_verify_digest_message_type_ECDSA(key_spec, signing_algorithm):
         Message=message,
         Signature=sign_response["Signature"],
         SigningAlgorithm=signing_algorithm,
+        MessageType="DIGEST",
     )
 
     assert verify_response["SignatureValid"] is True
@@ -1544,7 +1563,8 @@ def test_fail_verify_digest_message_type_ECDSA(key_spec, signing_algorithm):
     )
     key_id = key["KeyMetadata"]["KeyId"]
 
-    digest = hashes.Hash(hashes.SHA256())
+    # Sized for the signing algorithm's hash: DIGEST messages must match that length.
+    digest = hashes.Hash(_hash_for_signing_algorithm(signing_algorithm))
     digest.update(b"this works")
     digest.update(b"as well")
     falsified_digest = digest.copy()

--- a/tests/test_kms/test_kms.py
+++ b/tests/test_kms/test_kms.py
@@ -1846,3 +1846,167 @@ def test_ensure_key_can_be_verified_manually():
 
     public_key = serialization.load_der_public_key(public_key_data)
     public_key.verify(signature=raw_signature, data=message, **sign_kwargs)
+
+
+@mock_aws
+@pytest.mark.parametrize(
+    "signing_algorithm",
+    [
+        "RSASSA_PKCS1_V1_5_SHA_256",
+        "RSASSA_PKCS1_V1_5_SHA_384",
+        "RSASSA_PKCS1_V1_5_SHA_512",
+    ],
+)
+def test_sign_digest_is_equivalent_to_sign_raw_for_deterministic_rsa(signing_algorithm):
+    """RSASSA-PKCS1-v1_5 is deterministic, so signing a message RAW and signing its
+    digest with MessageType=DIGEST must produce byte-identical signatures — the defining
+    property of DIGEST ('skips the hashing step in the signing algorithm')."""
+    client = boto3.client("kms", region_name="us-west-2")
+    key_id = client.create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_2048")[
+        "KeyMetadata"
+    ]["KeyId"]
+
+    message = b"the same bytes, hashed once"
+    digest = hashes.Hash(_hash_for_signing_algorithm(signing_algorithm))
+    digest.update(message)
+
+    raw = client.sign(
+        KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm
+    )["Signature"]
+    digested = client.sign(
+        KeyId=key_id,
+        Message=digest.finalize(),
+        SigningAlgorithm=signing_algorithm,
+        MessageType="DIGEST",
+    )["Signature"]
+
+    assert raw == digested
+
+
+@mock_aws
+@pytest.mark.parametrize(
+    "key_spec, signing_algorithm",
+    [
+        ("RSA_2048", "RSASSA_PSS_SHA_256"),
+        ("RSA_2048", "RSASSA_PKCS1_V1_5_SHA_512"),
+        ("ECC_NIST_P256", "ECDSA_SHA_256"),
+        ("ECC_NIST_P384", "ECDSA_SHA_384"),
+    ],
+)
+def test_message_type_does_not_need_to_match_between_sign_and_verify(
+    key_spec, signing_algorithm
+):
+    """Per API_Verify.html: 'The message type does not need to be the same as the one
+    used for signing' — a message and its digest are the same message."""
+    client = boto3.client("kms", region_name="us-west-2")
+    key_id = client.create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)["KeyMetadata"][
+        "KeyId"
+    ]
+
+    message = b"sign raw, verify digest, and back again"
+    digest = hashes.Hash(_hash_for_signing_algorithm(signing_algorithm))
+    digest.update(message)
+    hashed = digest.finalize()
+
+    signed_raw = client.sign(
+        KeyId=key_id, Message=message, SigningAlgorithm=signing_algorithm
+    )["Signature"]
+    assert client.verify(
+        KeyId=key_id,
+        Message=hashed,
+        Signature=signed_raw,
+        SigningAlgorithm=signing_algorithm,
+        MessageType="DIGEST",
+    )["SignatureValid"]
+
+    signed_digest = client.sign(
+        KeyId=key_id,
+        Message=hashed,
+        SigningAlgorithm=signing_algorithm,
+        MessageType="DIGEST",
+    )["Signature"]
+    assert client.verify(
+        KeyId=key_id,
+        Message=message,
+        Signature=signed_digest,
+        SigningAlgorithm=signing_algorithm,
+    )["SignatureValid"]
+
+
+@mock_aws
+def test_sign_digest_verifies_outside_kms_with_the_public_key():
+    """The property partners depend on (and the regression that motivated DIGEST
+    support): a DIGEST signature must verify against GetPublicKey's key over the
+    ORIGINAL message, outside KMS."""
+    client = boto3.client("kms", region_name="us-west-2")
+    key_id = client.create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_2048")[
+        "KeyMetadata"
+    ]["KeyId"]
+
+    message = b"verified by someone who only has the public key"
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(message)
+
+    signature = client.sign(
+        KeyId=key_id,
+        Message=digest.finalize(),
+        SigningAlgorithm="RSASSA_PKCS1_V1_5_SHA_256",
+        MessageType="DIGEST",
+    )["Signature"]
+
+    public_key = serialization.load_der_public_key(
+        client.get_public_key(KeyId=key_id)["PublicKey"]
+    )
+    from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+
+    # Raises InvalidSignature on failure — verifying over the ORIGINAL message proves
+    # KMS signed the digest as-is rather than hashing it again.
+    public_key.verify(signature, message, asym_padding.PKCS1v15(), hashes.SHA256())
+
+
+@mock_aws
+@pytest.mark.parametrize("operation", ["sign", "verify"])
+def test_digest_with_wrong_length_is_rejected(operation):
+    """With MessageType=DIGEST 'the length of the Message value must match the length
+    of hashed messages for the specified signing algorithm' (API_Sign.html)."""
+    client = boto3.client("kms", region_name="us-west-2")
+    key_id = client.create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_2048")[
+        "KeyMetadata"
+    ]["KeyId"]
+
+    thirty_two_bytes = b"x" * 32  # SHA-256-sized, offered to a SHA-384 algorithm
+    kwargs = {
+        "KeyId": key_id,
+        "Message": thirty_two_bytes,
+        "SigningAlgorithm": "RSASSA_PKCS1_V1_5_SHA_384",
+        "MessageType": "DIGEST",
+    }
+    with pytest.raises(ClientError) as ex:
+        if operation == "sign":
+            client.sign(**kwargs)
+        else:
+            client.verify(Signature=b"irrelevant", **kwargs)
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert "Digest is invalid length for algorithm" in err["Message"]
+
+
+@mock_aws
+def test_sign_with_external_mu_message_type_is_not_supported():
+    """EXTERNAL_MU is a valid enum value (ML-DSA keys only), which moto does not
+    implement — the error must say so rather than call the value invalid."""
+    client = boto3.client("kms", region_name="us-west-2")
+    key_id = client.create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_2048")[
+        "KeyMetadata"
+    ]["KeyId"]
+
+    with pytest.raises(ClientError) as ex:
+        client.sign(
+            KeyId=key_id,
+            Message=b"m" * 64,
+            SigningAlgorithm="RSASSA_PKCS1_V1_5_SHA_256",
+            MessageType="EXTERNAL_MU",
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert "ML-DSA" in err["Message"]


### PR DESCRIPTION
Sign and Verify parsed MessageType and then ignored it (responses.py documented DIGEST as "not yet implemented"), so a DIGEST request had its digest hashed AGAIN. The resulting signature verifies against sha256(digest) instead of the digest — meaning any client that signs with MessageType=DIGEST (the documented way to sign large messages, and what real-world KMS JWT signers do) produced signatures that fail external verification against GetPublicKey, while identical code works on AWS.

Per API_Sign.html / API_Verify.html:
- DIGEST skips the hashing step; implemented with cryptography's Prehashed for RSASSA_PSS_*, RSASSA_PKCS1_V1_5_* and ECDSA_*.
- "the length of the Message value must match the length of hashed messages for the specified signing algorithm" — enforced on both operations, failing with ValidationException ("Digest is invalid length for algorithm ...").
- The MessageType enum is RAW | DIGEST | EXTERNAL_MU; an invalid value fails the enum constraint, and EXTERNAL_MU (ML-DSA keys only, not implemented in moto) is rejected with a message that says so instead of calling the value invalid.
- "The message type does not need to be the same as the one used for signing": sign(RAW, message) verifies as (DIGEST, hash(message)) and vice versa — covered by tests both ways, plus a byte-equality test for the deterministic RSASSA_PKCS1_V1_5 algorithms and an external verification test against GetPublicKey over the original message.

The existing digest tests encoded the old behaviour: they signed DIGEST and verified RAW with the same bytes (which only passes when both sides re-hash), and paired SHA-256-sized digests with SHA_384/512 algorithms (which real KMS rejects on length). They now hash with the signing algorithm's own hash and verify as DIGEST.

Not changed here: moto returns SignatureValid=false for a failed verification, where real KMS raises KMSInvalidSignatureException — a pre-existing, moto-wide divergence left for a separate discussion.