### PR TITLE
EC2: Add Traffic Mirror Session support

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -3506,7 +3506,7 @@
 - [X] create_tags
 - [X] create_traffic_mirror_filter
 - [ ] create_traffic_mirror_filter_rule
-- [ ] create_traffic_mirror_session
+- [X] create_traffic_mirror_session
 - [X] create_traffic_mirror_target
 - [X] create_transit_gateway
 - [ ] create_transit_gateway_connect
@@ -3598,7 +3598,7 @@
 - [X] delete_tags
 - [ ] delete_traffic_mirror_filter
 - [ ] delete_traffic_mirror_filter_rule
-- [ ] delete_traffic_mirror_session
+- [X] delete_traffic_mirror_session
 - [ ] delete_traffic_mirror_target
 - [X] delete_transit_gateway
 - [ ] delete_transit_gateway_client_vpn_attachment
@@ -3784,7 +3784,7 @@
 - [X] describe_tags
 - [ ] describe_traffic_mirror_filter_rules
 - [X] describe_traffic_mirror_filters
-- [ ] describe_traffic_mirror_sessions
+- [X] describe_traffic_mirror_sessions
 - [X] describe_traffic_mirror_targets
 - [X] describe_transit_gateway_attachments
 - [ ] describe_transit_gateway_connect_peers
@@ -4028,7 +4028,7 @@
 - [X] modify_subnet_attribute
 - [ ] modify_traffic_mirror_filter_network_services
 - [ ] modify_traffic_mirror_filter_rule
-- [ ] modify_traffic_mirror_session
+- [X] modify_traffic_mirror_session
 - [X] modify_transit_gateway
 - [ ] modify_transit_gateway_metering_policy
 - [ ] modify_transit_gateway_prefix_list_reference

--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -156,7 +156,7 @@ The CopyTagsFromSource-parameter is not yet implemented.
 - [X] create_tags
 - [X] create_traffic_mirror_filter
 - [ ] create_traffic_mirror_filter_rule
-- [ ] create_traffic_mirror_session
+- [X] create_traffic_mirror_session
 - [X] create_traffic_mirror_target
 - [X] create_transit_gateway
 - [ ] create_transit_gateway_connect
@@ -248,7 +248,7 @@ The CopyTagsFromSource-parameter is not yet implemented.
 - [X] delete_tags
 - [ ] delete_traffic_mirror_filter
 - [ ] delete_traffic_mirror_filter_rule
-- [ ] delete_traffic_mirror_session
+- [X] delete_traffic_mirror_session
 - [ ] delete_traffic_mirror_target
 - [X] delete_transit_gateway
 - [ ] delete_transit_gateway_client_vpn_attachment
@@ -451,7 +451,7 @@ The Filters-parameter is not yet implemented
 - [X] describe_tags
 - [ ] describe_traffic_mirror_filter_rules
 - [X] describe_traffic_mirror_filters
-- [ ] describe_traffic_mirror_sessions
+- [X] describe_traffic_mirror_sessions
 - [X] describe_traffic_mirror_targets
 - [X] describe_transit_gateway_attachments
 - [ ] describe_transit_gateway_connect_peers
@@ -714,7 +714,7 @@ The DryRun parameter is ignored.
 - [X] modify_subnet_attribute
 - [ ] modify_traffic_mirror_filter_network_services
 - [ ] modify_traffic_mirror_filter_rule
-- [ ] modify_traffic_mirror_session
+- [X] modify_traffic_mirror_session
 - [X] modify_transit_gateway
 - [ ] modify_transit_gateway_metering_policy
 - [ ] modify_transit_gateway_prefix_list_reference

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -251,6 +251,7 @@ class EC2Backend(
                 for subnets_by_az in self.subnets.values()
                 for subnet in subnets_by_az.values()
             ),
+            "ec2:traffic-mirror-session": self.traffic_mirror_sessions.values(),
             "ec2:transit-gateway": self.transit_gateways.values(),
             "ec2:transit-gateway-attachment": self.transit_gateway_attachments.values(),
             "ec2:volume": self.volumes.values(),

--- a/moto/ec2/models/traffic_mirrors.py
+++ b/moto/ec2/models/traffic_mirrors.py
@@ -7,6 +7,7 @@ from ..exceptions import InvalidInputError
 from ..utils import (
     convert_tag_spec,
     random_traffic_mirror_filter_id,
+    random_traffic_mirror_session_id,
     random_traffic_mirror_target_id,
 )
 from .core import TaggedEC2Resource
@@ -129,9 +130,69 @@ class TrafficMirrorTarget(TaggedEC2Resource):
         )
 
 
+class TrafficMirrorSession(TaggedEC2Resource):
+    def __init__(
+        self,
+        ec2_backend: Any,
+        network_interface_id: str,
+        traffic_mirror_target_id: str,
+        traffic_mirror_filter_id: str,
+        session_number: int,
+        packet_length: int | None,
+        virtual_network_id: int | None,
+        description: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
+        client_token: str | None,
+    ):
+        self.ec2_backend = ec2_backend
+        self.id = random_traffic_mirror_session_id()
+
+        self.network_interface_id = network_interface_id
+        self.traffic_mirror_target_id = traffic_mirror_target_id
+        self.traffic_mirror_filter_id = traffic_mirror_filter_id
+        self.session_number = session_number
+        self.packet_length = packet_length
+        self.virtual_network_id = virtual_network_id
+        self.description = description
+        self.client_token = client_token
+
+        self.tags: list[dict[str, str]] = []
+        if tag_specifications:
+            tag_spec = convert_tag_spec(tag_specifications)
+            self.add_tags(tag_spec.get("traffic-mirror-session", {}))
+            self.tags = self.get_tags()
+
+    @property
+    def owner_id(self) -> str:
+        return self.ec2_backend.account_id
+
+    @property
+    def arn(self) -> str:
+        return f"arn:{self.ec2_backend.partition}:ec2:{self.ec2_backend.region_name}:{self.ec2_backend.account_id}:traffic-mirror-session/{self.id}"
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "TrafficMirrorSessionId": self.id,
+            "TrafficMirrorTargetId": self.traffic_mirror_target_id,
+            "TrafficMirrorFilterId": self.traffic_mirror_filter_id,
+            "NetworkInterfaceId": self.network_interface_id,
+            "OwnerId": self.owner_id,
+            "SessionNumber": self.session_number,
+            "Tags": self.tags or [],
+        }
+        if self.packet_length is not None:
+            result["PacketLength"] = self.packet_length
+        if self.virtual_network_id is not None:
+            result["VirtualNetworkId"] = self.virtual_network_id
+        if self.description is not None:
+            result["Description"] = self.description
+        return result
+
+
 class TrafficMirrorsBackend:
     def __init__(self) -> None:
         self.traffic_mirror_filters: dict[str, TrafficMirrorFilter] = {}
+        self.traffic_mirror_sessions: dict[str, TrafficMirrorSession] = {}
         self.traffic_mirror_targets: dict[str, TrafficMirrorTarget] = {}
         self.tagger = TaggingService()
 
@@ -222,3 +283,94 @@ class TrafficMirrorsBackend:
             result = filter_resources(traffic_mirror_targets, filters, attr_pairs)
 
         return result
+
+    def create_traffic_mirror_session(
+        self,
+        network_interface_id: str,
+        traffic_mirror_target_id: str,
+        traffic_mirror_filter_id: str,
+        session_number: int,
+        packet_length: int | None,
+        virtual_network_id: int | None,
+        description: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
+        client_token: str | None,
+    ) -> TrafficMirrorSession:
+        mirror_session = TrafficMirrorSession(
+            self,
+            network_interface_id,
+            traffic_mirror_target_id,
+            traffic_mirror_filter_id,
+            session_number,
+            packet_length,
+            virtual_network_id,
+            description,
+            tag_specifications,
+            client_token,
+        )
+        self.traffic_mirror_sessions[mirror_session.id] = mirror_session
+        return mirror_session
+
+    def describe_traffic_mirror_sessions(
+        self,
+        traffic_mirror_session_ids: list[str] | None,
+        filters: list[Any] | None,
+    ) -> list[TrafficMirrorSession]:
+        traffic_mirror_sessions = list(self.traffic_mirror_sessions.values())
+
+        if traffic_mirror_session_ids:
+            traffic_mirror_sessions = [
+                item
+                for item in traffic_mirror_sessions
+                if item.id in traffic_mirror_session_ids
+            ]
+
+        attr_pairs = (
+            ("traffic-mirror-session-id", "id"),
+            ("traffic-mirror-target-id", "traffic_mirror_target_id"),
+            ("traffic-mirror-filter-id", "traffic_mirror_filter_id"),
+            ("network-interface-id", "network_interface_id"),
+            ("owner-id", "owner_id"),
+            ("session-number", "session_number"),
+            ("description", "description"),
+        )
+
+        result = traffic_mirror_sessions
+        if filters:
+            result = filter_resources(traffic_mirror_sessions, filters, attr_pairs)
+
+        return result
+
+    def delete_traffic_mirror_session(
+        self,
+        traffic_mirror_session_id: str,
+    ) -> str:
+        session = self.traffic_mirror_sessions.pop(traffic_mirror_session_id, None)
+        if session:
+            self.tagger.delete_all_tags_for_resource(session.arn)
+        return traffic_mirror_session_id
+
+    def modify_traffic_mirror_session(
+        self,
+        traffic_mirror_session_id: str,
+        traffic_mirror_target_id: str | None,
+        traffic_mirror_filter_id: str | None,
+        packet_length: int | None,
+        session_number: int | None,
+        virtual_network_id: int | None,
+        description: str | None,
+    ) -> TrafficMirrorSession:
+        session = self.traffic_mirror_sessions[traffic_mirror_session_id]
+        if traffic_mirror_target_id is not None:
+            session.traffic_mirror_target_id = traffic_mirror_target_id
+        if traffic_mirror_filter_id is not None:
+            session.traffic_mirror_filter_id = traffic_mirror_filter_id
+        if packet_length is not None:
+            session.packet_length = packet_length
+        if session_number is not None:
+            session.session_number = session_number
+        if virtual_network_id is not None:
+            session.virtual_network_id = virtual_network_id
+        if description is not None:
+            session.description = description
+        return session

--- a/moto/ec2/responses/traffic_mirrors.py
+++ b/moto/ec2/responses/traffic_mirrors.py
@@ -67,3 +67,73 @@ class TrafficMirrors(EC2BaseResponse):
         )
 
         return ActionResult({"TrafficMirrorTargets": mirror_targets})
+
+    def create_traffic_mirror_session(self) -> ActionResult:
+        network_interface_id = self._get_param("NetworkInterfaceId")
+        traffic_mirror_target_id = self._get_param("TrafficMirrorTargetId")
+        traffic_mirror_filter_id = self._get_param("TrafficMirrorFilterId")
+        session_number = self._get_int_param("SessionNumber")
+        packet_length = self._get_int_param("PacketLength")
+        virtual_network_id = self._get_int_param("VirtualNetworkId")
+        description = self._get_param("Description")
+        tag_specifications = self._get_param("TagSpecifications")
+        client_token = self._get_param("ClientToken")
+
+        mirror_session = self.ec2_backend.create_traffic_mirror_session(
+            network_interface_id=network_interface_id,
+            traffic_mirror_target_id=traffic_mirror_target_id,
+            traffic_mirror_filter_id=traffic_mirror_filter_id,
+            session_number=session_number,
+            packet_length=packet_length,
+            virtual_network_id=virtual_network_id,
+            description=description,
+            tag_specifications=tag_specifications,
+            client_token=client_token,
+        )
+
+        return ActionResult(
+            {
+                "TrafficMirrorSession": mirror_session.to_dict(),
+                "ClientToken": mirror_session.client_token,
+            }
+        )
+
+    def describe_traffic_mirror_sessions(self) -> ActionResult:
+        traffic_mirror_session_ids = self._get_param("TrafficMirrorSessionIds")
+        filters = self._filters_from_querystring()
+
+        mirror_sessions = self.ec2_backend.describe_traffic_mirror_sessions(
+            traffic_mirror_session_ids=traffic_mirror_session_ids, filters=filters
+        )
+
+        return ActionResult({"TrafficMirrorSessions": mirror_sessions})
+
+    def delete_traffic_mirror_session(self) -> ActionResult:
+        traffic_mirror_session_id = self._get_param("TrafficMirrorSessionId")
+
+        session_id = self.ec2_backend.delete_traffic_mirror_session(
+            traffic_mirror_session_id=traffic_mirror_session_id
+        )
+
+        return ActionResult({"TrafficMirrorSessionId": session_id})
+
+    def modify_traffic_mirror_session(self) -> ActionResult:
+        traffic_mirror_session_id = self._get_param("TrafficMirrorSessionId")
+        traffic_mirror_target_id = self._get_param("TrafficMirrorTargetId")
+        traffic_mirror_filter_id = self._get_param("TrafficMirrorFilterId")
+        packet_length = self._get_int_param("PacketLength")
+        session_number = self._get_int_param("SessionNumber")
+        virtual_network_id = self._get_int_param("VirtualNetworkId")
+        description = self._get_param("Description")
+
+        mirror_session = self.ec2_backend.modify_traffic_mirror_session(
+            traffic_mirror_session_id=traffic_mirror_session_id,
+            traffic_mirror_target_id=traffic_mirror_target_id,
+            traffic_mirror_filter_id=traffic_mirror_filter_id,
+            packet_length=packet_length,
+            session_number=session_number,
+            virtual_network_id=virtual_network_id,
+            description=description,
+        )
+
+        return ActionResult({"TrafficMirrorSession": mirror_session.to_dict()})

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -57,6 +57,7 @@ EC2_RESOURCE_TO_PREFIX = {
     "subnet-ipv6-cidr-block-association": "subnet-cidr-assoc",
     "reservation": "r",
     "traffic-mirror-filter": "traf-mir-fil",
+    "traffic-mirror-session": "tms",
     "traffic-mirror-target": "traf-mir-tar",
     "volume": "vol",
     "vpc": "vpc",
@@ -232,6 +233,10 @@ def random_traffic_mirror_filter_id() -> str:
 
 def random_traffic_mirror_target_id() -> str:
     return random_id(prefix=EC2_RESOURCE_TO_PREFIX["traffic-mirror-target"])
+
+
+def random_traffic_mirror_session_id() -> str:
+    return random_id(prefix=EC2_RESOURCE_TO_PREFIX["traffic-mirror-session"])
 
 
 def random_transit_gateway_route_table_id() -> str:

--- a/tests/test_ec2/test_traffic_mirrors.py
+++ b/tests/test_ec2/test_traffic_mirrors.py
@@ -3,6 +3,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID
 
 REGION = "us-east-1"
 
@@ -195,3 +196,274 @@ def test_describe_traffic_mirror_targets_by_id():
     assert len(described_traffic_mirrors) == 1
     my_traffic_mirror_target = described_traffic_mirrors[0]
     assert my_traffic_mirror_target["TrafficMirrorTargetId"] == traffic_mirror_target_id
+
+
+@mock_aws
+def test_create_traffic_mirror_session():
+    client = boto3.client("ec2", REGION)
+
+    # Create required filter and target first
+    filter_response = client.create_traffic_mirror_filter()
+    filter_id = filter_response["TrafficMirrorFilter"]["TrafficMirrorFilterId"]
+
+    target_response = client.create_traffic_mirror_target(
+        NetworkInterfaceId="eni-12345678"
+    )
+    target_id = target_response["TrafficMirrorTarget"]["TrafficMirrorTargetId"]
+
+    tags = [
+        {"Key": "key1", "Value": "value1"},
+        {"Key": "key2", "Value": "value2"},
+    ]
+    client_token = "test_token"
+
+    response = client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source123",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=1,
+        PacketLength=100,
+        VirtualNetworkId=12345,
+        Description="test_description",
+        TagSpecifications=[
+            {
+                "ResourceType": "traffic-mirror-session",
+                "Tags": tags,
+            },
+        ],
+        ClientToken=client_token,
+    )
+
+    metadata = response["ResponseMetadata"]
+    assert metadata["HTTPStatusCode"] == 200
+
+    session = response["TrafficMirrorSession"]
+    assert "TrafficMirrorSessionId" in session
+    assert session["TrafficMirrorSessionId"].startswith("tms-")
+    assert session["TrafficMirrorTargetId"] == target_id
+    assert session["TrafficMirrorFilterId"] == filter_id
+    assert session["NetworkInterfaceId"] == "eni-source123"
+    assert session["SessionNumber"] == 1
+    assert session["PacketLength"] == 100
+    assert session["VirtualNetworkId"] == 12345
+    assert session["Description"] == "test_description"
+    assert session["OwnerId"] == DEFAULT_ACCOUNT_ID
+    assert response["ClientToken"] == client_token
+    assert session["Tags"] == tags
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_describe_traffic_mirror_sessions():
+    client = boto3.client("ec2", REGION)
+    response = client.describe_traffic_mirror_sessions()
+    assert response["TrafficMirrorSessions"] == []
+
+
+@mock_aws
+def test_describe_traffic_mirror_sessions_by_id():
+    client = boto3.client("ec2", REGION)
+
+    # Create required filter and target
+    filter_response = client.create_traffic_mirror_filter()
+    filter_id = filter_response["TrafficMirrorFilter"]["TrafficMirrorFilterId"]
+
+    target_response = client.create_traffic_mirror_target(
+        NetworkInterfaceId="eni-12345678"
+    )
+    target_id = target_response["TrafficMirrorTarget"]["TrafficMirrorTargetId"]
+
+    # Create multiple sessions
+    client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source1",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=1,
+    )
+    client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source2",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=2,
+    )
+    response = client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source3",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=3,
+    )
+
+    session_id = response["TrafficMirrorSession"]["TrafficMirrorSessionId"]
+    described_sessions = client.describe_traffic_mirror_sessions(
+        TrafficMirrorSessionIds=[session_id]
+    )["TrafficMirrorSessions"]
+
+    assert len(described_sessions) == 1
+    assert described_sessions[0]["TrafficMirrorSessionId"] == session_id
+
+
+@mock_aws
+def test_describe_traffic_mirror_sessions_by_filtering():
+    client = boto3.client("ec2", REGION)
+
+    # Create required filter and target
+    filter_response = client.create_traffic_mirror_filter()
+    filter_id = filter_response["TrafficMirrorFilter"]["TrafficMirrorFilterId"]
+
+    target_response = client.create_traffic_mirror_target(
+        NetworkInterfaceId="eni-12345678"
+    )
+    target_id = target_response["TrafficMirrorTarget"]["TrafficMirrorTargetId"]
+
+    # Create multiple sessions
+    client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source1",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=1,
+    )
+    response = client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source2",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=2,
+    )
+
+    session_id = response["TrafficMirrorSession"]["TrafficMirrorSessionId"]
+
+    filters = [{"Name": "traffic-mirror-session-id", "Values": [session_id]}]
+    described_sessions = client.describe_traffic_mirror_sessions(Filters=filters)[
+        "TrafficMirrorSessions"
+    ]
+
+    assert len(described_sessions) == 1
+    assert described_sessions[0]["TrafficMirrorSessionId"] == session_id
+
+
+@mock_aws
+def test_delete_traffic_mirror_session():
+    client = boto3.client("ec2", REGION)
+
+    # Create required filter and target
+    filter_response = client.create_traffic_mirror_filter()
+    filter_id = filter_response["TrafficMirrorFilter"]["TrafficMirrorFilterId"]
+
+    target_response = client.create_traffic_mirror_target(
+        NetworkInterfaceId="eni-12345678"
+    )
+    target_id = target_response["TrafficMirrorTarget"]["TrafficMirrorTargetId"]
+
+    # Create a session
+    create_response = client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source1",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=1,
+    )
+    session_id = create_response["TrafficMirrorSession"]["TrafficMirrorSessionId"]
+
+    # Delete the session
+    delete_response = client.delete_traffic_mirror_session(
+        TrafficMirrorSessionId=session_id
+    )
+    assert delete_response["TrafficMirrorSessionId"] == session_id
+
+    # Verify it's gone
+    described = client.describe_traffic_mirror_sessions(
+        TrafficMirrorSessionIds=[session_id]
+    )["TrafficMirrorSessions"]
+    assert len(described) == 0
+
+
+@mock_aws
+def test_modify_traffic_mirror_session():
+    client = boto3.client("ec2", REGION)
+
+    # Create required filter and target
+    filter_response = client.create_traffic_mirror_filter()
+    filter_id = filter_response["TrafficMirrorFilter"]["TrafficMirrorFilterId"]
+
+    target_response = client.create_traffic_mirror_target(
+        NetworkInterfaceId="eni-12345678"
+    )
+    target_id = target_response["TrafficMirrorTarget"]["TrafficMirrorTargetId"]
+
+    # Create a session
+    create_response = client.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source1",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=1,
+        Description="original",
+    )
+    session_id = create_response["TrafficMirrorSession"]["TrafficMirrorSessionId"]
+
+    # Modify the session
+    modify_response = client.modify_traffic_mirror_session(
+        TrafficMirrorSessionId=session_id,
+        Description="modified",
+        SessionNumber=99,
+        PacketLength=200,
+        VirtualNetworkId=54321,
+    )
+
+    modified_session = modify_response["TrafficMirrorSession"]
+    assert modified_session["Description"] == "modified"
+    assert modified_session["SessionNumber"] == 99
+    assert modified_session["PacketLength"] == 200
+    assert modified_session["VirtualNetworkId"] == 54321
+
+
+@mock_aws
+def test_traffic_mirror_session_tags_via_rgta():
+    """Test that traffic mirror session tags surface through Resource Groups Tagging API."""
+    ec2 = boto3.client("ec2", REGION)
+    rgta = boto3.client("resourcegroupstaggingapi", REGION)
+
+    # Create required filter and target
+    filter_response = ec2.create_traffic_mirror_filter()
+    filter_id = filter_response["TrafficMirrorFilter"]["TrafficMirrorFilterId"]
+
+    target_response = ec2.create_traffic_mirror_target(
+        NetworkInterfaceId="eni-12345678"
+    )
+    target_id = target_response["TrafficMirrorTarget"]["TrafficMirrorTargetId"]
+
+    tags = [
+        {"Key": "ASV", "Value": "test-asv"},
+        {"Key": "BA", "Value": "test-ba"},
+        {"Key": "OwnerContact", "Value": "test@example.com"},
+    ]
+
+    # Create a session with tags
+    create_response = ec2.create_traffic_mirror_session(
+        NetworkInterfaceId="eni-source1",
+        TrafficMirrorTargetId=target_id,
+        TrafficMirrorFilterId=filter_id,
+        SessionNumber=1,
+        TagSpecifications=[
+            {
+                "ResourceType": "traffic-mirror-session",
+                "Tags": tags,
+            },
+        ],
+    )
+    session_id = create_response["TrafficMirrorSession"]["TrafficMirrorSessionId"]
+
+    # Query via RGTA
+    resources = rgta.get_resources(ResourceTypeFilters=["ec2:traffic-mirror-session"])[
+        "ResourceTagMappingList"
+    ]
+
+    # Find our session
+    session_resources = [r for r in resources if session_id in r["ResourceARN"]]
+    assert len(session_resources) == 1
+
+    resource = session_resources[0]
+    assert f"traffic-mirror-session/{session_id}" in resource["ResourceARN"]
+
+    # Verify tags
+    tag_map = {t["Key"]: t["Value"] for t in resource["Tags"]}
+    assert tag_map["ASV"] == "test-asv"
+    assert tag_map["BA"] == "test-ba"
+    assert tag_map["OwnerContact"] == "test@example.com"


### PR DESCRIPTION
Adds support for the EC2 Traffic Mirror Session API to moto,
Implements the following TrafficMirrorSession actions on the EC2 backend:

* CreateTrafficMirrorSession
* DescribeTrafficMirrorSessions (with filtering and lookup by id)
* ModifyTrafficMirrorSession
* DeleteTrafficMirrorSession