### PR TITLE
ServiceDiscovery: add service attributes support

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -10690,7 +10690,7 @@
 
 ## servicediscovery
 <details>
-<summary>90% implemented</summary>
+<summary>100% implemented</summary>
 
 - [X] create_http_namespace
 - [X] create_private_dns_namespace
@@ -10698,7 +10698,7 @@
 - [X] create_service
 - [X] delete_namespace
 - [X] delete_service
-- [ ] delete_service_attributes
+- [X] delete_service_attributes
 - [X] deregister_instance
 - [X] discover_instances
 - [X] discover_instances_revision
@@ -10707,7 +10707,7 @@
 - [X] get_namespace
 - [X] get_operation
 - [X] get_service
-- [ ] get_service_attributes
+- [X] get_service_attributes
 - [X] list_instances
 - [X] list_namespaces
 - [X] list_operations
@@ -10721,7 +10721,7 @@
 - [X] update_private_dns_namespace
 - [X] update_public_dns_namespace
 - [X] update_service
-- [ ] update_service_attributes
+- [X] update_service_attributes
 </details>
 
 ## ses

--- a/docs/docs/services/servicediscovery.rst
+++ b/docs/docs/services/servicediscovery.rst
@@ -22,7 +22,7 @@ servicediscovery
 - [X] create_service
 - [X] delete_namespace
 - [X] delete_service
-- [ ] delete_service_attributes
+- [X] delete_service_attributes
 - [X] deregister_instance
 - [X] discover_instances
 - [X] discover_instances_revision
@@ -31,7 +31,7 @@ servicediscovery
 - [X] get_namespace
 - [X] get_operation
 - [X] get_service
-- [ ] get_service_attributes
+- [X] get_service_attributes
 - [X] list_instances
 - [X] list_namespaces
   
@@ -57,5 +57,5 @@ Pagination or the Filters-argument is not yet implemented
 - [X] update_private_dns_namespace
 - [X] update_public_dns_namespace
 - [X] update_service
-- [ ] update_service_attributes
+- [X] update_service_attributes
 

--- a/moto/servicediscovery/exceptions.py
+++ b/moto/servicediscovery/exceptions.py
@@ -36,3 +36,8 @@ class CustomHealthNotFound(JsonRESTError):
 class InvalidInput(JsonRESTError):
     def __init__(self, message: str):
         super().__init__("InvalidInput", message)
+
+
+class ServiceAttributesLimitExceededException(JsonRESTError):
+    def __init__(self, message: str):
+        super().__init__("ServiceAttributesLimitExceededException", message)

--- a/moto/servicediscovery/models.py
+++ b/moto/servicediscovery/models.py
@@ -17,8 +17,12 @@ from .exceptions import (
     InvalidInput,
     NamespaceNotFound,
     OperationNotFound,
+    ServiceAttributesLimitExceededException,
     ServiceNotFound,
 )
+
+# The Cloud Map ServiceAttributesMap allows at most 30 attributes per service.
+MAX_SERVICE_ATTRIBUTES = 30
 
 
 def random_id(size: int) -> str:
@@ -84,6 +88,7 @@ class Service(BaseModel):
         service_type: str,
     ):
         self.id = f"srv-{random_id(8)}"
+        self.account_id = account_id
         self.arn = f"arn:{get_partition(region)}:servicediscovery:{region}:{account_id}:service/{self.id}"
         self.name = name
         self.namespace_id = namespace_id
@@ -96,6 +101,7 @@ class Service(BaseModel):
         self.created = unix_time()
         self.instances: list[ServiceInstance] = []
         self.instances_revision: dict[str, int] = {}
+        self.attributes: dict[str, str] = {}
 
     def update(self, details: dict[str, Any]) -> None:
         if "Description" in details:
@@ -125,6 +131,13 @@ class Service(BaseModel):
             "HealthCheckConfig": self.health_check_config,
             "HealthCheckCustomConfig": self.health_check_custom_config,
             "Type": self.service_type,
+        }
+
+    def attributes_to_json(self) -> dict[str, Any]:
+        return {
+            "ServiceArn": self.arn,
+            "ResourceOwner": self.account_id,
+            "Attributes": self.attributes,
         }
 
 
@@ -395,6 +408,27 @@ class ServiceDiscoveryBackend(BaseBackend):
             "UPDATE_SERVICE", targets={"SERVICE": service.id}
         )
         return operation_id
+
+    def get_service_attributes(self, service_id: str) -> Service:
+        return self.get_service(service_id)
+
+    def update_service_attributes(
+        self, service_id: str, attributes: dict[str, str]
+    ) -> None:
+        service = self.get_service(service_id)
+        updated = {**service.attributes, **attributes}
+        if len(updated) > MAX_SERVICE_ATTRIBUTES:
+            raise ServiceAttributesLimitExceededException(
+                f"Cannot update service attributes because the number of "
+                f"attributes for the service exceeds the limit of "
+                f"{MAX_SERVICE_ATTRIBUTES}."
+            )
+        service.attributes = updated
+
+    def delete_service_attributes(self, service_id: str, attributes: list[str]) -> None:
+        service = self.get_service(service_id)
+        for key in attributes:
+            service.attributes.pop(key, None)
 
     def update_http_namespace(
         self,

--- a/moto/servicediscovery/responses.py
+++ b/moto/servicediscovery/responses.py
@@ -175,6 +175,32 @@ class ServiceDiscoveryResponse(BaseResponse):
         )
         return json.dumps({"OperationId": operation_id})
 
+    def get_service_attributes(self) -> str:
+        params = json.loads(self.body)
+        service_id = params.get("ServiceId")
+        service = self.servicediscovery_backend.get_service_attributes(
+            service_id=service_id
+        )
+        return json.dumps({"ServiceAttributes": service.attributes_to_json()})
+
+    def update_service_attributes(self) -> str:
+        params = json.loads(self.body)
+        service_id = params.get("ServiceId")
+        attributes = params.get("Attributes")
+        self.servicediscovery_backend.update_service_attributes(
+            service_id=service_id, attributes=attributes
+        )
+        return "{}"
+
+    def delete_service_attributes(self) -> str:
+        params = json.loads(self.body)
+        service_id = params.get("ServiceId")
+        attributes = params.get("Attributes")
+        self.servicediscovery_backend.delete_service_attributes(
+            service_id=service_id, attributes=attributes
+        )
+        return "{}"
+
     def update_http_namespace(self) -> str:
         params = json.loads(self.body)
         _id = params.get("Id")

--- a/tests/test_servicediscovery/test_servicediscovery_service_attributes.py
+++ b/tests/test_servicediscovery/test_servicediscovery_service_attributes.py
@@ -1,0 +1,124 @@
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+
+# See our Development Tips on writing tests for hints on how to write good tests:
+# http://docs.getmoto.org/en/latest/docs/contributing/development_tips/tests.html
+
+
+def _create_service(client) -> str:
+    operation_id = client.create_http_namespace(Name="mynamespace")["OperationId"]
+    namespace_id = client.get_operation(OperationId=operation_id)["Operation"][
+        "Targets"
+    ]["NAMESPACE"]
+    return client.create_service(Name="my service", NamespaceId=namespace_id)[
+        "Service"
+    ]["Id"]
+
+
+@mock_aws
+def test_get_service_attributes_defaults_to_empty():
+    client = boto3.client("servicediscovery", region_name="eu-west-1")
+    service_id = _create_service(client)
+
+    resp = client.get_service_attributes(ServiceId=service_id)
+
+    attrs = resp["ServiceAttributes"]
+    assert attrs["ServiceArn"].endswith(f"service/{service_id}")
+    assert attrs["ResourceOwner"] == ACCOUNT_ID
+    assert attrs["Attributes"] == {}
+
+
+@mock_aws
+def test_update_and_get_service_attributes():
+    client = boto3.client("servicediscovery", region_name="ap-southeast-1")
+    service_id = _create_service(client)
+
+    client.update_service_attributes(
+        ServiceId=service_id,
+        Attributes={"key1": "value1", "key2": "value2"},
+    )
+
+    attrs = client.get_service_attributes(ServiceId=service_id)["ServiceAttributes"]
+    assert attrs["Attributes"] == {"key1": "value1", "key2": "value2"}
+
+
+@mock_aws
+def test_update_service_attributes_merges_existing():
+    client = boto3.client("servicediscovery", region_name="ap-southeast-1")
+    service_id = _create_service(client)
+
+    client.update_service_attributes(ServiceId=service_id, Attributes={"key1": "old"})
+    client.update_service_attributes(
+        ServiceId=service_id, Attributes={"key1": "new", "key2": "value2"}
+    )
+
+    attrs = client.get_service_attributes(ServiceId=service_id)["ServiceAttributes"]
+    assert attrs["Attributes"] == {"key1": "new", "key2": "value2"}
+
+
+@mock_aws
+def test_delete_service_attributes():
+    client = boto3.client("servicediscovery", region_name="eu-west-1")
+    service_id = _create_service(client)
+
+    client.update_service_attributes(
+        ServiceId=service_id,
+        Attributes={"key1": "value1", "key2": "value2", "key3": "value3"},
+    )
+
+    # Deleting unknown keys alongside known ones is a no-op for the unknown ones
+    client.delete_service_attributes(
+        ServiceId=service_id, Attributes=["key1", "unknown"]
+    )
+
+    attrs = client.get_service_attributes(ServiceId=service_id)["ServiceAttributes"]
+    assert attrs["Attributes"] == {"key2": "value2", "key3": "value3"}
+
+
+@mock_aws
+def test_update_service_attributes_limit_exceeded():
+    client = boto3.client("servicediscovery", region_name="ap-southeast-1")
+    service_id = _create_service(client)
+
+    client.update_service_attributes(
+        ServiceId=service_id,
+        Attributes={f"key{i}": str(i) for i in range(30)},
+    )
+
+    with pytest.raises(ClientError) as exc:
+        client.update_service_attributes(
+            ServiceId=service_id, Attributes={"one_too_many": "value"}
+        )
+    assert (
+        exc.value.response["Error"]["Code"] == "ServiceAttributesLimitExceededException"
+    )
+
+
+@mock_aws
+def test_get_service_attributes_unknown_service():
+    client = boto3.client("servicediscovery", region_name="ap-southeast-1")
+    with pytest.raises(ClientError) as exc:
+        client.get_service_attributes(ServiceId="unknown")
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFound"
+
+
+@mock_aws
+def test_update_service_attributes_unknown_service():
+    client = boto3.client("servicediscovery", region_name="ap-southeast-1")
+    with pytest.raises(ClientError) as exc:
+        client.update_service_attributes(
+            ServiceId="unknown", Attributes={"key1": "value1"}
+        )
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFound"
+
+
+@mock_aws
+def test_delete_service_attributes_unknown_service():
+    client = boto3.client("servicediscovery", region_name="ap-southeast-1")
+    with pytest.raises(ClientError) as exc:
+        client.delete_service_attributes(ServiceId="unknown", Attributes=["key1"])
+    assert exc.value.response["Error"]["Code"] == "ServiceNotFound"


### PR DESCRIPTION
Implements the Cloud Map service-attributes API, which was the remaining gap in the ServiceDiscovery coverage:

- `get_service_attributes`
- `update_service_attributes`
- `delete_service_attributes`

Attributes are stored per service. Updates merge into the existing map and are capped at 30 (`ServiceAttributesLimitExceededException` beyond that), matching the real API. `get_service_attributes` returns `ServiceArn`, `ResourceOwner` and the attribute map.

Added tests covering update/merge/delete (including deleting unknown keys), the unknown-service errors, and the attribute limit. Updated the implementation coverage docs — servicediscovery is now at 100%.