### PR TITLE
RDS: Fix MonitoringRoleArn validation when arn is an empty string

### DIFF
--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -1199,11 +1199,11 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self.enabled_cloudwatch_logs_exports = enable_cloudwatch_logs_exports or []
         self.monitoring_role_arn = monitoring_role_arn
         self.monitoring_interval = monitoring_interval
-        if self.monitoring_role_arn is not None and self.monitoring_interval == 0:
+        if self.monitoring_role_arn and self.monitoring_interval == 0:
             raise InvalidParameterCombination(
                 "You must specify a MonitoringInterval value other than 0 when you specify a MonitoringRoleARN value."
             )
-        if self.monitoring_role_arn is None and self.monitoring_interval != 0:
+        if not self.monitoring_role_arn and self.monitoring_interval != 0:
             raise InvalidParameterCombination(
                 "A MonitoringRoleARN value is required if you specify a MonitoringInterval value other than 0."
             )


### PR DESCRIPTION
Empty string in `monitoring_role_arn` should be treated the same as `None`.