### PR TITLE
Kinesis: emit basic CloudWatch stream metrics on PutRecord(s)

### DIFF
--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -10,6 +10,7 @@ from gzip import GzipFile
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any
 
+from moto.cloudwatch.models import cloudwatch_backends
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time, utcnow
@@ -689,6 +690,29 @@ class KinesisBackend(BaseBackend):
 
         return next_shard_iterator, records, millis_behind_latest
 
+    def _send_stream_metrics(
+        self, stream_name: str, incoming_bytes: int, incoming_records: int
+    ) -> None:
+        cloudwatch_backend = cloudwatch_backends[self.account_id][self.region_name]
+        dimensions = [{"Name": "StreamName", "Value": stream_name}]
+        cloudwatch_backend.put_metric_data(
+            namespace="AWS/Kinesis",
+            metric_data=[
+                {
+                    "MetricName": "IncomingBytes",
+                    "Value": incoming_bytes,
+                    "Unit": "Bytes",
+                    "Dimensions": dimensions,
+                },
+                {
+                    "MetricName": "IncomingRecords",
+                    "Value": incoming_records,
+                    "Unit": "Count",
+                    "Dimensions": dimensions,
+                },
+            ],
+        )
+
     def put_record(
         self,
         stream_arn: str,
@@ -701,6 +725,12 @@ class KinesisBackend(BaseBackend):
 
         sequence_number, shard_id = stream.put_record(
             partition_key, explicit_hash_key, data
+        )
+
+        self._send_stream_metrics(
+            stream.stream_name,
+            incoming_bytes=len(b64decode(data)) + len(partition_key),
+            incoming_records=1,
         )
 
         return sequence_number, shard_id
@@ -740,6 +770,12 @@ class KinesisBackend(BaseBackend):
             response["Records"].append(
                 {"SequenceNumber": sequence_number, "ShardId": shard_id}
             )
+
+        self._send_stream_metrics(
+            stream.stream_name,
+            incoming_bytes=sum(data_sizes),
+            incoming_records=len(records),
+        )
 
         return response
 

--- a/tests/test_kinesis/test_kinesis_monitoring.py
+++ b/tests/test_kinesis/test_kinesis_monitoring.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import boto3
 
 from moto import mock_aws
@@ -140,3 +142,70 @@ def test_disable_enhanced_monitoring_all():
     stream = client.describe_stream(StreamName=stream_name)["StreamDescription"]
     metrics = stream["EnhancedMonitoring"][0]["ShardLevelMetrics"]
     assert metrics == []
+
+
+@mock_aws
+def test_put_record_sends_basic_stream_metrics():
+    kinesis = boto3.client("kinesis", region_name="us-east-1")
+    cloudwatch = boto3.client("cloudwatch", region_name="us-east-1")
+    stream_name = "my_stream_metrics"
+    kinesis.create_stream(StreamName=stream_name, ShardCount=1)
+
+    utc_now = datetime.now(tz=timezone.utc)
+    kinesis.put_record(StreamName=stream_name, Data=b"hello world", PartitionKey="pk1")
+
+    for metric_name, expected_sum, expected_unit in [
+        ("IncomingBytes", len(b"hello world") + len("pk1"), "Bytes"),
+        ("IncomingRecords", 1, "Count"),
+    ]:
+        stats = cloudwatch.get_metric_statistics(
+            Namespace="AWS/Kinesis",
+            MetricName=metric_name,
+            Dimensions=[{"Name": "StreamName", "Value": stream_name}],
+            StartTime=utc_now - timedelta(seconds=60),
+            EndTime=utc_now + timedelta(seconds=60),
+            Period=60,
+            Statistics=["Sum"],
+        )
+        datapoint = stats["Datapoints"][0]
+        assert datapoint["Sum"] == expected_sum
+        assert datapoint["Unit"] == expected_unit
+
+
+@mock_aws
+def test_put_records_sends_aggregated_stream_metrics():
+    kinesis = boto3.client("kinesis", region_name="us-east-1")
+    cloudwatch = boto3.client("cloudwatch", region_name="us-east-1")
+    stream_name = "my_stream_metrics_batch"
+    kinesis.create_stream(StreamName=stream_name, ShardCount=1)
+
+    utc_now = datetime.now(tz=timezone.utc)
+    records = [
+        {"Data": b"rec1", "PartitionKey": "pk1"},
+        {"Data": b"rec2data", "PartitionKey": "pk2"},
+    ]
+    kinesis.put_records(StreamName=stream_name, Records=records)
+
+    expected_bytes = sum(len(r["Data"]) + len(r["PartitionKey"]) for r in records)
+
+    stats = cloudwatch.get_metric_statistics(
+        Namespace="AWS/Kinesis",
+        MetricName="IncomingBytes",
+        Dimensions=[{"Name": "StreamName", "Value": stream_name}],
+        StartTime=utc_now - timedelta(seconds=60),
+        EndTime=utc_now + timedelta(seconds=60),
+        Period=60,
+        Statistics=["Sum"],
+    )
+    assert stats["Datapoints"][0]["Sum"] == expected_bytes
+
+    stats = cloudwatch.get_metric_statistics(
+        Namespace="AWS/Kinesis",
+        MetricName="IncomingRecords",
+        Dimensions=[{"Name": "StreamName", "Value": stream_name}],
+        StartTime=utc_now - timedelta(seconds=60),
+        EndTime=utc_now + timedelta(seconds=60),
+        Period=60,
+        Statistics=["Sum"],
+    )
+    assert stats["Datapoints"][0]["Sum"] == len(records)


### PR DESCRIPTION
Closes #7498.

`put_record`/`put_records` now push `IncomingBytes` and `IncomingRecords` datapoints into the account's CloudWatch backend, under the `AWS/Kinesis` namespace and dimensioned by `StreamName`, matching AWS's [basic (stream-level) Kinesis metrics](https://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html#kinesis-metrics-stream).

`IncomingBytes` is computed the same way the existing size-limit validation in `put_records` already does (`len(b64decode(data)) + len(partition_key)`), so `put_record` and `put_records` stay consistent with each other.

This makes the metrics available immediately via `get_metric_statistics`/`get_metric_data`, useful for testing code that reacts to stream throughput (e.g. shard-scaling logic), without waiting on real AWS's ~1-minute CloudWatch delay.

Added two tests in `tests/test_kinesis/test_kinesis_monitoring.py` covering both the single-record and batch paths.