### PR TITLE
Add S3 GetBucketPolicyStatus support

### DIFF
--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -89,6 +89,7 @@ from .models import (
 from .utils import (
     ARCHIVE_STORAGE_CLASSES,
     bucket_name_from_url,
+    bucket_policy_is_public,
     compute_checksum,
     cors_matches_origin,
     metadata_from_headers,
@@ -106,6 +107,7 @@ ACTION_MAP = {
             "lifecycle": "GetLifecycleConfiguration",
             "versioning": "GetBucketVersioning",
             "policy": "GetBucketPolicy",
+            "policyStatus": "GetBucketPolicyStatus",
             "website": "GetBucketWebsite",
             "acl": "GetBucketAcl",
             "tagging": "GetBucketTagging",
@@ -632,6 +634,8 @@ class S3Response(BaseResponse):
             return self.get_bucket_lifecycle()
         elif "versioning" in querystring:
             return self.get_bucket_versioning()
+        elif "policyStatus" in querystring:
+            return self.get_bucket_policy_status()
         elif "policy" in querystring:
             return self.get_bucket_policy()
         elif "website" in querystring:
@@ -1398,6 +1402,17 @@ class S3Response(BaseResponse):
         if not policy:
             raise NoSuchBucketPolicy(bucket_name=self.bucket_name)
         return 200, {}, policy
+
+    def get_bucket_policy_status(self) -> TYPE_RESPONSE:
+        policy = self.backend.get_bucket_policy(self.bucket_name)
+        if not policy:
+            raise NoSuchBucketPolicy(bucket_name=self.bucket_name)
+        self.data["Action"] = "GetBucketPolicyStatus"
+        return self.serialized(
+            ActionResult(
+                {"PolicyStatus": {"IsPublic": bucket_policy_is_public(policy)}}
+            )
+        )
 
     def get_bucket_replication(self) -> str | TYPE_RESPONSE:
         self.data["Action"] = "GetBucketReplication"

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 import hashlib
+import json
 import logging
 import re
 import sys
@@ -240,4 +241,39 @@ def cors_matches_origin(origin_header: str, allowed_origins: list[str]) -> bool:
     for allowed in allowed_origins:
         if re.match(allowed.replace(".", "\\.").replace("*", ".*"), origin_header):
             return True
+    return False
+
+
+def bucket_policy_is_public(policy: bytes | str) -> bool:
+    """Determine whether a bucket policy makes the bucket public.
+
+    Mirrors the essence of AWS's public policy evaluation: a policy is public
+    if any statement allows access to a wildcard principal without narrowing
+    it down through a Condition block. Statements that carry any Condition are
+    treated as non-public, which matches how AWS treats condition keys that
+    restrict access (the full AWS evaluation of which condition keys still
+    count as public is intentionally out of scope here).
+    """
+    try:
+        parsed = json.loads(policy)
+    except (ValueError, TypeError):
+        return False
+
+    statements = parsed.get("Statement") or []
+    if isinstance(statements, dict):
+        statements = [statements]
+    for statement in statements:
+        if statement.get("Effect") != "Allow":
+            continue
+        if "Condition" in statement:
+            continue
+        principal = statement.get("Principal")
+        if principal == "*":
+            return True
+        if isinstance(principal, dict):
+            aws_principal = principal.get("AWS")
+            if aws_principal == "*":
+                return True
+            if isinstance(aws_principal, list) and "*" in aws_principal:
+                return True
     return False

--- a/tests/test_s3/test_s3_bucket_policy.py
+++ b/tests/test_s3/test_s3_bucket_policy.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 from botocore.exceptions import ClientError
 
-from moto import settings
+from moto import mock_aws, settings
 from moto.moto_server.threaded_moto_server import ThreadedMotoServer
 from tests.test_s3 import s3_aws_verified
 
@@ -176,3 +176,77 @@ def test_deny_delete_policy(bucket_name=None):
 
     # Delete Policy to make sure bucket can be emptied during teardown
     client.delete_bucket_policy(Bucket=bucket_name)
+
+
+@mock_aws
+def test_get_bucket_policy_status_without_policy():
+    client = boto3.client("s3", "us-east-1")
+    client.create_bucket(Bucket="policy-status-bucket")
+
+    with pytest.raises(ClientError) as exc:
+        client.get_bucket_policy_status(Bucket="policy-status-bucket")
+    assert exc.value.response["Error"]["Code"] == "NoSuchBucketPolicy"
+
+
+@mock_aws
+def test_get_bucket_policy_status_public_policy():
+    client = boto3.client("s3", "us-east-1")
+    client.create_bucket(Bucket="policy-status-bucket")
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::policy-status-bucket/*",
+            }
+        ],
+    }
+    client.put_bucket_policy(Bucket="policy-status-bucket", Policy=json.dumps(policy))
+
+    status = client.get_bucket_policy_status(Bucket="policy-status-bucket")
+    assert status["PolicyStatus"] == {"IsPublic": True}
+
+
+@mock_aws
+def test_get_bucket_policy_status_scoped_policy():
+    client = boto3.client("s3", "us-east-1")
+    client.create_bucket(Bucket="policy-status-bucket")
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "arn:aws:iam::123456789012:role/reader"},
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::policy-status-bucket/*",
+            }
+        ],
+    }
+    client.put_bucket_policy(Bucket="policy-status-bucket", Policy=json.dumps(policy))
+
+    status = client.get_bucket_policy_status(Bucket="policy-status-bucket")
+    assert status["PolicyStatus"] == {"IsPublic": False}
+
+
+@mock_aws
+def test_get_bucket_policy_status_wildcard_with_condition_is_not_public():
+    client = boto3.client("s3", "us-east-1")
+    client.create_bucket(Bucket="policy-status-bucket")
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::policy-status-bucket/*",
+                "Condition": {"StringEquals": {"aws:SourceVpc": "vpc-12345678"}},
+            }
+        ],
+    }
+    client.put_bucket_policy(Bucket="policy-status-bucket", Policy=json.dumps(policy))
+
+    status = client.get_bucket_policy_status(Bucket="policy-status-bucket")
+    assert status["PolicyStatus"] == {"IsPublic": False}


### PR DESCRIPTION
## What

Implements `GetBucketPolicyStatus` for S3.

## Why

Currently the call falls through to a generic empty response: `get_bucket_policy_status` returns `PolicyStatus: {}` regardless of whether the bucket has a policy, and never raises `NoSuchBucketPolicy`. We ran into this while testing a security-audit tool against moto (a tool that checks whether buckets are public), where the empty response is indistinguishable from a private bucket.

## How

- `NoSuchBucketPolicy` when the bucket has no policy (matches AWS).
- `IsPublic` is computed from the stored policy: an Allow statement with a wildcard principal (`"*"`, `{"AWS": "*"}` or a list containing `"*"`) and no `Condition` block makes the policy public. Statements carrying any `Condition` are treated as non-public, which matches how AWS treats access-restricting condition keys; the full AWS evaluation of which condition keys still count as public is intentionally out of scope and documented as such in the helper.
- Dispatch and `ACTION_MAP` entries follow the existing `GetBucketPolicy`/`GetPublicAccessBlock` patterns; the response uses the `ActionResult` serializer.

## Tests

Four new tests in `tests/test_s3/test_s3_bucket_policy.py`: no policy raises `NoSuchBucketPolicy`; wildcard-principal policy reports `IsPublic: True`; scoped principal reports `False`; wildcard with a `Condition` reports `False`. Full `-k "policy or public_access"` subset passes (25 tests), `ruff check` and `ruff format` clean.
