### PR TITLE
Techdebt: DataUpdate_SSMoptimizedAMIs red since 2026-04-01 - skip regions on any error, like the default-AMIs script

### DIFF
--- a/scripts/ssm_get_optimized_amis.py
+++ b/scripts/ssm_get_optimized_amis.py
@@ -4,7 +4,6 @@ from datetime import timezone
 from pathlib import Path
 
 import boto3
-import botocore
 
 from moto.core.utils import unix_time
 from moto.ec2.utils import gen_moto_amis
@@ -99,7 +98,7 @@ def main():
             save_to_file(destination_path, image_as_dicts)
 
             time.sleep(0.5)
-        except botocore.exceptions.ClientError as e:
+        except Exception as e:
             print(e)
             # We might encounter an error if we do not have access to a region - just ignore and try the next region
 


### PR DESCRIPTION
The monthly `DataUpdate_SSMoptimizedAMIs` job has failed on all 6 scheduled runs since 2026-04-01 (last success 2026-03-01), so the bundled ECS-optimized-AMI data in `moto/ssm/resources/ecs/optimized_amis/` and `moto/ec2/resources/ecs/optimized_amis/` has not been refreshed since #9802. The per-region loop in `scripts/ssm_get_optimized_amis.py` catches only `botocore.exceptions.ClientError` ([intent: "We might encounter an error if we do not have access to a region - just ignore and try the next region"](https://github.com/getmoto/moto/blob/716d6a89bebdc6e3300b9f6b9bf2682f92ba45f7/scripts/ssm_get_optimized_amis.py#L102-L104)), but `ssm.me-south-1.amazonaws.com` now fails with `botocore.exceptions.ConnectTimeoutError` — a `BotoCoreError`, not a `ClientError` — which escapes the catch, kills the script before `mx-central-1`/`sa-east-1`/`us-*` are reached, and leaves the `Create PR` step skipped. The sibling `scripts/ssm_get_default_amis.py` handles the same loop with [`except Exception`](https://github.com/getmoto/moto/blob/716d6a89bebdc6e3300b9f6b9bf2682f92ba45f7/scripts/ssm_get_default_amis.py#L78-L80) and its `DataUpdate_SSMdefaultAMIs` run passed the identical region gauntlet the same morning (run [33495637581](https://github.com/getmoto/moto/actions/runs/33495637581) → #10221).

This PR applies the sibling's catch to the optimized-AMIs script (and removes the then-unused `botocore` import).

**Run history** for the 6/6-failures claim:

| date | run | note |
|---|---|---|
| 2026-03-01 | [22541086837](https://github.com/getmoto/moto/actions/runs/22541086837) | last success → #9802, the last data refresh |
| 2026-04-01 | [23843885974](https://github.com/getmoto/moto/actions/runs/23843885974) | first failure (logs past 90-day retention; conclusion on record) |
| 2026-07-01 | [28512971362](https://github.com/getmoto/moto/actions/runs/28512971362) | log: `botocore.exceptions.ConnectTimeoutError: Connect timeout on endpoint URL: "https://ssm.me-south-1.amazonaws.com/"` |
| 2026-09-01 | [33495844837](https://github.com/getmoto/moto/actions/runs/33495844837) | identical signature; same log shows opt-in regions (`ap-east-2`, `ap-southeast-6`, `ap-southeast-7`) correctly caught as `UnrecognizedClientException` (a `ClientError`) moments earlier, then `me-south-1` raises `ConnectTimeoutError` and the process exits 1 with `Create PR` skipped |

**Reproduction on my fork** (invalid dummy credentials, so every region errors — the point is the control flow, which mirrors the scheduled runs exactly):

- unfixed script: run [33532406098](https://github.com/glaziermag/moto/actions/runs/33532406098) — 27 regions raise `ClientError` → caught and skipped; `me-south-1` raises `ConnectTimeoutError` → script dies, job fails
- with this PR's change: run [33532404570](https://github.com/glaziermag/moto/actions/runs/33532404570) — the `me-south-1` timeout is printed and skipped, all regions processed through `ap-southeast-5` at the end of the list, exit 0
- sibling `ssm_get_default_amis.py`, unchanged, same environment: the `sibling` job in both runs above — survives `me-south-1`, exit 0 (the pattern this PR copies)

After merging, a manual `workflow_dispatch` of `DataUpdate_SSMoptimizedAMIs` would backfill the six stale months without waiting for the Oct 1 cron.

Disclosure: found and drafted with AI assistance; I re-pulled the run history and logs, verified the exception hierarchy against botocore 1.43.85, and ran the fork A/B above before filing.
