### PR TITLE
EventBridge: add EC2 Instance State-change Notification events

### DIFF
--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -20,6 +20,8 @@ from moto.ec2.models.instance_types import (
 from moto.ec2.models.launch_templates import LaunchTemplateVersion
 from moto.ec2.models.security_groups import SecurityGroup
 from moto.ec2.models.subnets import Subnet
+from moto.events.notifications import send_notification as events_send_notification
+from moto.utilities.utils import get_partition
 
 from ..exceptions import (
     AvailabilityZoneNotFromRegionError,
@@ -938,7 +940,24 @@ class InstanceBackend:
                 for volume in volumes:
                     volume.add_tags(volume_tags)
 
+            self._send_instance_state_change_notification(new_instance)
+
         return new_reservation
+
+    def _send_instance_state_change_notification(self, instance: Instance) -> None:
+        partition = get_partition(instance.region_name)
+        events_send_notification(
+            source="aws.ec2",
+            event_name=instance._state.name,
+            region=instance.region_name,
+            resources=[
+                f"arn:{partition}:ec2:{instance.region_name}:{instance.ec2_backend.account_id}:instance/{instance.id}"
+            ],
+            detail={
+                "instance-id": instance.id,
+                "state": instance._state.name,
+            },
+        )
 
     def start_instances(
         self, instance_ids: list[str]
@@ -947,6 +966,7 @@ class InstanceBackend:
         for instance in self.get_multi_instances_by_id(instance_ids):
             previous_state = instance.start()
             started_instances.append((instance, previous_state))
+            self._send_instance_state_change_notification(instance)
 
         return started_instances
 
@@ -959,6 +979,7 @@ class InstanceBackend:
                 raise OperationDisableApiStopNotPermitted(instance.id)
             previous_state = instance.stop()
             stopped_instances.append((instance, previous_state))
+            self._send_instance_state_change_notification(instance)
 
         return stopped_instances
 
@@ -973,6 +994,7 @@ class InstanceBackend:
                 raise OperationNotPermitted4(instance.id)
             previous_state = instance.terminate()
             terminated_instances.append((instance, previous_state))
+            self._send_instance_state_change_notification(instance)
 
         return terminated_instances
 

--- a/moto/events/notifications.py
+++ b/moto/events/notifications.py
@@ -17,6 +17,19 @@ _EVENT_S3_OBJECT_CREATED: EventMessageType = {
     "detail": {},
 }
 
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instance-state-changes.html
+_EVENT_EC2_INSTANCE_STATE_CHANGE: EventMessageType = {
+    "version": "0",
+    "id": "17793124-05d4-b198-2fde-7ededc63b104",
+    "detail-type": "EC2 Instance State-change Notification",
+    "source": "aws.ec2",
+    "account": "123456789012",
+    "time": "2021-11-12T00:00:00Z",
+    "region": "us-west-2",
+    "resources": [],
+    "detail": {},
+}
+
 
 def send_notification(
     source: str, event_name: str, region: str, resources: Any, detail: Any
@@ -34,11 +47,25 @@ def _send_safe_notification(
     from .models import events_backends
 
     event = None
+    detail_key = "eventName"
     if source == "aws.s3" and event_name == "CreateBucket":
         event = _EVENT_S3_OBJECT_CREATED.copy()
         event["region"] = region
         event["resources"] = resources
         event["detail"] = detail
+    elif source == "aws.ec2" and event_name in (
+        "running",
+        "stopped",
+        "terminated",
+    ):
+        # EC2 Instance State-change Notification is a native EventBridge
+        # event, not a CloudTrail-forwarded API call - it's filtered on
+        # detail.state rather than detail.eventName
+        event = _EVENT_EC2_INSTANCE_STATE_CHANGE.copy()
+        event["region"] = region
+        event["resources"] = resources
+        event["detail"] = detail
+        detail_key = "state"
 
     if event is None:
         return
@@ -54,7 +81,7 @@ def _send_safe_notification(
                         continue
                     pattern = rule.event_pattern.get_pattern()
                     if source in pattern.get("source", []):
-                        if event_name in pattern.get("detail", {}).get("eventName", []):
+                        if event_name in pattern.get("detail", {}).get(detail_key, []):
                             applicable_targets.extend(rule.targets)
 
             for target in applicable_targets:

--- a/tests/test_events/test_events_ec2_integration.py
+++ b/tests/test_events/test_events_ec2_integration.py
@@ -1,0 +1,123 @@
+import json
+from uuid import uuid4
+
+import boto3
+
+from moto import mock_aws
+from tests import EXAMPLE_AMI_ID
+from tests.test_stepfunctions.test_stepfunctions import _get_default_role
+
+state_machine_definition = {
+    "StartAt": "HelloWorld",
+    "States": {"HelloWorld": {"Type": "Pass", "Result": "Hello World!", "End": True}},
+}
+
+
+def _create_state_machine_rule(sfn_client, events_client, state):
+    response = sfn_client.create_state_machine(
+        name=str(uuid4()),
+        definition=json.dumps(state_machine_definition),
+        roleArn=_get_default_role(),
+    )
+    state_machine_arn = response["stateMachineArn"]
+
+    rule_name = str(uuid4())
+    events_client.put_rule(
+        Name=rule_name,
+        EventPattern=json.dumps(
+            {
+                "source": ["aws.ec2"],
+                "detail-type": ["EC2 Instance State-change Notification"],
+                "detail": {"state": [state]},
+            }
+        ),
+        State="ENABLED",
+    )
+    events_client.put_targets(
+        Rule=rule_name,
+        Targets=[{"Id": "n/a", "Arn": state_machine_arn}],
+    )
+    return state_machine_arn
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_run_instances_invokes_stepfunction_for_running_state():
+    sfn_client = boto3.client("stepfunctions", "us-east-1")
+    events_client = boto3.client("events", "us-east-1")
+    ec2_client = boto3.client("ec2", "us-east-1")
+
+    state_machine_arn = _create_state_machine_rule(sfn_client, events_client, "running")
+
+    resp = ec2_client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
+    instance_id = resp["Instances"][0]["InstanceId"]
+
+    execs = sfn_client.list_executions(stateMachineArn=state_machine_arn)["executions"]
+    assert len(execs) == 1
+
+    execution_details = sfn_client.describe_execution(
+        executionArn=execs[0]["executionArn"]
+    )
+    execution_input = json.loads(execution_details["input"])
+    assert execution_input["source"] == "aws.ec2"
+    assert execution_input["detail-type"] == "EC2 Instance State-change Notification"
+    assert execution_input["detail"]["instance-id"] == instance_id
+    assert execution_input["detail"]["state"] == "running"
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_stop_instances_invokes_stepfunction_for_stopped_state():
+    sfn_client = boto3.client("stepfunctions", "us-east-1")
+    events_client = boto3.client("events", "us-east-1")
+    ec2_client = boto3.client("ec2", "us-east-1")
+
+    resp = ec2_client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
+    instance_id = resp["Instances"][0]["InstanceId"]
+
+    state_machine_arn = _create_state_machine_rule(sfn_client, events_client, "stopped")
+
+    ec2_client.stop_instances(InstanceIds=[instance_id])
+
+    execs = sfn_client.list_executions(stateMachineArn=state_machine_arn)["executions"]
+    assert len(execs) == 1
+    execution_input = json.loads(
+        sfn_client.describe_execution(executionArn=execs[0]["executionArn"])["input"]
+    )
+    assert execution_input["detail"]["state"] == "stopped"
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_terminate_instances_invokes_stepfunction_for_terminated_state():
+    sfn_client = boto3.client("stepfunctions", "us-east-1")
+    events_client = boto3.client("events", "us-east-1")
+    ec2_client = boto3.client("ec2", "us-east-1")
+
+    resp = ec2_client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
+    instance_id = resp["Instances"][0]["InstanceId"]
+
+    state_machine_arn = _create_state_machine_rule(
+        sfn_client, events_client, "terminated"
+    )
+
+    ec2_client.terminate_instances(InstanceIds=[instance_id])
+
+    execs = sfn_client.list_executions(stateMachineArn=state_machine_arn)["executions"]
+    assert len(execs) == 1
+    execution_input = json.loads(
+        sfn_client.describe_execution(executionArn=execs[0]["executionArn"])["input"]
+    )
+    assert execution_input["detail"]["state"] == "terminated"
+
+
+@mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
+def test_rule_does_not_fire_for_a_different_state():
+    sfn_client = boto3.client("stepfunctions", "us-east-1")
+    events_client = boto3.client("events", "us-east-1")
+    ec2_client = boto3.client("ec2", "us-east-1")
+
+    # Rule only matches "stopped" - starting/running an instance shouldn't fire it
+    state_machine_arn = _create_state_machine_rule(sfn_client, events_client, "stopped")
+
+    ec2_client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1)
+
+    execs = sfn_client.list_executions(stateMachineArn=state_machine_arn)["executions"]
+    assert len(execs) == 0


### PR DESCRIPTION
First step towards #8451 ("Support Eventbridge events delivered by Cloudtrail... Can we support other events?").

moto's EventBridge notification dispatcher (`moto/events/notifications.py`) previously only handled one event: S3's `CreateBucket`. This PR extends it to also emit EC2's native [`EC2 Instance State-change Notification`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instance-state-changes.html) event on `run_instances`/`start_instances`/`stop_instances`/`terminate_instances`.

One design note: the existing S3 event is matched by the CloudTrail-style `detail.eventName` filter. Real EC2 state-change notification rules aren't filtered that way though, they're filtered on `detail.state` (e.g. `{"detail": {"state": ["running"]}}`), since it's a native service event, not a CloudTrail-forwarded API call. So the dispatcher now supports either matcher depending on the event source, existing S3 behavior is untouched.

Verified end-to-end with a real EventBridge rule + Step Functions target: `run_instances` fires a rule matching `state: running`, `stop_instances` fires one matching `stopped`, `terminate_instances` fires one matching `terminated`, and a rule for a *different* state correctly does not fire.

4 new tests in `tests/test_events/test_events_ec2_integration.py`. Existing S3/events integration tests still pass unchanged.