### PR TITLE
SQS: Raise PurgeQueueInProgress on repeated purge within 60 seconds

### DIFF
--- a/moto/sqs/exceptions.py
+++ b/moto/sqs/exceptions.py
@@ -34,6 +34,14 @@ class QueueAlreadyExists(SQSException):
         super().__init__("QueueAlreadyExists", message)
 
 
+class PurgeQueueInProgress(SQSException):
+    def __init__(self, queue_name: str) -> None:
+        super().__init__(
+            "AWS.SimpleQueueService.PurgeQueueInProgress",
+            f"Only one PurgeQueue operation on {queue_name} is allowed every 60 seconds.",
+        )
+
+
 class EmptyBatchRequest(SQSException):
     def __init__(self, action: str = "Send") -> None:
         super().__init__(

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -32,6 +32,7 @@ from .exceptions import (
     MessageAttributesInvalid,
     MissingParameter,
     OverLimit,
+    PurgeQueueInProgress,
     QueueAlreadyExists,
     QueueDoesNotExist,
     ReceiptHandleIsInvalid,
@@ -253,6 +254,7 @@ class Queue(CloudFormationModel):
         self._pending_messages: set[Message] = set()
         self.deleted_messages: set[str] = set()
         self._messages_lock = Condition()
+        self.last_purged_at: float | None = None
 
         now = unix_time()
         self.created_timestamp = now
@@ -1136,6 +1138,10 @@ class SQSBackend(BaseBackend, TaggableResourcesMixin):
 
     def purge_queue(self, queue_name: str) -> None:
         queue = self.get_queue(queue_name)
+        now = unix_time()
+        if queue.last_purged_at is not None and now - queue.last_purged_at < 60:
+            raise PurgeQueueInProgress(queue.name)
+        queue.last_purged_at = now
         queue._messages = []
         queue._pending_messages = set()
 

--- a/tests/test_sqs/test_sqs.py
+++ b/tests/test_sqs/test_sqs.py
@@ -1757,6 +1757,46 @@ def test_purge_queue_before_delete_message():
 
 
 @mock_aws
+def test_purge_queue_twice_raises_purge_in_progress():
+    client = boto3.client("sqs", region_name=REGION)
+    name = f"purge-{str(uuid4())[0:6]}"
+    queue_url = client.create_queue(QueueName=name)["QueueUrl"]
+
+    client.send_message(QueueUrl=queue_url, MessageBody="first")
+    client.purge_queue(QueueUrl=queue_url)
+
+    with pytest.raises(ClientError) as exc:
+        client.purge_queue(QueueUrl=queue_url)
+
+    err = exc.value.response["Error"]
+    assert err["Code"] == "AWS.SimpleQueueService.PurgeQueueInProgress"
+    assert err["Message"] == (
+        f"Only one PurgeQueue operation on {name} is allowed every 60 seconds."
+    )
+
+
+@mock_aws
+def test_purge_queue_allowed_after_60_seconds():
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("Cant manipulate time in server mode")
+
+    client = boto3.client("sqs", region_name=REGION)
+    name = f"purge-{str(uuid4())[0:6]}"
+
+    with freeze_time("2015-01-01 12:00:00"):
+        queue_url = client.create_queue(QueueName=name)["QueueUrl"]
+        client.send_message(QueueUrl=queue_url, MessageBody="first")
+        client.purge_queue(QueueUrl=queue_url)
+
+    with freeze_time("2015-01-01 12:01:01"):
+        client.send_message(QueueUrl=queue_url, MessageBody="second")
+        client.purge_queue(QueueUrl=queue_url)
+
+        resp = client.receive_message(QueueUrl=queue_url)
+        assert resp.get("Messages", []) == []
+
+
+@mock_aws
 def test_delete_message_after_visibility_timeout():
     VISIBILITY_TIMEOUT = 1
     sqs = boto3.resource("sqs", region_name=REGION)


### PR DESCRIPTION
Fixes #10233

SQS allows only one `PurgeQueue` operation per queue every 60 seconds; a second call inside the window fails with `AWS.SimpleQueueService.PurgeQueueInProgress`. Moto allowed unlimited consecutive purges. The 60 second rule is documented in the PurgeQueue API reference and the `PurgeQueueInProgress` error shape is declared on the operation in the botocore service model.

Changes:

- `Queue` now records `last_purged_at`, and `purge_queue` raises the new `PurgeQueueInProgress` exception when called again within 60 seconds, following the existing SQS exception conventions (legacy query-compat error code, same shape as `QueueDoesNotExist`).
- Two tests: a plain double-purge test asserting the error code and message (runs in server mode too), and a freezegun test asserting the purge succeeds again once 60 seconds have passed (skipped in server mode like the other time-manipulation tests in the file).

Checked that nothing else in moto or its test suite purges a queue twice within a window, so no existing behavior breaks. Note this makes moto stricter in a way that matches AWS: a user suite that purges the same queue repeatedly in under 60 seconds of real time will now get the same error AWS would give (freezegun sidesteps it). If you would rather gate this behind a setting, happy to rework.

Testing: `pytest tests/test_sqs/` passes (the two `test_sqs_integration.py` Lambda-in-Docker tests fail identically on unmodified master in my environment, no Docker); the new tests fail before the fix and pass after; `ruff check` and `ruff format --check` clean with the pinned ruff 0.14.10.
