### PR TITLE
CloudFormation: raise ValidationError when template has no Resources key

### DIFF
--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -529,6 +529,10 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
         cross_stack_resources: dict[str, "Export"] | None,
     ):
         self._template = template
+        if template != {} and "Resources" not in template:
+            raise ValidationError(
+                message="Template format error: At least one Resources member must be defined."
+            )
         self._resource_json_map: dict[str, Any] = (
             template["Resources"] if template != {} else {}
         )

--- a/tests/test_cloudformation/test_cloudformation_stack_crud.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud.py
@@ -1009,6 +1009,24 @@ def test_create_stack_fail_missing_parameter():
 
 
 @mock_aws
+def test_create_stack_fail_missing_resources_key():
+    cf = boto3.client("cloudformation", region_name=REGION_NAME)
+
+    template = json.dumps(
+        {"AWSTemplateFormatVersion": "2010-09-09", "Description": "Stack 1"}
+    )
+
+    with pytest.raises(ClientError) as exc:
+        cf.create_stack(StackName="ts", TemplateBody=template)
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+    assert (
+        err["Message"]
+        == "Template format error: At least one Resources member must be defined."
+    )
+
+
+@mock_aws
 def test_create_stack_s3_long_name():
     cf = boto3.client("cloudformation", region_name=REGION_NAME)
 


### PR DESCRIPTION
## Summary
- `create_stack()` crashed with an unhandled `KeyError: 'Resources'` when a template had no top-level `Resources` key, instead of returning an AWS-style `ValidationError`.
- `ResourceMap.__init__` (moto/cloudformation/parsing.py) now raises a `ValidationError` with the message `Template format error: At least one Resources member must be defined.`, matching real AWS CloudFormation behavior.

Found while implementing an opt-in cfn-lint validation feature for #8585 — this is a pre-existing bug on master, unrelated to that PR.

## Repro (before fix)
```python
import boto3, json
from moto import mock_aws

@mock_aws
def repro():
    client = boto3.client("cloudformation", region_name="us-east-1")
    bad_template = json.dumps({"AWSTemplateFormatVersion": "2010-09-09", "Description": "Stack 1"})
    client.create_stack(StackName="test-stack", TemplateBody=bad_template)

repro()  # raised KeyError: 'Resources'
```

## Test plan
- [x] Added `test_create_stack_fail_missing_resources_key` in `tests/test_cloudformation/test_cloudformation_stack_crud.py`, asserting `create_stack` raises a `ClientError` with code `ValidationError` and the AWS-matching message.
- [x] Verified repro script now raises a proper `ClientError` instead of crashing.
- [x] Ran `test_cloudformation_stack_crud.py` and `test_cloudformation_stack_integration.py` — no new failures introduced (pre-existing unrelated EC2-mock failures confirmed present on `master` via a clean worktree check).
- [x] `ruff check` and `mypy` pass clean on both touched files.