### PR TITLE
S3Control: raise InvalidNextTokenException for bad tokens

### DIFF
--- a/moto/s3control/exceptions.py
+++ b/moto/s3control/exceptions.py
@@ -57,6 +57,13 @@ class NoSuchPublicAccessBlockConfiguration(S3ControlError):
         super().__init__("The public access block configuration was not found")
 
 
+class InvalidNextTokenException(S3ControlError):
+    code = "InvalidNextTokenException"
+
+    def __init__(self) -> None:
+        super().__init__("The nextToken provided is invalid")
+
+
 class InvalidRequestException(S3ControlError):
     code = "InvalidRequest"
 

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -19,6 +19,7 @@ from moto.utilities.utils import PARTITION_NAMES, get_partition
 from .exceptions import (
     AccessPointNotFound,
     AccessPointPolicyNotFound,
+    InvalidNextTokenException,
     InvalidRequestException,
     MultiRegionAccessPointNotFound,
     MultiRegionAccessPointOperationNotFound,
@@ -32,18 +33,21 @@ PAGINATION_MODEL = {
         "input_token": "next_token",
         "limit_default": 100,
         "unique_attribute": "id",
+        "fail_on_invalid_token": InvalidNextTokenException,
     },
     "list_access_points": {
         "input_token": "next_token",
         "limit_key": "max_results",
         "limit_default": 1000,
         "unique_attribute": "name",
+        "fail_on_invalid_token": InvalidNextTokenException,
     },
     "list_multi_region_access_points": {
         "input_token": "next_token",
         "limit_key": "max_results",
         "limit_default": 100,
         "unique_attribute": "name",
+        "fail_on_invalid_token": InvalidNextTokenException,
     },
 }
 

--- a/tests/test_s3control/test_s3control_access_points.py
+++ b/tests/test_s3control/test_s3control_access_points.py
@@ -121,6 +121,17 @@ def test_list_access_points():
     assert "NextToken" not in resp2
 
 
+@mock_aws
+def test_list_access_points_with_invalid_next_token():
+    client = boto3.client("s3control", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as exc:
+        client.list_access_points(AccountId="111111111111", NextToken="invalid")
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidNextTokenException"
+    assert err["Message"] == "The nextToken provided is invalid"
+
+
 @pytest.mark.aws_verified
 @s3_aws_verified
 def test_delete_access_point(bucket_name=None):


### PR DESCRIPTION
Closes #10239.

An undecodable NextToken on the three paginated s3control calls came back as code `400`, message `Bad Request`, so a caller had nothing to catch on. The s3control service model defines `InvalidNextTokenException` for this.

The paginator already handles it. `PAGINATION_MODEL` entries take a `fail_on_invalid_token` key naming the exception to raise, the way route53resolver and s3tables set it. The three s3control entries left it at the default and fell through to the generic `InvalidToken`, which s3control does not render.

The exception is declared locally in `moto/s3control/exceptions.py` on `S3ControlError` rather than reusing the one in `moto/core/exceptions.py`. The core one is a `JsonRESTError` written for AWS Config, and it renders as the same bare 400 through this service. Every other s3control error subclasses `S3ControlError`.

After:

```
400 InvalidNextTokenException The nextToken provided is invalid
```

for `list_access_points`, `list_multi_region_access_points` and `list_storage_lens_configurations`. Valid tokens behave exactly as before.

One thing I could not check. I have no AWS account to run this against, so the message string is moto's existing wording from `moto/core/exceptions.py` rather than something verified against the real service. The code is what matters for catching it, and that comes from the service model. Happy to change the message if someone can read the real one.

`tests/test_s3control` passes, 38 tests. The new test fails on master.