### PR TITLE
Glue: implement the Filter argument for GetConnections

### DIFF
--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -1490,8 +1490,31 @@ class GlueBackend(BaseBackend, TaggableResourcesMixin):
     def get_connections(
         self, catalog_id: str, filter: dict[str, Any], hide_password: bool
     ) -> list["FakeConnection"]:
-        # TODO: Implement filtering
-        return list(self.connections.values())
+        connections = list(self.connections.values())
+        if not filter:
+            return connections
+
+        connection_type = filter.get("ConnectionType")
+        if connection_type:
+            connections = [
+                c
+                for c in connections
+                if c.connection_input.get("ConnectionType") == connection_type
+            ]
+
+        # A connection matches when every criteria string in the filter is
+        # recorded on the connection. A connection with no MatchCriteria of its
+        # own therefore matches nothing.
+        match_criteria = filter.get("MatchCriteria")
+        if match_criteria:
+            wanted = set(match_criteria)
+            connections = [
+                c
+                for c in connections
+                if wanted.issubset(set(c.connection_input.get("MatchCriteria") or []))
+            ]
+
+        return connections
 
     def put_data_catalog_encryption_settings(
         self,

--- a/tests/test_glue/test_glue.py
+++ b/tests/test_glue/test_glue.py
@@ -1279,6 +1279,90 @@ def test_get_connections():
     assert connections[2]["Name"] == "test-connection-2"
 
 
+def _create_filterable_connections(client):
+    for name, conn_type, criteria in [
+        ("jdbc-prod-east", "JDBC", ["prod", "east"]),
+        ("jdbc-prod-west", "JDBC", ["prod", "west"]),
+        ("kafka-prod-east", "KAFKA", ["prod", "east"]),
+        ("jdbc-uncategorised", "JDBC", None),
+    ]:
+        connection_input = {
+            "Name": name,
+            "ConnectionType": conn_type,
+            "ConnectionProperties": {"key": "value"},
+        }
+        if criteria is not None:
+            connection_input["MatchCriteria"] = criteria
+        client.create_connection(ConnectionInput=connection_input)
+
+
+def _names(response):
+    return sorted(c["Name"] for c in response["ConnectionList"])
+
+
+@mock_aws
+def test_get_connections_filtered_by_connection_type():
+    client = boto3.client("glue", region_name="ap-southeast-1")
+    _create_filterable_connections(client)
+
+    response = client.get_connections(Filter={"ConnectionType": "KAFKA"})
+    assert _names(response) == ["kafka-prod-east"]
+
+    response = client.get_connections(Filter={"ConnectionType": "JDBC"})
+    assert _names(response) == [
+        "jdbc-prod-east",
+        "jdbc-prod-west",
+        "jdbc-uncategorised",
+    ]
+
+    response = client.get_connections(Filter={"ConnectionType": "MONGODB"})
+    assert _names(response) == []
+
+
+@mock_aws
+def test_get_connections_filtered_by_match_criteria():
+    client = boto3.client("glue", region_name="ap-southeast-1")
+    _create_filterable_connections(client)
+
+    # Every criteria in the filter has to be present on the connection, so
+    # "prod" alone matches the three that carry it and skips the one with no
+    # criteria at all.
+    response = client.get_connections(Filter={"MatchCriteria": ["prod"]})
+    assert _names(response) == ["jdbc-prod-east", "jdbc-prod-west", "kafka-prod-east"]
+
+    response = client.get_connections(Filter={"MatchCriteria": ["prod", "west"]})
+    assert _names(response) == ["jdbc-prod-west"]
+
+    response = client.get_connections(Filter={"MatchCriteria": ["staging"]})
+    assert _names(response) == []
+
+
+@mock_aws
+def test_get_connections_filtered_by_type_and_criteria():
+    client = boto3.client("glue", region_name="ap-southeast-1")
+    _create_filterable_connections(client)
+
+    response = client.get_connections(
+        Filter={"ConnectionType": "JDBC", "MatchCriteria": ["east"]}
+    )
+    assert _names(response) == ["jdbc-prod-east"]
+
+    # The type excludes the only connection the criteria would have matched.
+    response = client.get_connections(
+        Filter={"ConnectionType": "KAFKA", "MatchCriteria": ["west"]}
+    )
+    assert _names(response) == []
+
+
+@mock_aws
+def test_get_connections_with_empty_filter_returns_everything():
+    client = boto3.client("glue", region_name="ap-southeast-1")
+    _create_filterable_connections(client)
+
+    assert len(client.get_connections(Filter={})["ConnectionList"]) == 4
+    assert len(client.get_connections()["ConnectionList"]) == 4
+
+
 @mock_aws
 def test_put_data_catalog_encryption_settings():
     client = boto3.client("glue", region_name="us-east-1")


### PR DESCRIPTION
`GetConnections` accepted a `Filter` and dropped it. Every call returned the full connection list, so a filter that should match nothing matched everything:

```python
client.create_connection(ConnectionInput={"Name": "jdbc-a", "ConnectionType": "JDBC", "MatchCriteria": ["prod"], "ConnectionProperties": {}})
client.create_connection(ConnectionInput={"Name": "kafka-b", "ConnectionType": "KAFKA", "MatchCriteria": ["prod"], "ConnectionProperties": {}})

client.get_connections(Filter={"MatchCriteria": ["nope"]})
# ConnectionList -> ['jdbc-a', 'kafka-b']
```

The backend now applies both filter fields:

- `ConnectionType` is an exact match against the connection's type.
- `MatchCriteria` matches when every criteria string in the filter is recorded on the connection. A connection with no `MatchCriteria` of its own matches no criteria filter.

Both fields combine as an AND when supplied together. An absent or empty `Filter` keeps the old behaviour and returns everything.

`ConnectionSchemaVersion` is the third field on the shape. moto does not model a schema version on connections, so it is still ignored, and I left it alone rather than invent one.

Four tests cover type, criteria, the two combined, and the empty filter case. Three of them fail on current master.
