### PR TITLE
IdentityStore: implement GetGroupMembershipId, DescribeGroupMembership and IsMemberInGroups

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -6095,7 +6095,7 @@
 
 ## identitystore
 <details>
-<summary>73% implemented</summary>
+<summary>89% implemented</summary>
 
 - [X] create_group
 - [X] create_group_membership
@@ -6104,12 +6104,12 @@
 - [X] delete_group_membership
 - [X] delete_user
 - [X] describe_group
-- [ ] describe_group_membership
+- [X] describe_group_membership
 - [X] describe_user
 - [X] get_group_id
-- [ ] get_group_membership_id
+- [X] get_group_membership_id
 - [X] get_user_id
-- [ ] is_member_in_groups
+- [X] is_member_in_groups
 - [X] list_group_memberships
 - [X] list_group_memberships_for_member
 - [X] list_groups

--- a/docs/docs/services/identitystore.rst
+++ b/docs/docs/services/identitystore.rst
@@ -23,20 +23,20 @@ identitystore
 - [X] delete_group_membership
 - [X] delete_user
 - [X] describe_group
-- [ ] describe_group_membership
+- [X] describe_group_membership
 - [X] describe_user
 - [X] get_group_id
   
 The ExternalId alternate identifier is not yet implemented
 
 
-- [ ] get_group_membership_id
+- [X] get_group_membership_id
 - [X] get_user_id
   
 The ExternalId alternate identifier is not yet implemented
 
 
-- [ ] is_member_in_groups
+- [X] is_member_in_groups
 - [X] list_group_memberships
 - [X] list_group_memberships_for_member
 - [X] list_groups

--- a/moto/identitystore/models.py
+++ b/moto/identitystore/models.py
@@ -291,6 +291,56 @@ class IdentityStoreBackend(BaseBackend):
 
         return membership_id, identity_store_id
 
+    def get_group_membership_id(
+        self, identity_store_id: str, group_id: str, member_id: dict[str, str]
+    ) -> tuple[str, str]:
+        identity_store = self.__get_identity_store(identity_store_id)
+        user_id = member_id["UserId"]
+
+        for membership in identity_store.group_memberships.values():
+            if (
+                membership["GroupId"] == group_id
+                and membership["MemberId"]["UserId"] == user_id
+            ):
+                return membership["MembershipId"], identity_store_id
+
+        raise ResourceNotFoundException(
+            message="GROUP_MEMBERSHIP not found.", resource_type="GROUP_MEMBERSHIP"
+        )
+
+    def describe_group_membership(
+        self, identity_store_id: str, membership_id: str
+    ) -> dict[str, Any]:
+        identity_store = self.__get_identity_store(identity_store_id)
+
+        if membership_id in identity_store.group_memberships:
+            return identity_store.group_memberships[membership_id]
+
+        raise ResourceNotFoundException(
+            message="GROUP_MEMBERSHIP not found.", resource_type="GROUP_MEMBERSHIP"
+        )
+
+    def is_member_in_groups(
+        self, identity_store_id: str, member_id: dict[str, str], group_ids: list[str]
+    ) -> list[dict[str, Any]]:
+        identity_store = self.__get_identity_store(identity_store_id)
+        user_id = member_id["UserId"]
+
+        groups_of_member = {
+            m["GroupId"]
+            for m in identity_store.group_memberships.values()
+            if m["MemberId"]["UserId"] == user_id
+        }
+
+        return [
+            {
+                "GroupId": group_id,
+                "MemberId": {"UserId": user_id},
+                "MembershipExists": group_id in groups_of_member,
+            }
+            for group_id in group_ids
+        ]
+
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore
     def list_group_memberships(  # type: ignore[misc]
         self, identity_store_id: str, group_id: str

--- a/moto/identitystore/responses.py
+++ b/moto/identitystore/responses.py
@@ -84,6 +84,22 @@ class IdentityStoreResponse(BaseResponse):
         )
         return json.dumps({"UserId": user_id, "IdentityStoreId": identity_store_id})
 
+    def get_group_membership_id(self) -> str:
+        identity_store_id = self._get_param("IdentityStoreId")
+        group_id = self._get_param("GroupId")
+        member_id = self._get_param("MemberId")
+        (
+            membership_id,
+            identity_store_id,
+        ) = self.identitystore_backend.get_group_membership_id(
+            identity_store_id=identity_store_id,
+            group_id=group_id,
+            member_id=member_id,
+        )
+        return json.dumps(
+            {"MembershipId": membership_id, "IdentityStoreId": identity_store_id}
+        )
+
     def describe_user(self) -> str:
         identity_store_id = self._get_param("IdentityStoreId")
         user_id = self._get_param("UserId")
@@ -208,6 +224,22 @@ class IdentityStoreResponse(BaseResponse):
             }
         )
 
+    def describe_group_membership(self) -> str:
+        identity_store_id = self._get_param("IdentityStoreId")
+        membership_id = self._get_param("MembershipId")
+        membership = self.identitystore_backend.describe_group_membership(
+            identity_store_id=identity_store_id,
+            membership_id=membership_id,
+        )
+        return json.dumps(
+            {
+                "IdentityStoreId": membership["IdentityStoreId"],
+                "MembershipId": membership["MembershipId"],
+                "GroupId": membership["GroupId"],
+                "MemberId": membership["MemberId"],
+            }
+        )
+
     def list_users(self) -> str:
         identity_store_id = self._get_param("IdentityStoreId")
         max_results = self._get_param("MaxResults")
@@ -224,6 +256,17 @@ class IdentityStoreResponse(BaseResponse):
         )
 
         return json.dumps({"Users": users, "NextToken": next_token})
+
+    def is_member_in_groups(self) -> str:
+        identity_store_id = self._get_param("IdentityStoreId")
+        member_id = self._get_param("MemberId")
+        group_ids = self._get_param("GroupIds")
+        results = self.identitystore_backend.is_member_in_groups(
+            identity_store_id=identity_store_id,
+            member_id=member_id,
+            group_ids=group_ids,
+        )
+        return json.dumps({"Results": results})
 
     def delete_group(self) -> str:
         identity_store_id = self._get_param("IdentityStoreId")

--- a/tests/test_identitystore/test_identitystore.py
+++ b/tests/test_identitystore/test_identitystore.py
@@ -111,6 +111,202 @@ def test_create_group_membership():
 
 
 @mock_aws
+def test_get_group_membership_id():
+    client = boto3.client("identitystore", region_name="us-east-2")
+    identity_store_id = get_identity_store_id()
+
+    _, _, group_id = __create_test_group(client, identity_store_id)
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+
+    membership_id = client.create_group_membership(
+        IdentityStoreId=identity_store_id,
+        GroupId=group_id,
+        MemberId={"UserId": user_id},
+    )["MembershipId"]
+
+    response = client.get_group_membership_id(
+        IdentityStoreId=identity_store_id,
+        GroupId=group_id,
+        MemberId={"UserId": user_id},
+    )
+
+    assert response["MembershipId"] == membership_id
+    assert response["IdentityStoreId"] == identity_store_id
+
+
+@mock_aws
+def test_get_group_membership_id_does_not_exist():
+    client = boto3.client("identitystore", region_name="us-east-2")
+    identity_store_id = get_identity_store_id()
+
+    _, _, group_id = __create_test_group(client, identity_store_id)
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+
+    # The user and the group both exist, but the user is not a member of it
+    with pytest.raises(ClientError) as exc:
+        client.get_group_membership_id(
+            IdentityStoreId=identity_store_id,
+            GroupId=group_id,
+            MemberId={"UserId": user_id},
+        )
+    err = exc.value
+    assert err.response["Error"]["Code"] == "ResourceNotFoundException"
+    assert err.response["Error"]["Message"] == "GROUP_MEMBERSHIP not found."
+    assert err.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert err.response["ResourceType"] == "GROUP_MEMBERSHIP"
+    assert "RequestId" in err.response
+
+
+@mock_aws
+def test_get_group_membership_id_other_group():
+    client = boto3.client("identitystore", region_name="us-east-2")
+    identity_store_id = get_identity_store_id()
+
+    _, _, group_id = __create_test_group(client, identity_store_id)
+    _, _, other_group_id = __create_test_group(client, identity_store_id)
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+
+    client.create_group_membership(
+        IdentityStoreId=identity_store_id,
+        GroupId=group_id,
+        MemberId={"UserId": user_id},
+    )
+
+    # A membership for this user exists, but not in the group we ask about
+    with pytest.raises(ClientError) as exc:
+        client.get_group_membership_id(
+            IdentityStoreId=identity_store_id,
+            GroupId=other_group_id,
+            MemberId={"UserId": user_id},
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_describe_group_membership():
+    client = boto3.client("identitystore", region_name="eu-west-1")
+    identity_store_id = get_identity_store_id()
+
+    _, _, group_id = __create_test_group(client, identity_store_id)
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+
+    membership_id = client.create_group_membership(
+        IdentityStoreId=identity_store_id,
+        GroupId=group_id,
+        MemberId={"UserId": user_id},
+    )["MembershipId"]
+
+    response = client.describe_group_membership(
+        IdentityStoreId=identity_store_id, MembershipId=membership_id
+    )
+
+    assert response["IdentityStoreId"] == identity_store_id
+    assert response["MembershipId"] == membership_id
+    assert response["GroupId"] == group_id
+    assert response["MemberId"]["UserId"] == user_id
+
+
+@mock_aws
+def test_describe_group_membership_does_not_exist():
+    client = boto3.client("identitystore", region_name="eu-west-1")
+    identity_store_id = get_identity_store_id()
+
+    with pytest.raises(ClientError) as exc:
+        client.describe_group_membership(
+            IdentityStoreId=identity_store_id, MembershipId=str(uuid4())
+        )
+    err = exc.value
+    assert err.response["Error"]["Code"] == "ResourceNotFoundException"
+    assert err.response["Error"]["Message"] == "GROUP_MEMBERSHIP not found."
+    assert err.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert err.response["ResourceType"] == "GROUP_MEMBERSHIP"
+    assert "RequestId" in err.response
+
+
+@mock_aws
+def test_describe_group_membership_after_delete():
+    client = boto3.client("identitystore", region_name="eu-west-1")
+    identity_store_id = get_identity_store_id()
+
+    _, _, group_id = __create_test_group(client, identity_store_id)
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+
+    membership_id = client.create_group_membership(
+        IdentityStoreId=identity_store_id,
+        GroupId=group_id,
+        MemberId={"UserId": user_id},
+    )["MembershipId"]
+
+    client.delete_group_membership(
+        IdentityStoreId=identity_store_id, MembershipId=membership_id
+    )
+
+    with pytest.raises(ClientError) as exc:
+        client.describe_group_membership(
+            IdentityStoreId=identity_store_id, MembershipId=membership_id
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_is_member_in_groups():
+    client = boto3.client("identitystore", region_name="us-east-2")
+    identity_store_id = get_identity_store_id()
+
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+    _, _, member_of = __create_test_group(client, identity_store_id)
+    _, _, not_member_of = __create_test_group(client, identity_store_id)
+
+    client.create_group_membership(
+        IdentityStoreId=identity_store_id,
+        GroupId=member_of,
+        MemberId={"UserId": user_id},
+    )
+
+    response = client.is_member_in_groups(
+        IdentityStoreId=identity_store_id,
+        MemberId={"UserId": user_id},
+        GroupIds=[member_of, not_member_of],
+    )
+
+    results = response["Results"]
+    assert len(results) == 2
+
+    # The order of the results matches the order of the requested GroupIds
+    assert results[0]["GroupId"] == member_of
+    assert results[0]["MemberId"]["UserId"] == user_id
+    assert results[0]["MembershipExists"] is True
+
+    assert results[1]["GroupId"] == not_member_of
+    assert results[1]["MemberId"]["UserId"] == user_id
+    assert results[1]["MembershipExists"] is False
+
+
+@mock_aws
+def test_is_member_in_groups_ignores_other_members():
+    client = boto3.client("identitystore", region_name="us-east-2")
+    identity_store_id = get_identity_store_id()
+
+    user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+    other_user_id = __create_and_verify_sparse_user(client, identity_store_id)["UserId"]
+    _, _, group_id = __create_test_group(client, identity_store_id)
+
+    client.create_group_membership(
+        IdentityStoreId=identity_store_id,
+        GroupId=group_id,
+        MemberId={"UserId": other_user_id},
+    )
+
+    response = client.is_member_in_groups(
+        IdentityStoreId=identity_store_id,
+        MemberId={"UserId": user_id},
+        GroupIds=[group_id],
+    )
+
+    assert response["Results"][0]["MembershipExists"] is False
+
+
+@mock_aws
 def test_create_duplicate_username():
     client = boto3.client("identitystore", region_name="us-east-2")
     identity_store_id = get_identity_store_id()


### PR DESCRIPTION
Implements the three remaining read operations on IdentityStore group memberships:

- `GetGroupMembershipId` — resolves a `(GroupId, MemberId)` pair to its `MembershipId`, raising `ResourceNotFoundException` when that member is not in that group.
- `DescribeGroupMembership` — returns a membership by `MembershipId`.
- `IsMemberInGroups` — reports membership existence for a member across a list of group IDs, preserving the order of the requested `GroupIds`.

This takes `identitystore` from 73% to 89%; only `UpdateGroup` and `UpdateUser` remain.

Tests cover the happy path for each operation, plus: a member that exists but is not in the requested group, a membership that has been deleted, an unknown membership ID, and `IsMemberInGroups` correctly ignoring another user's membership in the same group. Verified in both decorator mode and server mode.

**Deliberately out of scope**

- `DescribeGroupMembership` returns the four required response fields (`IdentityStoreId`, `MembershipId`, `GroupId`, `MemberId`). The optional `CreatedAt` / `UpdatedAt` / `CreatedBy` / `UpdatedBy` fields are not returned, because memberships aren't currently stored with that metadata — populating them would mean changing the shape written by `CreateGroupMembership`, which seemed better kept out of this PR. Happy to do it as a follow-up if you'd like it.
- `IsMemberInGroups` reports `MembershipExists: false` for unknown members and unknown group IDs rather than raising. I wasn't able to verify against real AWS whether it raises `ResourceNotFoundException` for a member that doesn't exist, so I kept the behaviour that doesn't guess. If you know the real behaviour, I'll match it.