### PR TITLE
Cognito: basic PASSWORD_VERIFIER challenge checks (#7562)

### DIFF
--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -47,6 +47,16 @@ from .utils import (
 # FIXME: Should be per user and stored in the user's profile
 COGNITO_TOTP_MFA_SECRET: Final[str] = "asdfasdfasdf"
 
+# PASSWORD_VERIFIER challenge_responses required by Cognito. Signature crypto is
+# intentionally not verified — AWS has no public spec, and moto only checks that
+# these fields are present and that USERNAME / SECRET_BLOCK match the session.
+PASSWORD_VERIFIER_REQUIRED_RESPONSES: Final[tuple[str, ...]] = (
+    "USERNAME",
+    "PASSWORD_CLAIM_SIGNATURE",
+    "PASSWORD_CLAIM_SECRET_BLOCK",
+    "TIMESTAMP",
+)
+
 
 class UserStatus(str, enum.Enum):
     FORCE_CHANGE_PASSWORD = "FORCE_CHANGE_PASSWORD"
@@ -1613,6 +1623,43 @@ class CognitoIdpBackend(BaseBackend):
             session, client_id, challenge_name, challenge_responses
         )
 
+    def _resolve_password_verifier_session(
+        self,
+        session: str | None,
+        challenge_responses: dict[str, str] | None,
+    ) -> str:
+        responses = challenge_responses or {}
+        for field in PASSWORD_VERIFIER_REQUIRED_RESPONSES:
+            if not responses.get(field):
+                raise InvalidParameterException(f"Missing required parameter {field}")
+
+        secret_block = responses["PASSWORD_CLAIM_SECRET_BLOCK"]
+        # initiate_auth stores SECRET_BLOCK == Session. When the caller also
+        # sends Session, it must match; otherwise the secret block is the session.
+        if session and secret_block != session:
+            raise NotAuthorizedError("Incorrect username or password.")
+        return secret_block
+
+    def _password_verifier_username_matches(
+        self,
+        user_pool: CognitoIdpUserPool,
+        session_username: str,
+        challenge_username: str | None,
+    ) -> bool:
+        if not challenge_username:
+            return False
+        if challenge_username == session_username:
+            return True
+        session_user = user_pool._get_user(session_username)
+        if session_user is None:
+            return False
+        # pycognito / amplify send ChallengeParameters.USERNAME, which is the
+        # internal username (or sub) and can differ from the initiate_auth alias.
+        if challenge_username in {session_user.username, session_user.id}:
+            return True
+        challenge_user = user_pool._get_user(challenge_username)
+        return challenge_user is session_user
+
     def respond_to_auth_challenge(
         self,
         session: str,
@@ -1621,11 +1668,13 @@ class CognitoIdpBackend(BaseBackend):
         challenge_responses: dict[str, str],
     ) -> dict[str, Any]:
         if challenge_name == "PASSWORD_VERIFIER":
-            session = challenge_responses.get("PASSWORD_CLAIM_SECRET_BLOCK")  # type: ignore[assignment]
+            session = self._resolve_password_verifier_session(
+                session, challenge_responses
+            )
 
         if session not in self.sessions:
             raise ResourceNotFoundError(session)
-        _, user_pool = self.sessions[session]
+        session_username, user_pool = self.sessions[session]
 
         client = user_pool.clients.get(client_id)
         if not client:
@@ -1664,21 +1713,11 @@ class CognitoIdpBackend(BaseBackend):
             return self._log_user_in(user_pool, client, username)
         elif challenge_name == "PASSWORD_VERIFIER":
             username: str = challenge_responses.get("USERNAME")  # type: ignore[no-redef]
+            if not self._password_verifier_username_matches(
+                user_pool, session_username, username
+            ):
+                raise NotAuthorizedError("Incorrect username or password.")
             user = self.admin_get_user(user_pool.id, username)
-
-            password_claim_signature = challenge_responses.get(
-                "PASSWORD_CLAIM_SIGNATURE"
-            )
-            if not password_claim_signature:
-                raise ResourceNotFoundError(password_claim_signature)
-            password_claim_secret_block = challenge_responses.get(
-                "PASSWORD_CLAIM_SECRET_BLOCK"
-            )
-            if not password_claim_secret_block:
-                raise ResourceNotFoundError(password_claim_secret_block)
-            timestamp = challenge_responses.get("TIMESTAMP")
-            if not timestamp:
-                raise ResourceNotFoundError(timestamp)
 
             if user.status == UserStatus.FORCE_CHANGE_PASSWORD:
                 return {

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -5701,6 +5701,181 @@ def test_respond_to_auth_challenge_with_invalid_secret_hash():
     assert err["Code"] == "NotAuthorizedException"
 
 
+def _confirmed_srp_user(conn, username=None, user_pool_id=None, generate_secret=False):
+    """Create a confirmed user and return ids needed for USER_SRP_AUTH tests."""
+    username = username or str(uuid.uuid4())
+    password = "P2$Sword"
+    if user_pool_id is None:
+        user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"][
+            "Id"
+        ]
+    client_kwargs = {
+        "UserPoolId": user_pool_id,
+        "ClientName": str(uuid.uuid4()),
+    }
+    if generate_secret:
+        client_kwargs["GenerateSecret"] = True
+    client_id = conn.create_user_pool_client(**client_kwargs)["UserPoolClient"][
+        "ClientId"
+    ]
+    conn.sign_up(ClientId=client_id, Username=username, Password=password)
+    conn.confirm_sign_up(
+        ClientId=client_id, Username=username, ConfirmationCode="123456"
+    )
+    return {
+        "username": username,
+        "password": password,
+        "user_pool_id": user_pool_id,
+        "client_id": client_id,
+    }
+
+
+def _initiate_password_verifier(conn, client_id, username, secret_hash=None):
+    auth_parameters = {"USERNAME": username, "SRP_A": uuid.uuid4().hex}
+    if secret_hash:
+        auth_parameters["SECRET_HASH"] = secret_hash
+    return conn.initiate_auth(
+        ClientId=client_id,
+        AuthFlow="USER_SRP_AUTH",
+        AuthParameters=auth_parameters,
+    )
+
+
+def _password_verifier_responses(challenge, username):
+    return {
+        "PASSWORD_CLAIM_SIGNATURE": str(uuid.uuid4()),
+        "PASSWORD_CLAIM_SECRET_BLOCK": challenge["Session"],
+        "TIMESTAMP": str(uuid.uuid4()),
+        "USERNAME": username,
+    }
+
+
+@mock_aws
+def test_respond_to_auth_challenge_password_verifier_mismatched_username():
+    """Regression for getmoto/moto#7562: a different username must not succeed.
+
+    Moto still does not validate PASSWORD_CLAIM_SIGNATURE (no public SRP spec).
+    This only asserts the username is bound to the initiate_auth session.
+    """
+    conn = boto3.client("cognito-idp", "us-west-2")
+    user_pool_id = conn.create_user_pool(PoolName=str(uuid.uuid4()))["UserPool"]["Id"]
+    user_one = _confirmed_srp_user(conn, user_pool_id=user_pool_id)
+    user_two = _confirmed_srp_user(conn, user_pool_id=user_pool_id)
+
+    challenge = _initiate_password_verifier(
+        conn, user_one["client_id"], user_one["username"]
+    )
+    assert challenge["ChallengeName"] == "PASSWORD_VERIFIER"
+
+    with pytest.raises(ClientError) as exc:
+        conn.respond_to_auth_challenge(
+            ClientId=user_one["client_id"],
+            Session=challenge["Session"],
+            ChallengeName="PASSWORD_VERIFIER",
+            ChallengeResponses=_password_verifier_responses(
+                challenge, user_two["username"]
+            ),
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "NotAuthorizedException"
+    assert err["Message"] == "Incorrect username or password."
+
+
+@mock_aws
+def test_respond_to_auth_challenge_password_verifier_mismatched_secret_block():
+    """SECRET_BLOCK must match the session from initiate_auth."""
+    conn = boto3.client("cognito-idp", "us-west-2")
+    user = _confirmed_srp_user(conn)
+    challenge = _initiate_password_verifier(conn, user["client_id"], user["username"])
+
+    with pytest.raises(ClientError) as exc:
+        conn.respond_to_auth_challenge(
+            ClientId=user["client_id"],
+            Session=challenge["Session"],
+            ChallengeName="PASSWORD_VERIFIER",
+            ChallengeResponses={
+                "PASSWORD_CLAIM_SIGNATURE": str(uuid.uuid4()),
+                "PASSWORD_CLAIM_SECRET_BLOCK": str(uuid.uuid4()),
+                "TIMESTAMP": str(uuid.uuid4()),
+                "USERNAME": user["username"],
+            },
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "NotAuthorizedException"
+    assert err["Message"] == "Incorrect username or password."
+
+
+@mock_aws
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "USERNAME",
+        "PASSWORD_CLAIM_SIGNATURE",
+        "PASSWORD_CLAIM_SECRET_BLOCK",
+        "TIMESTAMP",
+    ],
+)
+def test_respond_to_auth_challenge_password_verifier_missing_fields(missing_field):
+    conn = boto3.client("cognito-idp", "us-west-2")
+    user = _confirmed_srp_user(conn)
+    challenge = _initiate_password_verifier(conn, user["client_id"], user["username"])
+    responses = _password_verifier_responses(challenge, user["username"])
+    del responses[missing_field]
+
+    with pytest.raises(ClientError) as exc:
+        conn.respond_to_auth_challenge(
+            ClientId=user["client_id"],
+            Session=challenge["Session"],
+            ChallengeName="PASSWORD_VERIFIER",
+            ChallengeResponses=responses,
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidParameterException"
+    assert missing_field in err["Message"]
+
+
+@mock_aws
+def test_respond_to_auth_challenge_password_verifier_dummy_signature_succeeds():
+    """Dummy signatures are accepted — SRP crypto is out of scope (see #7562)."""
+    conn = boto3.client("cognito-idp", "us-west-2")
+    user = _confirmed_srp_user(conn)
+    challenge = _initiate_password_verifier(conn, user["client_id"], user["username"])
+
+    result = conn.respond_to_auth_challenge(
+        ClientId=user["client_id"],
+        Session=challenge["Session"],
+        ChallengeName="PASSWORD_VERIFIER",
+        ChallengeResponses=_password_verifier_responses(challenge, user["username"]),
+    )
+
+    assert result["AuthenticationResult"]["IdToken"] != ""
+    assert result["AuthenticationResult"]["AccessToken"] != ""
+    assert result["AuthenticationResult"]["RefreshToken"] != ""
+
+
+@mock_aws
+def test_respond_to_auth_challenge_password_verifier_username_attribute_alias():
+    """Challenge USERNAME may be the internal username from ChallengeParameters."""
+    conn = boto3.client("cognito-idp", "us-west-2")
+    email = "alias-user@example.com"
+    user_pool_id = conn.create_user_pool(
+        PoolName=str(uuid.uuid4()), UsernameAttributes=["email"]
+    )["UserPool"]["Id"]
+    user = _confirmed_srp_user(conn, username=email, user_pool_id=user_pool_id)
+    challenge = _initiate_password_verifier(conn, user["client_id"], user["username"])
+
+    result = conn.respond_to_auth_challenge(
+        ClientId=user["client_id"],
+        Session=challenge["Session"],
+        ChallengeName="PASSWORD_VERIFIER",
+        ChallengeResponses=_password_verifier_responses(
+            challenge, challenge["ChallengeParameters"]["USERNAME"]
+        ),
+    )
+
+    assert result["AuthenticationResult"]["AccessToken"] != ""
+
+
 @mock_aws
 def test_admin_set_user_password():
     conn = boto3.client("cognito-idp", "us-west-2")


### PR DESCRIPTION
## Problem

`respond_to_auth_challenge` with `ChallengeName=PASSWORD_VERIFIER` did not bind the challenge to the `initiate_auth` session. A response could swap in another pool user's `USERNAME` and moto would still complete auth. Missing fields raised `ResourceNotFoundException` (or were not checked for `USERNAME`).

The original report asked for password / SRP verification. Maintainer [bblommers scoped this to basic checks only](https://github.com/getmoto/moto/issues/7562#issuecomment-2068471640): verify the four values exist, and that `username` and `secret_block` match the session — not full SRP signature crypto.

A later attempt (#8204) was closed because it was incomplete.

## Scope

This implements only those basic checks. It does not implement SRP or validate `PASSWORD_CLAIM_SIGNATURE`. Dummy signatures still succeed, which matches existing tests and the maintainer's request.

What changed:

1. Require `USERNAME`, `PASSWORD_CLAIM_SIGNATURE`, `PASSWORD_CLAIM_SECRET_BLOCK`, and `TIMESTAMP`. Missing fields raise `InvalidParameterException`.
2. If `Session` is sent, `PASSWORD_CLAIM_SECRET_BLOCK` must equal it. Mismatch raises `NotAuthorizedException: Incorrect username or password.`
3. `USERNAME` must identify the same user as the session created by `initiate_auth` (session username, internal username / `sub`, or a `UsernameAttributes` alias). Mismatch raises `NotAuthorizedException`.

Unknown sessions still raise `ResourceNotFoundException`, same as other challenge types.

## Tests

- New PASSWORD_VERIFIER regressions in `tests/test_cognitoidp/test_cognitoidp.py`
- Full `tests/test_cognitoidp/` (excluding server tests)

New cases cover mismatched `USERNAME`, mismatched `SECRET_BLOCK` vs `Session`, missing required fields, alias usernames, and documenting that dummy signatures still succeed.

Fixes #7562 (partially: basic checks only).