### PR TITLE
EC2: support UserData in LaunchTemplateSpecification

### DIFF
--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -73,6 +73,12 @@ class Fleet(TaggedEC2Resource):
             else:
                 continue
 
+            launch_spec_userdata = (
+                launch_spec.get("LaunchTemplateSpecificationUserData")
+                if self.fleet_type == "instant"
+                else None
+            )
+
             # Resolve $Latest or $Default to actual version number
             resolved_launch_spec = launch_spec.copy()
             if resolved_launch_spec.get("Version") == "$Latest":
@@ -112,7 +118,7 @@ class Fleet(TaggedEC2Resource):
                         spot_price=spec.get("SpotPrice"),
                         subnet_id=spec.get("SubnetId"),
                         tag_specifications=tags,
-                        user_data=spec.get("UserData"),
+                        user_data=launch_spec_userdata or spec.get("UserData"),
                         weighted_capacity=spec.get("WeightedCapacity", 1),
                         launch_template_spec=resolved_launch_spec,
                         overrides=override if override else None,

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -1042,6 +1042,48 @@ def test_user_data():
     assert attrs["UserData"]["Value"] == str(user_data)
 
 
+@mock_aws
+def test_launch_spec_user_data():
+    ec2_client = boto3.client("ec2", region_name="us-west-2")
+    template_user_data = Base64EncodedString.from_raw_string("template user data")
+    spec_user_data = Base64EncodedString.from_raw_string("spec user data")
+    template_args = {
+        "LaunchTemplateName": "test-template",
+        "LaunchTemplateData": {
+            "ImageId": "ami-0157ed312f9c59a91",
+            "InstanceType": "t3.nano",
+            "UserData": str(template_user_data),
+        },
+    }
+    ec2_client.create_launch_template(**template_args)
+    fleet_args = {
+        "OnDemandOptions": {
+            "AllocationStrategy": "lowest-price",
+        },
+        "TargetCapacitySpecification": {
+            "TotalTargetCapacity": 1,
+            "DefaultTargetCapacityType": "on-demand",
+        },
+        "LaunchTemplateConfigs": [
+            {
+                "LaunchTemplateSpecification": {
+                    "LaunchTemplateName": "test-template",
+                    "Version": "$Latest",
+                    "LaunchTemplateSpecificationUserData": str(spec_user_data),
+                },
+            },
+        ],
+        "Type": "instant",
+    }
+    fleet = ec2_client.create_fleet(**fleet_args)
+    instance = fleet["Instances"][0]
+    attrs = ec2_client.describe_instance_attribute(
+        InstanceId=instance["InstanceIds"][0],
+        Attribute="userData",
+    )
+    assert attrs["UserData"]["Value"] == str(spec_user_data)
+
+
 @pytest.mark.aws_verified
 @ec2_aws_verified()
 @pytest.mark.parametrize("version_specified", ["$Latest", "$Default"])

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -1006,8 +1006,9 @@ def test_create_fleet_api_response():
 def test_user_data():
     ec2_client = boto3.client("ec2", region_name="us-west-2")
     user_data = Base64EncodedString.from_raw_string("test user data")
+    template_name = "test" + str(uuid4())
     template_args = {
-        "LaunchTemplateName": "test-template",
+        "LaunchTemplateName": template_name,
         "LaunchTemplateData": {
             "ImageId": "ami-0157ed312f9c59a91",
             "InstanceType": "t3.nano",
@@ -1026,7 +1027,7 @@ def test_user_data():
         "LaunchTemplateConfigs": [
             {
                 "LaunchTemplateSpecification": {
-                    "LaunchTemplateName": "test-template",
+                    "LaunchTemplateName": template_name,
                     "Version": "$Latest",
                 },
             },
@@ -1047,8 +1048,9 @@ def test_launch_spec_user_data():
     ec2_client = boto3.client("ec2", region_name="us-west-2")
     template_user_data = Base64EncodedString.from_raw_string("template user data")
     spec_user_data = Base64EncodedString.from_raw_string("spec user data")
+    template_name = "test" + str(uuid4())
     template_args = {
-        "LaunchTemplateName": "test-template",
+        "LaunchTemplateName": template_name,
         "LaunchTemplateData": {
             "ImageId": "ami-0157ed312f9c59a91",
             "InstanceType": "t3.nano",
@@ -1067,7 +1069,7 @@ def test_launch_spec_user_data():
         "LaunchTemplateConfigs": [
             {
                 "LaunchTemplateSpecification": {
-                    "LaunchTemplateName": "test-template",
+                    "LaunchTemplateName": template_name,
                     "Version": "$Latest",
                     "LaunchTemplateSpecificationUserData": str(spec_user_data),
                 },


### PR DESCRIPTION
EC2 now supports[1] specifying UserData with the launch template specification when creating a fleet.  Add support for passing the user data through to the resulting instance.

Experimentally, it appears that AWS will override the UserData specified in the launch template if this is supplied.

[1] https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_FleetLaunchTemplateSpecificationRequest.html