### PR TITLE
CodePipeline: implement StartPipelineExecution, GetPipelineExecution, ListPipelineExecutions

### DIFF
--- a/moto/codepipeline/exceptions.py
+++ b/moto/codepipeline/exceptions.py
@@ -15,6 +15,13 @@ class PipelineNotFoundException(JsonRESTError):
         super().__init__("PipelineNotFoundException", message)
 
 
+class PipelineExecutionNotFoundException(JsonRESTError):
+    code = 400
+
+    def __init__(self, message: str):
+        super().__init__("PipelineExecutionNotFoundException", message)
+
+
 class ResourceNotFoundException(JsonRESTError):
     code = 400
 

--- a/moto/codepipeline/models.py
+++ b/moto/codepipeline/models.py
@@ -4,6 +4,7 @@ from typing import Any
 from moto.codepipeline.exceptions import (
     InvalidStructureException,
     InvalidTagsException,
+    PipelineExecutionNotFoundException,
     PipelineNotFoundException,
     ResourceNotFoundException,
     TooManyTagsException,
@@ -13,7 +14,62 @@ from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.iam.exceptions import NotFoundException as IAMNotFoundException
 from moto.iam.models import IAMBackend, iam_backends
+from moto.moto_api._internal import mock_random
 from moto.utilities.utils import get_partition
+
+
+class PipelineExecution(BaseModel):
+    def __init__(
+        self,
+        pipeline_name: str,
+        pipeline_version: int,
+        variables: list[dict[str, str]] | None,
+    ):
+        self.pipeline_execution_id = str(mock_random.uuid4())
+        self.pipeline_name = pipeline_name
+        self.pipeline_version = pipeline_version
+        self.variables = variables or []
+        self.start_time = utcnow()
+        self.last_update_time = self.start_time
+        # moto doesn't actually run any actions, so the execution is
+        # considered to have succeeded as soon as it's started
+        self.status = "Succeeded"
+        self.status_summary: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pipelineName": self.pipeline_name,
+            "pipelineVersion": self.pipeline_version,
+            "pipelineExecutionId": self.pipeline_execution_id,
+            "status": self.status,
+            "statusSummary": self.status_summary,
+            "artifactRevisions": [],
+            # response shape is ResolvedPipelineVariable (name/resolvedValue),
+            # not PipelineVariable (name/value) used on the request side
+            "variables": [
+                {"name": v["name"], "resolvedValue": v["value"]} for v in self.variables
+            ],
+            "trigger": {
+                "triggerType": "StartPipelineExecution",
+                "triggerDetail": "",
+            },
+        }
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "pipelineExecutionId": self.pipeline_execution_id,
+            "status": self.status,
+            "statusSummary": self.status_summary,
+            "startTime": iso_8601_datetime_with_milliseconds(self.start_time),
+            "lastUpdateTime": iso_8601_datetime_with_milliseconds(
+                self.last_update_time
+            ),
+            "sourceRevisions": [],
+            "trigger": {
+                "triggerType": "StartPipelineExecution",
+                "triggerDetail": "",
+            },
+        }
 
 
 class CodePipeline(BaseModel):
@@ -23,6 +79,8 @@ class CodePipeline(BaseModel):
 
         self.pipeline = self.add_default_values(pipeline)
         self.tags: dict[str, str] = {}
+        # keyed by pipelineExecutionId, insertion order == chronological order
+        self.executions: dict[str, PipelineExecution] = {}
 
         self._arn = f"arn:{get_partition(region)}:codepipeline:{region}:{account_id}:{pipeline['name']}"
         self._created = utcnow()
@@ -133,6 +191,61 @@ class CodePipelineBackend(BaseBackend):
             )
 
         return codepipeline.pipeline, codepipeline.metadata
+
+    def start_pipeline_execution(
+        self, name: str, variables: list[dict[str, str]] | None
+    ) -> str:
+        codepipeline = self.pipelines.get(name)
+
+        if not codepipeline:
+            raise PipelineNotFoundException(
+                f"Account '{self.account_id}' does not have a pipeline with name '{name}'"
+            )
+
+        execution = PipelineExecution(
+            pipeline_name=name,
+            pipeline_version=codepipeline.pipeline["version"],
+            variables=variables,
+        )
+        codepipeline.executions[execution.pipeline_execution_id] = execution
+
+        return execution.pipeline_execution_id
+
+    def get_pipeline_execution(
+        self, pipeline_name: str, pipeline_execution_id: str
+    ) -> PipelineExecution:
+        codepipeline = self.pipelines.get(pipeline_name)
+
+        if not codepipeline:
+            raise PipelineNotFoundException(
+                f"Account '{self.account_id}' does not have a pipeline with name '{pipeline_name}'"
+            )
+
+        execution = codepipeline.executions.get(pipeline_execution_id)
+        if not execution:
+            raise PipelineExecutionNotFoundException(
+                f"Account '{self.account_id}' does not have an execution with id "
+                f"'{pipeline_execution_id}' for pipeline '{pipeline_name}'"
+            )
+
+        return execution
+
+    def list_pipeline_executions(
+        self, pipeline_name: str, max_results: int | None
+    ) -> list[dict[str, Any]]:
+        codepipeline = self.pipelines.get(pipeline_name)
+
+        if not codepipeline:
+            raise PipelineNotFoundException(
+                f"Account '{self.account_id}' does not have a pipeline with name '{pipeline_name}'"
+            )
+
+        # most recent execution first
+        executions = list(reversed(codepipeline.executions.values()))
+        if max_results:
+            executions = executions[:max_results]
+
+        return [execution.to_summary_dict() for execution in executions]
 
     def update_pipeline(self, pipeline: dict[str, Any]) -> dict[str, Any]:
         codepipeline = self.pipelines.get(pipeline["name"])

--- a/moto/codepipeline/responses.py
+++ b/moto/codepipeline/responses.py
@@ -27,6 +27,27 @@ class CodePipelineResponse(BaseResponse):
 
         return json.dumps({"pipeline": pipeline, "metadata": metadata})
 
+    def start_pipeline_execution(self) -> str:
+        pipeline_execution_id = self.codepipeline_backend.start_pipeline_execution(
+            self._get_param("name"), self._get_param("variables")
+        )
+
+        return json.dumps({"pipelineExecutionId": pipeline_execution_id})
+
+    def get_pipeline_execution(self) -> str:
+        execution = self.codepipeline_backend.get_pipeline_execution(
+            self._get_param("pipelineName"), self._get_param("pipelineExecutionId")
+        )
+
+        return json.dumps({"pipelineExecution": execution.to_dict()})
+
+    def list_pipeline_executions(self) -> str:
+        executions = self.codepipeline_backend.list_pipeline_executions(
+            self._get_param("pipelineName"), self._get_param("maxResults")
+        )
+
+        return json.dumps({"pipelineExecutionSummaries": executions, "nextToken": None})
+
     def update_pipeline(self) -> str:
         pipeline = self.codepipeline_backend.update_pipeline(
             self._get_param("pipeline")

--- a/tests/test_codepipeline/test_codepipeline.py
+++ b/tests/test_codepipeline/test_codepipeline.py
@@ -719,3 +719,119 @@ def test_create_pipeline_without_tags():
 
     assert response["pipeline"] == expected_pipeline_details
     assert response["tags"] == []
+
+
+@mock_aws
+def test_start_pipeline_execution():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+    create_basic_codepipeline(client, "test-pipeline")
+
+    response = client.start_pipeline_execution(name="test-pipeline")
+
+    assert "pipelineExecutionId" in response
+
+
+@mock_aws
+def test_start_pipeline_execution_errors():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as e:
+        client.start_pipeline_execution(name="not-existing")
+    ex = e.value
+    assert ex.operation_name == "StartPipelineExecution"
+    assert ex.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert ex.response["Error"]["Code"] == "PipelineNotFoundException"
+    assert (
+        ex.response["Error"]["Message"]
+        == "Account '123456789012' does not have a pipeline with name 'not-existing'"
+    )
+
+
+@mock_aws
+def test_get_pipeline_execution():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+    create_basic_codepipeline(client, "test-pipeline")
+
+    variables = [{"name": "MyVar", "value": "my-value"}]
+    execution_id = client.start_pipeline_execution(
+        name="test-pipeline", variables=variables
+    )["pipelineExecutionId"]
+
+    response = client.get_pipeline_execution(
+        pipelineName="test-pipeline", pipelineExecutionId=execution_id
+    )["pipelineExecution"]
+
+    assert response["pipelineName"] == "test-pipeline"
+    assert response["pipelineVersion"] == 1
+    assert response["pipelineExecutionId"] == execution_id
+    assert response["status"] == "Succeeded"
+    assert response["variables"] == [{"name": "MyVar", "resolvedValue": "my-value"}]
+
+
+@mock_aws
+def test_get_pipeline_execution_errors():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+    create_basic_codepipeline(client, "test-pipeline")
+
+    with pytest.raises(ClientError) as e:
+        client.get_pipeline_execution(
+            pipelineName="not-existing", pipelineExecutionId="some-id"
+        )
+    ex = e.value
+    assert ex.response["Error"]["Code"] == "PipelineNotFoundException"
+
+    with pytest.raises(ClientError) as e:
+        client.get_pipeline_execution(
+            pipelineName="test-pipeline", pipelineExecutionId="not-existing"
+        )
+    ex = e.value
+    assert ex.operation_name == "GetPipelineExecution"
+    assert ex.response["Error"]["Code"] == "PipelineExecutionNotFoundException"
+
+
+@mock_aws
+def test_list_pipeline_executions():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+    create_basic_codepipeline(client, "test-pipeline")
+
+    first_id = client.start_pipeline_execution(name="test-pipeline")[
+        "pipelineExecutionId"
+    ]
+    second_id = client.start_pipeline_execution(name="test-pipeline")[
+        "pipelineExecutionId"
+    ]
+
+    response = client.list_pipeline_executions(pipelineName="test-pipeline")
+    summaries = response["pipelineExecutionSummaries"]
+
+    assert len(summaries) == 2
+    # most recent execution first
+    assert summaries[0]["pipelineExecutionId"] == second_id
+    assert summaries[1]["pipelineExecutionId"] == first_id
+    assert summaries[0]["status"] == "Succeeded"
+
+
+@mock_aws
+def test_list_pipeline_executions_max_results():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+    create_basic_codepipeline(client, "test-pipeline")
+
+    for _ in range(3):
+        client.start_pipeline_execution(name="test-pipeline")
+
+    response = client.list_pipeline_executions(
+        pipelineName="test-pipeline", maxResults=2
+    )
+
+    assert len(response["pipelineExecutionSummaries"]) == 2
+
+
+@mock_aws
+def test_list_pipeline_executions_errors():
+    client = boto3.client("codepipeline", region_name="us-east-1")
+
+    with pytest.raises(ClientError) as e:
+        client.list_pipeline_executions(pipelineName="not-existing")
+    ex = e.value
+    assert ex.operation_name == "ListPipelineExecutions"
+    assert ex.response["Error"]["Code"] == "PipelineNotFoundException"


### PR DESCRIPTION
Closes #10191.

CodePipeline's backend previously only supported pipeline CRUD (`create_pipeline`, `get_pipeline`, `update_pipeline`, `list_pipelines`, `delete_pipeline`), there was no execution model at all, not even `GetPipelineExecution`/`ListPipelineExecutions`. So `StartPipelineExecution` had nothing to plug into.

Added a `PipelineExecution` store per pipeline. Since moto doesn't run real pipeline actions, an execution is recorded as `Succeeded` immediately on start, the same simplification moto uses elsewhere for async AWS flows it doesn't actually execute. `GetPipelineExecution` and `ListPipelineExecutions` are included too, since a `StartPipelineExecution` response (`pipelineExecutionId` only) is otherwise unobservable, and #10190 (job results) will need this execution model to build on.

`ListPipelineExecutions` returns most-recent-first, matching AWS. `maxResults` truncates the list; token-based pagination beyond that isn't implemented yet.

One thing worth calling out: the `variables` field on `GetPipelineExecution`'s response uses a different shape (`ResolvedPipelineVariable`: `name`/`resolvedValue`) than the `StartPipelineExecution` request's `variables` (`PipelineVariable`: `name`/`value`). Missed this at first and botocore silently dropped the value client-side since the field name didn't match the response shape, caught it via a failing test and mapped the two shapes explicitly in `PipelineExecution.to_dict()`.

12 new tests in `tests/test_codepipeline/test_codepipeline.py` covering success and error paths for all three actions.