### PR TITLE
Kafka: apply the cluster name and type filters when listing

### DIFF
--- a/moto/kafka/models.py
+++ b/moto/kafka/models.py
@@ -211,9 +211,22 @@ class KafkaBackend(BaseBackend, TaggableResourcesMixin):
         next_token: str | None,
     ) -> tuple[list[dict[str, Any]], str | None]:
         cluster_info_list = []
-        for cluster_arn in self.clusters.keys():
-            cluster_info = self.describe_cluster_v2(cluster_arn)
-            cluster_info_list.append(cluster_info)
+        for cluster_arn, cluster in self.clusters.items():
+            # Both filters were accepted and then ignored, so a caller asking
+            # for one name got back every cluster in the account. AWS matches
+            # ClusterNameFilter on the start of the name, and treats
+            # ClusterTypeFilter of ALL the same as leaving it out.
+            if cluster_name_filter and not cluster.cluster_name.startswith(
+                cluster_name_filter
+            ):
+                continue
+            if (
+                cluster_type_filter
+                and cluster_type_filter.upper() != "ALL"
+                and cluster.cluster_type != cluster_type_filter.upper()
+            ):
+                continue
+            cluster_info_list.append(self.describe_cluster_v2(cluster_arn))
 
         return cluster_info_list, None
 
@@ -309,7 +322,10 @@ class KafkaBackend(BaseBackend, TaggableResourcesMixin):
                 "creationTime": cluster.creation_time,
                 "clusterType": cluster.cluster_type,
             }
-            for cluster_arn, cluster in self.clusters.items()
+            for cluster in self.clusters.values()
+            # Matched on the start of the name, the way AWS documents it.
+            if not cluster_name_filter
+            or cluster.cluster_name.startswith(cluster_name_filter)
         ]
 
         return cluster_info_list, None

--- a/moto/kafka/models.py
+++ b/moto/kafka/models.py
@@ -212,10 +212,6 @@ class KafkaBackend(BaseBackend, TaggableResourcesMixin):
     ) -> tuple[list[dict[str, Any]], str | None]:
         cluster_info_list = []
         for cluster_arn, cluster in self.clusters.items():
-            # Both filters were accepted and then ignored, so a caller asking
-            # for one name got back every cluster in the account. AWS matches
-            # ClusterNameFilter on the start of the name, and treats
-            # ClusterTypeFilter of ALL the same as leaving it out.
             if cluster_name_filter and not cluster.cluster_name.startswith(
                 cluster_name_filter
             ):

--- a/tests/test_kafka/test_kafka.py
+++ b/tests/test_kafka/test_kafka.py
@@ -440,3 +440,112 @@ def test_list_clusters_pagination_terminates():
 
     assert len(pages) == 1
     assert len(pages[0]["ClusterInfoList"]) == 3
+
+
+def _create_serverless_cluster(client, name):
+    return client.create_cluster_v2(
+        ClusterName=name,
+        Serverless={
+            "VpcConfigs": [
+                {
+                    "SubnetIds": ["subnet-0123456789abcdef0"],
+                    "SecurityGroupIds": ["sg-0123456789abcdef0"],
+                }
+            ]
+        },
+    )
+
+
+def _create_provisioned_cluster(client, name):
+    return client.create_cluster_v2(
+        ClusterName=name,
+        Provisioned={
+            "BrokerNodeGroupInfo": {
+                "InstanceType": "kafka.m5.large",
+                "ClientSubnets": ["subnet-0123456789abcdef0"],
+                "SecurityGroups": ["sg-0123456789abcdef0"],
+            },
+            "KafkaVersion": "2.8.1",
+            "NumberOfBrokerNodes": 3,
+        },
+    )
+
+
+@mock_aws
+def test_list_clusters_v2_applies_the_cluster_name_filter():
+    client = boto3.client("kafka", region_name="eu-west-1")
+    _create_serverless_cluster(client, "analytics-stream")
+    _create_provisioned_cluster(client, "analytics-batch")
+    _create_provisioned_cluster(client, "billing")
+
+    clusters = client.list_clusters_v2(ClusterNameFilter="analytics")
+
+    names = sorted(c["ClusterName"] for c in clusters["ClusterInfoList"])
+    assert names == ["analytics-batch", "analytics-stream"]
+
+
+@mock_aws
+def test_list_clusters_v2_matches_the_name_filter_at_the_start_only():
+    client = boto3.client("kafka", region_name="eu-west-1")
+    _create_provisioned_cluster(client, "prod-events")
+    _create_provisioned_cluster(client, "events-prod")
+
+    clusters = client.list_clusters_v2(ClusterNameFilter="events")
+
+    names = [c["ClusterName"] for c in clusters["ClusterInfoList"]]
+    assert names == ["events-prod"]
+
+
+@mock_aws
+def test_list_clusters_v2_applies_the_cluster_type_filter():
+    client = boto3.client("kafka", region_name="eu-west-1")
+    _create_serverless_cluster(client, "stream")
+    _create_provisioned_cluster(client, "batch")
+
+    serverless = client.list_clusters_v2(ClusterTypeFilter="SERVERLESS")
+    provisioned = client.list_clusters_v2(ClusterTypeFilter="PROVISIONED")
+    every = client.list_clusters_v2(ClusterTypeFilter="ALL")
+
+    assert [c["ClusterName"] for c in serverless["ClusterInfoList"]] == ["stream"]
+    assert [c["ClusterName"] for c in provisioned["ClusterInfoList"]] == ["batch"]
+    assert len(every["ClusterInfoList"]) == 2
+
+
+@mock_aws
+def test_list_clusters_v2_combines_both_filters():
+    client = boto3.client("kafka", region_name="eu-west-1")
+    _create_serverless_cluster(client, "analytics-stream")
+    _create_provisioned_cluster(client, "analytics-batch")
+    _create_serverless_cluster(client, "billing-stream")
+
+    clusters = client.list_clusters_v2(
+        ClusterNameFilter="analytics", ClusterTypeFilter="SERVERLESS"
+    )
+
+    assert [c["ClusterName"] for c in clusters["ClusterInfoList"]] == [
+        "analytics-stream"
+    ]
+
+
+@mock_aws
+def test_list_clusters_applies_the_cluster_name_filter():
+    client = boto3.client("kafka", region_name="eu-west-1")
+    _create_provisioned_cluster(client, "analytics-batch")
+    _create_provisioned_cluster(client, "billing")
+
+    clusters = client.list_clusters(ClusterNameFilter="analytics")
+
+    assert [c["ClusterName"] for c in clusters["ClusterInfoList"]] == [
+        "analytics-batch"
+    ]
+
+
+@mock_aws
+def test_list_clusters_without_a_filter_returns_everything():
+    client = boto3.client("kafka", region_name="eu-west-1")
+    _create_provisioned_cluster(client, "analytics-batch")
+    _create_provisioned_cluster(client, "billing")
+
+    clusters = client.list_clusters()
+
+    assert len(clusters["ClusterInfoList"]) == 2


### PR DESCRIPTION
Fixes #10247

Both list calls accepted `ClusterNameFilter`, and `list_clusters_v2` also accepted `ClusterTypeFilter`. Neither was read, so you got every cluster in the account whatever you asked for.

`ClusterNameFilter` now matches on the start of the name, the way AWS documents it, so `events` finds `events-prod` and not `prod-events`. `ClusterTypeFilter` compares against the cluster's own type. `ALL` means no filter.

Six tests, five of which fail on the parent commit. The sixth lists without a filter and passes either way; it is there to show the unfiltered path did not move.

`tests/test_kafka/`: 18 passed, with `mypy moto/kafka/models.py` and `ruff format --check` clean. `ruff check` reports one `DTZ005` at `models.py:50`; that one is on `main` already and is not part of this change.