### PR TITLE
Payment Cryptography: stop echoing the request token from list calls

### DIFF
--- a/moto/paymentcryptography/models.py
+++ b/moto/paymentcryptography/models.py
@@ -198,13 +198,17 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         keys = list(self.keys.values())
         if key_state:
             keys = [key for key in keys if key.key_state == key_state]
-        return [key.to_dict() for key in keys], next_token
+        # None, not the caller's own token. Every key comes back in one
+        # page, and handing the incoming token back made botocore raise
+        # "The same next token was received twice" on a resumed listing.
+        return [key.to_dict() for key in keys], None
 
     def list_tags_for_resource(
         self, resource_arn: str, next_token: Optional[str], max_results: Optional[int]
     ) -> tuple[list[dict[str, str]], Optional[str]]:
         tags = self.tagger.list_tags_for_resource(resource_arn)["Tags"]
-        return tags, next_token
+        # See list_keys: the incoming token must not come back out.
+        return tags, None
 
     def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
         self.tagger.tag_resource(resource_arn, tags)
@@ -370,7 +374,8 @@ class PaymentCryptographyControlPlaneBackend(BaseBackend):
         aliases = list(self.aliases.values())
         if key_arn is not None:
             aliases = [alias for alias in aliases if alias.key_arn == key_arn]
-        return [alias.to_dict() for alias in aliases], next_token
+        # See list_keys: the incoming token must not come back out.
+        return [alias.to_dict() for alias in aliases], None
 
     def update_alias(self, alias_name: str, key_arn: Optional[str]) -> dict[str, Any]:
         if alias_name not in self.aliases:

--- a/tests/test_paymentcryptography/test_paymentcryptography.py
+++ b/tests/test_paymentcryptography/test_paymentcryptography.py
@@ -810,3 +810,69 @@ def test_stop_key_usage_not_found():
     with pytest.raises(ClientError) as exc:
         client.stop_key_usage(KeyIdentifier=missing_arn)
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def _make_key(client):
+    return client.create_key(
+        Exportable=True,
+        KeyAttributes=KEY_ATTRIBUTES_1,
+    )["Key"]
+
+
+@mock_aws
+@pytest.mark.parametrize("operation", ["list_keys", "list_aliases"])
+def test_list_operations_do_not_echo_the_request_token(operation):
+    """A listing must not hand the caller's own NextToken back.
+
+    Every result fits in one page here, so the correct answer is no token at
+    all. Returning the incoming one makes a resumed listing repeat forever,
+    which botocore stops with "The same next token was received twice".
+    """
+    client = boto3.client("payment-cryptography", region_name="us-east-1")
+    _make_key(client)
+
+    response = getattr(client, operation)(NextToken="resume-token")
+
+    assert "NextToken" not in response
+
+
+@mock_aws
+def test_list_tags_for_resource_does_not_echo_the_request_token():
+    client = boto3.client("payment-cryptography", region_name="us-east-1")
+    key = _make_key(client)
+    client.tag_resource(
+        ResourceArn=key["KeyArn"], Tags=[{"Key": "Env", "Value": "test"}]
+    )
+
+    response = client.list_tags_for_resource(
+        ResourceArn=key["KeyArn"], NextToken="resume-token"
+    )
+
+    assert "NextToken" not in response
+
+
+@mock_aws
+@pytest.mark.parametrize("operation", ["list_keys", "list_aliases"])
+def test_paginating_from_a_token_terminates(operation):
+    client = boto3.client("payment-cryptography", region_name="us-east-1")
+    _make_key(client)
+
+    pages = list(
+        client.get_paginator(operation).paginate(
+            PaginationConfig={"StartingToken": "resume-token"}
+        )
+    )
+
+    assert len(pages) == 1
+
+
+@mock_aws
+def test_list_keys_still_filters_by_key_state():
+    client = boto3.client("payment-cryptography", region_name="us-east-1")
+    _make_key(client)
+
+    matching = client.list_keys(KeyState="CREATE_COMPLETE")
+    other = client.list_keys(KeyState="DELETE_PENDING")
+
+    assert len(matching["Keys"]) == 1
+    assert other["Keys"] == []


### PR DESCRIPTION
Fixes #10249

`list_keys`, `list_aliases` and `list_tags_for_resource` each returned the `next_token` they were given. Resuming a listing from a token handed it back unchanged, which botocore reports as `The same next token was received twice`.

All three now return `None`. Every result fits in one page, so that is the accurate answer, and it matches what `list_clusters` in kafka was changed to in #10237.

Six tests. Five fail on the parent commit, two of them with the `PaginationError` above. The sixth pins that `list_keys` still filters on `KeyState` and passes either way.

`tests/test_paymentcryptography/test_paymentcryptography.py`: 39 passed, with `ruff`, `ruff format --check` and `mypy` clean. `test_server.py` does not collect without `flask` installed; that is the same on `master`.