### PR TITLE
Glue: honor HidePassword parameter

### DIFF
--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -1477,7 +1477,6 @@ class GlueBackend(BaseBackend, TaggableResourcesMixin):
         self,
         catalog_id: str,
         name: str,
-        hide_password: bool,
         apply_override_for_compute_environment: str,
     ) -> "FakeConnection":
         # TODO: Implement filtering
@@ -1488,7 +1487,7 @@ class GlueBackend(BaseBackend, TaggableResourcesMixin):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def get_connections(
-        self, catalog_id: str, filter: dict[str, Any], hide_password: bool
+        self, catalog_id: str, filter: dict[str, Any]
     ) -> list["FakeConnection"]:
         # TODO: Implement filtering
         return list(self.connections.values())
@@ -2619,12 +2618,29 @@ class FakeConnection(BaseModel):
         self.athena_properties = self.connection_input.get("AthenaProperties", {})
         self.python_properties = self.connection_input.get("PythonProperties", {})
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self, hide_password: bool = False) -> dict[str, Any]:
+        connection_input = self.connection_input
+        connection_properties = self.connection_properties
+        if hide_password:
+            # HidePassword was carried all the way to the backend and then
+            # dropped, so a caller asking for the metadata without the secret
+            # got the secret. AWS leaves the PASSWORD entry out entirely
+            # rather than blanking it. Both copies of the properties are
+            # redacted, since the nested Connection carries them too.
+            connection_properties = {
+                key: value
+                for key, value in connection_properties.items()
+                if key != "PASSWORD"
+            }
+            connection_input = {
+                **connection_input,
+                "ConnectionProperties": connection_properties,
+            }
         return {
             "Name": self.name,
             "Description": self.description,
-            "Connection": self.connection_input,
-            "ConnectionProperties": self.connection_properties,
+            "Connection": connection_input,
+            "ConnectionProperties": connection_properties,
             "AthenaProperties": self.athena_properties,
             "SparkProperties": self.spark_properties,
             "PythonProperties": self.python_properties,

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -2622,11 +2622,8 @@ class FakeConnection(BaseModel):
         connection_input = self.connection_input
         connection_properties = self.connection_properties
         if hide_password:
-            # HidePassword was carried all the way to the backend and then
-            # dropped, so a caller asking for the metadata without the secret
-            # got the secret. AWS leaves the PASSWORD entry out entirely
-            # rather than blanking it. Both copies of the properties are
-            # redacted, since the nested Connection carries them too.
+            # AWS leaves the PASSWORD entry out entirely rather than blanking it.
+            # Both copies of the properties are redacted, since the nested Connection carries them too.
             connection_properties = {
                 key: value
                 for key, value in connection_properties.items()

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -946,10 +946,9 @@ class GlueResponse(BaseResponse):
         connection = self.glue_backend.get_connection(
             catalog_id=catalog_id,
             name=name,
-            hide_password=hide_password,
             apply_override_for_compute_environment=apply_override_for_compute_environment,
         )
-        return ActionResult({"Connection": connection.as_dict()})
+        return ActionResult({"Connection": connection.as_dict(hide_password)})
 
     def get_connections(self) -> ActionResult:
         catalog_id = self._get_param("CatalogId")
@@ -960,11 +959,12 @@ class GlueResponse(BaseResponse):
         connections, next_token = self.glue_backend.get_connections(
             catalog_id=catalog_id,
             filter=filter,
-            hide_password=hide_password,
             next_token=next_token,
             max_results=max_results,
         )
-        connection_list = [connection.as_dict() for connection in connections]
+        connection_list = [
+            connection.as_dict(hide_password) for connection in connections
+        ]
         return ActionResult(
             {"ConnectionList": connection_list, "NextToken": next_token}
         )

--- a/tests/test_glue/test_glue.py
+++ b/tests/test_glue/test_glue.py
@@ -1958,3 +1958,62 @@ def test_glue_resources_tagging_via_rgta():
 
     wf_arn = next(a for a in tags_by_arn if a.endswith("workflow/workflow-1"))
     assert tags_by_arn[wf_arn] == {"ASV": "ASVBAR"}
+
+
+CONNECTION_WITH_PASSWORD = {
+    "Name": "prod-db",
+    "ConnectionType": "JDBC",
+    "ConnectionProperties": {
+        "JDBC_CONNECTION_URL": "jdbc:mysql://host:3306/db",
+        "USERNAME": "admin",
+        "PASSWORD": "hunter2",
+    },
+}
+
+
+@mock_aws
+def test_get_connection_hides_the_password_when_asked():
+    """HidePassword must actually drop the secret.
+
+    AWS leaves the PASSWORD entry out rather than blanking it, so a test
+    asserting the key is absent should pass under moto too.
+    """
+    client = boto3.client("glue", region_name="us-east-2")
+    client.create_connection(ConnectionInput=CONNECTION_WITH_PASSWORD)
+
+    connection = client.get_connection(Name="prod-db", HidePassword=True)["Connection"]
+
+    assert "PASSWORD" not in connection["ConnectionProperties"]
+    assert connection["ConnectionProperties"]["USERNAME"] == "admin"
+
+
+@mock_aws
+def test_get_connection_returns_the_password_by_default():
+    client = boto3.client("glue", region_name="us-east-2")
+    client.create_connection(ConnectionInput=CONNECTION_WITH_PASSWORD)
+
+    connection = client.get_connection(Name="prod-db")["Connection"]
+
+    assert connection["ConnectionProperties"]["PASSWORD"] == "hunter2"
+
+
+@mock_aws
+def test_get_connections_hides_the_password_when_asked():
+    client = boto3.client("glue", region_name="us-east-2")
+    client.create_connection(ConnectionInput=CONNECTION_WITH_PASSWORD)
+
+    connections = client.get_connections(HidePassword=True)["ConnectionList"]
+
+    assert "PASSWORD" not in connections[0]["ConnectionProperties"]
+
+
+@mock_aws
+def test_hiding_the_password_does_not_change_the_stored_connection():
+    """The redaction is applied on the way out, not to the stored copy."""
+    client = boto3.client("glue", region_name="us-east-2")
+    client.create_connection(ConnectionInput=CONNECTION_WITH_PASSWORD)
+
+    client.get_connection(Name="prod-db", HidePassword=True)
+    connection = client.get_connection(Name="prod-db")["Connection"]
+
+    assert connection["ConnectionProperties"]["PASSWORD"] == "hunter2"


### PR DESCRIPTION
Fixes #10251

`HidePassword` reached the backend and was then ignored, so asking for a connection without its secret returned the secret.

`as_dict` now takes the flag and drops the `PASSWORD` entry, which is what AWS does rather than blanking the value. Both copies are redacted: the top level `ConnectionProperties` and the nested `Connection`, which carries the same dict.

The redaction happens on the way out, so the stored connection keeps its password and a later call without the flag still returns it.

I also dropped `hide_password` from the two backend signatures. With the redaction in `as_dict` nothing in the backend reads it, and leaving a parameter that is never looked at is what caused this in the first place.

Four tests. Two fail on the parent commit; the other two pin that the default still returns the password and that hiding it does not change what is stored.

`tests/test_glue/`: 296 passed, with `ruff format --check` and `mypy` clean. `ruff check` reports 7 findings under `moto/glue/`; the same 7 are on `master` and none are in this change.