### PR TITLE
ResourceGroups: use the configured region in group ARNs

### DIFF
--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -34,7 +34,7 @@ class FakeResourceGroup(BaseModel):
         if self._validate_tags(value=tags):
             self._tags = tags
         self._raise_errors()
-        self.arn = f"arn:{get_partition(region_name)}:resource-groups:us-west-1:{account_id}:group/{name}"
+        self.arn = f"arn:{get_partition(region_name)}:resource-groups:{region_name}:{account_id}:group/{name}"
         self.configuration = configuration
 
     @staticmethod

--- a/tests/test_resourcegroups/test_resourcegroups.py
+++ b/tests/test_resourcegroups/test_resourcegroups.py
@@ -28,13 +28,27 @@ def create_group(client):
 
 
 @mock_aws
-def test_create_group():
-    resource_groups = boto3.client("resource-groups", region_name="us-east-1")
+@pytest.mark.parametrize(
+    "region_name,partition",
+    [
+        ("us-east-1", "aws"),
+        ("us-west-1", "aws"),
+        ("us-west-2", "aws"),
+        ("us-gov-west-1", "aws-us-gov"),
+        ("cn-north-1", "aws-cn"),
+    ],
+)
+def test_create_group(region_name, partition, account_id):
+    resource_groups = boto3.client("resource-groups", region_name=region_name)
 
     response = create_group(client=resource_groups)
     assert "test_resource_group" in response["Group"]["Name"]
     assert "TAG_FILTERS_1_0" in response["ResourceQuery"]["Type"]
     assert "resource_group_tag_value" in response["Tags"]["resource_group_tag_key"]
+    assert (
+        response["Group"]["GroupArn"]
+        == f"arn:{partition}:resource-groups:{region_name}:{account_id}:group/test_resource_group"
+    )
 
 
 @mock_aws


### PR DESCRIPTION
Resource groups created outside `us-west-1` currently return a `GroupArn` whose region is always `us-west-1`, including groups in the GovCloud and China partitions. Use the group’s configured region when constructing its ARN.

The existing `create_group` test now checks the exact ARN in five regions across the standard AWS, GovCloud, and China partitions, including `us-west-1` as a control.

Validation: the regression fails in four regions before the change and passes in all five after it. The Resource Groups suite passes all 24 tests on macOS and Linux, and all 24 tests also pass against a local Moto server on Linux. Ruff 0.14.10, formatting, and targeted mypy pass on both platforms. Linux tests run with external networking disabled; no real AWS services were used.
