### PR TITLE
EC2: honor MaxCount when launching instances

### DIFF
--- a/moto/ec2/responses/instances.py
+++ b/moto/ec2/responses/instances.py
@@ -48,6 +48,7 @@ class InstanceResponse(EC2BaseResponse):
 
     def run_instances(self) -> ActionResult:
         min_count = int(self._get_param("MinCount", if_none="1"))
+        max_count = int(self._get_param("MaxCount", if_none=str(min_count)))
         image_id = self._get_param("ImageId")
         user_data = parse_user_data(self._get_param("UserData"))
         security_group_names = self._get_param("SecurityGroups", [])
@@ -104,7 +105,7 @@ class InstanceResponse(EC2BaseResponse):
             )
         self.error_on_dryrun()
         new_reservation = self.ec2_backend.run_instances(
-            image_id, min_count, user_data, security_group_names, **kwargs
+            image_id, max_count, user_data, security_group_names, **kwargs
         )
         if iam_instance_profile_name:
             self.ec2_backend.associate_iam_instance_profile(

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -23,17 +23,28 @@ from .helpers import assert_dryrun_error
 decode_method = base64.decodebytes
 
 
+@pytest.mark.parametrize("min_count,max_count", [(1, 1), (2, 2), (1, 3), (2, 4)])
 @mock_aws
-def test_add_servers():
+def test_add_servers(min_count, max_count):
     client = boto3.client("ec2", region_name="us-east-1")
-    resp = client.run_instances(ImageId=EXAMPLE_AMI_ID, MinCount=2, MaxCount=2)
+    resp = client.run_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=min_count, MaxCount=max_count
+    )
+    assert len(resp["Instances"]) == max_count
+    assert len({instance["InstanceId"] for instance in resp["Instances"]}) == max_count
     for i in resp["Instances"]:
         assert i["ImageId"] == EXAMPLE_AMI_ID
 
-    instances = client.describe_instances(
+    reservations = client.describe_instances(
         InstanceIds=[i["InstanceId"] for i in resp["Instances"]]
-    )["Reservations"][0]["Instances"]
-    assert len(instances) == 2
+    )["Reservations"]
+    assert len(reservations) == 1
+    assert reservations[0]["ReservationId"] == resp["ReservationId"]
+    instances = reservations[0]["Instances"]
+    assert len(instances) == max_count
+    assert {i["InstanceId"] for i in instances} == {
+        i["InstanceId"] for i in resp["Instances"]
+    }
     for i in instances:
         assert i["ImageId"] == EXAMPLE_AMI_ID
 


### PR DESCRIPTION
Closes #10215.

`run_instances(MinCount=1, MaxCount=3)` currently creates only one instance because the response handler passes `MinCount` to the backend. Pass `MaxCount` instead, matching the [RunInstances behavior when capacity is available](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html). Requests omitting `MaxCount` keep Moto's existing fallback to `MinCount`.

The existing `test_add_servers` now covers equal and unequal counts and checks that `DescribeInstances` returns the same reservation and unique instance IDs. The shared backend interface is unchanged; this does not add capacity simulation or new invalid-count validation.

Validation:

- The four-case regression produces 2 failures and 2 passes with the original handler, then 4 passes with the fix on Linux.
- `tests/test_ec2`: 959 passed on macOS and Linux.
- Linux ServerMode: 907 passed, 52 skipped, with the upstream CI setting `MOTO_EC2_LOAD_DEFAULT_AMIS=false`.
- Full Ruff checks and formatting (2,527 files), plus mypy (1,146 source files), passed on Linux.

All tests used local mocks or a loopback server, with no live AWS requests.
