### PR TITLE
Bedrock AgentCore: initial implementation

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -1115,6 +1115,79 @@
 - [ ] validate_flow_definition
 </details>
 
+## bedrock-agentcore
+<details>
+<summary>5% implemented</summary>
+
+- [ ] batch_create_memory_records
+- [ ] batch_delete_memory_records
+- [ ] batch_update_memory_records
+- [ ] complete_resource_token_auth
+- [ ] create_ab_test
+- [X] create_event
+- [ ] create_payment_instrument
+- [ ] create_payment_session
+- [ ] delete_ab_test
+- [ ] delete_batch_evaluation
+- [ ] delete_capacity_provider_session
+- [X] delete_event
+- [ ] delete_memory_record
+- [ ] delete_payment_instrument
+- [ ] delete_payment_session
+- [ ] delete_recommendation
+- [ ] evaluate
+- [ ] get_ab_test
+- [ ] get_agent_card
+- [ ] get_batch_evaluation
+- [ ] get_browser_session
+- [ ] get_code_interpreter_session
+- [X] get_event
+- [ ] get_memory_record
+- [ ] get_payment_instrument
+- [ ] get_payment_instrument_balance
+- [ ] get_payment_session
+- [ ] get_recommendation
+- [ ] get_resource_api_key
+- [ ] get_resource_oauth2_token
+- [ ] get_resource_payment_token
+- [ ] get_workload_access_token
+- [ ] get_workload_access_token_for_jwt
+- [ ] get_workload_access_token_for_user_id
+- [ ] ingest_data
+- [ ] invoke_agent_runtime
+- [ ] invoke_agent_runtime_command
+- [ ] invoke_browser
+- [ ] invoke_code_interpreter
+- [ ] invoke_harness
+- [ ] list_ab_tests
+- [ ] list_actors
+- [ ] list_batch_evaluations
+- [ ] list_browser_sessions
+- [ ] list_code_interpreter_sessions
+- [X] list_events
+- [ ] list_memory_extraction_jobs
+- [ ] list_memory_records
+- [ ] list_payment_instruments
+- [ ] list_payment_sessions
+- [ ] list_recommendations
+- [ ] list_sessions
+- [ ] process_payment
+- [ ] retrieve_memory_records
+- [ ] save_browser_session_profile
+- [ ] search_registry_records
+- [ ] start_batch_evaluation
+- [ ] start_browser_session
+- [ ] start_code_interpreter_session
+- [ ] start_memory_extraction_job
+- [ ] start_recommendation
+- [ ] stop_batch_evaluation
+- [ ] stop_browser_session
+- [ ] stop_code_interpreter_session
+- [ ] stop_runtime_session
+- [ ] update_ab_test
+- [ ] update_browser_stream
+</details>
+
 ## bedrock-agentcore-control
 <details>
 <summary>17% implemented</summary>
@@ -12049,7 +12122,6 @@
 - bcm-pricing-calculator
 - bcm-recommended-actions
 - bedrock-agent-runtime
-- bedrock-agentcore
 - bedrock-data-automation
 - bedrock-data-automation-runtime
 - billing

--- a/docs/docs/services/bedrock-agentcore.rst
+++ b/docs/docs/services/bedrock-agentcore.rst
@@ -1,0 +1,86 @@
+.. _implementedservice_bedrock-agentcore:
+
+.. |start-h3| raw:: html
+
+    <h3>
+
+.. |end-h3| raw:: html
+
+    </h3>
+
+=================
+bedrock-agentcore
+=================
+
+.. autoclass:: moto.bedrockagentcore.models.BedrockAgentCoreBackend
+
+|start-h3| Implemented features for this service |end-h3|
+
+- [ ] batch_create_memory_records
+- [ ] batch_delete_memory_records
+- [ ] batch_update_memory_records
+- [ ] complete_resource_token_auth
+- [ ] create_ab_test
+- [X] create_event
+- [ ] create_payment_instrument
+- [ ] create_payment_session
+- [ ] delete_ab_test
+- [ ] delete_batch_evaluation
+- [ ] delete_capacity_provider_session
+- [X] delete_event
+- [ ] delete_memory_record
+- [ ] delete_payment_instrument
+- [ ] delete_payment_session
+- [ ] delete_recommendation
+- [ ] evaluate
+- [ ] get_ab_test
+- [ ] get_agent_card
+- [ ] get_batch_evaluation
+- [ ] get_browser_session
+- [ ] get_code_interpreter_session
+- [X] get_event
+- [ ] get_memory_record
+- [ ] get_payment_instrument
+- [ ] get_payment_instrument_balance
+- [ ] get_payment_session
+- [ ] get_recommendation
+- [ ] get_resource_api_key
+- [ ] get_resource_oauth2_token
+- [ ] get_resource_payment_token
+- [ ] get_workload_access_token
+- [ ] get_workload_access_token_for_jwt
+- [ ] get_workload_access_token_for_user_id
+- [ ] ingest_data
+- [ ] invoke_agent_runtime
+- [ ] invoke_agent_runtime_command
+- [ ] invoke_browser
+- [ ] invoke_code_interpreter
+- [ ] invoke_harness
+- [ ] list_ab_tests
+- [ ] list_actors
+- [ ] list_batch_evaluations
+- [ ] list_browser_sessions
+- [ ] list_code_interpreter_sessions
+- [X] list_events
+- [ ] list_memory_extraction_jobs
+- [ ] list_memory_records
+- [ ] list_payment_instruments
+- [ ] list_payment_sessions
+- [ ] list_recommendations
+- [ ] list_sessions
+- [ ] process_payment
+- [ ] retrieve_memory_records
+- [ ] save_browser_session_profile
+- [ ] search_registry_records
+- [ ] start_batch_evaluation
+- [ ] start_browser_session
+- [ ] start_code_interpreter_session
+- [ ] start_memory_extraction_job
+- [ ] start_recommendation
+- [ ] stop_batch_evaluation
+- [ ] stop_browser_session
+- [ ] stop_code_interpreter_session
+- [ ] stop_runtime_session
+- [ ] update_ab_test
+- [ ] update_browser_stream
+

--- a/moto/backend_index.py
+++ b/moto/backend_index.py
@@ -32,6 +32,10 @@ backend_url_patterns = [
     ("bedrock", re.compile("https?://bedrock\\.(.+)\\.amazonaws\\.com")),
     ("bedrockagent", re.compile("https?://bedrock-agent\\.(.+)\\.amazonaws\\.com")),
     (
+        "bedrockagentcore",
+        re.compile("https?://bedrock-agentcore\\.(.+)\\.amazonaws\\.com"),
+    ),
+    (
         "bedrockagentcorecontrol",
         re.compile("https?://bedrock-agentcore-control\\.(.+)\\.amazonaws\\.com"),
     ),

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from moto.batch.models import BatchBackend
     from moto.bedrock.models import BedrockBackend
     from moto.bedrockagent.models import AgentsforBedrockBackend
+    from moto.bedrockagentcore.models import BedrockAgentCoreBackend
     from moto.bedrockagentcorecontrol.models import BedrockAgentCoreControlBackend
     from moto.bedrockruntime.models import BedrockRuntimeBackend
     from moto.budgets.models import BudgetsBackend
@@ -221,6 +222,7 @@ SERVICE_NAMES = Union[
     "Literal['batch']",
     "Literal['bedrock']",
     "Literal['bedrock-agent']",
+    "Literal['bedrock-agentcore']",
     "Literal['bedrock-agentcore-control']",
     "Literal['bedrock-runtime']",
     "Literal['budgets']",
@@ -418,6 +420,10 @@ def get_backend(name: "Literal['bedrock']") -> "BackendDict[BedrockBackend]": ..
 def get_backend(
     name: "Literal['bedrock-agent']",
 ) -> "BackendDict[AgentsforBedrockBackend]": ...
+@overload
+def get_backend(
+    name: "Literal['bedrock-agentcore']",
+) -> "BackendDict[BedrockAgentCoreBackend]": ...
 @overload
 def get_backend(
     name: "Literal['bedrock-agentcore-control']",

--- a/moto/bedrockagentcore/__init__.py
+++ b/moto/bedrockagentcore/__init__.py
@@ -1,0 +1,1 @@
+from .models import bedrockagentcore_backends  # noqa: F401

--- a/moto/bedrockagentcore/exceptions.py
+++ b/moto/bedrockagentcore/exceptions.py
@@ -1,0 +1,15 @@
+"""BedrockAgentCore exceptions."""
+
+from moto.core.exceptions import ServiceException
+
+
+class BedrockAgentCoreClientError(ServiceException):
+    pass
+
+
+class ResourceNotFoundException(BedrockAgentCoreClientError):
+    code = "ResourceNotFoundException"
+
+
+class ValidationException(BedrockAgentCoreClientError):
+    code = "ValidationException"

--- a/moto/bedrockagentcore/models.py
+++ b/moto/bedrockagentcore/models.py
@@ -1,0 +1,150 @@
+"""BedrockAgentCore models."""
+
+from typing import Any
+
+from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.common_models import BaseModel
+from moto.core.utils import unix_time, utcnow
+from moto.moto_api._internal import mock_random
+
+from .exceptions import ResourceNotFoundException, ValidationException
+
+
+class Event(BaseModel):
+    def __init__(
+        self,
+        memory_id: str,
+        actor_id: str,
+        session_id: str,
+        event_timestamp: Any,
+        payload: list[dict[str, Any]],
+        branch: dict[str, Any] | None,
+        metadata: dict[str, Any] | None,
+    ):
+        self.memory_id = memory_id
+        self.actor_id = actor_id
+        self.session_id = session_id
+        # real AWS event ids look like "<epoch-millis>#<hex>"
+        self.event_id = f"{int(unix_time() * 1000)}#{mock_random.get_random_hex(16)}"
+        self.event_timestamp = event_timestamp or utcnow()
+        self.payload = payload
+        self.branch = branch or {"name": "main"}
+        self.metadata = metadata or {}
+
+    def to_dict(self, include_payload: bool = True) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "memoryId": self.memory_id,
+            "actorId": self.actor_id,
+            "sessionId": self.session_id,
+            "eventId": self.event_id,
+            "eventTimestamp": self.event_timestamp,
+            "branch": self.branch,
+        }
+        if include_payload:
+            result["payload"] = self.payload
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
+
+
+class BedrockAgentCoreBackend(BaseBackend):
+    """Implementation of BedrockAgentCore APIs."""
+
+    def __init__(self, region_name: str, account_id: str) -> None:
+        super().__init__(region_name, account_id)
+        # keyed by (memoryId, actorId, sessionId), values keyed by eventId,
+        # insertion order == chronological order
+        self.events: dict[tuple[str, str, str], dict[str, Event]] = {}
+
+    def create_event(
+        self,
+        memory_id: str,
+        actor_id: str | None,
+        session_id: str | None,
+        event_timestamp: Any,
+        payload: list[dict[str, Any]] | None,
+        branch: dict[str, Any] | None,
+        metadata: dict[str, Any] | None,
+    ) -> Event:
+        if not actor_id:
+            raise ValidationException(
+                "1 validation error detected: Value at 'actorId' failed to satisfy constraint: Member must not be null"
+            )
+        if not session_id:
+            raise ValidationException(
+                "1 validation error detected: Value at 'sessionId' failed to satisfy constraint: Member must not be null"
+            )
+        if not payload:
+            raise ValidationException(
+                "1 validation error detected: Value at 'payload' failed to satisfy constraint: Member must not be empty"
+            )
+
+        event = Event(
+            memory_id=memory_id,
+            actor_id=actor_id,
+            session_id=session_id,
+            event_timestamp=event_timestamp,
+            payload=payload,
+            branch=branch,
+            metadata=metadata,
+        )
+        key = (memory_id, actor_id, session_id)
+        self.events.setdefault(key, {})[event.event_id] = event
+        return event
+
+    def get_event(
+        self, memory_id: str, actor_id: str, session_id: str, event_id: str
+    ) -> Event:
+        event = self.events.get((memory_id, actor_id, session_id), {}).get(event_id)
+        if not event:
+            raise ResourceNotFoundException(f"Event {event_id} not found")
+        return event
+
+    def list_events(
+        self,
+        memory_id: str,
+        actor_id: str,
+        session_id: str,
+        max_results: int | None,
+    ) -> list[Event]:
+        events = list(self.events.get((memory_id, actor_id, session_id), {}).values())
+        if max_results:
+            events = events[:max_results]
+        return events
+
+    def delete_event(
+        self, memory_id: str, actor_id: str, session_id: str, event_id: str
+    ) -> str:
+        key = (memory_id, actor_id, session_id)
+        if event_id not in self.events.get(key, {}):
+            raise ResourceNotFoundException(f"Event {event_id} not found")
+        del self.events[key][event_id]
+        return event_id
+
+
+bedrockagentcore_backends = BackendDict(
+    BedrockAgentCoreBackend,
+    "bedrock-agentcore",
+    # matches the workaround already used by the sibling
+    # bedrock-agentcore-control service (see its models.py) -
+    # moto's own region list for this service doesn't include it yet
+    use_boto3_regions=False,
+    additional_regions=[
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "ap-south-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "eu-north-1",
+        "sa-east-1",
+    ],
+)

--- a/moto/bedrockagentcore/responses.py
+++ b/moto/bedrockagentcore/responses.py
@@ -1,0 +1,66 @@
+"""Handles incoming bedrockagentcore requests, invokes methods, returns responses."""
+
+from moto.core.responses import ActionResult, BaseResponse
+
+from .models import BedrockAgentCoreBackend, bedrockagentcore_backends
+
+
+class BedrockAgentCoreResponse(BaseResponse):
+    """Handler for BedrockAgentCore requests and responses."""
+
+    def __init__(self) -> None:
+        super().__init__(service_name="bedrock-agentcore")
+        self.automated_parameter_parsing = True
+
+    @property
+    def backend(self) -> BedrockAgentCoreBackend:
+        return bedrockagentcore_backends[self.current_account][self.region]
+
+    def create_event(self) -> ActionResult:
+        params = self._get_params()
+        event = self.backend.create_event(
+            memory_id=params["memoryId"],
+            actor_id=params.get("actorId"),
+            session_id=params.get("sessionId"),
+            event_timestamp=params.get("eventTimestamp"),
+            payload=params.get("payload"),
+            branch=params.get("branch"),
+            metadata=params.get("metadata"),
+        )
+        return ActionResult({"event": event.to_dict()})
+
+    def get_event(self) -> ActionResult:
+        params = self._get_params()
+        event = self.backend.get_event(
+            memory_id=params["memoryId"],
+            actor_id=params["actorId"],
+            session_id=params["sessionId"],
+            event_id=params["eventId"],
+        )
+        return ActionResult({"event": event.to_dict()})
+
+    def list_events(self) -> ActionResult:
+        params = self._get_params()
+        include_payloads = params.get("includePayloads", False)
+        events = self.backend.list_events(
+            memory_id=params["memoryId"],
+            actor_id=params["actorId"],
+            session_id=params["sessionId"],
+            max_results=params.get("maxResults"),
+        )
+        return ActionResult(
+            {
+                "events": [e.to_dict(include_payload=include_payloads) for e in events],
+                "nextToken": None,
+            }
+        )
+
+    def delete_event(self) -> ActionResult:
+        params = self._get_params()
+        event_id = self.backend.delete_event(
+            memory_id=params["memoryId"],
+            actor_id=params["actorId"],
+            session_id=params["sessionId"],
+            event_id=params["eventId"],
+        )
+        return ActionResult({"eventId": event_id})

--- a/moto/bedrockagentcore/urls.py
+++ b/moto/bedrockagentcore/urls.py
@@ -1,0 +1,11 @@
+"""BedrockAgentCore URLs."""
+
+from .responses import BedrockAgentCoreResponse
+
+url_bases = [
+    r"https?://bedrock-agentcore\.(.+)\.amazonaws\.com",
+]
+
+url_paths = {
+    "{0}/.*$": BedrockAgentCoreResponse.dispatch,
+}

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -44,7 +44,6 @@ UNSIGNED_ACTIONS = {
 
 # Some services have v4 signing names that differ from the backend service name/id.
 SIGNING_ALIASES = {
-    "bedrock-agentcore": "bedrock-agentcore-control",
     "eventbridge": "events",
     "execute-api": "iot",
     "iotdata": "data.iot",
@@ -178,6 +177,27 @@ class DomainDispatcherApplication:
             host = "sesv2"
         elif service == "memorydb":
             host = f"memory-db.{region}.amazonaws.com"
+        elif service == "bedrock-agentcore":
+            from moto.bedrockagentcore.responses import BedrockAgentCoreResponse
+            from moto.bedrockagentcorecontrol.responses import (
+                BedrockAgentCoreControlResponse,
+            )
+
+            service_to_response = {
+                "bedrock-agentcore": BedrockAgentCoreResponse,
+                "bedrock-agentcore-control": BedrockAgentCoreControlResponse,
+            }
+            for service_name, response_class in service_to_response.items():
+                resp = response_class()
+                resp.region = region
+                action = resp._get_action_from_method_and_request_uri(
+                    method=environ["REQUEST_METHOD"],
+                    request_uri=environ["PATH_INFO"],
+                )
+                if action:
+                    service = service_name
+                    break
+            host = f"{service}.{region}.amazonaws.com"
         elif service == "bedrock":
             # Multiple Bedrock services use the same signing name (bedrock).
             # This is obviously a hack, but it automatically differentiates

--- a/tests/test_bedrockagentcore/test_bedrockagentcore.py
+++ b/tests/test_bedrockagentcore/test_bedrockagentcore.py
@@ -1,0 +1,249 @@
+"""Unit tests for bedrock-agentcore-supported APIs."""
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws
+
+TEST_REGION = "us-east-1"
+MEMORY_ID = "mtest12345-abcdefghij"
+
+
+def _create_client():
+    return boto3.client("bedrock-agentcore", region_name=TEST_REGION)
+
+
+def _payload(text="hello"):
+    return [{"conversational": {"content": {"text": text}, "role": "USER"}}]
+
+
+@mock_aws
+def test_create_event():
+    client = _create_client()
+
+    resp = client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+    )
+
+    event = resp["event"]
+    assert event["memoryId"] == MEMORY_ID
+    assert event["actorId"] == "actor-1"
+    assert event["sessionId"] == "session-1"
+    assert "eventId" in event
+    assert event["payload"] == _payload()
+    assert event["branch"] == {"name": "main"}
+
+
+@mock_aws
+def test_create_event_with_metadata_and_branch():
+    client = _create_client()
+
+    resp = client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+        branch={"name": "feature-branch"},
+        metadata={"source": {"stringValue": "unit-test"}},
+    )
+
+    event = resp["event"]
+    assert event["branch"] == {"name": "feature-branch"}
+    assert event["metadata"] == {"source": {"stringValue": "unit-test"}}
+
+
+@mock_aws
+def test_create_event_errors():
+    client = _create_client()
+
+    with pytest.raises(ClientError) as exc:
+        client.create_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            eventTimestamp="2026-01-01T00:00:00Z",
+            payload=_payload(),
+        )
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+
+    with pytest.raises(ClientError) as exc:
+        client.create_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            sessionId="session-1",
+            eventTimestamp="2026-01-01T00:00:00Z",
+            payload=[],
+        )
+    assert exc.value.response["Error"]["Code"] == "ValidationException"
+
+
+@mock_aws
+def test_get_event():
+    client = _create_client()
+    created = client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+    )["event"]
+
+    resp = client.get_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventId=created["eventId"],
+    )
+
+    assert resp["event"]["eventId"] == created["eventId"]
+    assert resp["event"]["payload"] == _payload()
+
+
+@mock_aws
+def test_get_event_not_found():
+    client = _create_client()
+
+    with pytest.raises(ClientError) as exc:
+        client.get_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            sessionId="session-1",
+            eventId="not-a-real-event",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_list_events():
+    client = _create_client()
+    for text in ("first", "second", "third"):
+        client.create_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            sessionId="session-1",
+            eventTimestamp="2026-01-01T00:00:00Z",
+            payload=_payload(text),
+        )
+
+    resp = client.list_events(
+        memoryId=MEMORY_ID, actorId="actor-1", sessionId="session-1"
+    )
+
+    assert len(resp["events"]) == 3
+    # payloads are not included by default
+    assert "payload" not in resp["events"][0]
+
+
+@mock_aws
+def test_list_events_include_payloads():
+    client = _create_client()
+    client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+    )
+
+    resp = client.list_events(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        includePayloads=True,
+    )
+
+    assert resp["events"][0]["payload"] == _payload()
+
+
+@mock_aws
+def test_list_events_max_results():
+    client = _create_client()
+    for _ in range(3):
+        client.create_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            sessionId="session-1",
+            eventTimestamp="2026-01-01T00:00:00Z",
+            payload=_payload(),
+        )
+
+    resp = client.list_events(
+        memoryId=MEMORY_ID, actorId="actor-1", sessionId="session-1", maxResults=2
+    )
+
+    assert len(resp["events"]) == 2
+
+
+@mock_aws
+def test_list_events_scoped_to_session():
+    client = _create_client()
+    client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+    )
+    client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-2",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+    )
+
+    resp = client.list_events(
+        memoryId=MEMORY_ID, actorId="actor-1", sessionId="session-1"
+    )
+
+    assert len(resp["events"]) == 1
+
+
+@mock_aws
+def test_delete_event():
+    client = _create_client()
+    created = client.create_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventTimestamp="2026-01-01T00:00:00Z",
+        payload=_payload(),
+    )["event"]
+
+    resp = client.delete_event(
+        memoryId=MEMORY_ID,
+        actorId="actor-1",
+        sessionId="session-1",
+        eventId=created["eventId"],
+    )
+
+    assert resp["eventId"] == created["eventId"]
+
+    with pytest.raises(ClientError) as exc:
+        client.get_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            sessionId="session-1",
+            eventId=created["eventId"],
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+@mock_aws
+def test_delete_event_not_found():
+    client = _create_client()
+
+    with pytest.raises(ClientError) as exc:
+        client.delete_event(
+            memoryId=MEMORY_ID,
+            actorId="actor-1",
+            sessionId="session-1",
+            eventId="not-a-real-event",
+        )
+    assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -103,7 +103,7 @@ def test_bedrock_service_resolution(moto_server: str) -> None:
 
 def test_bedrock_agentcore_service_resolution(moto_server: str) -> None:
     # Multiple Bedrock services use the same signing name (bedrock-agentcore),
-    # so this test checks that a bedrock-runtime request is correctly
+    # so this test checks that a bedrock-agentcore request is correctly
     # differentiated in server mode (where there is no host name available).
     from botocore.exceptions import UnknownServiceError
 

--- a/tests/test_core/test_server.py
+++ b/tests/test_core/test_server.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+import uuid
 from collections.abc import Iterable
 from unittest.mock import Mock, patch
 
@@ -98,3 +99,28 @@ def test_bedrock_service_resolution(moto_server: str) -> None:
         )
         assert resp["performanceConfigLatency"] == "optimized"
         assert resp["serviceTier"] == "flex"
+
+
+def test_bedrock_agentcore_service_resolution(moto_server: str) -> None:
+    # Multiple Bedrock services use the same signing name (bedrock-agentcore),
+    # so this test checks that a bedrock-runtime request is correctly
+    # differentiated in server mode (where there is no host name available).
+    from botocore.exceptions import UnknownServiceError
+
+    try:
+        client = boto3.client(
+            "bedrock-agentcore", region_name="us-east-1", endpoint_url=moto_server
+        )
+    except UnknownServiceError:
+        pytest.skip("Bedrock AgentCore not supported in this version of Botocore.")
+    else:
+        resp = client.create_event(
+            memoryId=str(uuid.uuid4()),
+            actorId="actor-1",
+            sessionId="session-1",
+            eventTimestamp="2026-01-01T00:00:00Z",
+            payload=[
+                {"conversational": {"content": {"text": "test text"}, "role": "USER"}}
+            ],
+        )
+        assert "event" in resp


### PR DESCRIPTION
Closes #9518.

Implements the four documented AWS AgentCore Memory short-term operations: `create_event`, `get_event`, `list_events`, `delete_event`, backed by an in-memory store keyed by `(memoryId, actorId, sessionId)`.

A previous attempt at this in #9856 got partway there before going stale and being closed for inactivity. This is a fresh implementation, informed by the review comments already left on that PR (validation ordering, response shape accuracy).

All response shapes were verified against the actual botocore service model rather than guessed. That caught one real bug before it shipped: the metadata value on `GetEvent`'s response is a structure (`MetadataValue` with a `stringValue` member), not a plain string like the request side accepts loosely. A first pass reused the same shape for both directions; botocore silently drops the field client-side when a response key doesn't match the declared shape, no error, just missing data, and a test assertion caught the mismatch.

11 tests in `tests/test_bedrockagentcore/test_bedrockagentcore.py`, covering create/get/list/delete, validation errors (missing sessionId/payload), pagination via maxResults, and session-scoped listing. mypy and ruff clean. Docs page generated via `scripts/implementation_coverage.py`, with unrelated pre-existing drift in other services' entries from that script reverted so this diff stays scoped to the new service.