### PR TITLE
CodeBuild: serialise build timestamps as epoch seconds

### DIFF
--- a/moto/codebuild/models.py
+++ b/moto/codebuild/models.py
@@ -1,11 +1,9 @@
-import datetime
 from collections import defaultdict
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
-from moto.core.parse import default_timestamp_parser
-from moto.core.utils import iso_8601_datetime_with_milliseconds, unix_time
+from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.utils import get_partition
 
@@ -21,7 +19,7 @@ class CodeBuildProjectMetadata(BaseModel):
         build_id: str,
         service_role: str,
     ):
-        current_date = iso_8601_datetime_with_milliseconds()
+        current_date = unix_time()
         self.build_metadata: dict[str, Any] = {}
 
         self.build_metadata["id"] = build_id
@@ -246,7 +244,7 @@ class CodeBuildBackend(BaseBackend):
         return self.build_metadata[project_name].build_metadata
 
     def _set_phases(self, phases: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        current_date = iso_8601_datetime_with_milliseconds()
+        current_date = unix_time()
         # No phaseStatus for QUEUED on first start
         for existing_phase in phases:
             if existing_phase["phaseType"] == "QUEUED":
@@ -282,9 +280,8 @@ class CodeBuildBackend(BaseBackend):
             for build in metadata:
                 if build["id"] in ids:
                     build["phases"] = self._set_phases(build["phases"])
-                    build["endTime"] = iso_8601_datetime_with_milliseconds(
-                        default_timestamp_parser(build["startTime"])
-                        + datetime.timedelta(minutes=mock_random.randint(1, 5))
+                    build["endTime"] = build["startTime"] + 60 * mock_random.randint(
+                        1, 5
                     )
                     build["currentPhase"] = "COMPLETED"
                     build["buildStatus"] = "SUCCEEDED"
@@ -316,9 +313,8 @@ class CodeBuildBackend(BaseBackend):
                 if build["id"] == build_id:
                     # set completion properties with variable completion time
                     build["phases"] = self._set_phases(build["phases"])
-                    build["endTime"] = iso_8601_datetime_with_milliseconds(
-                        default_timestamp_parser(build["startTime"])
-                        + datetime.timedelta(minutes=mock_random.randint(1, 5))
+                    build["endTime"] = build["startTime"] + 60 * mock_random.randint(
+                        1, 5
                     )
                     build["currentPhase"] = "COMPLETED"
                     build["buildStatus"] = "STOPPED"

--- a/tests/test_codebuild/test_server.py
+++ b/tests/test_codebuild/test_server.py
@@ -1,0 +1,65 @@
+import json
+
+import boto3
+
+from moto import mock_aws, server
+from moto.utilities.constants import APPLICATION_AMZ_JSON_1_1
+from tests import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+
+
+def _post(test_client, target, body):
+    headers = {
+        "X-Amz-Target": f"CodeBuild_20161006.{target}",
+        "Content-Type": APPLICATION_AMZ_JSON_1_1,
+        # The Authorization header is how the server learns the region.
+        "Authorization": (
+            "AWS4-HMAC-SHA256 Credential=test/20260911/eu-west-1/codebuild/aws4_request, "
+            "SignedHeaders=host;x-amz-target, Signature=0"
+        ),
+    }
+    res = test_client.post("/", headers=headers, data=json.dumps(body))
+    return json.loads(res.data.decode("utf-8"))
+
+
+def _assert_epoch(build):
+    # CodeBuild's JSON protocol declares startTime/endTime as `timestamp`, which on the wire is epoch seconds.
+    # botocore happens to parse ISO strings too, but the AWS SDK for JavaScript v3 (expectNumber) and Go v2 do not,
+    # so a string here breaks clients that pass boto3-based tests.
+    assert isinstance(build["startTime"], (int, float)), build["startTime"]
+    if "endTime" in build:
+        assert isinstance(build["endTime"], (int, float)), build["endTime"]
+        assert build["endTime"] >= build["startTime"]
+    for phase in build["phases"]:
+        for key in ("startTime", "endTime"):
+            if key in phase:
+                assert isinstance(phase[key], (int, float)), (phase["phaseType"], key)
+
+
+@mock_aws
+def test_build_timestamps_are_epoch_seconds_on_the_wire():
+    client = boto3.client("codebuild", region_name="eu-west-1")
+    client.create_project(
+        name="my_project",
+        source={"type": "S3", "location": "bucketname/path/file.zip"},
+        artifacts={"type": "NO_ARTIFACTS"},
+        environment={
+            "type": "LINUX_CONTAINER",
+            "image": "contents_not_validated",
+            "computeType": "BUILD_GENERAL1_SMALL",
+        },
+        serviceRole=f"arn:aws:iam::{ACCOUNT_ID}:role/service-role/my-codebuild-service-role",
+    )
+
+    test_client = server.create_backend_app("codebuild").test_client()
+
+    started = _post(test_client, "StartBuild", {"projectName": "my_project"})["build"]
+    _assert_epoch(started)
+
+    fetched = _post(test_client, "BatchGetBuilds", {"ids": [started["id"]]})["builds"][
+        0
+    ]
+    _assert_epoch(fetched)
+    assert fetched["currentPhase"] == "COMPLETED"
+
+    stopped = _post(test_client, "StopBuild", {"id": started["id"]})["build"]
+    _assert_epoch(stopped)


### PR DESCRIPTION
## What

`StartBuild`, `BatchGetBuilds` and `StopBuild` returned `startTime`/`endTime` — on the build and on every phase — as ISO-8601 strings:

```json
{"build": {"startTime": "2026-09-11T16:10:18.103Z", "phases": [{"phaseType": "SUBMITTED", "startTime": "2026-09-11T16:10:18.103Z", ...}]}}
```

CodeBuild's JSON protocol declares these as `timestamp`, which on the wire is epoch seconds (the way `Project.created` / `lastModified` already are in this same backend, via `unix_time()`).

## Why it matters

botocore parses either form, so the existing boto3-based tests pass. Clients that follow the protocol strictly do not: the AWS SDK for JavaScript v3 fails to deserialise the response with

```
Expected real number, got implicit NaN
  Deserialization error: to see the raw response, inspect the hidden field {error}.$response on this object.
```

so a JS/TS application that talks to moto server can create the project and start the build, then dies on the very next call. Found while running a Next.js deploy pipeline against `motoserver/moto:5.2.3`.

## Change

- `Build.__init__` and `_set_phases` use `unix_time()` instead of `iso_8601_datetime_with_milliseconds()`.
- `endTime` is derived arithmetically from the numeric `startTime` (the `default_timestamp_parser` + `timedelta` round-trip is no longer needed).
- New `tests/test_codebuild/test_server.py` posts to the server app and asserts on the **raw** JSON, so the wire format is pinned regardless of what the client tolerates. Verified failing on `master` (`AssertionError: 2026-09-11T18:55:04.222Z`) and passing with the change. `tests/test_codebuild` → 20 passed; `ruff check`/`ruff format --check` clean on the touched files; `mypy` clean on `models.py`.

Behaviour for boto3 users is unchanged: they still get `datetime` objects.

Made with [Cursor](https://cursor.com)