### PR TITLE
CodeBuild: migrate to new response serialization

### DIFF
--- a/moto/codebuild/responses.py
+++ b/moto/codebuild/responses.py
@@ -1,8 +1,7 @@
-import json
 import re
 from typing import Any
 
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 from moto.utilities.utils import get_partition
 
 from .exceptions import (
@@ -104,7 +103,7 @@ class CodeBuildResponse(BaseResponse):
     def codebuild_backend(self) -> CodeBuildBackend:
         return codebuild_backends[self.current_account][self.region]
 
-    def list_builds_for_project(self) -> str:
+    def list_builds_for_project(self) -> ActionResult:
         _validate_required_params_project_name(self._get_param("projectName"))
 
         if (
@@ -120,9 +119,9 @@ class CodeBuildResponse(BaseResponse):
             self._get_param("projectName")
         )
 
-        return json.dumps({"ids": ids})
+        return ActionResult({"ids": ids})
 
-    def create_project(self) -> str:
+    def create_project(self) -> ActionResult:
         _validate_required_params_source(self._get_param("source"))
         service_role = self._get_param("serviceRole")
         _validate_required_params_service_role(
@@ -154,18 +153,18 @@ class CodeBuildResponse(BaseResponse):
             vpc_config=self._get_param("vpcConfig"),
         )
 
-        return json.dumps({"project": project_metadata})
+        return ActionResult({"project": project_metadata})
 
-    def list_projects(self) -> str:
+    def list_projects(self) -> ActionResult:
         project_metadata = self.codebuild_backend.list_projects()
-        return json.dumps({"projects": project_metadata})
+        return ActionResult({"projects": project_metadata})
 
-    def batch_get_projects(self) -> str:
+    def batch_get_projects(self) -> ActionResult:
         names = self._get_param("names")
         project_metadata = self.codebuild_backend.batch_get_projects(names)
-        return json.dumps({"projects": project_metadata})
+        return ActionResult({"projects": project_metadata})
 
-    def start_build(self) -> str:
+    def start_build(self) -> ActionResult:
         _validate_required_params_project_name(self._get_param("projectName"))
 
         if (
@@ -182,30 +181,30 @@ class CodeBuildResponse(BaseResponse):
             self._get_param("sourceVersion"),
             self._get_param("artifactsOverride"),
         )
-        return json.dumps({"build": metadata})
+        return ActionResult({"build": metadata})
 
-    def batch_get_builds(self) -> str:
+    def batch_get_builds(self) -> ActionResult:
         for build_id in self._get_param("ids"):
             if ":" not in build_id:
                 raise InvalidInputException("Invalid build ID provided")
 
         metadata = self.codebuild_backend.batch_get_builds(self._get_param("ids"))
-        return json.dumps({"builds": metadata})
+        return ActionResult({"builds": metadata})
 
-    def list_builds(self) -> str:
+    def list_builds(self) -> ActionResult:
         ids = self.codebuild_backend.list_builds()
-        return json.dumps({"ids": ids})
+        return ActionResult({"ids": ids})
 
-    def delete_project(self) -> str:
+    def delete_project(self) -> EmptyResult:
         _validate_required_params_project_name(self._get_param("name"))
 
         self.codebuild_backend.delete_project(self._get_param("name"))
-        return "{}"
+        return EmptyResult()
 
-    def stop_build(self) -> str:
+    def stop_build(self) -> ActionResult:
         _validate_required_params_id(
             self._get_param("id"), self.codebuild_backend.list_builds()
         )
 
         metadata = self.codebuild_backend.stop_build(self._get_param("id"))
-        return json.dumps({"build": metadata})
+        return ActionResult({"build": metadata})

--- a/other_langs/tests_js/codebuild.test.js
+++ b/other_langs/tests_js/codebuild.test.js
@@ -1,0 +1,39 @@
+import { BatchGetBuildsCommand, CodeBuildClient, CreateProjectCommand, StartBuildCommand, StopBuildCommand } from '@aws-sdk/client-codebuild'
+
+process.env['AWS_ACCESS_KEY_ID'] = 'test'
+process.env['AWS_SECRET_ACCESS_KEY'] = 'test'
+
+const client = new CodeBuildClient({region: 'us-east-1', endpoint: 'http://localhost:5000'});
+
+const projectName = "test-project-" + Math.floor(Math.random() * 10000);
+
+const createProjectCommand = new CreateProjectCommand({
+    name: projectName,
+    source: {
+        type: "S3",
+        location: "bucketname/path/file.zip",
+    },
+    artifacts: {
+        type: "NO_ARTIFACTS",
+    },
+    environment: {
+        type: "LINUX_CONTAINER",
+        image: "contents_not_validated",
+        computeType: "BUILD_GENERAL1_SMALL",
+    },
+    serviceRole: "arn:aws:iam::123456789012:role/service-role/my-codebuild-service-role",
+});
+
+await client.send(createProjectCommand);
+
+const startBuildCommand = new StartBuildCommand({projectName: projectName});
+const { build } = await client.send(startBuildCommand);
+console.log(build);
+
+const batchGetBuildsCommand = new BatchGetBuildsCommand({ids: [build.id]});
+const { builds } = await client.send(batchGetBuildsCommand);
+console.log(builds);
+
+const stopBuildCommand = new StopBuildCommand({id: build.id});
+const response = await client.send(stopBuildCommand);
+console.log(response);

--- a/other_langs/tests_js/package.json
+++ b/other_langs/tests_js/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
+    "@aws-sdk/client-codebuild": "^3.749.0",
     "@aws-sdk/client-ec2": "^3.749.0",
     "@aws-sdk/client-lambda": "^3.749.0",
     "@aws-sdk/client-rds": "^3.749.0",


### PR DESCRIPTION
Fixes the issue identified in #10257 at the serialization level and adds a dedicated JS client test to cover the exact conditions under which the error arises.

Supersedes and Closes #10257 