### PR TITLE
Admin: fix test asserts after Botocore behavior change

### DIFF
--- a/tests/test_scheduler/__init__.py
+++ b/tests/test_scheduler/__init__.py
@@ -3,18 +3,14 @@ from datetime import datetime, timedelta
 from moto.core.utils import utcnow
 
 
-def pytest_parametrize_test_create_get_schedule__with_start_date() -> list[
-    tuple[datetime, datetime]
-]:
+def pytest_parametrize_test_create_get_schedule__with_start_date() -> list[datetime]:
     now = utcnow()
     timedelta_kwargs = {"days": 1, "hours": 1, "weeks": 1}
     return_ = []
     for k, v in timedelta_kwargs.items():
-        to_append = now + timedelta(**{k: v})
-        return_.append((to_append, to_append.replace(microsecond=0)))
+        return_.append(now + timedelta(**{k: v}))
     else:
-        to_append = now.replace(year=now.year + 1)
-        return_.append((to_append, to_append.replace(microsecond=0)))
+        return_.append(now.replace(year=now.year + 1))
     return return_
 
 

--- a/tests/test_scheduler/test_scheduler.py
+++ b/tests/test_scheduler/test_scheduler.py
@@ -238,10 +238,10 @@ def test_delete_schedule_for_none_existing_schedule():
 
 @mock_aws
 @pytest.mark.parametrize(
-    "start_date,expected_start_date",
+    "start_date",
     pytest_parametrize_test_create_get_schedule__with_start_date(),
 )
-def test_create_get_schedule__with_start_date(start_date, expected_start_date):
+def test_create_get_schedule__with_start_date(start_date):
     # Act
     client = boto3.client("scheduler", region_name="eu-west-1")
     client.create_schedule(
@@ -263,7 +263,9 @@ def test_create_get_schedule__with_start_date(start_date, expected_start_date):
     start_date_as_utc = datetime.astimezone(resp["StartDate"], timezone.utc).replace(
         tzinfo=None
     )
-    assert start_date_as_utc == expected_start_date
+    # Older versions of botocore truncate sub-second precision when sending
+    # unix timestamps, newer versions send the microseconds as-is
+    assert start_date_as_utc in [start_date, start_date.replace(microsecond=0)]
 
 
 @mock_aws


### PR DESCRIPTION
Refactor timestamp asserts to work pre- and post-merge of boto/botocore#3796, which preserves sub-second precision when serializing `unixTimestamp` request parameters.